### PR TITLE
Add regression test for transferFrom bug

### DIFF
--- a/test/token_wrapper_test.ts
+++ b/test/token_wrapper_test.ts
@@ -89,7 +89,8 @@ describe('TokenWrapper', () => {
                 token.address, fromAddress, toAddress, senderAddress, transferAmount,
             )).to.be.rejectedWith(ZeroExError.INSUFFICIENT_ALLOWANCE_FOR_TRANSFER);
         });
-        it('should fail to transfer tokens if set allowance for toAddress instead of senderAddress', async () => {
+        it('[regression] should fail to transfer tokens if set allowance for toAddress instead of senderAddress',
+            async () => {
             const fromAddress = coinbase;
             const transferAmount = new BigNumber(42);
 


### PR DESCRIPTION
There was a bug, when we checked the allowance of `toAddress` instead of `senderAddress`
This PR:
* adds a regression test for it