### PR TITLE
Portal fill with mixed decimals (18 and 6)

### DIFF
--- a/packages/website/ts/components/fill_order.tsx
+++ b/packages/website/ts/components/fill_order.tsx
@@ -198,11 +198,13 @@ export class FillOrder extends React.Component<FillOrderProps, FillOrderState> {
             symbol: takerToken.symbol,
         };
         const parsedOrderExpiration = new BigNumber(this.state.parsedOrder.signedOrder.expirationUnixTimestampSec);
-        const exchangeRate = orderMakerAmount.div(orderTakerAmount);
 
         let orderReceiveAmount = 0;
         if (!_.isUndefined(this.props.orderFillAmount)) {
-            const orderReceiveAmountBigNumber = exchangeRate.mul(this.props.orderFillAmount);
+            const orderReceiveAmountBigNumber = orderMakerAmount
+                .times(this.props.orderFillAmount)
+                .dividedBy(orderTakerAmount)
+                .floor();
             orderReceiveAmount = this._formatCurrencyAmount(orderReceiveAmountBigNumber, makerToken.decimals);
         }
         const isUserMaker =


### PR DESCRIPTION


<!--- Thank you for taking the time to submit a Pull Request -->

<!--- Provide a general summary of the issue in the Title above -->

## Description

Remove any remainder when multiplying in base units.

## Motivation and Context

When the token pair has different decimal precision we can end up with a remainder when multiplying by an exchange rate (as one is in 18 decimals and the other is 6 for example)

Passing a BigNumber into toUnitAmount will fail as it expects no decimals.

Also preventing multiplying the error by calculating the exchange rate and expected order fill amount simultaneously.

## How Has This Been Tested?

Manually tested in local portal

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOGs.
*   [ ] Updated the new versions of the changed packages in the relevant CHANGELOGs.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
