### PR TITLE
Cancel maker's orders before a certain time (Revised)

### DIFF
--- a/packages/contracts/src/contracts/current/protocol/Exchange/Exchange.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/Exchange.sol
@@ -30,7 +30,7 @@ contract Exchange is
     MixinSettlementProxy,
     MixinWrapperFunctions
 {
-    string constant public VERSION = "2.0.0-alpha";
+    string constant public VERSION = "2.0.1-alpha";
 
     function Exchange(
         IToken _zrxToken,

--- a/packages/contracts/src/contracts/current/protocol/Exchange/IExchange.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/IExchange.sol
@@ -163,8 +163,8 @@ contract IExchange {
         returns (uint256 takerTokenCancelledAmount);
 
     /// @dev Cancels all orders for a specified maker up to a certain time.
-    /// @param salt Orders created with a lower salt value will be cancelled
-    function cancelOrdersBefore(uint256 salt)
+    /// @param salt Orders created with a salt less or equal to this value will be cancelled.
+    function cancelOrdersUpTo(uint256 salt)
         external;
 
     /// @dev Fills an order with specified parameters and ECDSA signature. Throws if specified amount not filled entirely.

--- a/packages/contracts/src/contracts/current/protocol/Exchange/IExchange.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/IExchange.sol
@@ -53,38 +53,43 @@ contract IExchange {
         uint256 takerTokenCancelledAmount,
         bytes32 indexed orderHash
     );
-    
+
+    event LogCancelBefore(
+        address indexed maker,
+        uint256 salt
+    );
+
     function ZRX_TOKEN_CONTRACT()
       public view
       returns (address);
-      
+
     function TOKEN_TRANSFER_PROXY_CONTRACT()
       public view
       returns (address);
-      
+
     function EXTERNAL_QUERY_GAS_LIMIT()
       public view
       returns (uint16);
-      
+
     function VERSION()
       public view
       returns (string);
-    
+
     function filled(bytes32)
       public view
       returns (uint256);
-      
+
     function cancelled(bytes32)
       public view
       returns (uint256);
-    
+
     /// @dev Calculates the sum of values already filled and cancelled for a given order.
     /// @param orderHash The Keccak-256 hash of the given order.
     /// @return Sum of values already filled and cancelled.
     function getUnavailableTakerTokenAmount(bytes32 orderHash)
         public view
         returns (uint256 unavailableTakerTokenAmount);
-    
+
     /// @dev Calculates partial value given a numerator and denominator.
     /// @param numerator Numerator.
     /// @param denominator Denominator.
@@ -93,7 +98,7 @@ contract IExchange {
     function getPartialAmount(uint256 numerator, uint256 denominator, uint256 target)
         public pure
         returns (uint256 partialAmount);
-    
+
     /// @dev Checks if rounding error > 0.1%.
     /// @param numerator Numerator.
     /// @param denominator Denominator.
@@ -102,7 +107,7 @@ contract IExchange {
     function isRoundingError(uint256 numerator, uint256 denominator, uint256 target)
         public pure
         returns (bool isError);
-      
+
     /// @dev Calculates Keccak-256 hash of order with specified parameters.
     /// @param orderAddresses Array of order's maker, taker, makerToken, takerToken, and feeRecipient.
     /// @param orderValues Array of order's makerTokenAmount, takerTokenAmount, makerFee, takerFee, expirationTimestampInSec, and salt.
@@ -110,7 +115,7 @@ contract IExchange {
     function getOrderHash(address[5] orderAddresses, uint256[6] orderValues)
         public view
         returns (bytes32 orderHash);
-        
+
     /// @dev Verifies that an order signature is valid.
     /// @param signer address of signer.
     /// @param hash Signed Keccak-256 hash.
@@ -126,7 +131,7 @@ contract IExchange {
         bytes32 s)
         public pure
         returns (bool isValid);
-    
+
     /// @dev Fills the input order.
     /// @param orderAddresses Array of order's maker, taker, makerToken, takerToken, and feeRecipient.
     /// @param orderValues Array of order's makerTokenAmount, takerTokenAmount, makerFee, takerFee, expirationTimestampInSec, and salt.
@@ -144,7 +149,7 @@ contract IExchange {
           bytes32 s)
           public
           returns (uint256 takerTokenFilledAmount);
-      
+
     /// @dev Cancels the input order.
     /// @param orderAddresses Array of order's maker, taker, makerToken, takerToken, and feeRecipient.
     /// @param orderValues Array of order's makerTokenAmount, takerTokenAmount, makerFee, takerFee, expirationTimestampInSec, and salt.
@@ -157,6 +162,9 @@ contract IExchange {
         public
         returns (uint256 takerTokenCancelledAmount);
 
+    /// @dev Cancels all orders for a specified maker up to a certain time.
+    /// @param salt Orders created with a lower salt value will be cancelled
+    function cancelOrdersBefore(uint256 salt) external;
 
     /// @dev Fills an order with specified parameters and ECDSA signature. Throws if specified amount not filled entirely.
     /// @param orderAddresses Array of order's maker, taker, makerToken, takerToken, and feeRecipient.

--- a/packages/contracts/src/contracts/current/protocol/Exchange/IExchange.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/IExchange.sol
@@ -164,7 +164,8 @@ contract IExchange {
 
     /// @dev Cancels all orders for a specified maker up to a certain time.
     /// @param salt Orders created with a lower salt value will be cancelled
-    function cancelOrdersBefore(uint256 salt) external;
+    function cancelOrdersBefore(uint256 salt)
+        external;
 
     /// @dev Fills an order with specified parameters and ECDSA signature. Throws if specified amount not filled entirely.
     /// @param orderAddresses Array of order's maker, taker, makerToken, takerToken, and feeRecipient.

--- a/packages/contracts/src/contracts/current/protocol/Exchange/MixinExchangeCore.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/MixinExchangeCore.sol
@@ -70,9 +70,9 @@ contract MixinExchangeCore is
         bytes32 indexed orderHash
     );
 
-    event LogCancelBefore(
+    event LogCancelUpTo(
         address indexed maker,
-        uint256 salt
+        uint256 makerEpoch
     );
 
     /*
@@ -202,13 +202,14 @@ contract MixinExchangeCore is
         return takerTokenCancelledAmount;
     }
 
-    /// @param salt Orders created with a salt less than this value will be cancelled.
-    function cancelOrdersBefore(uint256 salt)
+    /// @param salt Orders created with a salt less or equal to this value will be cancelled.
+    function cancelOrdersUpTo(uint256 salt)
         external
     {
-        require(salt > makerEpoch[msg.sender]); // epoch must be monotonically increasing
-        makerEpoch[msg.sender] = salt;
-        LogCancelBefore(msg.sender, salt);
+        uint256 newMakerEpoch = salt + 1;                // makerEpoch is initialized to 0, so to cancelUpTo we need salt+1
+        require(newMakerEpoch > makerEpoch[msg.sender]); // epoch must be monotonically increasing
+        makerEpoch[msg.sender] = newMakerEpoch;
+        LogCancelUpTo(msg.sender, newMakerEpoch);
     }
 
     /// @dev Checks if rounding error > 0.1%.

--- a/packages/contracts/src/contracts/current/protocol/Exchange/mixins/MExchangeCore.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/mixins/MExchangeCore.sol
@@ -36,6 +36,6 @@ contract MExchangeCore is LibOrder {
         public
         returns (uint256 takerTokenCancelledAmount);
 
-    function cancelOrdersBefore(uint256 salt)
+ function cancelOrdersUpTo(uint256 salt)
         external;
 }

--- a/packages/contracts/src/contracts/current/protocol/Exchange/mixins/MExchangeCore.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/mixins/MExchangeCore.sol
@@ -36,7 +36,6 @@ contract MExchangeCore is LibOrder {
         public
         returns (uint256 takerTokenCancelledAmount);
 
-    function cancelOrdersBefore(
-        uint256 salt)
+    function cancelOrdersBefore(uint256 salt)
         external;
 }

--- a/packages/contracts/src/contracts/current/protocol/Exchange/mixins/MExchangeCore.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/mixins/MExchangeCore.sol
@@ -36,4 +36,7 @@ contract MExchangeCore is LibOrder {
         public
         returns (uint256 takerTokenCancelledAmount);
 
+    function cancelOrdersBefore(
+        uint256 salt)
+        external;
 }

--- a/packages/contracts/src/utils/exchange_wrapper.ts
+++ b/packages/contracts/src/utils/exchange_wrapper.ts
@@ -168,11 +168,11 @@ export class ExchangeWrapper {
         return tx;
     }
     public async cancelOrdersBeforeAsync(
-        timestamp: BigNumber,
+        salt: BigNumber,
         from: string,
     ): Promise<TransactionReceiptWithDecodedLogs> {
         const txHash = await this._exchange.cancelOrdersBefore.sendTransactionAsync(
-            timestamp,
+            salt,
             { from },
         );
         const tx = await this._getTxWithDecodedExchangeLogsAsync(txHash);

--- a/packages/contracts/src/utils/exchange_wrapper.ts
+++ b/packages/contracts/src/utils/exchange_wrapper.ts
@@ -167,11 +167,11 @@ export class ExchangeWrapper {
         const tx = await this._getTxWithDecodedExchangeLogsAsync(txHash);
         return tx;
     }
-    public async cancelOrdersBeforeAsync(
+    public async cancelOrdersUpToAsync(
         salt: BigNumber,
         from: string,
     ): Promise<TransactionReceiptWithDecodedLogs> {
-        const txHash = await this._exchange.cancelOrdersBefore.sendTransactionAsync(
+        const txHash = await this._exchange.cancelOrdersUpTo.sendTransactionAsync(
             salt,
             { from },
         );

--- a/packages/contracts/src/utils/exchange_wrapper.ts
+++ b/packages/contracts/src/utils/exchange_wrapper.ts
@@ -167,6 +167,18 @@ export class ExchangeWrapper {
         const tx = await this._getTxWithDecodedExchangeLogsAsync(txHash);
         return tx;
     }
+    public async cancelOrdersBeforeAsync(
+      timestamp: BigNumber,
+      from: string,
+    ): Promise<TransactionReceiptWithDecodedLogs> {
+        const txHash = await this._exchange.cancelOrdersBefore.sendTransactionAsync(
+            timestamp,
+            { from },
+        );
+        const tx = await this._getTxWithDecodedExchangeLogsAsync(txHash);
+        return tx;
+    }
+
     public async getOrderHashAsync(signedOrder: SignedOrder): Promise<string> {
         const order = orderUtils.getOrderStruct(signedOrder);
         const orderHash = await this._exchange.getOrderHash.callAsync(order);

--- a/packages/contracts/src/utils/exchange_wrapper.ts
+++ b/packages/contracts/src/utils/exchange_wrapper.ts
@@ -168,8 +168,8 @@ export class ExchangeWrapper {
         return tx;
     }
     public async cancelOrdersBeforeAsync(
-      timestamp: BigNumber,
-      from: string,
+        timestamp: BigNumber,
+        from: string,
     ): Promise<TransactionReceiptWithDecodedLogs> {
         const txHash = await this._exchange.cancelOrdersBefore.sendTransactionAsync(
             timestamp,

--- a/packages/contracts/src/utils/types.ts
+++ b/packages/contracts/src/utils/types.ts
@@ -28,6 +28,10 @@ export interface BatchCancelOrders {
     takerTokenCancelAmounts: BigNumber[];
 }
 
+export interface CancelOrdersBefore {
+    timestamp: BigNumber;
+}
+
 export interface DefaultOrderParams {
     exchangeAddress: string;
     makerAddress: string;

--- a/packages/contracts/src/utils/types.ts
+++ b/packages/contracts/src/utils/types.ts
@@ -29,7 +29,7 @@ export interface BatchCancelOrders {
 }
 
 export interface CancelOrdersBefore {
-    timestamp: BigNumber;
+    salt: BigNumber;
 }
 
 export interface DefaultOrderParams {

--- a/packages/contracts/test/exchange/core.ts
+++ b/packages/contracts/test/exchange/core.ts
@@ -743,30 +743,30 @@ describe('Exchange', () => {
     });
 
    describe('cancelOrdersBefore', () => {
-        it('should fail to set timestamp less than existing CancelBefore timestamp', async () => {
-            const timestamp = new BigNumber(1);
-            await exWrapper.cancelOrdersBeforeAsync(timestamp, makerAddress);
-            const lesser_timestamp = new BigNumber(0);
+        it('should fail to set makerEpoch less than current makerEpoch', async () => {
+            const makerEpoch = new BigNumber(1);
+            await exWrapper.cancelOrdersBeforeAsync(makerEpoch, makerAddress);
+            const lesserMakerEpoch = new BigNumber(0);
             return expect(
-                exWrapper.cancelOrdersBeforeAsync(lesser_timestamp, makerAddress),
+                exWrapper.cancelOrdersBeforeAsync(lesserMakerEpoch, makerAddress),
             ).to.be.rejectedWith(constants.REVERT);
         });
 
-        it('should fail to set timestamp equal to existing CancelBefore timestamp', async () => {
-            const timestamp = new BigNumber(1);
-            await exWrapper.cancelOrdersBeforeAsync(timestamp, makerAddress);
+        it('should fail to set makerEpoch equal to existing makerEpoch', async () => {
+            const makerEpoch = new BigNumber(1);
+            await exWrapper.cancelOrdersBeforeAsync(makerEpoch, makerAddress);
             return expect(
-                exWrapper.cancelOrdersBeforeAsync(timestamp, makerAddress),
+                exWrapper.cancelOrdersBeforeAsync(makerEpoch, makerAddress),
             ).to.be.rejectedWith(constants.REVERT);
         });
 
-        it('should cancel only orders with a timestamp less than CancelBefore timestamp', async () => {
-            // Cancel all transactions with a timestamp less than 1
-            const timestamp = new BigNumber(1);
-            await exWrapper.cancelOrdersBeforeAsync(timestamp, makerAddress);
+        it('should cancel only orders with a makerEpoch less than existing makerEpoch', async () => {
+            // Cancel all transactions with a makerEpoch less than 1
+            const makerEpoch = new BigNumber(1);
+            await exWrapper.cancelOrdersBeforeAsync(makerEpoch, makerAddress);
 
-            // Create 3 orders with timestamps 0,1,2
-            // Since we cancelled with timestamp=1, orders with timestamp<1 will not be processed
+            // Create 3 orders with makerEpoch values: 0,1,2
+            // Since we cancelled with makerEpoch=1, orders with makerEpoch<1 will not be processed
             balances = await dmyBalances.getAsync();
             const signedOrders = await Promise.all([
                 orderFactory.newSignedOrder({

--- a/packages/contracts/test/exchange/core.ts
+++ b/packages/contracts/test/exchange/core.ts
@@ -744,12 +744,12 @@ describe('Exchange', () => {
 
    describe('cancelOrdersBefore', () => {
         it('should fail to set timestamp less than existing CancelBefore timestamp', async () => {
-           const timestamp = new BigNumber(1);
-           await exWrapper.cancelOrdersBeforeAsync(timestamp, makerAddress);
-           const lesser_timestamp = new BigNumber(0);
-           return expect(
-               exWrapper.cancelOrdersBeforeAsync(lesser_timestamp, makerAddress),
-           ).to.be.rejectedWith(constants.REVERT);
+            const timestamp = new BigNumber(1);
+            await exWrapper.cancelOrdersBeforeAsync(timestamp, makerAddress);
+            const lesser_timestamp = new BigNumber(0);
+            return expect(
+                exWrapper.cancelOrdersBeforeAsync(lesser_timestamp, makerAddress),
+            ).to.be.rejectedWith(constants.REVERT);
         });
 
         it('should fail to set timestamp equal to existing CancelBefore timestamp', async () => {
@@ -761,51 +761,51 @@ describe('Exchange', () => {
         });
 
         it('should cancel only orders with a timestamp less than CancelBefore timestamp', async () => {
-          // Cancel all transactions with a timestamp less than 1
-          const timestamp = new BigNumber(1);
-          await exWrapper.cancelOrdersBeforeAsync(timestamp, makerAddress);
+            // Cancel all transactions with a timestamp less than 1
+            const timestamp = new BigNumber(1);
+            await exWrapper.cancelOrdersBeforeAsync(timestamp, makerAddress);
 
-          // Create 3 orders with timestamps 0,1,2
-          // Since we cancelled with timestamp=1, orders with timestamp<1 will not be processed
-          balances = await dmyBalances.getAsync();
-          const signedOrders = await Promise.all([
-              orderFactory.newSignedOrder({
-                makerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(17), 18),
-                takerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(17), 18),
-                salt: new BigNumber(0)}),
-              orderFactory.newSignedOrder({
-                makerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(97), 18),
-                takerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(97), 18),
-                salt: new BigNumber(1)}),
-              orderFactory.newSignedOrder({
-                makerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(979), 18),
-                takerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(979), 18),
-                salt: new BigNumber(2)}),
-          ]);
-          await exWrapper.batchFillOrdersNoThrowAsync(signedOrders, takerAddress);
+            // Create 3 orders with timestamps 0,1,2
+            // Since we cancelled with timestamp=1, orders with timestamp<1 will not be processed
+            balances = await dmyBalances.getAsync();
+            const signedOrders = await Promise.all([
+                orderFactory.newSignedOrder({
+                    makerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(17), 18),
+                    takerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(17), 18),
+                    salt: new BigNumber(0)}),
+                orderFactory.newSignedOrder({
+                    makerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(97), 18),
+                    takerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(97), 18),
+                    salt: new BigNumber(1)}),
+                orderFactory.newSignedOrder({
+                    makerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(979), 18),
+                    takerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(979), 18),
+                    salt: new BigNumber(2)}),
+            ]);
+            await exWrapper.batchFillOrdersNoThrowAsync(signedOrders, takerAddress);
 
-          const newBalances = await dmyBalances.getAsync();
-          const fillMakerTokenAmount = signedOrders[1].makerTokenAmount.add(signedOrders[2].makerTokenAmount);
-          const fillTakerTokenAmount = signedOrders[1].takerTokenAmount.add(signedOrders[2].takerTokenAmount);
-          const makerFeeAmount = signedOrders[1].makerFeeAmount.add(signedOrders[2].makerFeeAmount);
-          const takerFeeAmount = signedOrders[1].takerFeeAmount.add(signedOrders[2].takerFeeAmount);
-          expect(newBalances[makerAddress][signedOrders[2].makerTokenAddress]).to.be.bignumber.equal(
-              balances[makerAddress][signedOrders[2].makerTokenAddress].minus(fillMakerTokenAmount),
-          );
-          expect(newBalances[makerAddress][signedOrders[2].takerTokenAddress]).to.be.bignumber.equal(
-              balances[makerAddress][signedOrders[2].takerTokenAddress].add(fillTakerTokenAmount),
-          );
-          expect(newBalances[makerAddress][zrx.address]).to.be.bignumber.equal(balances[makerAddress][zrx.address].minus(makerFeeAmount));
-          expect(newBalances[takerAddress][signedOrders[2].takerTokenAddress]).to.be.bignumber.equal(
-              balances[takerAddress][signedOrders[2].takerTokenAddress].minus(fillTakerTokenAmount),
-          );
-          expect(newBalances[takerAddress][signedOrders[2].makerTokenAddress]).to.be.bignumber.equal(
-              balances[takerAddress][signedOrders[2].makerTokenAddress].add(fillMakerTokenAmount),
-          );
-          expect(newBalances[takerAddress][zrx.address]).to.be.bignumber.equal(balances[takerAddress][zrx.address].minus(takerFeeAmount));
-          expect(newBalances[feeRecipientAddress][zrx.address]).to.be.bignumber.equal(
-              balances[feeRecipientAddress][zrx.address].add(makerFeeAmount.add(takerFeeAmount)),
-          );
+            const newBalances = await dmyBalances.getAsync();
+            const fillMakerTokenAmount = signedOrders[1].makerTokenAmount.add(signedOrders[2].makerTokenAmount);
+            const fillTakerTokenAmount = signedOrders[1].takerTokenAmount.add(signedOrders[2].takerTokenAmount);
+            const makerFeeAmount = signedOrders[1].makerFeeAmount.add(signedOrders[2].makerFeeAmount);
+            const takerFeeAmount = signedOrders[1].takerFeeAmount.add(signedOrders[2].takerFeeAmount);
+            expect(newBalances[makerAddress][signedOrders[2].makerTokenAddress]).to.be.bignumber.equal(
+                balances[makerAddress][signedOrders[2].makerTokenAddress].minus(fillMakerTokenAmount),
+            );
+            expect(newBalances[makerAddress][signedOrders[2].takerTokenAddress]).to.be.bignumber.equal(
+                balances[makerAddress][signedOrders[2].takerTokenAddress].add(fillTakerTokenAmount),
+            );
+            expect(newBalances[makerAddress][zrx.address]).to.be.bignumber.equal(balances[makerAddress][zrx.address].minus(makerFeeAmount));
+            expect(newBalances[takerAddress][signedOrders[2].takerTokenAddress]).to.be.bignumber.equal(
+                balances[takerAddress][signedOrders[2].takerTokenAddress].minus(fillTakerTokenAmount),
+            );
+            expect(newBalances[takerAddress][signedOrders[2].makerTokenAddress]).to.be.bignumber.equal(
+                balances[takerAddress][signedOrders[2].makerTokenAddress].add(fillMakerTokenAmount),
+            );
+            expect(newBalances[takerAddress][zrx.address]).to.be.bignumber.equal(balances[takerAddress][zrx.address].minus(takerFeeAmount));
+            expect(newBalances[feeRecipientAddress][zrx.address]).to.be.bignumber.equal(
+                balances[feeRecipientAddress][zrx.address].add(makerFeeAmount.add(takerFeeAmount)),
+            );
         });
     });
 }); // tslint:disable-line:max-file-line-count

--- a/packages/contracts/test/exchange/core.ts
+++ b/packages/contracts/test/exchange/core.ts
@@ -741,4 +741,71 @@ describe('Exchange', () => {
             expect(errCode).to.be.equal(ExchangeContractErrs.ERROR_ORDER_EXPIRED);
         });
     });
+
+   describe('cancelOrdersBefore', () => {
+        it('should fail to set timestamp less than existing CancelBefore timestamp', async () => {
+           const timestamp = new BigNumber(1);
+           await exWrapper.cancelOrdersBeforeAsync(timestamp, makerAddress);
+           const lesser_timestamp = new BigNumber(0);
+           return expect(
+               exWrapper.cancelOrdersBeforeAsync(lesser_timestamp, makerAddress),
+           ).to.be.rejectedWith(constants.REVERT);
+        });
+
+        it('should fail to set timestamp equal to existing CancelBefore timestamp', async () => {
+            const timestamp = new BigNumber(1);
+            await exWrapper.cancelOrdersBeforeAsync(timestamp, makerAddress);
+            return expect(
+                exWrapper.cancelOrdersBeforeAsync(timestamp, makerAddress),
+            ).to.be.rejectedWith(constants.REVERT);
+        });
+
+        it('should cancel only orders with a timestamp less than CancelBefore timestamp', async () => {
+          // Cancel all transactions with a timestamp less than 1
+          const timestamp = new BigNumber(1);
+          await exWrapper.cancelOrdersBeforeAsync(timestamp, makerAddress);
+
+          // Create 3 orders with timestamps 0,1,2
+          // Since we cancelled with timestamp=1, orders with timestamp<1 will not be processed
+          balances = await dmyBalances.getAsync();
+          const signedOrders = await Promise.all([
+              orderFactory.newSignedOrder({
+                makerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(17), 18),
+                takerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(17), 18),
+                salt: new BigNumber(0)}),
+              orderFactory.newSignedOrder({
+                makerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(97), 18),
+                takerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(97), 18),
+                salt: new BigNumber(1)}),
+              orderFactory.newSignedOrder({
+                makerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(979), 18),
+                takerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(979), 18),
+                salt: new BigNumber(2)}),
+          ]);
+          await exWrapper.batchFillOrdersNoThrowAsync(signedOrders, takerAddress);
+
+          const newBalances = await dmyBalances.getAsync();
+          const fillMakerTokenAmount = signedOrders[1].makerTokenAmount.add(signedOrders[2].makerTokenAmount);
+          const fillTakerTokenAmount = signedOrders[1].takerTokenAmount.add(signedOrders[2].takerTokenAmount);
+          const makerFeeAmount = signedOrders[1].makerFeeAmount.add(signedOrders[2].makerFeeAmount);
+          const takerFeeAmount = signedOrders[1].takerFeeAmount.add(signedOrders[2].takerFeeAmount);
+          expect(newBalances[makerAddress][signedOrders[2].makerTokenAddress]).to.be.bignumber.equal(
+              balances[makerAddress][signedOrders[2].makerTokenAddress].minus(fillMakerTokenAmount),
+          );
+          expect(newBalances[makerAddress][signedOrders[2].takerTokenAddress]).to.be.bignumber.equal(
+              balances[makerAddress][signedOrders[2].takerTokenAddress].add(fillTakerTokenAmount),
+          );
+          expect(newBalances[makerAddress][zrx.address]).to.be.bignumber.equal(balances[makerAddress][zrx.address].minus(makerFeeAmount));
+          expect(newBalances[takerAddress][signedOrders[2].takerTokenAddress]).to.be.bignumber.equal(
+              balances[takerAddress][signedOrders[2].takerTokenAddress].minus(fillTakerTokenAmount),
+          );
+          expect(newBalances[takerAddress][signedOrders[2].makerTokenAddress]).to.be.bignumber.equal(
+              balances[takerAddress][signedOrders[2].makerTokenAddress].add(fillMakerTokenAmount),
+          );
+          expect(newBalances[takerAddress][zrx.address]).to.be.bignumber.equal(balances[takerAddress][zrx.address].minus(takerFeeAmount));
+          expect(newBalances[feeRecipientAddress][zrx.address]).to.be.bignumber.equal(
+              balances[feeRecipientAddress][zrx.address].add(makerFeeAmount.add(takerFeeAmount)),
+          );
+        });
+    });
 }); // tslint:disable-line:max-file-line-count

--- a/packages/contracts/test/exchange/core.ts
+++ b/packages/contracts/test/exchange/core.ts
@@ -742,7 +742,7 @@ describe('Exchange', () => {
         });
     });
 
-   describe('cancelOrdersBefore', () => {
+   describe('cancelOrdersUpTo', () => {
         it('should fail to set makerEpoch less than current makerEpoch', async () => {
             const makerEpoch = new BigNumber(1);
             await exWrapper.cancelOrdersUpToAsync(makerEpoch, makerAddress);


### PR DESCRIPTION
Implementation and tests in the protocol for cancelling all of a maker's orders before a certain time.

<!--- Thank you for taking the time to submit a Pull Request -->

<!--- Provide a general summary of the issue in the Title above -->

## Description

A change to the protocol which allows makers to cancel all of their orders up to a specific time.

ZEIP: https://github.com/0xProject/ZEIPs/issues/20

<!--- Describe your changes in detail -->

## Motivation and Context

The existing batchCancelOrders is granular but expensive. This change introduces a very inexpensive strategy for cancelling all orders that were created before a specific time. Makers are able to timestamp their orders by overloading the salt value. Timestamps follow minimal specs; for example, a specific unit of time is not enforced.

We detect the salt value has been overloaded as a timestamp when the "cancelOrdersBefore" is called. Since timestamps and salts serve similar purposes, only one should be necessary. There is probably a better / more explicit way to do this, which will be explored after benchmarking and feedback from relayers.

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Run `yarn test` in the `packages/contracts` directory.

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* [x] Change requires a change to the documentation.
* [x] Added tests to cover my changes.
* [ ] Added new entries to the relevant CHANGELOGs.
* [ ] Updated the new versions of the changed packages in the relevant CHANGELOGs.
* [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
* [ ] Labeled this PR with the labels corresponding to the changed package.
