### PR TITLE
Add tslint command to npm scripts and fix linting errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build:bundle": "webpack",
     "build:commonjs": "tsc",
     "build:es6": "tsc -m es6 --outDir lib-esm",
-    "build": "npm run clean && run-p build:*"
+    "build": "npm run clean && run-p build:*",
+    "lint": "tslint src/ts/**/*"
   },
   "repository": {
     "type": "git",
@@ -28,7 +29,8 @@
     "awesome-typescript-loader": "^3.1.3",
     "npm-run-all": "^4.0.2",
     "shx": "^0.2.2",
-    "tslint-config-0xproject": "^0.0.0",
+    "tslint": "^5.3.2",
+    "tslint-config-0xproject": "^0.0.2",
     "typescript": "^2.3.3",
     "webpack": "^2.6.0"
   }

--- a/src/ts/0x.js.ts
+++ b/src/ts/0x.js.ts
@@ -1,4 +1,4 @@
-export class zeroEx {
+export class ZeroEx {
     public verifySignature() {
         // TODO
     }


### PR DESCRIPTION
This PR:
* Adds tslint
* Adds `lint` command
* renames the class from `zeroEx` to `ZeroEx`