### PR TITLE
Allow LedgerSubprovider to return any number of accounts

### DIFF
--- a/packages/subproviders/CHANGELOG.md
+++ b/packages/subproviders/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.6.0 - _TBD_
 
     * Move web3 types from being a devDep to a dep since one cannot use this package without it (#429)
-    * Add `numberOfAccounts` param to `LedgerSubprovider` method `getAccountsAsync`
+    * Add `numberOfAccounts` param to `LedgerSubprovider` method `getAccountsAsync` (#432)
 
 ## v0.5.0 - _February 16, 2018_
 

--- a/packages/subproviders/CHANGELOG.md
+++ b/packages/subproviders/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v0.5.1 - _TBD, 2018_
+
+    * Add `numberOfAccounts` param to `LedgerSubprovider` method `getAccountsAsync`
+
 ## v0.5.0 - _February 16, 2018_
 
     * Add EmptyWalletSubprovider and FakeGasEstimateSubprovider (#392)

--- a/packages/subproviders/src/subproviders/ledger.ts
+++ b/packages/subproviders/src/subproviders/ledger.ts
@@ -19,7 +19,7 @@ import {
 import { Subprovider } from './subprovider';
 
 const DEFAULT_DERIVATION_PATH = `44'/60'/0'`;
-const NUM_ADDRESSES_TO_FETCH = 10;
+const DEFAULT_NUM_ADDRESSES_TO_FETCH = 10;
 const ASK_FOR_ON_DEVICE_CONFIRMATION = false;
 const SHOULD_GET_CHAIN_CODE = true;
 
@@ -129,7 +129,7 @@ export class LedgerSubprovider extends Subprovider {
                 return;
         }
     }
-    public async getAccountsAsync(): Promise<string[]> {
+    public async getAccountsAsync(numberOfAccounts: number = DEFAULT_NUM_ADDRESSES_TO_FETCH): Promise<string[]> {
         this._ledgerClientIfExists = await this._createLedgerClientAsync();
 
         let ledgerResponse;
@@ -148,7 +148,7 @@ export class LedgerSubprovider extends Subprovider {
         hdKey.chainCode = new Buffer(ledgerResponse.chainCode, 'hex');
 
         const accounts = [];
-        for (let i = 0; i < NUM_ADDRESSES_TO_FETCH; i++) {
+        for (let i = 0; i < numberOfAccounts; i++) {
             const derivedHDNode = hdKey.derive(`m/${i + this._derivationPathIndex}`);
             const derivedPublicKey = derivedHDNode.publicKey;
             const shouldSanitizePublicKey = true;

--- a/packages/subproviders/test/integration/ledger_subprovider_test.ts
+++ b/packages/subproviders/test/integration/ledger_subprovider_test.ts
@@ -26,10 +26,16 @@ describe('LedgerSubprovider', () => {
         });
     });
     describe('direct method calls', () => {
-        it('returns a list of accounts', async () => {
+        it('returns defaut number of accounts', async () => {
             const accounts = await ledgerSubprovider.getAccountsAsync();
             expect(accounts[0]).to.not.be.an('undefined');
             expect(accounts.length).to.be.equal(10);
+        });
+        it('returns requested number of accounts', async () => {
+            const numberOfAccounts = 20;
+            const accounts = await ledgerSubprovider.getAccountsAsync(numberOfAccounts);
+            expect(accounts[0]).to.not.be.an('undefined');
+            expect(accounts.length).to.be.equal(numberOfAccounts);
         });
         it('signs a personal message', async () => {
             const data = ethUtils.bufferToHex(ethUtils.toBuffer('hello world'));
@@ -172,7 +178,7 @@ describe('LedgerSubprovider', () => {
                 };
                 const callback = reportCallbackErrors(done)((err: Error, response: Web3.JSONRPCResponsePayload) => {
                     expect(err).to.be.a('null');
-                    const result = response.result.result;
+                    const result = response.result;
                     expect(result.length).to.be.equal(66);
                     expect(result.substr(0, 2)).to.be.equal('0x');
                     done();

--- a/packages/subproviders/test/integration/ledger_subprovider_test.ts
+++ b/packages/subproviders/test/integration/ledger_subprovider_test.ts
@@ -26,7 +26,7 @@ describe('LedgerSubprovider', () => {
         });
     });
     describe('direct method calls', () => {
-        it('returns defaut number of accounts', async () => {
+        it('returns default number of accounts', async () => {
             const accounts = await ledgerSubprovider.getAccountsAsync();
             expect(accounts[0]).to.not.be.an('undefined');
             expect(accounts.length).to.be.equal(10);

--- a/packages/subproviders/test/unit/ledger_subprovider_test.ts
+++ b/packages/subproviders/test/unit/ledger_subprovider_test.ts
@@ -62,10 +62,16 @@ describe('LedgerSubprovider', () => {
     });
     describe('direct method calls', () => {
         describe('success cases', () => {
-            it('returns a list of accounts', async () => {
+            it('returns defaut number of accounts', async () => {
                 const accounts = await ledgerSubprovider.getAccountsAsync();
                 expect(accounts[0]).to.be.equal(FAKE_ADDRESS);
                 expect(accounts.length).to.be.equal(10);
+            });
+            it('returns requested number of accounts', async () => {
+                const numberOfAccounts = 20;
+                const accounts = await ledgerSubprovider.getAccountsAsync(numberOfAccounts);
+                expect(accounts[0]).to.be.equal(FAKE_ADDRESS);
+                expect(accounts.length).to.be.equal(numberOfAccounts);
             });
             it('signs a personal message', async () => {
                 const data = ethUtils.bufferToHex(ethUtils.toBuffer('hello world'));

--- a/packages/subproviders/test/unit/ledger_subprovider_test.ts
+++ b/packages/subproviders/test/unit/ledger_subprovider_test.ts
@@ -62,7 +62,7 @@ describe('LedgerSubprovider', () => {
     });
     describe('direct method calls', () => {
         describe('success cases', () => {
-            it('returns defaut number of accounts', async () => {
+            it('returns default number of accounts', async () => {
                 const accounts = await ledgerSubprovider.getAccountsAsync();
                 expect(accounts[0]).to.be.equal(FAKE_ADDRESS);
                 expect(accounts.length).to.be.equal(10);


### PR DESCRIPTION
<!--- Thank you for taking the time to submit a Pull Request -->

<!--- Provide a general summary of the issue in the Title above -->

## Description

Previously `getAccountsAsync` always returned 10 accounts. Now the caller can specify any number of accounts to fetch. Either way, only a single request is sent to the Ledger device, fetching the public key and chainCode. We then use the key path derivation scheme to generate the requested account addresses locally.

<!--- Describe your changes in detail -->

## Motivation and Context

People use more then the first 10 accounts on their Ledger (or they should!), so why not allow developers to fetch them as well.

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Added unit and integration tests

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [x] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [x] Added tests to cover my changes.
*   [x] Added new entries to the relevant CHANGELOGs.
*   [x] Updated the new versions of the changed packages in the relevant CHANGELOGs.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
