### PR TITLE
Add SignedOrder, Order, and ECSignature types to the types package

### DIFF
--- a/packages/0x.js/CHANGELOG.md
+++ b/packages/0x.js/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.33.2 - _TBD, 2018_
 
     * Consolidate all `console.log` calls into `logUtils` in the `@0xproject/utils` package (#452)
-    * Consolidate `Order`, `SignedOrder`, and `ECSignature into` the `@0xproject/types` package (#456)
+    * Consolidate `Order`, `SignedOrder`, and `ECSignature` into the `@0xproject/types` package (#456)
 
 ## v0.33.1 - _March 8, 2018_
 

--- a/packages/0x.js/CHANGELOG.md
+++ b/packages/0x.js/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.33.2 - _TBD, 2018_
 
     * Consolidate all `console.log` calls into `logUtils` in the `@0xproject/utils` package (#452)
+    * Consolidate `Order`, `SignedOrder`, and `ECSignature into` the `@0xproject/types` package (#456)
 
 ## v0.33.1 - _March 8, 2018_
 

--- a/packages/0x.js/src/0x.ts
+++ b/packages/0x.js/src/0x.ts
@@ -1,5 +1,5 @@
 import { schemas, SchemaValidator } from '@0xproject/json-schemas';
-import { TransactionReceiptWithDecodedLogs } from '@0xproject/types';
+import { ECSignature, Order, SignedOrder, TransactionReceiptWithDecodedLogs } from '@0xproject/types';
 import { AbiDecoder, BigNumber, intervalUtils } from '@0xproject/utils';
 import { Web3Wrapper } from '@0xproject/web3-wrapper';
 import * as ethUtil from 'ethereumjs-util';
@@ -15,7 +15,7 @@ import { OrderStateWatcher } from './order_watcher/order_state_watcher';
 import { zeroExConfigSchema } from './schemas/zero_ex_config_schema';
 import { zeroExPrivateNetworkConfigSchema } from './schemas/zero_ex_private_network_config_schema';
 import { zeroExPublicNetworkConfigSchema } from './schemas/zero_ex_public_network_config_schema';
-import { ECSignature, Order, SignedOrder, Web3Provider, ZeroExConfig, ZeroExError } from './types';
+import { Web3Provider, ZeroExConfig, ZeroExError } from './types';
 import { assert } from './utils/assert';
 import { constants } from './utils/constants';
 import { decorators } from './utils/decorators';

--- a/packages/0x.js/src/contract_wrappers/exchange_wrapper.ts
+++ b/packages/0x.js/src/contract_wrappers/exchange_wrapper.ts
@@ -1,5 +1,12 @@
 import { schemas } from '@0xproject/json-schemas';
-import { BlockParamLiteral, DecodedLogArgs, LogWithDecodedArgs } from '@0xproject/types';
+import {
+    BlockParamLiteral,
+    DecodedLogArgs,
+    ECSignature,
+    LogWithDecodedArgs,
+    Order,
+    SignedOrder,
+} from '@0xproject/types';
 import { AbiDecoder, BigNumber } from '@0xproject/utils';
 import { Web3Wrapper } from '@0xproject/web3-wrapper';
 import * as _ from 'lodash';
@@ -8,19 +15,16 @@ import * as Web3 from 'web3';
 import { artifacts } from '../artifacts';
 import {
     BlockRange,
-    ECSignature,
     EventCallback,
     ExchangeContractErrCodes,
     ExchangeContractErrs,
     IndexedFilterValues,
     MethodOpts,
-    Order,
     OrderAddresses,
     OrderCancellationRequest,
     OrderFillRequest,
     OrderTransactionOpts,
     OrderValues,
-    SignedOrder,
     ValidateOrderFillableOpts,
 } from '../types';
 import { assert } from '../utils/assert';

--- a/packages/0x.js/src/index.ts
+++ b/packages/0x.js/src/index.ts
@@ -1,9 +1,6 @@
 export { ZeroEx } from './0x';
 
 export {
-    Order,
-    SignedOrder,
-    ECSignature,
     ZeroExError,
     EventCallback,
     ExchangeContractErrs,
@@ -34,6 +31,9 @@ export {
     BlockParam,
     ContractEventArg,
     LogWithDecodedArgs,
+    Order,
+    SignedOrder,
+    ECSignature,
     TransactionReceipt,
     TransactionReceiptWithDecodedLogs,
 } from '@0xproject/types';

--- a/packages/0x.js/src/order_watcher/order_state_watcher.ts
+++ b/packages/0x.js/src/order_watcher/order_state_watcher.ts
@@ -1,5 +1,5 @@
 import { schemas } from '@0xproject/json-schemas';
-import { BlockParamLiteral, LogWithDecodedArgs } from '@0xproject/types';
+import { BlockParamLiteral, LogWithDecodedArgs, SignedOrder } from '@0xproject/types';
 import { AbiDecoder, intervalUtils } from '@0xproject/utils';
 import { Web3Wrapper } from '@0xproject/web3-wrapper';
 import * as _ from 'lodash';
@@ -31,7 +31,6 @@ import {
     OnOrderStateChangeCallback,
     OrderState,
     OrderStateWatcherConfig,
-    SignedOrder,
     ZeroExError,
 } from '../types';
 import { assert } from '../utils/assert';

--- a/packages/0x.js/src/order_watcher/remaining_fillable_calculator.ts
+++ b/packages/0x.js/src/order_watcher/remaining_fillable_calculator.ts
@@ -1,6 +1,5 @@
+import { SignedOrder } from '@0xproject/types';
 import { BigNumber } from '@0xproject/utils';
-
-import { SignedOrder } from '../types';
 
 export class RemainingFillableCalculator {
     private _signedOrder: SignedOrder;

--- a/packages/0x.js/src/types.ts
+++ b/packages/0x.js/src/types.ts
@@ -1,6 +1,13 @@
 import { BigNumber } from '@0xproject/utils';
 
-import { BlockParam, BlockParamLiteral, ContractEventArg, LogWithDecodedArgs } from '@0xproject/types';
+import {
+    BlockParam,
+    BlockParamLiteral,
+    ContractEventArg,
+    LogWithDecodedArgs,
+    Order,
+    SignedOrder,
+} from '@0xproject/types';
 
 import * as Web3 from 'web3';
 
@@ -35,15 +42,6 @@ export enum InternalZeroExError {
     NoAbiDecoder = 'NO_ABI_DECODER',
     ZrxNotInTokenRegistry = 'ZRX_NOT_IN_TOKEN_REGISTRY',
     WethNotInTokenRegistry = 'WETH_NOT_IN_TOKEN_REGISTRY',
-}
-
-/**
- * Elliptic Curve signature
- */
-export interface ECSignature {
-    v: number;
-    r: string;
-    s: string;
 }
 
 export type OrderAddresses = [string, string, string, string, string];
@@ -106,25 +104,6 @@ export interface ContractEvent {
 }
 
 export type ContractEventArgs = ExchangeContractEventArgs | TokenContractEventArgs | EtherTokenContractEventArgs;
-
-export interface Order {
-    maker: string;
-    taker: string;
-    makerFee: BigNumber;
-    takerFee: BigNumber;
-    makerTokenAmount: BigNumber;
-    takerTokenAmount: BigNumber;
-    makerTokenAddress: string;
-    takerTokenAddress: string;
-    salt: BigNumber;
-    exchangeContractAddress: string;
-    feeRecipient: string;
-    expirationUnixTimestampSec: BigNumber;
-}
-
-export interface SignedOrder extends Order {
-    ecSignature: ECSignature;
-}
 
 //                          [address, name, symbol, decimals, ipfsHash, swarmHash]
 export type TokenMetadata = [string, string, string, number, string, string];

--- a/packages/0x.js/src/utils/assert.ts
+++ b/packages/0x.js/src/utils/assert.ts
@@ -3,11 +3,11 @@ import { assert as sharedAssert } from '@0xproject/assert';
 // tslint:disable-next-line:no-unused-variable
 import { Schema } from '@0xproject/json-schemas';
 // tslint:disable-next-line:no-unused-variable
+import { ECSignature } from '@0xproject/types';
 import { BigNumber } from '@0xproject/utils';
 import { Web3Wrapper } from '@0xproject/web3-wrapper';
 import * as _ from 'lodash';
 
-import { ECSignature } from '../types';
 import { signatureUtils } from '../utils/signature_utils';
 
 export const assert = {

--- a/packages/0x.js/src/utils/order_state_utils.ts
+++ b/packages/0x.js/src/utils/order_state_utils.ts
@@ -1,3 +1,4 @@
+import { SignedOrder } from '@0xproject/types';
 import { BigNumber } from '@0xproject/utils';
 import * as _ from 'lodash';
 
@@ -6,14 +7,7 @@ import { ExchangeWrapper } from '../contract_wrappers/exchange_wrapper';
 import { RemainingFillableCalculator } from '../order_watcher/remaining_fillable_calculator';
 import { BalanceAndProxyAllowanceLazyStore } from '../stores/balance_proxy_allowance_lazy_store';
 import { OrderFilledCancelledLazyStore } from '../stores/order_filled_cancelled_lazy_store';
-import {
-    ExchangeContractErrs,
-    OrderRelevantState,
-    OrderState,
-    OrderStateInvalid,
-    OrderStateValid,
-    SignedOrder,
-} from '../types';
+import { ExchangeContractErrs, OrderRelevantState, OrderState, OrderStateInvalid, OrderStateValid } from '../types';
 
 const ACCEPTABLE_RELATIVE_ROUNDING_ERROR = 0.0001;
 

--- a/packages/0x.js/src/utils/order_validation_utils.ts
+++ b/packages/0x.js/src/utils/order_validation_utils.ts
@@ -1,9 +1,10 @@
+import { Order, SignedOrder } from '@0xproject/types';
 import { BigNumber } from '@0xproject/utils';
 import * as _ from 'lodash';
 
 import { ZeroEx } from '../0x';
 import { ExchangeWrapper } from '../contract_wrappers/exchange_wrapper';
-import { ExchangeContractErrs, Order, SignedOrder, TradeSide, TransferType, ZeroExError } from '../types';
+import { ExchangeContractErrs, TradeSide, TransferType, ZeroExError } from '../types';
 import { constants } from '../utils/constants';
 import { utils } from '../utils/utils';
 

--- a/packages/0x.js/src/utils/signature_utils.ts
+++ b/packages/0x.js/src/utils/signature_utils.ts
@@ -1,6 +1,5 @@
+import { ECSignature } from '@0xproject/types';
 import * as ethUtil from 'ethereumjs-util';
-
-import { ECSignature } from '../types';
 
 export const signatureUtils = {
     isValidSignature(data: string, signature: ECSignature, signerAddress: string): boolean {

--- a/packages/0x.js/src/utils/utils.ts
+++ b/packages/0x.js/src/utils/utils.ts
@@ -1,11 +1,9 @@
-import { SolidityTypes } from '@0xproject/types';
+import { Order, SignedOrder, SolidityTypes } from '@0xproject/types';
 import { BigNumber } from '@0xproject/utils';
 import BN = require('bn.js');
 import * as ethABI from 'ethereumjs-abi';
 import * as ethUtil from 'ethereumjs-util';
 import * as _ from 'lodash';
-
-import { Order, SignedOrder } from '../types';
 
 export const utils = {
     /**

--- a/packages/0x.js/test/remaining_fillable_calculator_test.ts
+++ b/packages/0x.js/test/remaining_fillable_calculator_test.ts
@@ -1,10 +1,10 @@
+import { ECSignature, SignedOrder } from '@0xproject/types';
 import { BigNumber } from '@0xproject/utils';
 import * as chai from 'chai';
 import 'mocha';
 
 import { ZeroEx } from '../src/0x';
 import { RemainingFillableCalculator } from '../src/order_watcher/remaining_fillable_calculator';
-import { ECSignature, SignedOrder } from '../src/types';
 
 import { chaiSetup } from './utils/chai_setup';
 

--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.6.3 - _TBD, 2018_
 
-    * Consolidate `Order`, `SignedOrder`, and `ECSignature into` the `@0xproject/types` package (#456)
+    * Consolidate `Order`, `SignedOrder`, and `ECSignature` into the `@0xproject/types` package (#456)
 
 ## v0.6.2 - _February 16, 2018_
 

--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v0.6.3 - _TBD, 2018_
+
+    * Consolidate `Order`, `SignedOrder`, and `ECSignature into` the `@0xproject/types` package (#456)
+
 ## v0.6.2 - _February 16, 2018_
 
     * Fix JSON parse empty response (#407)

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -50,6 +50,7 @@
     "dependencies": {
         "@0xproject/assert": "^0.2.0",
         "@0xproject/json-schemas": "^0.7.14",
+        "@0xproject/types": "^0.3.1",
         "@0xproject/utils": "^0.4.1",
         "isomorphic-fetch": "^2.2.1",
         "lodash": "^4.17.4",
@@ -82,6 +83,6 @@
         "web3-typescript-typings": "^0.10.0"
     },
     "publishConfig": {
-      "access": "public"
+        "access": "public"
     }
 }

--- a/packages/connect/src/http_client.ts
+++ b/packages/connect/src/http_client.ts
@@ -1,5 +1,6 @@
 import { assert } from '@0xproject/assert';
 import { schemas } from '@0xproject/json-schemas';
+import { SignedOrder } from '@0xproject/types';
 import 'isomorphic-fetch';
 import * as _ from 'lodash';
 import * as queryString from 'query-string';
@@ -15,7 +16,6 @@ import {
     OrderbookResponse,
     OrdersRequestOpts,
     PagedRequestOpts,
-    SignedOrder,
     TokenPairsItem,
     TokenPairsRequestOpts,
 } from './types';

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -2,10 +2,8 @@ export { HttpClient } from './http_client';
 export { WebSocketOrderbookChannel } from './ws_orderbook_channel';
 export {
     Client,
-    ECSignature,
     FeesRequest,
     FeesResponse,
-    Order,
     OrderbookChannel,
     OrderbookChannelHandler,
     OrderbookChannelSubscriptionOpts,
@@ -13,9 +11,10 @@ export {
     OrderbookResponse,
     OrdersRequestOpts,
     PagedRequestOpts,
-    SignedOrder,
     TokenPairsItem,
     TokenPairsRequestOpts,
     TokenTradeInfo,
     WebSocketOrderbookChannelConfig,
 } from './types';
+
+export { ECSignature, Order, SignedOrder } from '@0xproject/types';

--- a/packages/connect/src/types.ts
+++ b/packages/connect/src/types.ts
@@ -1,33 +1,5 @@
+import { ECSignature, Order, SignedOrder } from '@0xproject/types';
 import { BigNumber } from '@0xproject/utils';
-
-// TODO: Consolidate Order, SignedOrder and ECSignature into a shared package instead of duplicating them from 0x.js
-export interface Order {
-    maker: string;
-    taker: string;
-    makerFee: BigNumber;
-    takerFee: BigNumber;
-    makerTokenAmount: BigNumber;
-    takerTokenAmount: BigNumber;
-    makerTokenAddress: string;
-    takerTokenAddress: string;
-    salt: BigNumber;
-    exchangeContractAddress: string;
-    feeRecipient: string;
-    expirationUnixTimestampSec: BigNumber;
-}
-
-export interface SignedOrder extends Order {
-    ecSignature: ECSignature;
-}
-
-/**
- * Elliptic Curve signature
- */
-export interface ECSignature {
-    v: number;
-    r: string;
-    s: string;
-}
 
 export interface Client {
     getTokenPairsAsync: (requestOpts?: TokenPairsRequestOpts & PagedRequestOpts) => Promise<TokenPairsItem[]>;

--- a/packages/connect/src/utils/relayer_response_json_parsers.ts
+++ b/packages/connect/src/utils/relayer_response_json_parsers.ts
@@ -1,8 +1,9 @@
 import { assert } from '@0xproject/assert';
 import { schemas } from '@0xproject/json-schemas';
+import { SignedOrder } from '@0xproject/types';
 import * as _ from 'lodash';
 
-import { FeesResponse, OrderbookResponse, SignedOrder, TokenPairsItem } from '../types';
+import { FeesResponse, OrderbookResponse, TokenPairsItem } from '../types';
 
 import { typeConverters } from './type_converters';
 

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.4.0 - _TBD, 2018_
 
     * Remove `JSONRPCPayload` (#426)
+    * Consolidate `Order`, `SignedOrder`, and `ECSignature into` the `@0xproject/types` package (#456)
 
 ## v0.3.1 - _March 8, 2018_
 

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.4.0 - _TBD, 2018_
 
     * Remove `JSONRPCPayload` (#426)
-    * Consolidate `Order`, `SignedOrder`, and `ECSignature into` the `@0xproject/types` package (#456)
+    * Consolidate `Order`, `SignedOrder`, and `ECSignature` into the `@0xproject/types` package (#456)
 
 ## v0.3.1 - _March 8, 2018_
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -73,3 +73,31 @@ export interface RawLogEntry {
     data: string;
     topics: string[];
 }
+
+export interface Order {
+    maker: string;
+    taker: string;
+    makerFee: BigNumber;
+    takerFee: BigNumber;
+    makerTokenAmount: BigNumber;
+    takerTokenAmount: BigNumber;
+    makerTokenAddress: string;
+    takerTokenAddress: string;
+    salt: BigNumber;
+    exchangeContractAddress: string;
+    feeRecipient: string;
+    expirationUnixTimestampSec: BigNumber;
+}
+
+export interface SignedOrder extends Order {
+    ecSignature: ECSignature;
+}
+
+/**
+ * Elliptic Curve signature
+ */
+export interface ECSignature {
+    v: number;
+    r: string;
+    s: string;
+}


### PR DESCRIPTION
<!--- Thank you for taking the time to submit a Pull Request -->

<!--- Provide a general summary of the issue in the Title above -->

## Description

Add SignedOrder, Order, and ECSignature types to the types package, remove the duplicated definitions from `types.ts` in 0x.js and connect.

## Motivation and Context

There are duplicated definitions for SignedOrder, Order, and ECSignature

## How Has This Been Tested?

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [x] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [] Added tests to cover my changes.
*   [x] Added new entries to the relevant CHANGELOGs.
*   [x] Updated the new versions of the changed packages in the relevant CHANGELOGs.
*   [x] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [x] Labeled this PR with the labels corresponding to the changed package.
