### PR TITLE
Run coverage only for commonjs test

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "npm run clean && run-p build:*:prod",
     "lint": "tslint src/**/*.ts",
     "test": "run-s test:commonjs test:umd",
-    "test:coverage": "nyc npm run test --all",
+    "test:coverage": "nyc npm run test:commonjs --all",
     "update_contracts": "for i in ${npm_package_config_artifacts}; do copyfiles -u 4 ../contracts/build/contracts/$i.json ../0x.js/src/artifacts; done;",
     "testrpc": "testrpc -p 8545 --networkId 50",
     "docs:json": "typedoc --json docs/index.json .",


### PR DESCRIPTION
This PR:
* Runs coverage only for commonjs tests cause otherwise the test coverage tool goes nuts