### PR TITLE
Add Missing README Instructions

### DIFF
--- a/packages/0x.js/CHANGELOG.md
+++ b/packages/0x.js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v0.33.1 - _March 5, 2018_
+
+    * Add missing EthersJs typescript typings as dependency
+
 ## v0.33.0 - _March 4, 2018_
 
     * Validate and lowercase all addresses in public methods (#373)

--- a/packages/0x.js/CHANGELOG.md
+++ b/packages/0x.js/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## v0.33.1 - _March 5, 2018_
+## v0.33.1 - _TBD, 2018_
 
     * Add missing EthersJs typescript typings as dependency
 

--- a/packages/0x.js/README.md
+++ b/packages/0x.js/README.md
@@ -18,6 +18,15 @@ npm install 0x.js --save
 import { ZeroEx } from '0x.js';
 ```
 
+If your project is in [TypeScript](https://www.typescriptlang.org/), add the following to your `tsconfig.json`:
+
+```
+"include": [
+    "./node_modules/web3-typescript-typings/index.d.ts",
+    "./node_modules/ethers-typescript-typings/index.d.ts"
+]
+```
+
 #### UMD:
 
 **Install**

--- a/packages/0x.js/package.json
+++ b/packages/0x.js/package.json
@@ -93,6 +93,7 @@
         "ethereumjs-blockstream": "^2.0.6",
         "ethereumjs-util": "^5.1.1",
         "ethers-contracts": "^2.2.1",
+        "ethers-typescript-typings": "^0.0.2",
         "js-sha3": "^0.7.0",
         "lodash": "^4.17.4",
         "uuid": "^3.1.0",

--- a/packages/0x.js/package.json
+++ b/packages/0x.js/package.json
@@ -61,7 +61,6 @@
         "copyfiles": "^1.2.0",
         "coveralls": "^3.0.0",
         "dirty-chai": "^2.0.1",
-        "ethers-typescript-typings": "^0.0.2",
         "json-loader": "^0.5.4",
         "mocha": "^4.0.1",
         "npm-run-all": "^4.1.2",

--- a/packages/assert/README.md
+++ b/packages/assert/README.md
@@ -8,6 +8,14 @@ Standard type and schema assertions to be used across all 0x projects and packag
 yarn add @0xproject/assert
 ```
 
+If your project is in [TypeScript](https://www.typescriptlang.org/), add the following to your `tsconfig.json`:
+
+```
+"include": [
+    "./node_modules/web3-typescript-typings/index.d.ts",
+]
+```
+
 ## Usage
 
 ```typescript

--- a/packages/base-contract/README.md
+++ b/packages/base-contract/README.md
@@ -8,6 +8,15 @@ BaseContract to derive all auto-generated wrappers from
 yarn add @0xproject/base-contract
 ```
 
+If your project is in [TypeScript](https://www.typescriptlang.org/), add the following to your `tsconfig.json`:
+
+```
+"include": [
+    "./node_modules/web3-typescript-typings/index.d.ts",
+    "./node_modules/ethers-typescript-typings/index.d.ts"
+]
+```
+
 ## Usage
 
 ```javascript

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -8,6 +8,14 @@ This repository contains a Javascript library that makes it easy to interact wit
 yarn add @0xproject/connect
 ```
 
+If your project is in [TypeScript](https://www.typescriptlang.org/), add the following to your `tsconfig.json`:
+
+```
+"include": [
+    "./node_modules/web3-typescript-typings/index.d.ts",
+]
+```
+
 ## Usage
 
 *   [Docs](https://0xproject.com/docs/connect)

--- a/packages/dev-utils/README.md
+++ b/packages/dev-utils/README.md
@@ -7,3 +7,11 @@ Dev utils to be shared across 0x projects and packages
 ```bash
 yarn add @0xproject/dev-utils
 ```
+
+If your project is in [TypeScript](https://www.typescriptlang.org/), add the following to your `tsconfig.json`:
+
+```
+"include": [
+    "./node_modules/web3-typescript-typings/index.d.ts",
+]
+```

--- a/packages/subproviders/README.md
+++ b/packages/subproviders/README.md
@@ -10,6 +10,14 @@ We have written up a [Wiki](https://0xproject.com/wiki#Web3-Provider-Examples) a
 yarn add @0xproject/subproviders
 ```
 
+If your project is in [TypeScript](https://www.typescriptlang.org/), add the following to your `tsconfig.json`:
+
+```
+"include": [
+    "./node_modules/web3-typescript-typings/index.d.ts",
+]
+```
+
 ## Usage
 
 Simply import the subprovider you are interested in using:

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -8,6 +8,14 @@ Typescript types shared across 0x projects and packages
 yarn add -D @0xproject/types
 ```
 
+If your project is in [TypeScript](https://www.typescriptlang.org/), add the following to your `tsconfig.json`:
+
+```
+"include": [
+    "./node_modules/web3-typescript-typings/index.d.ts",
+]
+```
+
 ## Usage
 
 ```javascript

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -8,6 +8,14 @@ Utils to be shared across 0x projects and packages
 yarn add @0xproject/utils
 ```
 
+If your project is in [TypeScript](https://www.typescriptlang.org/), add the following to your `tsconfig.json`:
+
+```
+"include": [
+    "./node_modules/web3-typescript-typings/index.d.ts",
+]
+```
+
 ## Usage
 
 ```javascript

--- a/packages/web3-wrapper/README.md
+++ b/packages/web3-wrapper/README.md
@@ -8,6 +8,14 @@ Wrapped version of web3 with a nicer interface that is used across 0x projects a
 yarn add @0xproject/web3-wrapper
 ```
 
+If your project is in [TypeScript](https://www.typescriptlang.org/), add the following to your `tsconfig.json`:
+
+```
+"include": [
+    "./node_modules/web3-typescript-typings/index.d.ts",
+]
+```
+
 ## Usage
 
 ```typescript


### PR DESCRIPTION
<!--- Thank you for taking the time to submit a Pull Request -->

<!--- Provide a general summary of the issue in the Title above -->

## Description

Currently, many of our libraries require users to include external typings by specifying them in the `tsconfig.json` `include` section. This PR adds this instruction to all the relevant projects, to help get user's up and running.

Open question: Is there a way to eliminate the need for users to perform this step? It's quite cumbersome and error prone.

<!--- Describe your changes in detail -->

## Motivation and Context

Tried using each library in stand-alone project and ran into this issue.

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

N/A

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [x] Added new entries to the relevant CHANGELOGs.
*   [ ] Updated the new versions of the changed packages in the relevant CHANGELOGs.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
