### PR TITLE
Add actual type for contract event arguments

### DIFF
--- a/src/contract_wrappers/exchange_wrapper.ts
+++ b/src/contract_wrappers/exchange_wrapper.ts
@@ -22,7 +22,7 @@ import {
     ContractResponse,
     OrderCancellationRequest,
     OrderFillRequest,
-    LogErrorArgs,
+    LogErrorContractEventArgs,
 } from '../types';
 import {assert} from '../utils/assert';
 import {utils} from '../utils/utils';
@@ -713,7 +713,7 @@ export class ExchangeWrapper extends ContractWrapper {
     private _throwErrorLogsAsErrors(logs: ContractEvent[]): void {
         const errEvent = _.find(logs, {event: 'LogError'});
         if (!_.isUndefined(errEvent)) {
-            const errCode = (errEvent.args as LogErrorArgs).errorId.toNumber()
+            const errCode = (errEvent.args as LogErrorContractEventArgs).errorId.toNumber()
             const errMessage = this._exchangeContractErrCodesToMsg[errCode];
             throw new Error(errMessage);
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,9 +19,9 @@ export {
     OrderCancellationRequest,
     OrderFillRequest,
     ContractEventEmitter,
-    LogErrorArgs,
+    LogErrorContractEventArgs,
     LogCancelArgs,
     LogFillArgs,
-    EventArgs,
+    ContractEventArgs,
     Web3Provider,
 } from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -191,7 +191,7 @@ export interface ContractEvent {
     address: string;
     type: string;
     event: string;
-    args: EventArgs;
+    args: ContractEventArgs;
 }
 
 export interface LogFillArgs {
@@ -217,11 +217,11 @@ export interface LogCancelArgs {
     tokens: string;
     orderHash: string;
 }
-export interface LogErrorArgs {
+export interface LogErrorContractEventArgs {
     errorId: BigNumber.BigNumber;
     orderHash: string;
 }
-export type EventArgs = LogFillArgs|LogCancelArgs|LogErrorArgs;
+export type ContractEventArgs = LogFillArgs|LogCancelArgs|LogErrorContractEventArgs;
 
 export interface Order {
     maker: string;


### PR DESCRIPTION
This PR:
* Adds `EventArgs`, `LogCancellArgs`, `LogFillArgs` and `LogErrorArgs` types
