### PR TITLE
Add marketBuyOrders

### DIFF
--- a/packages/contracts/src/contracts/current/protocol/Exchange/ISigner.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/ISigner.sol
@@ -23,7 +23,7 @@ contract ISigner {
 
     function isValidSignature(
         bytes32 hash,
-        bytes signature)
+        bytes memory signature)
         public view
         returns (bool isValid);
 }

--- a/packages/contracts/src/contracts/current/protocol/Exchange/LibErrors.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/LibErrors.sol
@@ -30,6 +30,6 @@ contract LibErrors {
         INSUFFICIENT_BALANCE_OR_ALLOWANCE // Insufficient balance or allowance for token transfer
     }
 
-    event LogError(uint8 indexed errorId, bytes32 indexed orderHash);
+    event ExchangeError(uint8 indexed errorId, bytes32 indexed orderHash);
 
 }

--- a/packages/contracts/src/contracts/current/protocol/Exchange/LibOrder.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/LibOrder.sol
@@ -28,8 +28,8 @@ contract LibOrder {
         "address makerTokenAddress",
         "address takerTokenAddress",
         "address feeRecipientAddress",
-        "uint256 makerSellAmount",
-        "uint256 makerBuyAmount",
+        "uint256 makerTokenAmount",
+        "uint256 takerTokenAmount",
         "uint256 makerFee",
         "uint256 takerFee",
         "uint256 expirationTimeSeconds",
@@ -42,8 +42,8 @@ contract LibOrder {
         address makerTokenAddress;
         address takerTokenAddress;
         address feeRecipientAddress;
-        uint256 makerSellAmount;
-        uint256 makerBuyAmount;
+        uint256 makerTokenAmount;
+        uint256 takerTokenAmount;
         uint256 makerFee;
         uint256 takerFee;
         uint256 expirationTimeSeconds;
@@ -68,8 +68,8 @@ contract LibOrder {
                 order.makerTokenAddress,
                 order.takerTokenAddress,
                 order.feeRecipientAddress,
-                order.makerSellAmount,
-                order.makerBuyAmount,
+                order.makerTokenAmount,
+                order.takerTokenAmount,
                 order.makerFee,
                 order.takerFee,
                 order.expirationTimeSeconds,

--- a/packages/contracts/src/contracts/current/protocol/Exchange/LibOrder.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/LibOrder.sol
@@ -28,10 +28,10 @@ contract LibOrder {
         "address makerTokenAddress",
         "address takerTokenAddress",
         "address feeRecipientAddress",
-        "uint256 makerTokenAmount",
-        "uint256 takerTokenAmount",
-        "uint256 makerFeeAmount",
-        "uint256 takerFeeAmount",
+        "uint256 makerSellAmount",
+        "uint256 makerBuyAmount",
+        "uint256 makerFee",
+        "uint256 takerFee",
         "uint256 expirationTimeSeconds",
         "uint256 salt"
     );
@@ -42,10 +42,10 @@ contract LibOrder {
         address makerTokenAddress;
         address takerTokenAddress;
         address feeRecipientAddress;
-        uint256 makerTokenAmount;
-        uint256 takerTokenAmount;
-        uint256 makerFeeAmount;
-        uint256 takerFeeAmount;
+        uint256 makerSellAmount;
+        uint256 makerBuyAmount;
+        uint256 makerFee;
+        uint256 takerFee;
         uint256 expirationTimeSeconds;
         uint256 salt;
     }
@@ -68,10 +68,10 @@ contract LibOrder {
                 order.makerTokenAddress,
                 order.takerTokenAddress,
                 order.feeRecipientAddress,
-                order.makerTokenAmount,
-                order.takerTokenAmount,
-                order.makerFeeAmount,
-                order.takerFeeAmount,
+                order.makerSellAmount,
+                order.makerBuyAmount,
+                order.makerFee,
+                order.takerFee,
                 order.expirationTimeSeconds,
                 order.salt
             )

--- a/packages/contracts/src/contracts/current/protocol/Exchange/MixinSettlementProxy.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/MixinSettlementProxy.sol
@@ -59,21 +59,21 @@ contract MixinSettlementProxy is
     function settleOrder(
         Order memory order,
         address takerAddress,
-        uint256 takerAmountSold)
+        uint256 takerTokenFilledAmount)
         internal
         returns (
-            uint256 makerAmountSold,
+            uint256 makerTokenFilledAmount,
             uint256 makerFeePaid,
             uint256 takerFeePaid
         )
     {
-        makerAmountSold = getPartialAmount(takerAmountSold, order.makerBuyAmount, order.makerSellAmount);
+        makerTokenFilledAmount = getPartialAmount(takerTokenFilledAmount, order.takerTokenAmount, order.makerTokenAmount);
         require(
             TRANSFER_PROXY.transferFrom(
                 order.makerTokenAddress,
                 order.makerAddress,
                 takerAddress,
-                makerAmountSold
+                makerTokenFilledAmount
             )
         );
         require(
@@ -81,12 +81,12 @@ contract MixinSettlementProxy is
                 order.takerTokenAddress,
                 takerAddress,
                 order.makerAddress,
-                takerAmountSold
+                takerTokenFilledAmount
             )
         );
         if (order.feeRecipientAddress != address(0)) {
             if (order.makerFee > 0) {
-                makerFeePaid = getPartialAmount(takerAmountSold, order.makerBuyAmount, order.makerFee);
+                makerFeePaid = getPartialAmount(takerTokenFilledAmount, order.takerTokenAmount, order.makerFee);
                 require(
                     TRANSFER_PROXY.transferFrom(
                         ZRX_TOKEN,
@@ -97,7 +97,7 @@ contract MixinSettlementProxy is
                 );
             }
             if (order.takerFee > 0) {
-                takerFeePaid = getPartialAmount(takerAmountSold, order.makerBuyAmount, order.takerFee);
+                takerFeePaid = getPartialAmount(takerTokenFilledAmount, order.takerTokenAmount, order.takerFee);
                 require(
                     TRANSFER_PROXY.transferFrom(
                         ZRX_TOKEN,
@@ -108,6 +108,6 @@ contract MixinSettlementProxy is
                 );
             }
         }
-        return (makerAmountSold, makerFeePaid, takerFeePaid);
+        return (makerTokenFilledAmount, makerFeePaid, takerFeePaid);
     }
 }

--- a/packages/contracts/src/contracts/current/protocol/Exchange/MixinSignatureValidator.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/MixinSignatureValidator.sol
@@ -39,7 +39,7 @@ contract MixinSignatureValidator is
     function isValidSignature(
         bytes32 hash,
         address signer,
-        bytes signature)
+        bytes memory signature)
         public view
         returns (bool isValid)
     {
@@ -145,7 +145,7 @@ contract MixinSignatureValidator is
         revert();
     }
 
-    function get32(bytes b, uint256 index)
+    function get32(bytes memory b, uint256 index)
         private pure
         returns (bytes32 result)
     {

--- a/packages/contracts/src/contracts/current/protocol/Exchange/MixinWrapperFunctions.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/MixinWrapperFunctions.sol
@@ -31,8 +31,8 @@ contract MixinWrapperFunctions is
 {
     /// @dev Fills the input order. Reverts if exact takerSellAmount not filled.
     /// @param order Order struct containing order specifications.
-    /// @param takerSellAmount Desired amount of takerToken to fill.
-    /// @param signature Maker's signature of the order.
+    /// @param takerSellAmount Desired amount of takerToken to sell.
+    /// @param signature Proof that order has been created by maker.
     function fillOrKillOrder(
         Order memory order,
         uint256 takerSellAmount,
@@ -52,8 +52,8 @@ contract MixinWrapperFunctions is
     /// @dev Fills an order with specified parameters and ECDSA signature.
     ///      Returns false if the transaction would otherwise revert.
     /// @param order Order struct containing order specifications.
-    /// @param takerSellAmount Desired amount of takerToken to fill.
-    /// @param signature Maker's signature of the order.
+    /// @param takerSellAmount Desired amount of takerToken to sell.
+    /// @param signature Proof that order has been created by maker.
     /// @return Amounts filled and fees paid by maker and taker.
     function fillOrderNoThrow(
         Order memory order,
@@ -154,10 +154,10 @@ contract MixinWrapperFunctions is
         return fillResults;
     }
 
-    /// @dev Synchronously executes multiple calls of fillOrder in a single transaction.
-    /// @param orders Array of orders.
-    /// @param takerSellAmounts Array of desired amounts of takerToken to fill in orders.
-    /// @param signatures Maker's signatures of the orders.
+    /// @dev Synchronously executes multiple calls of fillOrder.
+    /// @param orders Array of order specifications.
+    /// @param takerSellAmounts Array of desired amounts of takerToken to sell in orders.
+    /// @param signatures Proofs that orders have been created by makers.
     function batchFillOrders(
         Order[] memory orders,
         uint256[] memory takerSellAmounts,
@@ -173,10 +173,10 @@ contract MixinWrapperFunctions is
         }
     }
 
-    /// @dev Synchronously executes multiple calls of fillOrKill in a single transaction.
-    /// @param orders Array of orders.
-    /// @param takerSellAmounts Array of desired amounts of takerToken to fill in orders.
-    /// @param signatures Maker's signatures of the orders.
+    /// @dev Synchronously executes multiple calls of fillOrKill.
+    /// @param orders Array of order specifications.
+    /// @param takerSellAmounts Array of desired amounts of takerToken to sell in orders.
+    /// @param signatures Proofs that orders have been created by makers.
     function batchFillOrKillOrders(
         Order[] memory orders,
         uint256[] memory takerSellAmounts,
@@ -192,10 +192,11 @@ contract MixinWrapperFunctions is
         }
     }
 
-    /// @dev Fills an order with specified parameters and ECDSA signature. Returns false if the transaction would otherwise revert.
-    /// @param orders Array of orders.
-    /// @param takerSellAmounts Array of desired amounts of takerToken to fill in orders.
-    /// @param signatures Maker's signatures of the orders.
+    /// @dev Fills an order with specified parameters and ECDSA signature.
+    ///      Returns false if the transaction would otherwise revert.
+    /// @param orders Array of order specifications.
+    /// @param takerSellAmounts Array of desired amounts of takerToken to sell in orders.
+    /// @param signatures Proofs that orders have been created by makers.
     function batchFillOrdersNoThrow(
         Order[] memory orders,
         uint256[] memory takerSellAmounts,
@@ -211,11 +212,11 @@ contract MixinWrapperFunctions is
         }
     }
 
-    /// @dev Synchronously executes multiple fill orders in a single transaction until total amount is sold by taker.
-    /// @param orders Array of orders.
+    /// @dev Synchronously executes multiple calls of fillOrder until total amount of takerToken is sold by taker.
+    /// @param orders Array of order specifications.
     /// @param takerSellAmount Desired amount of takerToken to sell.
-    /// @param signatures Maker's signatures of the orders.
-    /// @return Total amount of tokens sold by taker in orders.
+    /// @param signatures Proofs that orders have been created by makers.
+    /// @return Amounts filled and fees paid by makers and taker.
     function marketSellOrders(
         Order[] memory orders,
         uint256 takerSellAmount,
@@ -242,12 +243,12 @@ contract MixinWrapperFunctions is
         return fillResults;
     }
 
-    /// @dev Synchronously executes multiple calls of fillOrderNoThrow in a single transaction until total amount is sold by taker.
+    /// @dev Synchronously executes multiple calls of fillOrder until total amount of takerToken is sold by taker.
     ///      Returns false if the transaction would otherwise revert.
-    /// @param orders Array of orders.
+    /// @param orders Array of order specifications.
     /// @param takerSellAmount Desired amount of takerToken to sell.
-    /// @param signatures Maker's signatures of the orders.
-    /// @return Total amount of tokens sold by taker in orders.
+    /// @param signatures Proofs that orders have been signed by makers.
+    /// @return Amounts filled and fees paid by makers and taker.
     function marketSellOrdersNoThrow(
         Order[] memory orders,
         uint256 takerSellAmount,
@@ -274,11 +275,11 @@ contract MixinWrapperFunctions is
         return fillResults;
     }
 
-    /// @dev Synchronously executes multiple fill orders in a single transaction until total amount is bought by taker.
-    /// @param orders Array of orders.
+    /// @dev Synchronously executes multiple calls of fillOrder until total amount of makerToken is bought by taker.
+    /// @param orders Array of order specifications.
     /// @param takerBuyAmount Desired amount of makerToken to buy.
-    /// @param signatures Maker's signatures of the orders.
-    /// @return Total amount of takerTokenFillAmount filled in orders.
+    /// @param signatures Proofs that orders have been signed by makers.
+    /// @return Amounts filled and fees paid by makers and taker.
     function marketBuyOrders(
         Order[] memory orders,
         uint256 takerBuyAmount,
@@ -312,10 +313,10 @@ contract MixinWrapperFunctions is
 
     /// @dev Synchronously executes multiple fill orders in a single transaction until total amount is bought by taker.
     ///      Returns false if the transaction would otherwise revert.
-    /// @param orders Array of orders.
-    /// @param takerBuyAmount Desired amount of makerToken to fill.
-    /// @param signatures Maker's signatures of the orders.
-    /// @return Total amount of takerTokenFillAmount filled in orders.
+    /// @param orders Array of order specifications.
+    /// @param takerBuyAmount Desired amount of makerToken to buy.
+    /// @param signatures Proofs that orders have been signed by makers.
+    /// @return Amounts filled and fees paid by makers and taker.
     function marketBuyOrdersNoThrow(
         Order[] memory orders,
         uint256 takerBuyAmount,
@@ -348,7 +349,7 @@ contract MixinWrapperFunctions is
     }
 
     /// @dev Synchronously cancels multiple orders in a single transaction.
-    /// @param orders Array of orders.
+    /// @param orders Array of order specifications.
     function batchCancelOrders(Order[] memory orders)
         public
     {

--- a/packages/contracts/src/contracts/current/protocol/Exchange/MixinWrapperFunctions.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/MixinWrapperFunctions.sol
@@ -278,7 +278,7 @@ contract MixinWrapperFunctions is
         returns (uint256 takerAmountBought)
     {
         for (uint256 i = 0; i < orders.length; i++) {
-            require(orders[i].takerTokenAddress == orders[0].takerTokenAddress);
+            require(orders[i].makerTokenAddress == orders[0].makerTokenAddress);
             uint256 remainingTakerBuyAmount = safeSub(takerBuyAmount, takerAmountBought);
             uint256 takerSellAmount = getPartialAmount(
                 orders[i].makerBuyAmount,
@@ -319,7 +319,7 @@ contract MixinWrapperFunctions is
         returns (uint256 takerAmountBought)
     {
         for (uint256 i = 0; i < orders.length; i++) {
-            require(orders[i].takerTokenAddress == orders[0].takerTokenAddress);
+            require(orders[i].makerTokenAddress == orders[0].makerTokenAddress);
             uint256 remainingTakerBuyAmount = safeSub(takerBuyAmount, takerAmountBought);
             uint256 takerSellAmount = getPartialAmount(
                 orders[i].makerBuyAmount,

--- a/packages/contracts/src/contracts/current/protocol/Exchange/mixins/MExchangeCore.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/mixins/MExchangeCore.sol
@@ -24,15 +24,15 @@ import "../LibOrder.sol";
 contract MExchangeCore is LibOrder {
 
     struct FillResults {
-        uint256 makerAmountSold;
-        uint256 takerAmountSold;
+        uint256 makerTokenFilledAmount;
+        uint256 takerTokenFilledAmount;
         uint256 makerFeePaid;
         uint256 takerFeePaid;
     }
 
     function fillOrder(
         Order memory order,
-        uint256 takerSellAmount,
+        uint256 takerTokenFillAmount,
         bytes memory signature)
         public
         returns (FillResults memory fillResults);

--- a/packages/contracts/src/contracts/current/protocol/Exchange/mixins/MExchangeCore.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/mixins/MExchangeCore.sol
@@ -23,17 +23,24 @@ import "../LibOrder.sol";
 
 contract MExchangeCore is LibOrder {
 
-    function fillOrder(
-        Order order,
-        uint256 takerTokenFillAmount,
-        bytes signature)
-        public
-        returns (uint256 takerTokenFilledAmount);
+    struct FillResults {
+        uint256 makerAmountSold;
+        uint256 takerAmountSold;
+        uint256 makerFeePaid;
+        uint256 takerFeePaid;
+    }
 
-    function cancelOrder(Order order)
+    function fillOrder(
+        Order memory order,
+        uint256 takerSellAmount,
+        bytes memory signature)
+        public
+        returns (FillResults memory fillResults);
+
+    function cancelOrder(Order memory order)
         public
         returns (bool);
 
- function cancelOrdersUpTo(uint256 salt)
+    function cancelOrdersUpTo(uint256 salt)
         external;
 }

--- a/packages/contracts/src/contracts/current/protocol/Exchange/mixins/MSettlement.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/mixins/MSettlement.sol
@@ -24,14 +24,14 @@ import "../LibOrder.sol";
 contract MSettlement is LibOrder {
 
     function settleOrder(
-        Order order,
-        address taker,
-        uint256 takerTokenFilledAmount)
+        Order memory order,
+        address takerAddress,
+        uint256 takerAmountSold)
         internal
         returns (
-            uint256 makerTokenFilledAmount,
-            uint256 makerFeeAmountPaid,
-            uint256 takerFeeAmountPaid
+            uint256 makerAmountSold,
+            uint256 makerFeePaid,
+            uint256 takerFeePaid
         );
 
 }

--- a/packages/contracts/src/contracts/current/protocol/Exchange/mixins/MSettlement.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/mixins/MSettlement.sol
@@ -26,10 +26,10 @@ contract MSettlement is LibOrder {
     function settleOrder(
         Order memory order,
         address takerAddress,
-        uint256 takerAmountSold)
+        uint256 takerTokenFilledAmount)
         internal
         returns (
-            uint256 makerAmountSold,
+            uint256 makerTokenFilledAmount,
             uint256 makerFeePaid,
             uint256 takerFeePaid
         );

--- a/packages/contracts/src/contracts/current/protocol/Exchange/mixins/MSignatureValidator.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/mixins/MSignatureValidator.sol
@@ -29,7 +29,7 @@ contract MSignatureValidator {
     function isValidSignature(
         bytes32 hash,
         address signer,
-        bytes signature)
+        bytes memory signature)
         public view
         returns (bool isValid);
 }

--- a/packages/contracts/src/utils/exchange_wrapper.ts
+++ b/packages/contracts/src/utils/exchange_wrapper.ts
@@ -22,12 +22,12 @@ export class ExchangeWrapper {
     public async fillOrderAsync(
         signedOrder: SignedOrder,
         from: string,
-        opts: { takerSellAmount?: BigNumber } = {},
+        opts: { takerTokenFillAmount?: BigNumber } = {},
     ): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = orderUtils.createFill(signedOrder, opts.takerSellAmount);
+        const params = orderUtils.createFill(signedOrder, opts.takerTokenFillAmount);
         const txHash = await this._exchange.fillOrder.sendTransactionAsync(
             params.order,
-            params.takerSellAmount,
+            params.takerTokenFillAmount,
             params.signature,
             { from },
         );
@@ -43,12 +43,12 @@ export class ExchangeWrapper {
     public async fillOrKillOrderAsync(
         signedOrder: SignedOrder,
         from: string,
-        opts: { takerSellAmount?: BigNumber } = {},
+        opts: { takerTokenFillAmount?: BigNumber } = {},
     ): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = orderUtils.createFill(signedOrder, opts.takerSellAmount);
+        const params = orderUtils.createFill(signedOrder, opts.takerTokenFillAmount);
         const txHash = await this._exchange.fillOrKillOrder.sendTransactionAsync(
             params.order,
-            params.takerSellAmount,
+            params.takerTokenFillAmount,
             params.signature,
             { from },
         );
@@ -58,12 +58,12 @@ export class ExchangeWrapper {
     public async fillOrderNoThrowAsync(
         signedOrder: SignedOrder,
         from: string,
-        opts: { takerSellAmount?: BigNumber } = {},
+        opts: { takerTokenFillAmount?: BigNumber } = {},
     ): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = orderUtils.createFill(signedOrder, opts.takerSellAmount);
+        const params = orderUtils.createFill(signedOrder, opts.takerTokenFillAmount);
         const txHash = await this._exchange.fillOrderNoThrow.sendTransactionAsync(
             params.order,
-            params.takerSellAmount,
+            params.takerTokenFillAmount,
             params.signature,
             { from },
         );
@@ -73,12 +73,12 @@ export class ExchangeWrapper {
     public async batchFillOrdersAsync(
         orders: SignedOrder[],
         from: string,
-        opts: { takerSellAmounts?: BigNumber[] } = {},
+        opts: { takerTokenFillAmounts?: BigNumber[] } = {},
     ): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = formatters.createBatchFill(orders, opts.takerSellAmounts);
+        const params = formatters.createBatchFill(orders, opts.takerTokenFillAmounts);
         const txHash = await this._exchange.batchFillOrders.sendTransactionAsync(
             params.orders,
-            params.takerSellAmounts,
+            params.takerTokenFillAmounts,
             params.signatures,
             { from },
         );
@@ -88,12 +88,12 @@ export class ExchangeWrapper {
     public async batchFillOrKillOrdersAsync(
         orders: SignedOrder[],
         from: string,
-        opts: { takerSellAmounts?: BigNumber[] } = {},
+        opts: { takerTokenFillAmounts?: BigNumber[] } = {},
     ): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = formatters.createBatchFill(orders, opts.takerSellAmounts);
+        const params = formatters.createBatchFill(orders, opts.takerTokenFillAmounts);
         const txHash = await this._exchange.batchFillOrKillOrders.sendTransactionAsync(
             params.orders,
-            params.takerSellAmounts,
+            params.takerTokenFillAmounts,
             params.signatures,
             { from },
         );
@@ -103,12 +103,12 @@ export class ExchangeWrapper {
     public async batchFillOrdersNoThrowAsync(
         orders: SignedOrder[],
         from: string,
-        opts: { takerSellAmounts?: BigNumber[] } = {},
+        opts: { takerTokenFillAmounts?: BigNumber[] } = {},
     ): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = formatters.createBatchFill(orders, opts.takerSellAmounts);
+        const params = formatters.createBatchFill(orders, opts.takerTokenFillAmounts);
         const txHash = await this._exchange.batchFillOrdersNoThrow.sendTransactionAsync(
             params.orders,
-            params.takerSellAmounts,
+            params.takerTokenFillAmounts,
             params.signatures,
             { from },
         );
@@ -118,12 +118,12 @@ export class ExchangeWrapper {
     public async marketSellOrdersAsync(
         orders: SignedOrder[],
         from: string,
-        opts: { takerSellAmount: BigNumber },
+        opts: { takerTokenFillAmount: BigNumber },
     ): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = formatters.createMarketSellOrders(orders, opts.takerSellAmount);
+        const params = formatters.createMarketSellOrders(orders, opts.takerTokenFillAmount);
         const txHash = await this._exchange.marketSellOrders.sendTransactionAsync(
             params.orders,
-            params.takerSellAmount,
+            params.takerTokenFillAmount,
             params.signatures,
             { from },
         );
@@ -133,12 +133,12 @@ export class ExchangeWrapper {
     public async marketSellOrdersNoThrowAsync(
         orders: SignedOrder[],
         from: string,
-        opts: { takerSellAmount: BigNumber },
+        opts: { takerTokenFillAmount: BigNumber },
     ): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = formatters.createMarketSellOrders(orders, opts.takerSellAmount);
+        const params = formatters.createMarketSellOrders(orders, opts.takerTokenFillAmount);
         const txHash = await this._exchange.marketSellOrdersNoThrow.sendTransactionAsync(
             params.orders,
-            params.takerSellAmount,
+            params.takerTokenFillAmount,
             params.signatures,
             { from },
         );
@@ -148,12 +148,12 @@ export class ExchangeWrapper {
     public async marketBuyOrdersAsync(
         orders: SignedOrder[],
         from: string,
-        opts: { takerBuyAmount: BigNumber },
+        opts: { makerTokenFillAmount: BigNumber },
     ): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = formatters.createMarketBuyOrders(orders, opts.takerBuyAmount);
+        const params = formatters.createMarketBuyOrders(orders, opts.makerTokenFillAmount);
         const txHash = await this._exchange.marketBuyOrders.sendTransactionAsync(
             params.orders,
-            params.takerBuyAmount,
+            params.makerTokenFillAmount,
             params.signatures,
             { from },
         );
@@ -163,12 +163,12 @@ export class ExchangeWrapper {
     public async marketBuyOrdersNoThrowAsync(
         orders: SignedOrder[],
         from: string,
-        opts: { takerBuyAmount: BigNumber },
+        opts: { makerTokenFillAmount: BigNumber },
     ): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = formatters.createMarketBuyOrders(orders, opts.takerBuyAmount);
+        const params = formatters.createMarketBuyOrders(orders, opts.makerTokenFillAmount);
         const txHash = await this._exchange.marketBuyOrdersNoThrow.sendTransactionAsync(
             params.orders,
-            params.takerBuyAmount,
+            params.makerTokenFillAmount,
             params.signatures,
             { from },
         );
@@ -221,7 +221,7 @@ export class ExchangeWrapper {
         );
         return partialAmount;
     }
-    public async getMakerAmountBoughtAsync(orderHashHex: string): Promise<BigNumber> {
+    public async getTakerTokenFilledAmount(orderHashHex: string): Promise<BigNumber> {
         const filledAmount = new BigNumber(await this._exchange.filled.callAsync(orderHashHex));
         return filledAmount;
     }

--- a/packages/contracts/src/utils/exchange_wrapper.ts
+++ b/packages/contracts/src/utils/exchange_wrapper.ts
@@ -22,12 +22,12 @@ export class ExchangeWrapper {
     public async fillOrderAsync(
         signedOrder: SignedOrder,
         from: string,
-        opts: { takerTokenFillAmount?: BigNumber } = {},
+        opts: { takerSellAmount?: BigNumber } = {},
     ): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = orderUtils.createFill(signedOrder, opts.takerTokenFillAmount);
+        const params = orderUtils.createFill(signedOrder, opts.takerSellAmount);
         const txHash = await this._exchange.fillOrder.sendTransactionAsync(
             params.order,
-            params.takerTokenFillAmount,
+            params.takerSellAmount,
             params.signature,
             { from },
         );
@@ -43,12 +43,12 @@ export class ExchangeWrapper {
     public async fillOrKillOrderAsync(
         signedOrder: SignedOrder,
         from: string,
-        opts: { takerTokenFillAmount?: BigNumber } = {},
+        opts: { takerSellAmount?: BigNumber } = {},
     ): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = orderUtils.createFill(signedOrder, opts.takerTokenFillAmount);
+        const params = orderUtils.createFill(signedOrder, opts.takerSellAmount);
         const txHash = await this._exchange.fillOrKillOrder.sendTransactionAsync(
             params.order,
-            params.takerTokenFillAmount,
+            params.takerSellAmount,
             params.signature,
             { from },
         );
@@ -58,12 +58,12 @@ export class ExchangeWrapper {
     public async fillOrderNoThrowAsync(
         signedOrder: SignedOrder,
         from: string,
-        opts: { takerTokenFillAmount?: BigNumber } = {},
+        opts: { takerSellAmount?: BigNumber } = {},
     ): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = orderUtils.createFill(signedOrder, opts.takerTokenFillAmount);
+        const params = orderUtils.createFill(signedOrder, opts.takerSellAmount);
         const txHash = await this._exchange.fillOrderNoThrow.sendTransactionAsync(
             params.order,
-            params.takerTokenFillAmount,
+            params.takerSellAmount,
             params.signature,
             { from },
         );
@@ -73,12 +73,12 @@ export class ExchangeWrapper {
     public async batchFillOrdersAsync(
         orders: SignedOrder[],
         from: string,
-        opts: { takerTokenFillAmounts?: BigNumber[] } = {},
+        opts: { takerSellAmounts?: BigNumber[] } = {},
     ): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = formatters.createBatchFill(orders, opts.takerTokenFillAmounts);
+        const params = formatters.createBatchFill(orders, opts.takerSellAmounts);
         const txHash = await this._exchange.batchFillOrders.sendTransactionAsync(
             params.orders,
-            params.takerTokenFillAmounts,
+            params.takerSellAmounts,
             params.signatures,
             { from },
         );
@@ -88,12 +88,12 @@ export class ExchangeWrapper {
     public async batchFillOrKillOrdersAsync(
         orders: SignedOrder[],
         from: string,
-        opts: { takerTokenFillAmounts?: BigNumber[] } = {},
+        opts: { takerSellAmounts?: BigNumber[] } = {},
     ): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = formatters.createBatchFill(orders, opts.takerTokenFillAmounts);
+        const params = formatters.createBatchFill(orders, opts.takerSellAmounts);
         const txHash = await this._exchange.batchFillOrKillOrders.sendTransactionAsync(
             params.orders,
-            params.takerTokenFillAmounts,
+            params.takerSellAmounts,
             params.signatures,
             { from },
         );
@@ -103,42 +103,72 @@ export class ExchangeWrapper {
     public async batchFillOrdersNoThrowAsync(
         orders: SignedOrder[],
         from: string,
-        opts: { takerTokenFillAmounts?: BigNumber[] } = {},
+        opts: { takerSellAmounts?: BigNumber[] } = {},
     ): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = formatters.createBatchFill(orders, opts.takerTokenFillAmounts);
+        const params = formatters.createBatchFill(orders, opts.takerSellAmounts);
         const txHash = await this._exchange.batchFillOrdersNoThrow.sendTransactionAsync(
             params.orders,
-            params.takerTokenFillAmounts,
+            params.takerSellAmounts,
             params.signatures,
             { from },
         );
         const tx = await this._getTxWithDecodedExchangeLogsAsync(txHash);
         return tx;
     }
-    public async marketFillOrdersAsync(
+    public async marketSellOrdersAsync(
         orders: SignedOrder[],
         from: string,
-        opts: { takerTokenFillAmount: BigNumber },
+        opts: { takerSellAmount: BigNumber },
     ): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = formatters.createMarketFillOrders(orders, opts.takerTokenFillAmount);
-        const txHash = await this._exchange.marketFillOrders.sendTransactionAsync(
+        const params = formatters.createMarketSellOrders(orders, opts.takerSellAmount);
+        const txHash = await this._exchange.marketSellOrders.sendTransactionAsync(
             params.orders,
-            params.takerTokenFillAmount,
+            params.takerSellAmount,
             params.signatures,
             { from },
         );
         const tx = await this._getTxWithDecodedExchangeLogsAsync(txHash);
         return tx;
     }
-    public async marketFillOrdersNoThrowAsync(
+    public async marketSellOrdersNoThrowAsync(
         orders: SignedOrder[],
         from: string,
-        opts: { takerTokenFillAmount: BigNumber },
+        opts: { takerSellAmount: BigNumber },
     ): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = formatters.createMarketFillOrders(orders, opts.takerTokenFillAmount);
-        const txHash = await this._exchange.marketFillOrdersNoThrow.sendTransactionAsync(
+        const params = formatters.createMarketSellOrders(orders, opts.takerSellAmount);
+        const txHash = await this._exchange.marketSellOrdersNoThrow.sendTransactionAsync(
             params.orders,
-            params.takerTokenFillAmount,
+            params.takerSellAmount,
+            params.signatures,
+            { from },
+        );
+        const tx = await this._getTxWithDecodedExchangeLogsAsync(txHash);
+        return tx;
+    }
+    public async marketBuyOrdersAsync(
+        orders: SignedOrder[],
+        from: string,
+        opts: { takerBuyAmount: BigNumber },
+    ): Promise<TransactionReceiptWithDecodedLogs> {
+        const params = formatters.createMarketBuyOrders(orders, opts.takerBuyAmount);
+        const txHash = await this._exchange.marketBuyOrders.sendTransactionAsync(
+            params.orders,
+            params.takerBuyAmount,
+            params.signatures,
+            { from },
+        );
+        const tx = await this._getTxWithDecodedExchangeLogsAsync(txHash);
+        return tx;
+    }
+    public async marketBuyOrdersNoThrowAsync(
+        orders: SignedOrder[],
+        from: string,
+        opts: { takerBuyAmount: BigNumber },
+    ): Promise<TransactionReceiptWithDecodedLogs> {
+        const params = formatters.createMarketBuyOrders(orders, opts.takerBuyAmount);
+        const txHash = await this._exchange.marketBuyOrdersNoThrow.sendTransactionAsync(
+            params.orders,
+            params.takerBuyAmount,
             params.signatures,
             { from },
         );
@@ -191,7 +221,7 @@ export class ExchangeWrapper {
         );
         return partialAmount;
     }
-    public async getFilledTakerTokenAmountAsync(orderHashHex: string): Promise<BigNumber> {
+    public async getMakerAmountBoughtAsync(orderHashHex: string): Promise<BigNumber> {
         const filledAmount = new BigNumber(await this._exchange.filled.callAsync(orderHashHex));
         return filledAmount;
     }

--- a/packages/contracts/src/utils/formatters.ts
+++ b/packages/contracts/src/utils/formatters.ts
@@ -5,27 +5,27 @@ import { orderUtils } from './order_utils';
 import { BatchCancelOrders, BatchFillOrders, MarketBuyOrders, MarketSellOrders, SignedOrder } from './types';
 
 export const formatters = {
-    createBatchFill(signedOrders: SignedOrder[], takerSellAmounts: BigNumber[] = []) {
+    createBatchFill(signedOrders: SignedOrder[], takerTokenFillAmounts: BigNumber[] = []) {
         const batchFill: BatchFillOrders = {
             orders: [],
             signatures: [],
-            takerSellAmounts,
+            takerTokenFillAmounts,
         };
         _.forEach(signedOrders, signedOrder => {
             const orderStruct = orderUtils.getOrderStruct(signedOrder);
             batchFill.orders.push(orderStruct);
             batchFill.signatures.push(signedOrder.signature);
-            if (takerSellAmounts.length < signedOrders.length) {
-                batchFill.takerSellAmounts.push(signedOrder.makerBuyAmount);
+            if (takerTokenFillAmounts.length < signedOrders.length) {
+                batchFill.takerTokenFillAmounts.push(signedOrder.takerTokenAmount);
             }
         });
         return batchFill;
     },
-    createMarketSellOrders(signedOrders: SignedOrder[], takerSellAmount: BigNumber) {
+    createMarketSellOrders(signedOrders: SignedOrder[], takerTokenFillAmount: BigNumber) {
         const marketSellOrders: MarketSellOrders = {
             orders: [],
             signatures: [],
-            takerSellAmount,
+            takerTokenFillAmount,
         };
         _.forEach(signedOrders, signedOrder => {
             const orderStruct = orderUtils.getOrderStruct(signedOrder);
@@ -34,11 +34,11 @@ export const formatters = {
         });
         return marketSellOrders;
     },
-    createMarketBuyOrders(signedOrders: SignedOrder[], takerBuyAmount: BigNumber) {
+    createMarketBuyOrders(signedOrders: SignedOrder[], makerTokenFillAmount: BigNumber) {
         const marketBuyOrders: MarketBuyOrders = {
             orders: [],
             signatures: [],
-            takerBuyAmount,
+            makerTokenFillAmount,
         };
         _.forEach(signedOrders, signedOrder => {
             const orderStruct = orderUtils.getOrderStruct(signedOrder);

--- a/packages/contracts/src/utils/formatters.ts
+++ b/packages/contracts/src/utils/formatters.ts
@@ -1,78 +1,59 @@
 import { BigNumber } from '@0xproject/utils';
 import * as _ from 'lodash';
 
-import { BatchCancelOrders, BatchFillOrders, MarketFillOrders, SignedOrder } from './types';
+import { orderUtils } from './order_utils';
+import { BatchCancelOrders, BatchFillOrders, MarketBuyOrders, MarketSellOrders, SignedOrder } from './types';
 
 export const formatters = {
-    createBatchFill(signedOrders: SignedOrder[], takerTokenFillAmounts: BigNumber[] = []) {
+    createBatchFill(signedOrders: SignedOrder[], takerSellAmounts: BigNumber[] = []) {
         const batchFill: BatchFillOrders = {
             orders: [],
             signatures: [],
-            takerTokenFillAmounts,
+            takerSellAmounts,
         };
         _.forEach(signedOrders, signedOrder => {
-            batchFill.orders.push({
-                makerAddress: signedOrder.makerAddress,
-                takerAddress: signedOrder.takerAddress,
-                makerTokenAddress: signedOrder.makerTokenAddress,
-                takerTokenAddress: signedOrder.takerTokenAddress,
-                feeRecipientAddress: signedOrder.feeRecipientAddress,
-                makerTokenAmount: signedOrder.makerTokenAmount,
-                takerTokenAmount: signedOrder.takerTokenAmount,
-                makerFeeAmount: signedOrder.makerFeeAmount,
-                takerFeeAmount: signedOrder.takerFeeAmount,
-                expirationTimeSeconds: signedOrder.expirationTimeSeconds,
-                salt: signedOrder.salt,
-            });
+            const orderStruct = orderUtils.getOrderStruct(signedOrder);
+            batchFill.orders.push(orderStruct);
             batchFill.signatures.push(signedOrder.signature);
-            if (takerTokenFillAmounts.length < signedOrders.length) {
-                batchFill.takerTokenFillAmounts.push(signedOrder.takerTokenAmount);
+            if (takerSellAmounts.length < signedOrders.length) {
+                batchFill.takerSellAmounts.push(signedOrder.makerBuyAmount);
             }
         });
         return batchFill;
     },
-    createMarketFillOrders(signedOrders: SignedOrder[], takerTokenFillAmount: BigNumber) {
-        const marketFillOrders: MarketFillOrders = {
+    createMarketSellOrders(signedOrders: SignedOrder[], takerSellAmount: BigNumber) {
+        const marketSellOrders: MarketSellOrders = {
             orders: [],
             signatures: [],
-            takerTokenFillAmount,
+            takerSellAmount,
         };
         _.forEach(signedOrders, signedOrder => {
-            marketFillOrders.orders.push({
-                makerAddress: signedOrder.makerAddress,
-                takerAddress: signedOrder.takerAddress,
-                makerTokenAddress: signedOrder.makerTokenAddress,
-                takerTokenAddress: signedOrder.takerTokenAddress,
-                feeRecipientAddress: signedOrder.feeRecipientAddress,
-                makerTokenAmount: signedOrder.makerTokenAmount,
-                takerTokenAmount: signedOrder.takerTokenAmount,
-                makerFeeAmount: signedOrder.makerFeeAmount,
-                takerFeeAmount: signedOrder.takerFeeAmount,
-                expirationTimeSeconds: signedOrder.expirationTimeSeconds,
-                salt: signedOrder.salt,
-            });
-            marketFillOrders.signatures.push(signedOrder.signature);
+            const orderStruct = orderUtils.getOrderStruct(signedOrder);
+            marketSellOrders.orders.push(orderStruct);
+            marketSellOrders.signatures.push(signedOrder.signature);
         });
-        return marketFillOrders;
+        return marketSellOrders;
+    },
+    createMarketBuyOrders(signedOrders: SignedOrder[], takerBuyAmount: BigNumber) {
+        const marketBuyOrders: MarketBuyOrders = {
+            orders: [],
+            signatures: [],
+            takerBuyAmount,
+        };
+        _.forEach(signedOrders, signedOrder => {
+            const orderStruct = orderUtils.getOrderStruct(signedOrder);
+            marketBuyOrders.orders.push(orderStruct);
+            marketBuyOrders.signatures.push(signedOrder.signature);
+        });
+        return marketBuyOrders;
     },
     createBatchCancel(signedOrders: SignedOrder[]) {
         const batchCancel: BatchCancelOrders = {
             orders: [],
         };
         _.forEach(signedOrders, signedOrder => {
-            batchCancel.orders.push({
-                makerAddress: signedOrder.makerAddress,
-                takerAddress: signedOrder.takerAddress,
-                makerTokenAddress: signedOrder.makerTokenAddress,
-                takerTokenAddress: signedOrder.takerTokenAddress,
-                feeRecipientAddress: signedOrder.feeRecipientAddress,
-                makerTokenAmount: signedOrder.makerTokenAmount,
-                takerTokenAmount: signedOrder.takerTokenAmount,
-                makerFeeAmount: signedOrder.makerFeeAmount,
-                takerFeeAmount: signedOrder.takerFeeAmount,
-                expirationTimeSeconds: signedOrder.expirationTimeSeconds,
-                salt: signedOrder.salt,
-            });
+            const orderStruct = orderUtils.getOrderStruct(signedOrder);
+            batchCancel.orders.push(orderStruct);
         });
         return batchCancel;
     },

--- a/packages/contracts/src/utils/order_utils.ts
+++ b/packages/contracts/src/utils/order_utils.ts
@@ -7,10 +7,10 @@ import { crypto } from './crypto';
 import { OrderStruct, SignatureType, SignedOrder, UnsignedOrder } from './types';
 
 export const orderUtils = {
-    createFill: (signedOrder: SignedOrder, takerTokenFillAmount?: BigNumber) => {
+    createFill: (signedOrder: SignedOrder, takerSellAmount?: BigNumber) => {
         const fill = {
             order: orderUtils.getOrderStruct(signedOrder),
-            takerTokenFillAmount: takerTokenFillAmount || signedOrder.takerTokenAmount,
+            takerSellAmount: takerSellAmount || signedOrder.makerBuyAmount,
             signature: signedOrder.signature,
         };
         return fill;
@@ -18,7 +18,7 @@ export const orderUtils = {
     createCancel(signedOrder: SignedOrder, takerTokenCancelAmount?: BigNumber) {
         const cancel = {
             order: orderUtils.getOrderStruct(signedOrder),
-            takerTokenCancelAmount: takerTokenCancelAmount || signedOrder.takerTokenAmount,
+            takerTokenCancelAmount: takerTokenCancelAmount || signedOrder.makerBuyAmount,
         };
         return cancel;
     },
@@ -29,10 +29,10 @@ export const orderUtils = {
             makerTokenAddress: signedOrder.makerTokenAddress,
             takerTokenAddress: signedOrder.takerTokenAddress,
             feeRecipientAddress: signedOrder.feeRecipientAddress,
-            makerTokenAmount: signedOrder.makerTokenAmount,
-            takerTokenAmount: signedOrder.takerTokenAmount,
-            makerFeeAmount: signedOrder.makerFeeAmount,
-            takerFeeAmount: signedOrder.takerFeeAmount,
+            makerSellAmount: signedOrder.makerSellAmount,
+            makerBuyAmount: signedOrder.makerBuyAmount,
+            makerFee: signedOrder.makerFee,
+            takerFee: signedOrder.takerFee,
             expirationTimeSeconds: signedOrder.expirationTimeSeconds,
             salt: signedOrder.salt,
         };
@@ -46,10 +46,10 @@ export const orderUtils = {
             'address makerTokenAddress',
             'address takerTokenAddress',
             'address feeRecipientAddress',
-            'uint256 makerTokenAmount',
-            'uint256 takerTokenAmount',
-            'uint256 makerFeeAmount',
-            'uint256 takerFeeAmount',
+            'uint256 makerSellAmount',
+            'uint256 makerBuyAmount',
+            'uint256 makerFee',
+            'uint256 takerFee',
             'uint256 expirationTimeSeconds',
             'uint256 salt',
         ]);
@@ -60,10 +60,10 @@ export const orderUtils = {
             order.makerTokenAddress,
             order.takerTokenAddress,
             order.feeRecipientAddress,
-            order.makerTokenAmount,
-            order.takerTokenAmount,
-            order.makerFeeAmount,
-            order.takerFeeAmount,
+            order.makerSellAmount,
+            order.makerBuyAmount,
+            order.makerFee,
+            order.takerFee,
             order.expirationTimeSeconds,
             order.salt,
         ]);

--- a/packages/contracts/src/utils/order_utils.ts
+++ b/packages/contracts/src/utils/order_utils.ts
@@ -7,10 +7,10 @@ import { crypto } from './crypto';
 import { OrderStruct, SignatureType, SignedOrder, UnsignedOrder } from './types';
 
 export const orderUtils = {
-    createFill: (signedOrder: SignedOrder, takerSellAmount?: BigNumber) => {
+    createFill: (signedOrder: SignedOrder, takerTokenFillAmount?: BigNumber) => {
         const fill = {
             order: orderUtils.getOrderStruct(signedOrder),
-            takerSellAmount: takerSellAmount || signedOrder.makerBuyAmount,
+            takerTokenFillAmount: takerTokenFillAmount || signedOrder.takerTokenAmount,
             signature: signedOrder.signature,
         };
         return fill;
@@ -18,7 +18,7 @@ export const orderUtils = {
     createCancel(signedOrder: SignedOrder, takerTokenCancelAmount?: BigNumber) {
         const cancel = {
             order: orderUtils.getOrderStruct(signedOrder),
-            takerTokenCancelAmount: takerTokenCancelAmount || signedOrder.makerBuyAmount,
+            takerTokenCancelAmount: takerTokenCancelAmount || signedOrder.takerTokenAmount,
         };
         return cancel;
     },
@@ -29,8 +29,8 @@ export const orderUtils = {
             makerTokenAddress: signedOrder.makerTokenAddress,
             takerTokenAddress: signedOrder.takerTokenAddress,
             feeRecipientAddress: signedOrder.feeRecipientAddress,
-            makerSellAmount: signedOrder.makerSellAmount,
-            makerBuyAmount: signedOrder.makerBuyAmount,
+            makerTokenAmount: signedOrder.makerTokenAmount,
+            takerTokenAmount: signedOrder.takerTokenAmount,
             makerFee: signedOrder.makerFee,
             takerFee: signedOrder.takerFee,
             expirationTimeSeconds: signedOrder.expirationTimeSeconds,
@@ -46,8 +46,8 @@ export const orderUtils = {
             'address makerTokenAddress',
             'address takerTokenAddress',
             'address feeRecipientAddress',
-            'uint256 makerSellAmount',
-            'uint256 makerBuyAmount',
+            'uint256 makerTokenAmount',
+            'uint256 takerTokenAmount',
             'uint256 makerFee',
             'uint256 takerFee',
             'uint256 expirationTimeSeconds',
@@ -60,8 +60,8 @@ export const orderUtils = {
             order.makerTokenAddress,
             order.takerTokenAddress,
             order.feeRecipientAddress,
-            order.makerSellAmount,
-            order.makerBuyAmount,
+            order.makerTokenAmount,
+            order.takerTokenAmount,
             order.makerFee,
             order.takerFee,
             order.expirationTimeSeconds,

--- a/packages/contracts/src/utils/types.ts
+++ b/packages/contracts/src/utils/types.ts
@@ -14,19 +14,19 @@ export interface SubmissionContractEventArgs {
 export interface BatchFillOrders {
     orders: OrderStruct[];
     signatures: string[];
-    takerSellAmounts: BigNumber[];
+    takerTokenFillAmounts: BigNumber[];
 }
 
 export interface MarketSellOrders {
     orders: OrderStruct[];
     signatures: string[];
-    takerSellAmount: BigNumber;
+    takerTokenFillAmount: BigNumber;
 }
 
 export interface MarketBuyOrders {
     orders: OrderStruct[];
     signatures: string[];
-    takerBuyAmount: BigNumber;
+    makerTokenFillAmount: BigNumber;
 }
 
 export interface BatchCancelOrders {
@@ -43,8 +43,8 @@ export interface DefaultOrderParams {
     feeRecipientAddress: string;
     makerTokenAddress: string;
     takerTokenAddress: string;
-    makerSellAmount: BigNumber;
-    makerBuyAmount: BigNumber;
+    makerTokenAmount: BigNumber;
+    takerTokenAmount: BigNumber;
     makerFee: BigNumber;
     takerFee: BigNumber;
 }
@@ -128,8 +128,8 @@ export interface OrderStruct {
     makerTokenAddress: string;
     takerTokenAddress: string;
     feeRecipientAddress: string;
-    makerSellAmount: BigNumber;
-    makerBuyAmount: BigNumber;
+    makerTokenAmount: BigNumber;
+    takerTokenAmount: BigNumber;
     makerFee: BigNumber;
     takerFee: BigNumber;
     expirationTimeSeconds: BigNumber;

--- a/packages/contracts/src/utils/types.ts
+++ b/packages/contracts/src/utils/types.ts
@@ -14,13 +14,19 @@ export interface SubmissionContractEventArgs {
 export interface BatchFillOrders {
     orders: OrderStruct[];
     signatures: string[];
-    takerTokenFillAmounts: BigNumber[];
+    takerSellAmounts: BigNumber[];
 }
 
-export interface MarketFillOrders {
+export interface MarketSellOrders {
     orders: OrderStruct[];
     signatures: string[];
-    takerTokenFillAmount: BigNumber;
+    takerSellAmount: BigNumber;
+}
+
+export interface MarketBuyOrders {
+    orders: OrderStruct[];
+    signatures: string[];
+    takerBuyAmount: BigNumber;
 }
 
 export interface BatchCancelOrders {
@@ -37,10 +43,10 @@ export interface DefaultOrderParams {
     feeRecipientAddress: string;
     makerTokenAddress: string;
     takerTokenAddress: string;
-    makerTokenAmount: BigNumber;
-    takerTokenAmount: BigNumber;
-    makerFeeAmount: BigNumber;
-    takerFeeAmount: BigNumber;
+    makerSellAmount: BigNumber;
+    makerBuyAmount: BigNumber;
+    makerFee: BigNumber;
+    takerFee: BigNumber;
 }
 
 export interface TransactionDataParams {
@@ -122,10 +128,10 @@ export interface OrderStruct {
     makerTokenAddress: string;
     takerTokenAddress: string;
     feeRecipientAddress: string;
-    makerTokenAmount: BigNumber;
-    takerTokenAmount: BigNumber;
-    makerFeeAmount: BigNumber;
-    takerFeeAmount: BigNumber;
+    makerSellAmount: BigNumber;
+    makerBuyAmount: BigNumber;
+    makerFee: BigNumber;
+    takerFee: BigNumber;
     expirationTimeSeconds: BigNumber;
     salt: BigNumber;
 }

--- a/packages/contracts/test/exchange/core.ts
+++ b/packages/contracts/test/exchange/core.ts
@@ -501,6 +501,32 @@ describe('Exchange', () => {
             return expect(exWrapper.fillOrderAsync(signedOrder, takerAddress)).to.be.rejectedWith(constants.REVERT);
         });
 
+        it('should throw if makerTokenAmount is 0', async () => {
+            signedOrder = orderFactory.newSignedOrder({
+                makerTokenAmount: new BigNumber(0),
+            });
+
+            return expect(exWrapper.fillOrderAsync(signedOrder, takerAddress)).to.be.rejectedWith(constants.REVERT);
+        });
+
+        it('should throw if takerTokenAmount is 0', async () => {
+            signedOrder = orderFactory.newSignedOrder({
+                takerTokenAmount: new BigNumber(0),
+            });
+
+            return expect(exWrapper.fillOrderAsync(signedOrder, takerAddress)).to.be.rejectedWith(constants.REVERT);
+        });
+
+        it('should throw if takerTokenFillAmount is 0', async () => {
+            signedOrder = orderFactory.newSignedOrder();
+
+            return expect(
+                exWrapper.fillOrderAsync(signedOrder, takerAddress, {
+                    takerTokenFillAmount: new BigNumber(0),
+                }),
+            ).to.be.rejectedWith(constants.REVERT);
+        });
+
         it('should throw if maker balances are too low to fill order', async () => {
             signedOrder = orderFactory.newSignedOrder({
                 makerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(100000), 18),
@@ -579,6 +605,22 @@ describe('Exchange', () => {
 
         it('should throw if not sent by maker', async () => {
             return expect(exWrapper.cancelOrderAsync(signedOrder, takerAddress)).to.be.rejectedWith(constants.REVERT);
+        });
+
+        it('should throw if makerTokenAmount is 0', async () => {
+            signedOrder = orderFactory.newSignedOrder({
+                makerTokenAmount: new BigNumber(0),
+            });
+
+            return expect(exWrapper.cancelOrderAsync(signedOrder, makerAddress)).to.be.rejectedWith(constants.REVERT);
+        });
+
+        it('should throw if takerTokenAmount is 0', async () => {
+            signedOrder = orderFactory.newSignedOrder({
+                takerTokenAmount: new BigNumber(0),
+            });
+
+            return expect(exWrapper.cancelOrderAsync(signedOrder, makerAddress)).to.be.rejectedWith(constants.REVERT);
         });
 
         it('should be able to cancel a full order', async () => {

--- a/packages/contracts/test/exchange/core.ts
+++ b/packages/contracts/test/exchange/core.ts
@@ -9,10 +9,10 @@ import * as Web3 from 'web3';
 
 import { DummyTokenContract } from '../../src/contract_wrappers/generated/dummy_token';
 import {
+    CancelContractEventArgs,
     ExchangeContract,
-    LogCancelContractEventArgs,
-    LogErrorContractEventArgs,
-    LogFillContractEventArgs,
+    ExchangeErrorContractEventArgs,
+    FillContractEventArgs,
 } from '../../src/contract_wrappers/generated/exchange';
 import { TokenTransferProxyContract } from '../../src/contract_wrappers/generated/token_transfer_proxy';
 import { Balances } from '../../src/utils/balances';
@@ -394,8 +394,8 @@ describe('Exchange', () => {
             const res = await exWrapper.fillOrderAsync(signedOrder, takerAddress, {
                 takerSellAmount: signedOrder.makerBuyAmount,
             });
-            const log = res.logs[0] as LogWithDecodedArgs<LogFillContractEventArgs>;
-            expect(log.args.makerAmountBought).to.be.bignumber.equal(signedOrder.makerBuyAmount.minus(takerSellAmount));
+            const log = res.logs[0] as LogWithDecodedArgs<FillContractEventArgs>;
+            expect(log.args.takerAmountSold).to.be.bignumber.equal(signedOrder.makerBuyAmount.minus(takerSellAmount));
             const newBalances = await dmyBalances.getAsync();
 
             expect(newBalances[makerAddress][signedOrder.makerTokenAddress]).to.be.bignumber.equal(
@@ -428,7 +428,7 @@ describe('Exchange', () => {
             });
             expect(res.logs).to.have.length(1);
 
-            const log = res.logs[0] as LogWithDecodedArgs<LogFillContractEventArgs>;
+            const log = res.logs[0] as LogWithDecodedArgs<FillContractEventArgs>;
             const logArgs = log.args;
             const expectedFilledMakerTokenAmount = signedOrder.makerSellAmount.div(divisor);
             const expectedFilledTakerTokenAmount = signedOrder.makerBuyAmount.div(divisor);
@@ -441,7 +441,7 @@ describe('Exchange', () => {
             expect(signedOrder.makerTokenAddress).to.be.equal(logArgs.makerTokenAddress);
             expect(signedOrder.takerTokenAddress).to.be.equal(logArgs.takerTokenAddress);
             expect(expectedFilledMakerTokenAmount).to.be.bignumber.equal(logArgs.makerAmountSold);
-            expect(expectedFilledTakerTokenAmount).to.be.bignumber.equal(logArgs.makerAmountBought);
+            expect(expectedFilledTakerTokenAmount).to.be.bignumber.equal(logArgs.takerAmountSold);
             expect(expectedFeeMPaid).to.be.bignumber.equal(logArgs.makerFeePaid);
             expect(expectedFeeTPaid).to.be.bignumber.equal(logArgs.takerFeePaid);
             expect(orderUtils.getOrderHashHex(signedOrder)).to.be.equal(logArgs.orderHash);
@@ -457,7 +457,7 @@ describe('Exchange', () => {
             });
             expect(res.logs).to.have.length(1);
 
-            const log = res.logs[0] as LogWithDecodedArgs<LogFillContractEventArgs>;
+            const log = res.logs[0] as LogWithDecodedArgs<FillContractEventArgs>;
             const logArgs = log.args;
             const expectedFilledMakerTokenAmount = signedOrder.makerSellAmount.div(divisor);
             const expectedFilledTakerTokenAmount = signedOrder.makerBuyAmount.div(divisor);
@@ -470,7 +470,7 @@ describe('Exchange', () => {
             expect(signedOrder.makerTokenAddress).to.be.equal(logArgs.makerTokenAddress);
             expect(signedOrder.takerTokenAddress).to.be.equal(logArgs.takerTokenAddress);
             expect(expectedFilledMakerTokenAmount).to.be.bignumber.equal(logArgs.makerAmountSold);
-            expect(expectedFilledTakerTokenAmount).to.be.bignumber.equal(logArgs.makerAmountBought);
+            expect(expectedFilledTakerTokenAmount).to.be.bignumber.equal(logArgs.takerAmountSold);
             expect(expectedFeeMPaid).to.be.bignumber.equal(logArgs.makerFeePaid);
             expect(expectedFeeTPaid).to.be.bignumber.equal(logArgs.takerFeePaid);
             expect(orderUtils.getOrderHashHex(signedOrder)).to.be.equal(logArgs.orderHash);
@@ -552,7 +552,7 @@ describe('Exchange', () => {
 
             const res = await exWrapper.fillOrderAsync(signedOrder, takerAddress);
             expect(res.logs).to.have.length(1);
-            const log = res.logs[0] as LogWithDecodedArgs<LogErrorContractEventArgs>;
+            const log = res.logs[0] as LogWithDecodedArgs<ExchangeErrorContractEventArgs>;
             const errCode = log.args.errorId;
             expect(errCode).to.be.equal(ExchangeContractErrs.ERROR_ORDER_EXPIRED);
         });
@@ -563,7 +563,7 @@ describe('Exchange', () => {
 
             const res = await exWrapper.fillOrderAsync(signedOrder, takerAddress);
             expect(res.logs).to.have.length(1);
-            const log = res.logs[0] as LogWithDecodedArgs<LogErrorContractEventArgs>;
+            const log = res.logs[0] as LogWithDecodedArgs<ExchangeErrorContractEventArgs>;
             const errCode = log.args.errorId;
             expect(errCode).to.be.equal(ExchangeContractErrs.ERROR_ORDER_FULLY_FILLED);
         });
@@ -594,7 +594,7 @@ describe('Exchange', () => {
             const res = await exWrapper.cancelOrderAsync(signedOrder, makerAddress);
             expect(res.logs).to.have.length(1);
 
-            const log = res.logs[0] as LogWithDecodedArgs<LogCancelContractEventArgs>;
+            const log = res.logs[0] as LogWithDecodedArgs<CancelContractEventArgs>;
             const logArgs = log.args;
 
             expect(signedOrder.makerAddress).to.be.equal(logArgs.makerAddress);
@@ -609,7 +609,7 @@ describe('Exchange', () => {
 
             const res = await exWrapper.cancelOrderAsync(signedOrder, makerAddress);
             expect(res.logs).to.have.length(1);
-            const log = res.logs[0] as LogWithDecodedArgs<LogErrorContractEventArgs>;
+            const log = res.logs[0] as LogWithDecodedArgs<ExchangeErrorContractEventArgs>;
             const errCode = log.args.errorId;
             expect(errCode).to.be.equal(ExchangeContractErrs.ERROR_ORDER_CANCELLED);
         });
@@ -621,7 +621,7 @@ describe('Exchange', () => {
 
             const res = await exWrapper.cancelOrderAsync(signedOrder, makerAddress);
             expect(res.logs).to.have.length(1);
-            const log = res.logs[0] as LogWithDecodedArgs<LogErrorContractEventArgs>;
+            const log = res.logs[0] as LogWithDecodedArgs<ExchangeErrorContractEventArgs>;
             const errCode = log.args.errorId;
             expect(errCode).to.be.equal(ExchangeContractErrs.ERROR_ORDER_EXPIRED);
         });

--- a/packages/contracts/test/exchange/helpers.ts
+++ b/packages/contracts/test/exchange/helpers.ts
@@ -52,10 +52,10 @@ describe('Exchange', () => {
             feeRecipientAddress,
             makerTokenAddress: rep.address,
             takerTokenAddress: dgd.address,
-            makerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(100), 18),
-            takerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(200), 18),
-            makerFeeAmount: ZeroEx.toBaseUnitAmount(new BigNumber(1), 18),
-            takerFeeAmount: ZeroEx.toBaseUnitAmount(new BigNumber(1), 18),
+            makerSellAmount: ZeroEx.toBaseUnitAmount(new BigNumber(100), 18),
+            makerBuyAmount: ZeroEx.toBaseUnitAmount(new BigNumber(200), 18),
+            makerFee: ZeroEx.toBaseUnitAmount(new BigNumber(1), 18),
+            takerFee: ZeroEx.toBaseUnitAmount(new BigNumber(1), 18),
         };
         const privateKey = constants.TESTRPC_PRIVATE_KEYS[0];
         orderFactory = new OrderFactory(privateKey, defaultOrderParams);

--- a/packages/contracts/test/exchange/helpers.ts
+++ b/packages/contracts/test/exchange/helpers.ts
@@ -52,8 +52,8 @@ describe('Exchange', () => {
             feeRecipientAddress,
             makerTokenAddress: rep.address,
             takerTokenAddress: dgd.address,
-            makerSellAmount: ZeroEx.toBaseUnitAmount(new BigNumber(100), 18),
-            makerBuyAmount: ZeroEx.toBaseUnitAmount(new BigNumber(200), 18),
+            makerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(100), 18),
+            takerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(200), 18),
             makerFee: ZeroEx.toBaseUnitAmount(new BigNumber(1), 18),
             takerFee: ZeroEx.toBaseUnitAmount(new BigNumber(1), 18),
         };

--- a/packages/contracts/test/exchange/wrapper.ts
+++ b/packages/contracts/test/exchange/wrapper.ts
@@ -84,8 +84,8 @@ describe('Exchange', () => {
             feeRecipientAddress,
             makerTokenAddress: rep.address,
             takerTokenAddress: dgd.address,
-            makerSellAmount: ZeroEx.toBaseUnitAmount(new BigNumber(100), 18),
-            makerBuyAmount: ZeroEx.toBaseUnitAmount(new BigNumber(200), 18),
+            makerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(100), 18),
+            takerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(200), 18),
             makerFee: ZeroEx.toBaseUnitAmount(new BigNumber(1), 18),
             takerFee: ZeroEx.toBaseUnitAmount(new BigNumber(1), 18),
         };
@@ -118,39 +118,39 @@ describe('Exchange', () => {
     describe('fillOrKillOrder', () => {
         it('should transfer the correct amounts', async () => {
             const signedOrder = orderFactory.newSignedOrder({
-                makerSellAmount: ZeroEx.toBaseUnitAmount(new BigNumber(100), 18),
-                makerBuyAmount: ZeroEx.toBaseUnitAmount(new BigNumber(200), 18),
+                makerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(100), 18),
+                takerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(200), 18),
             });
-            const takerSellAmount = signedOrder.makerBuyAmount.div(2);
+            const takerTokenFillAmount = signedOrder.takerTokenAmount.div(2);
             await exWrapper.fillOrKillOrderAsync(signedOrder, takerAddress, {
-                takerSellAmount,
+                takerTokenFillAmount,
             });
 
             const newBalances = await dmyBalances.getAsync();
 
-            const makerAmountSold = takerSellAmount
-                .times(signedOrder.makerSellAmount)
-                .dividedToIntegerBy(signedOrder.makerBuyAmount);
+            const makerTokenFilledAmount = takerTokenFillAmount
+                .times(signedOrder.makerTokenAmount)
+                .dividedToIntegerBy(signedOrder.takerTokenAmount);
             const makerFee = signedOrder.makerFee
-                .times(makerAmountSold)
-                .dividedToIntegerBy(signedOrder.makerSellAmount);
+                .times(makerTokenFilledAmount)
+                .dividedToIntegerBy(signedOrder.makerTokenAmount);
             const takerFee = signedOrder.takerFee
-                .times(makerAmountSold)
-                .dividedToIntegerBy(signedOrder.makerSellAmount);
+                .times(makerTokenFilledAmount)
+                .dividedToIntegerBy(signedOrder.makerTokenAmount);
             expect(newBalances[makerAddress][signedOrder.makerTokenAddress]).to.be.bignumber.equal(
-                balances[makerAddress][signedOrder.makerTokenAddress].minus(makerAmountSold),
+                balances[makerAddress][signedOrder.makerTokenAddress].minus(makerTokenFilledAmount),
             );
             expect(newBalances[makerAddress][signedOrder.takerTokenAddress]).to.be.bignumber.equal(
-                balances[makerAddress][signedOrder.takerTokenAddress].add(takerSellAmount),
+                balances[makerAddress][signedOrder.takerTokenAddress].add(takerTokenFillAmount),
             );
             expect(newBalances[makerAddress][zrx.address]).to.be.bignumber.equal(
                 balances[makerAddress][zrx.address].minus(makerFee),
             );
             expect(newBalances[takerAddress][signedOrder.takerTokenAddress]).to.be.bignumber.equal(
-                balances[takerAddress][signedOrder.takerTokenAddress].minus(takerSellAmount),
+                balances[takerAddress][signedOrder.takerTokenAddress].minus(takerTokenFillAmount),
             );
             expect(newBalances[takerAddress][signedOrder.makerTokenAddress]).to.be.bignumber.equal(
-                balances[takerAddress][signedOrder.makerTokenAddress].add(makerAmountSold),
+                balances[takerAddress][signedOrder.makerTokenAddress].add(makerTokenFilledAmount),
             );
             expect(newBalances[takerAddress][zrx.address]).to.be.bignumber.equal(
                 balances[takerAddress][zrx.address].minus(takerFee),
@@ -170,11 +170,11 @@ describe('Exchange', () => {
             );
         });
 
-        it('should throw if entire takerSellAmount not filled', async () => {
+        it('should throw if entire takerTokenFillAmount not filled', async () => {
             const signedOrder = orderFactory.newSignedOrder();
 
             await exWrapper.fillOrderAsync(signedOrder, takerAddress, {
-                takerSellAmount: signedOrder.makerBuyAmount.div(2),
+                takerTokenFillAmount: signedOrder.takerTokenAmount.div(2),
             });
 
             return expect(exWrapper.fillOrKillOrderAsync(signedOrder, takerAddress)).to.be.rejectedWith(
@@ -186,39 +186,39 @@ describe('Exchange', () => {
     describe('fillOrderNoThrow', () => {
         it('should transfer the correct amounts', async () => {
             const signedOrder = orderFactory.newSignedOrder({
-                makerSellAmount: ZeroEx.toBaseUnitAmount(new BigNumber(100), 18),
-                makerBuyAmount: ZeroEx.toBaseUnitAmount(new BigNumber(200), 18),
+                makerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(100), 18),
+                takerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(200), 18),
             });
-            const takerSellAmount = signedOrder.makerBuyAmount.div(2);
+            const takerTokenFillAmount = signedOrder.takerTokenAmount.div(2);
             await exWrapper.fillOrderNoThrowAsync(signedOrder, takerAddress, {
-                takerSellAmount,
+                takerTokenFillAmount,
             });
 
             const newBalances = await dmyBalances.getAsync();
 
-            const makerAmountSold = takerSellAmount
-                .times(signedOrder.makerSellAmount)
-                .dividedToIntegerBy(signedOrder.makerBuyAmount);
+            const makerTokenFilledAmount = takerTokenFillAmount
+                .times(signedOrder.makerTokenAmount)
+                .dividedToIntegerBy(signedOrder.takerTokenAmount);
             const makerFee = signedOrder.makerFee
-                .times(makerAmountSold)
-                .dividedToIntegerBy(signedOrder.makerSellAmount);
+                .times(makerTokenFilledAmount)
+                .dividedToIntegerBy(signedOrder.makerTokenAmount);
             const takerFee = signedOrder.takerFee
-                .times(makerAmountSold)
-                .dividedToIntegerBy(signedOrder.makerSellAmount);
+                .times(makerTokenFilledAmount)
+                .dividedToIntegerBy(signedOrder.makerTokenAmount);
             expect(newBalances[makerAddress][signedOrder.makerTokenAddress]).to.be.bignumber.equal(
-                balances[makerAddress][signedOrder.makerTokenAddress].minus(makerAmountSold),
+                balances[makerAddress][signedOrder.makerTokenAddress].minus(makerTokenFilledAmount),
             );
             expect(newBalances[makerAddress][signedOrder.takerTokenAddress]).to.be.bignumber.equal(
-                balances[makerAddress][signedOrder.takerTokenAddress].add(takerSellAmount),
+                balances[makerAddress][signedOrder.takerTokenAddress].add(takerTokenFillAmount),
             );
             expect(newBalances[makerAddress][zrx.address]).to.be.bignumber.equal(
                 balances[makerAddress][zrx.address].minus(makerFee),
             );
             expect(newBalances[takerAddress][signedOrder.takerTokenAddress]).to.be.bignumber.equal(
-                balances[takerAddress][signedOrder.takerTokenAddress].minus(takerSellAmount),
+                balances[takerAddress][signedOrder.takerTokenAddress].minus(takerTokenFillAmount),
             );
             expect(newBalances[takerAddress][signedOrder.makerTokenAddress]).to.be.bignumber.equal(
-                balances[takerAddress][signedOrder.makerTokenAddress].add(makerAmountSold),
+                balances[takerAddress][signedOrder.makerTokenAddress].add(makerTokenFilledAmount),
             );
             expect(newBalances[takerAddress][zrx.address]).to.be.bignumber.equal(
                 balances[takerAddress][zrx.address].minus(takerFee),
@@ -230,7 +230,7 @@ describe('Exchange', () => {
 
         it('should not change balances if maker balances are too low to fill order', async () => {
             const signedOrder = orderFactory.newSignedOrder({
-                makerSellAmount: ZeroEx.toBaseUnitAmount(new BigNumber(100000), 18),
+                makerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(100000), 18),
             });
 
             await exWrapper.fillOrderNoThrowAsync(signedOrder, takerAddress);
@@ -240,7 +240,7 @@ describe('Exchange', () => {
 
         it('should not change balances if taker balances are too low to fill order', async () => {
             const signedOrder = orderFactory.newSignedOrder({
-                makerBuyAmount: ZeroEx.toBaseUnitAmount(new BigNumber(100000), 18),
+                takerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(100000), 18),
             });
 
             await exWrapper.fillOrderNoThrowAsync(signedOrder, takerAddress);
@@ -276,11 +276,11 @@ describe('Exchange', () => {
             expect(newBalances).to.be.deep.equal(balances);
         });
 
-        it('should not change balances if makerTokenAddress is ZRX, makerSellAmount + makerFee > maker balance', async () => {
+        it('should not change balances if makerTokenAddress is ZRX, makerTokenAmount + makerFee > maker balance', async () => {
             const makerZRXBalance = new BigNumber(balances[makerAddress][zrx.address]);
             const signedOrder = orderFactory.newSignedOrder({
                 makerTokenAddress: zrx.address,
-                makerSellAmount: makerZRXBalance,
+                makerTokenAmount: makerZRXBalance,
                 makerFee: new BigNumber(1),
             });
             await exWrapper.fillOrderNoThrowAsync(signedOrder, takerAddress);
@@ -288,11 +288,11 @@ describe('Exchange', () => {
             expect(newBalances).to.be.deep.equal(balances);
         });
 
-        it('should not change balances if makerTokenAddress is ZRX, makerSellAmount + makerFee > maker allowance', async () => {
+        it('should not change balances if makerTokenAddress is ZRX, makerTokenAmount + makerFee > maker allowance', async () => {
             const makerZRXAllowance = await zrx.allowance.callAsync(makerAddress, tokenTransferProxy.address);
             const signedOrder = orderFactory.newSignedOrder({
                 makerTokenAddress: zrx.address,
-                makerSellAmount: new BigNumber(makerZRXAllowance),
+                makerTokenAmount: new BigNumber(makerZRXAllowance),
                 makerFee: new BigNumber(1),
             });
             await exWrapper.fillOrderNoThrowAsync(signedOrder, takerAddress);
@@ -300,11 +300,11 @@ describe('Exchange', () => {
             expect(newBalances).to.be.deep.equal(balances);
         });
 
-        it('should not change balances if takerTokenAddress is ZRX, makerBuyAmount + takerFee > taker balance', async () => {
+        it('should not change balances if takerTokenAddress is ZRX, takerTokenAmount + takerFee > taker balance', async () => {
             const takerZRXBalance = new BigNumber(balances[takerAddress][zrx.address]);
             const signedOrder = orderFactory.newSignedOrder({
                 takerTokenAddress: zrx.address,
-                makerBuyAmount: takerZRXBalance,
+                takerTokenAmount: takerZRXBalance,
                 takerFee: new BigNumber(1),
             });
             await exWrapper.fillOrderNoThrowAsync(signedOrder, takerAddress);
@@ -312,11 +312,11 @@ describe('Exchange', () => {
             expect(newBalances).to.be.deep.equal(balances);
         });
 
-        it('should not change balances if takerTokenAddress is ZRX, makerBuyAmount + takerFee > taker allowance', async () => {
+        it('should not change balances if takerTokenAddress is ZRX, takerTokenAmount + takerFee > taker allowance', async () => {
             const takerZRXAllowance = await zrx.allowance.callAsync(takerAddress, tokenTransferProxy.address);
             const signedOrder = orderFactory.newSignedOrder({
                 takerTokenAddress: zrx.address,
-                makerBuyAmount: new BigNumber(takerZRXAllowance),
+                takerTokenAmount: new BigNumber(takerZRXAllowance),
                 takerFee: new BigNumber(1),
             });
             await exWrapper.fillOrderNoThrowAsync(signedOrder, takerAddress);
@@ -337,33 +337,33 @@ describe('Exchange', () => {
 
         describe('batchFillOrders', () => {
             it('should transfer the correct amounts', async () => {
-                const takerSellAmounts: BigNumber[] = [];
+                const takerTokenFillAmounts: BigNumber[] = [];
                 const makerTokenAddress = rep.address;
                 const takerTokenAddress = dgd.address;
                 _.forEach(signedOrders, signedOrder => {
-                    const takerSellAmount = signedOrder.makerBuyAmount.div(2);
-                    const makerAmountSold = takerSellAmount
-                        .times(signedOrder.makerSellAmount)
-                        .dividedToIntegerBy(signedOrder.makerBuyAmount);
+                    const takerTokenFillAmount = signedOrder.takerTokenAmount.div(2);
+                    const makerTokenFilledAmount = takerTokenFillAmount
+                        .times(signedOrder.makerTokenAmount)
+                        .dividedToIntegerBy(signedOrder.takerTokenAmount);
                     const makerFee = signedOrder.makerFee
-                        .times(makerAmountSold)
-                        .dividedToIntegerBy(signedOrder.makerSellAmount);
+                        .times(makerTokenFilledAmount)
+                        .dividedToIntegerBy(signedOrder.makerTokenAmount);
                     const takerFee = signedOrder.takerFee
-                        .times(makerAmountSold)
-                        .dividedToIntegerBy(signedOrder.makerSellAmount);
-                    takerSellAmounts.push(takerSellAmount);
+                        .times(makerTokenFilledAmount)
+                        .dividedToIntegerBy(signedOrder.makerTokenAmount);
+                    takerTokenFillAmounts.push(takerTokenFillAmount);
                     balances[makerAddress][makerTokenAddress] = balances[makerAddress][makerTokenAddress].minus(
-                        makerAmountSold,
+                        makerTokenFilledAmount,
                     );
                     balances[makerAddress][takerTokenAddress] = balances[makerAddress][takerTokenAddress].add(
-                        takerSellAmount,
+                        takerTokenFillAmount,
                     );
                     balances[makerAddress][zrx.address] = balances[makerAddress][zrx.address].minus(makerFee);
                     balances[takerAddress][makerTokenAddress] = balances[takerAddress][makerTokenAddress].add(
-                        makerAmountSold,
+                        makerTokenFilledAmount,
                     );
                     balances[takerAddress][takerTokenAddress] = balances[takerAddress][takerTokenAddress].minus(
-                        takerSellAmount,
+                        takerTokenFillAmount,
                     );
                     balances[takerAddress][zrx.address] = balances[takerAddress][zrx.address].minus(takerFee);
                     balances[feeRecipientAddress][zrx.address] = balances[feeRecipientAddress][zrx.address].add(
@@ -372,7 +372,7 @@ describe('Exchange', () => {
                 });
 
                 await exWrapper.batchFillOrdersAsync(signedOrders, takerAddress, {
-                    takerSellAmounts,
+                    takerTokenFillAmounts,
                 });
 
                 const newBalances = await dmyBalances.getAsync();
@@ -382,33 +382,33 @@ describe('Exchange', () => {
 
         describe('batchFillOrKillOrders', () => {
             it('should transfer the correct amounts', async () => {
-                const takerSellAmounts: BigNumber[] = [];
+                const takerTokenFillAmounts: BigNumber[] = [];
                 const makerTokenAddress = rep.address;
                 const takerTokenAddress = dgd.address;
                 _.forEach(signedOrders, signedOrder => {
-                    const takerSellAmount = signedOrder.makerBuyAmount.div(2);
-                    const makerAmountSold = takerSellAmount
-                        .times(signedOrder.makerSellAmount)
-                        .dividedToIntegerBy(signedOrder.makerBuyAmount);
+                    const takerTokenFillAmount = signedOrder.takerTokenAmount.div(2);
+                    const makerTokenFilledAmount = takerTokenFillAmount
+                        .times(signedOrder.makerTokenAmount)
+                        .dividedToIntegerBy(signedOrder.takerTokenAmount);
                     const makerFee = signedOrder.makerFee
-                        .times(makerAmountSold)
-                        .dividedToIntegerBy(signedOrder.makerSellAmount);
+                        .times(makerTokenFilledAmount)
+                        .dividedToIntegerBy(signedOrder.makerTokenAmount);
                     const takerFee = signedOrder.takerFee
-                        .times(makerAmountSold)
-                        .dividedToIntegerBy(signedOrder.makerSellAmount);
-                    takerSellAmounts.push(takerSellAmount);
+                        .times(makerTokenFilledAmount)
+                        .dividedToIntegerBy(signedOrder.makerTokenAmount);
+                    takerTokenFillAmounts.push(takerTokenFillAmount);
                     balances[makerAddress][makerTokenAddress] = balances[makerAddress][makerTokenAddress].minus(
-                        makerAmountSold,
+                        makerTokenFilledAmount,
                     );
                     balances[makerAddress][takerTokenAddress] = balances[makerAddress][takerTokenAddress].add(
-                        takerSellAmount,
+                        takerTokenFillAmount,
                     );
                     balances[makerAddress][zrx.address] = balances[makerAddress][zrx.address].minus(makerFee);
                     balances[takerAddress][makerTokenAddress] = balances[takerAddress][makerTokenAddress].add(
-                        makerAmountSold,
+                        makerTokenFilledAmount,
                     );
                     balances[takerAddress][takerTokenAddress] = balances[takerAddress][takerTokenAddress].minus(
-                        takerSellAmount,
+                        takerTokenFillAmount,
                     );
                     balances[takerAddress][zrx.address] = balances[takerAddress][zrx.address].minus(takerFee);
                     balances[feeRecipientAddress][zrx.address] = balances[feeRecipientAddress][zrx.address].add(
@@ -417,7 +417,7 @@ describe('Exchange', () => {
                 });
 
                 await exWrapper.batchFillOrKillOrdersAsync(signedOrders, takerAddress, {
-                    takerSellAmounts,
+                    takerTokenFillAmounts,
                 });
 
                 const newBalances = await dmyBalances.getAsync();
@@ -425,17 +425,17 @@ describe('Exchange', () => {
             });
 
             it('should throw if a single signedOrder does not fill the expected amount', async () => {
-                const takerSellAmounts: BigNumber[] = [];
+                const takerTokenFillAmounts: BigNumber[] = [];
                 _.forEach(signedOrders, signedOrder => {
-                    const takerSellAmount = signedOrder.makerBuyAmount.div(2);
-                    takerSellAmounts.push(takerSellAmount);
+                    const takerTokenFillAmount = signedOrder.takerTokenAmount.div(2);
+                    takerTokenFillAmounts.push(takerTokenFillAmount);
                 });
 
                 await exWrapper.fillOrKillOrderAsync(signedOrders[0], takerAddress);
 
                 return expect(
                     exWrapper.batchFillOrKillOrdersAsync(signedOrders, takerAddress, {
-                        takerSellAmounts,
+                        takerTokenFillAmounts,
                     }),
                 ).to.be.rejectedWith(constants.REVERT);
             });
@@ -443,33 +443,33 @@ describe('Exchange', () => {
 
         describe('batchFillOrdersNoThrow', async () => {
             it('should transfer the correct amounts', async () => {
-                const takerSellAmounts: BigNumber[] = [];
+                const takerTokenFillAmounts: BigNumber[] = [];
                 const makerTokenAddress = rep.address;
                 const takerTokenAddress = dgd.address;
                 _.forEach(signedOrders, signedOrder => {
-                    const takerSellAmount = signedOrder.makerBuyAmount.div(2);
-                    const makerAmountSold = takerSellAmount
-                        .times(signedOrder.makerSellAmount)
-                        .dividedToIntegerBy(signedOrder.makerBuyAmount);
+                    const takerTokenFillAmount = signedOrder.takerTokenAmount.div(2);
+                    const makerTokenFilledAmount = takerTokenFillAmount
+                        .times(signedOrder.makerTokenAmount)
+                        .dividedToIntegerBy(signedOrder.takerTokenAmount);
                     const makerFee = signedOrder.makerFee
-                        .times(makerAmountSold)
-                        .dividedToIntegerBy(signedOrder.makerSellAmount);
+                        .times(makerTokenFilledAmount)
+                        .dividedToIntegerBy(signedOrder.makerTokenAmount);
                     const takerFee = signedOrder.takerFee
-                        .times(makerAmountSold)
-                        .dividedToIntegerBy(signedOrder.makerSellAmount);
-                    takerSellAmounts.push(takerSellAmount);
+                        .times(makerTokenFilledAmount)
+                        .dividedToIntegerBy(signedOrder.makerTokenAmount);
+                    takerTokenFillAmounts.push(takerTokenFillAmount);
                     balances[makerAddress][makerTokenAddress] = balances[makerAddress][makerTokenAddress].minus(
-                        makerAmountSold,
+                        makerTokenFilledAmount,
                     );
                     balances[makerAddress][takerTokenAddress] = balances[makerAddress][takerTokenAddress].add(
-                        takerSellAmount,
+                        takerTokenFillAmount,
                     );
                     balances[makerAddress][zrx.address] = balances[makerAddress][zrx.address].minus(makerFee);
                     balances[takerAddress][makerTokenAddress] = balances[takerAddress][makerTokenAddress].add(
-                        makerAmountSold,
+                        makerTokenFilledAmount,
                     );
                     balances[takerAddress][takerTokenAddress] = balances[takerAddress][takerTokenAddress].minus(
-                        takerSellAmount,
+                        takerTokenFillAmount,
                     );
                     balances[takerAddress][zrx.address] = balances[takerAddress][zrx.address].minus(takerFee);
                     balances[feeRecipientAddress][zrx.address] = balances[feeRecipientAddress][zrx.address].add(
@@ -478,7 +478,7 @@ describe('Exchange', () => {
                 });
 
                 await exWrapper.batchFillOrdersNoThrowAsync(signedOrders, takerAddress, {
-                    takerSellAmounts,
+                    takerTokenFillAmounts,
                 });
 
                 const newBalances = await dmyBalances.getAsync();
@@ -486,7 +486,7 @@ describe('Exchange', () => {
             });
 
             it('should not throw if an order is invalid and fill the remaining orders', async () => {
-                const takerSellAmounts: BigNumber[] = [];
+                const takerTokenFillAmounts: BigNumber[] = [];
                 const makerTokenAddress = rep.address;
                 const takerTokenAddress = dgd.address;
 
@@ -496,31 +496,31 @@ describe('Exchange', () => {
                 };
                 const validOrders = signedOrders.slice(1);
 
-                takerSellAmounts.push(invalidOrder.makerBuyAmount.div(2));
+                takerTokenFillAmounts.push(invalidOrder.takerTokenAmount.div(2));
                 _.forEach(validOrders, signedOrder => {
-                    const takerSellAmount = signedOrder.makerBuyAmount.div(2);
-                    const makerAmountSold = takerSellAmount
-                        .times(signedOrder.makerSellAmount)
-                        .dividedToIntegerBy(signedOrder.makerBuyAmount);
+                    const takerTokenFillAmount = signedOrder.takerTokenAmount.div(2);
+                    const makerTokenFilledAmount = takerTokenFillAmount
+                        .times(signedOrder.makerTokenAmount)
+                        .dividedToIntegerBy(signedOrder.takerTokenAmount);
                     const makerFee = signedOrder.makerFee
-                        .times(makerAmountSold)
-                        .dividedToIntegerBy(signedOrder.makerSellAmount);
+                        .times(makerTokenFilledAmount)
+                        .dividedToIntegerBy(signedOrder.makerTokenAmount);
                     const takerFee = signedOrder.takerFee
-                        .times(makerAmountSold)
-                        .dividedToIntegerBy(signedOrder.makerSellAmount);
-                    takerSellAmounts.push(takerSellAmount);
+                        .times(makerTokenFilledAmount)
+                        .dividedToIntegerBy(signedOrder.makerTokenAmount);
+                    takerTokenFillAmounts.push(takerTokenFillAmount);
                     balances[makerAddress][makerTokenAddress] = balances[makerAddress][makerTokenAddress].minus(
-                        makerAmountSold,
+                        makerTokenFilledAmount,
                     );
                     balances[makerAddress][takerTokenAddress] = balances[makerAddress][takerTokenAddress].add(
-                        takerSellAmount,
+                        takerTokenFillAmount,
                     );
                     balances[makerAddress][zrx.address] = balances[makerAddress][zrx.address].minus(makerFee);
                     balances[takerAddress][makerTokenAddress] = balances[takerAddress][makerTokenAddress].add(
-                        makerAmountSold,
+                        makerTokenFilledAmount,
                     );
                     balances[takerAddress][takerTokenAddress] = balances[takerAddress][takerTokenAddress].minus(
-                        takerSellAmount,
+                        takerTokenFillAmount,
                     );
                     balances[takerAddress][zrx.address] = balances[takerAddress][zrx.address].minus(takerFee);
                     balances[feeRecipientAddress][zrx.address] = balances[feeRecipientAddress][zrx.address].add(
@@ -530,7 +530,7 @@ describe('Exchange', () => {
 
                 const newOrders = [invalidOrder, ...validOrders];
                 await exWrapper.batchFillOrdersNoThrowAsync(newOrders, takerAddress, {
-                    takerSellAmounts,
+                    takerTokenFillAmounts,
                 });
 
                 const newBalances = await dmyBalances.getAsync();
@@ -539,33 +539,35 @@ describe('Exchange', () => {
         });
 
         describe('marketSellOrders', () => {
-            it('should stop when the entire takerSellAmount is filled', async () => {
-                const takerSellAmount = signedOrders[0].makerBuyAmount.plus(signedOrders[1].makerBuyAmount.div(2));
+            it('should stop when the entire takerTokenFillAmount is filled', async () => {
+                const takerTokenFillAmount = signedOrders[0].takerTokenAmount.plus(
+                    signedOrders[1].takerTokenAmount.div(2),
+                );
                 await exWrapper.marketSellOrdersAsync(signedOrders, takerAddress, {
-                    takerSellAmount,
+                    takerTokenFillAmount,
                 });
 
                 const newBalances = await dmyBalances.getAsync();
 
-                const makerAmountSold = signedOrders[0].makerSellAmount.add(
-                    signedOrders[1].makerSellAmount.dividedToIntegerBy(2),
+                const makerTokenFilledAmount = signedOrders[0].makerTokenAmount.add(
+                    signedOrders[1].makerTokenAmount.dividedToIntegerBy(2),
                 );
                 const makerFee = signedOrders[0].makerFee.add(signedOrders[1].makerFee.dividedToIntegerBy(2));
                 const takerFee = signedOrders[0].takerFee.add(signedOrders[1].takerFee.dividedToIntegerBy(2));
                 expect(newBalances[makerAddress][signedOrders[0].makerTokenAddress]).to.be.bignumber.equal(
-                    balances[makerAddress][signedOrders[0].makerTokenAddress].minus(makerAmountSold),
+                    balances[makerAddress][signedOrders[0].makerTokenAddress].minus(makerTokenFilledAmount),
                 );
                 expect(newBalances[makerAddress][signedOrders[0].takerTokenAddress]).to.be.bignumber.equal(
-                    balances[makerAddress][signedOrders[0].takerTokenAddress].add(takerSellAmount),
+                    balances[makerAddress][signedOrders[0].takerTokenAddress].add(takerTokenFillAmount),
                 );
                 expect(newBalances[makerAddress][zrx.address]).to.be.bignumber.equal(
                     balances[makerAddress][zrx.address].minus(makerFee),
                 );
                 expect(newBalances[takerAddress][signedOrders[0].takerTokenAddress]).to.be.bignumber.equal(
-                    balances[takerAddress][signedOrders[0].takerTokenAddress].minus(takerSellAmount),
+                    balances[takerAddress][signedOrders[0].takerTokenAddress].minus(takerTokenFillAmount),
                 );
                 expect(newBalances[takerAddress][signedOrders[0].makerTokenAddress]).to.be.bignumber.equal(
-                    balances[takerAddress][signedOrders[0].makerTokenAddress].add(makerAmountSold),
+                    balances[takerAddress][signedOrders[0].makerTokenAddress].add(makerTokenFilledAmount),
                 );
                 expect(newBalances[takerAddress][zrx.address]).to.be.bignumber.equal(
                     balances[takerAddress][zrx.address].minus(takerFee),
@@ -575,24 +577,24 @@ describe('Exchange', () => {
                 );
             });
 
-            it('should fill all signedOrders if cannot fill entire takerSellAmount', async () => {
-                const takerSellAmount = ZeroEx.toBaseUnitAmount(new BigNumber(100000), 18);
+            it('should fill all signedOrders if cannot fill entire takerTokenFillAmount', async () => {
+                const takerTokenFillAmount = ZeroEx.toBaseUnitAmount(new BigNumber(100000), 18);
                 _.forEach(signedOrders, signedOrder => {
                     balances[makerAddress][signedOrder.makerTokenAddress] = balances[makerAddress][
                         signedOrder.makerTokenAddress
-                    ].minus(signedOrder.makerSellAmount);
+                    ].minus(signedOrder.makerTokenAmount);
                     balances[makerAddress][signedOrder.takerTokenAddress] = balances[makerAddress][
                         signedOrder.takerTokenAddress
-                    ].add(signedOrder.makerBuyAmount);
+                    ].add(signedOrder.takerTokenAmount);
                     balances[makerAddress][zrx.address] = balances[makerAddress][zrx.address].minus(
                         signedOrder.makerFee,
                     );
                     balances[takerAddress][signedOrder.makerTokenAddress] = balances[takerAddress][
                         signedOrder.makerTokenAddress
-                    ].add(signedOrder.makerSellAmount);
+                    ].add(signedOrder.makerTokenAmount);
                     balances[takerAddress][signedOrder.takerTokenAddress] = balances[takerAddress][
                         signedOrder.takerTokenAddress
-                    ].minus(signedOrder.makerBuyAmount);
+                    ].minus(signedOrder.takerTokenAmount);
                     balances[takerAddress][zrx.address] = balances[takerAddress][zrx.address].minus(
                         signedOrder.takerFee,
                     );
@@ -601,7 +603,7 @@ describe('Exchange', () => {
                     );
                 });
                 await exWrapper.marketSellOrdersAsync(signedOrders, takerAddress, {
-                    takerSellAmount,
+                    takerTokenFillAmount,
                 });
 
                 const newBalances = await dmyBalances.getAsync();
@@ -617,40 +619,42 @@ describe('Exchange', () => {
 
                 return expect(
                     exWrapper.marketSellOrdersAsync(signedOrders, takerAddress, {
-                        takerSellAmount: ZeroEx.toBaseUnitAmount(new BigNumber(1000), 18),
+                        takerTokenFillAmount: ZeroEx.toBaseUnitAmount(new BigNumber(1000), 18),
                     }),
                 ).to.be.rejectedWith(constants.REVERT);
             });
         });
 
         describe('marketSellOrdersNoThrow', () => {
-            it('should stop when the entire takerSellAmount is filled', async () => {
-                const takerSellAmount = signedOrders[0].makerBuyAmount.plus(signedOrders[1].makerBuyAmount.div(2));
+            it('should stop when the entire takerTokenFillAmount is filled', async () => {
+                const takerTokenFillAmount = signedOrders[0].takerTokenAmount.plus(
+                    signedOrders[1].takerTokenAmount.div(2),
+                );
                 await exWrapper.marketSellOrdersNoThrowAsync(signedOrders, takerAddress, {
-                    takerSellAmount,
+                    takerTokenFillAmount,
                 });
 
                 const newBalances = await dmyBalances.getAsync();
 
-                const makerAmountSold = signedOrders[0].makerSellAmount.add(
-                    signedOrders[1].makerSellAmount.dividedToIntegerBy(2),
+                const makerTokenFilledAmount = signedOrders[0].makerTokenAmount.add(
+                    signedOrders[1].makerTokenAmount.dividedToIntegerBy(2),
                 );
                 const makerFee = signedOrders[0].makerFee.add(signedOrders[1].makerFee.dividedToIntegerBy(2));
                 const takerFee = signedOrders[0].takerFee.add(signedOrders[1].takerFee.dividedToIntegerBy(2));
                 expect(newBalances[makerAddress][signedOrders[0].makerTokenAddress]).to.be.bignumber.equal(
-                    balances[makerAddress][signedOrders[0].makerTokenAddress].minus(makerAmountSold),
+                    balances[makerAddress][signedOrders[0].makerTokenAddress].minus(makerTokenFilledAmount),
                 );
                 expect(newBalances[makerAddress][signedOrders[0].takerTokenAddress]).to.be.bignumber.equal(
-                    balances[makerAddress][signedOrders[0].takerTokenAddress].add(takerSellAmount),
+                    balances[makerAddress][signedOrders[0].takerTokenAddress].add(takerTokenFillAmount),
                 );
                 expect(newBalances[makerAddress][zrx.address]).to.be.bignumber.equal(
                     balances[makerAddress][zrx.address].minus(makerFee),
                 );
                 expect(newBalances[takerAddress][signedOrders[0].takerTokenAddress]).to.be.bignumber.equal(
-                    balances[takerAddress][signedOrders[0].takerTokenAddress].minus(takerSellAmount),
+                    balances[takerAddress][signedOrders[0].takerTokenAddress].minus(takerTokenFillAmount),
                 );
                 expect(newBalances[takerAddress][signedOrders[0].makerTokenAddress]).to.be.bignumber.equal(
-                    balances[takerAddress][signedOrders[0].makerTokenAddress].add(makerAmountSold),
+                    balances[takerAddress][signedOrders[0].makerTokenAddress].add(makerTokenFilledAmount),
                 );
                 expect(newBalances[takerAddress][zrx.address]).to.be.bignumber.equal(
                     balances[takerAddress][zrx.address].minus(takerFee),
@@ -660,24 +664,24 @@ describe('Exchange', () => {
                 );
             });
 
-            it('should fill all signedOrders if cannot fill entire takerSellAmount', async () => {
-                const takerSellAmount = ZeroEx.toBaseUnitAmount(new BigNumber(100000), 18);
+            it('should fill all signedOrders if cannot fill entire takerTokenFillAmount', async () => {
+                const takerTokenFillAmount = ZeroEx.toBaseUnitAmount(new BigNumber(100000), 18);
                 _.forEach(signedOrders, signedOrder => {
                     balances[makerAddress][signedOrder.makerTokenAddress] = balances[makerAddress][
                         signedOrder.makerTokenAddress
-                    ].minus(signedOrder.makerSellAmount);
+                    ].minus(signedOrder.makerTokenAmount);
                     balances[makerAddress][signedOrder.takerTokenAddress] = balances[makerAddress][
                         signedOrder.takerTokenAddress
-                    ].add(signedOrder.makerBuyAmount);
+                    ].add(signedOrder.takerTokenAmount);
                     balances[makerAddress][zrx.address] = balances[makerAddress][zrx.address].minus(
                         signedOrder.makerFee,
                     );
                     balances[takerAddress][signedOrder.makerTokenAddress] = balances[takerAddress][
                         signedOrder.makerTokenAddress
-                    ].add(signedOrder.makerSellAmount);
+                    ].add(signedOrder.makerTokenAmount);
                     balances[takerAddress][signedOrder.takerTokenAddress] = balances[takerAddress][
                         signedOrder.takerTokenAddress
-                    ].minus(signedOrder.makerBuyAmount);
+                    ].minus(signedOrder.takerTokenAmount);
                     balances[takerAddress][zrx.address] = balances[takerAddress][zrx.address].minus(
                         signedOrder.takerFee,
                     );
@@ -686,7 +690,7 @@ describe('Exchange', () => {
                     );
                 });
                 await exWrapper.marketSellOrdersNoThrowAsync(signedOrders, takerAddress, {
-                    takerSellAmount,
+                    takerTokenFillAmount,
                 });
 
                 const newBalances = await dmyBalances.getAsync();
@@ -702,28 +706,30 @@ describe('Exchange', () => {
 
                 return expect(
                     exWrapper.marketSellOrdersNoThrowAsync(signedOrders, takerAddress, {
-                        takerSellAmount: ZeroEx.toBaseUnitAmount(new BigNumber(1000), 18),
+                        takerTokenFillAmount: ZeroEx.toBaseUnitAmount(new BigNumber(1000), 18),
                     }),
                 ).to.be.rejectedWith(constants.REVERT);
             });
         });
 
         describe('marketBuyOrders', () => {
-            it('should stop when the entire takerBuyAmount is filled', async () => {
-                const takerBuyAmount = signedOrders[0].makerSellAmount.plus(signedOrders[1].makerSellAmount.div(2));
+            it('should stop when the entire makerTokenFillAmount is filled', async () => {
+                const makerTokenFillAmount = signedOrders[0].makerTokenAmount.plus(
+                    signedOrders[1].makerTokenAmount.div(2),
+                );
                 await exWrapper.marketBuyOrdersAsync(signedOrders, takerAddress, {
-                    takerBuyAmount,
+                    makerTokenFillAmount,
                 });
 
                 const newBalances = await dmyBalances.getAsync();
 
-                const makerAmountBought = signedOrders[0].makerBuyAmount.add(
-                    signedOrders[1].makerBuyAmount.dividedToIntegerBy(2),
+                const makerAmountBought = signedOrders[0].takerTokenAmount.add(
+                    signedOrders[1].takerTokenAmount.dividedToIntegerBy(2),
                 );
                 const makerFee = signedOrders[0].makerFee.add(signedOrders[1].makerFee.dividedToIntegerBy(2));
                 const takerFee = signedOrders[0].takerFee.add(signedOrders[1].takerFee.dividedToIntegerBy(2));
                 expect(newBalances[makerAddress][signedOrders[0].makerTokenAddress]).to.be.bignumber.equal(
-                    balances[makerAddress][signedOrders[0].makerTokenAddress].minus(takerBuyAmount),
+                    balances[makerAddress][signedOrders[0].makerTokenAddress].minus(makerTokenFillAmount),
                 );
                 expect(newBalances[makerAddress][signedOrders[0].takerTokenAddress]).to.be.bignumber.equal(
                     balances[makerAddress][signedOrders[0].takerTokenAddress].add(makerAmountBought),
@@ -735,7 +741,7 @@ describe('Exchange', () => {
                     balances[takerAddress][signedOrders[0].takerTokenAddress].minus(makerAmountBought),
                 );
                 expect(newBalances[takerAddress][signedOrders[0].makerTokenAddress]).to.be.bignumber.equal(
-                    balances[takerAddress][signedOrders[0].makerTokenAddress].add(takerBuyAmount),
+                    balances[takerAddress][signedOrders[0].makerTokenAddress].add(makerTokenFillAmount),
                 );
                 expect(newBalances[takerAddress][zrx.address]).to.be.bignumber.equal(
                     balances[takerAddress][zrx.address].minus(takerFee),
@@ -745,24 +751,24 @@ describe('Exchange', () => {
                 );
             });
 
-            it('should fill all signedOrders if cannot fill entire takerBuyAmount', async () => {
-                const takerBuyAmount = ZeroEx.toBaseUnitAmount(new BigNumber(100000), 18);
+            it('should fill all signedOrders if cannot fill entire makerTokenFillAmount', async () => {
+                const makerTokenFillAmount = ZeroEx.toBaseUnitAmount(new BigNumber(100000), 18);
                 _.forEach(signedOrders, signedOrder => {
                     balances[makerAddress][signedOrder.makerTokenAddress] = balances[makerAddress][
                         signedOrder.makerTokenAddress
-                    ].minus(signedOrder.makerSellAmount);
+                    ].minus(signedOrder.makerTokenAmount);
                     balances[makerAddress][signedOrder.takerTokenAddress] = balances[makerAddress][
                         signedOrder.takerTokenAddress
-                    ].add(signedOrder.makerBuyAmount);
+                    ].add(signedOrder.takerTokenAmount);
                     balances[makerAddress][zrx.address] = balances[makerAddress][zrx.address].minus(
                         signedOrder.makerFee,
                     );
                     balances[takerAddress][signedOrder.makerTokenAddress] = balances[takerAddress][
                         signedOrder.makerTokenAddress
-                    ].add(signedOrder.makerSellAmount);
+                    ].add(signedOrder.makerTokenAmount);
                     balances[takerAddress][signedOrder.takerTokenAddress] = balances[takerAddress][
                         signedOrder.takerTokenAddress
-                    ].minus(signedOrder.makerBuyAmount);
+                    ].minus(signedOrder.takerTokenAmount);
                     balances[takerAddress][zrx.address] = balances[takerAddress][zrx.address].minus(
                         signedOrder.takerFee,
                     );
@@ -771,7 +777,7 @@ describe('Exchange', () => {
                     );
                 });
                 await exWrapper.marketBuyOrdersAsync(signedOrders, takerAddress, {
-                    takerBuyAmount,
+                    makerTokenFillAmount,
                 });
 
                 const newBalances = await dmyBalances.getAsync();
@@ -787,28 +793,30 @@ describe('Exchange', () => {
 
                 return expect(
                     exWrapper.marketBuyOrdersAsync(signedOrders, takerAddress, {
-                        takerBuyAmount: ZeroEx.toBaseUnitAmount(new BigNumber(1000), 18),
+                        makerTokenFillAmount: ZeroEx.toBaseUnitAmount(new BigNumber(1000), 18),
                     }),
                 ).to.be.rejectedWith(constants.REVERT);
             });
         });
 
         describe('marketBuyOrdersNoThrow', () => {
-            it('should stop when the entire takerBuyAmount is filled', async () => {
-                const takerBuyAmount = signedOrders[0].makerSellAmount.plus(signedOrders[1].makerSellAmount.div(2));
+            it('should stop when the entire makerTokenFillAmount is filled', async () => {
+                const makerTokenFillAmount = signedOrders[0].makerTokenAmount.plus(
+                    signedOrders[1].makerTokenAmount.div(2),
+                );
                 await exWrapper.marketBuyOrdersNoThrowAsync(signedOrders, takerAddress, {
-                    takerBuyAmount,
+                    makerTokenFillAmount,
                 });
 
                 const newBalances = await dmyBalances.getAsync();
 
-                const makerAmountBought = signedOrders[0].makerBuyAmount.add(
-                    signedOrders[1].makerBuyAmount.dividedToIntegerBy(2),
+                const makerAmountBought = signedOrders[0].takerTokenAmount.add(
+                    signedOrders[1].takerTokenAmount.dividedToIntegerBy(2),
                 );
                 const makerFee = signedOrders[0].makerFee.add(signedOrders[1].makerFee.dividedToIntegerBy(2));
                 const takerFee = signedOrders[0].takerFee.add(signedOrders[1].takerFee.dividedToIntegerBy(2));
                 expect(newBalances[makerAddress][signedOrders[0].makerTokenAddress]).to.be.bignumber.equal(
-                    balances[makerAddress][signedOrders[0].makerTokenAddress].minus(takerBuyAmount),
+                    balances[makerAddress][signedOrders[0].makerTokenAddress].minus(makerTokenFillAmount),
                 );
                 expect(newBalances[makerAddress][signedOrders[0].takerTokenAddress]).to.be.bignumber.equal(
                     balances[makerAddress][signedOrders[0].takerTokenAddress].add(makerAmountBought),
@@ -820,7 +828,7 @@ describe('Exchange', () => {
                     balances[takerAddress][signedOrders[0].takerTokenAddress].minus(makerAmountBought),
                 );
                 expect(newBalances[takerAddress][signedOrders[0].makerTokenAddress]).to.be.bignumber.equal(
-                    balances[takerAddress][signedOrders[0].makerTokenAddress].add(takerBuyAmount),
+                    balances[takerAddress][signedOrders[0].makerTokenAddress].add(makerTokenFillAmount),
                 );
                 expect(newBalances[takerAddress][zrx.address]).to.be.bignumber.equal(
                     balances[takerAddress][zrx.address].minus(takerFee),
@@ -830,24 +838,24 @@ describe('Exchange', () => {
                 );
             });
 
-            it('should fill all signedOrders if cannot fill entire takerSellAmount', async () => {
-                const takerSellAmount = ZeroEx.toBaseUnitAmount(new BigNumber(100000), 18);
+            it('should fill all signedOrders if cannot fill entire takerTokenFillAmount', async () => {
+                const takerTokenFillAmount = ZeroEx.toBaseUnitAmount(new BigNumber(100000), 18);
                 _.forEach(signedOrders, signedOrder => {
                     balances[makerAddress][signedOrder.makerTokenAddress] = balances[makerAddress][
                         signedOrder.makerTokenAddress
-                    ].minus(signedOrder.makerSellAmount);
+                    ].minus(signedOrder.makerTokenAmount);
                     balances[makerAddress][signedOrder.takerTokenAddress] = balances[makerAddress][
                         signedOrder.takerTokenAddress
-                    ].add(signedOrder.makerBuyAmount);
+                    ].add(signedOrder.takerTokenAmount);
                     balances[makerAddress][zrx.address] = balances[makerAddress][zrx.address].minus(
                         signedOrder.makerFee,
                     );
                     balances[takerAddress][signedOrder.makerTokenAddress] = balances[takerAddress][
                         signedOrder.makerTokenAddress
-                    ].add(signedOrder.makerSellAmount);
+                    ].add(signedOrder.makerTokenAmount);
                     balances[takerAddress][signedOrder.takerTokenAddress] = balances[takerAddress][
                         signedOrder.takerTokenAddress
-                    ].minus(signedOrder.makerBuyAmount);
+                    ].minus(signedOrder.takerTokenAmount);
                     balances[takerAddress][zrx.address] = balances[takerAddress][zrx.address].minus(
                         signedOrder.takerFee,
                     );
@@ -856,7 +864,7 @@ describe('Exchange', () => {
                     );
                 });
                 await exWrapper.marketSellOrdersNoThrowAsync(signedOrders, takerAddress, {
-                    takerSellAmount,
+                    takerTokenFillAmount,
                 });
 
                 const newBalances = await dmyBalances.getAsync();
@@ -872,7 +880,7 @@ describe('Exchange', () => {
 
                 return expect(
                     exWrapper.marketBuyOrdersNoThrowAsync(signedOrders, takerAddress, {
-                        takerBuyAmount: ZeroEx.toBaseUnitAmount(new BigNumber(1000), 18),
+                        makerTokenFillAmount: ZeroEx.toBaseUnitAmount(new BigNumber(1000), 18),
                     }),
                 ).to.be.rejectedWith(constants.REVERT);
             });
@@ -880,11 +888,11 @@ describe('Exchange', () => {
 
         describe('batchCancelOrders', () => {
             it('should be able to cancel multiple signedOrders', async () => {
-                const takerTokenCancelAmounts = _.map(signedOrders, signedOrder => signedOrder.makerBuyAmount);
+                const takerTokenCancelAmounts = _.map(signedOrders, signedOrder => signedOrder.takerTokenAmount);
                 await exWrapper.batchCancelOrdersAsync(signedOrders, makerAddress);
 
                 await exWrapper.batchFillOrdersAsync(signedOrders, takerAddress, {
-                    takerSellAmounts: takerTokenCancelAmounts,
+                    takerTokenFillAmounts: takerTokenCancelAmounts,
                 });
                 const newBalances = await dmyBalances.getAsync();
                 expect(balances).to.be.deep.equal(newBalances);

--- a/packages/contracts/test/exchange/wrapper.ts
+++ b/packages/contracts/test/exchange/wrapper.ts
@@ -7,12 +7,7 @@ import * as _ from 'lodash';
 import * as Web3 from 'web3';
 
 import { DummyTokenContract } from '../../src/contract_wrappers/generated/dummy_token';
-import {
-    ExchangeContract,
-    LogCancelContractEventArgs,
-    LogErrorContractEventArgs,
-    LogFillContractEventArgs,
-} from '../../src/contract_wrappers/generated/exchange';
+import { ExchangeContract } from '../../src/contract_wrappers/generated/exchange';
 import { TokenRegistryContract } from '../../src/contract_wrappers/generated/token_registry';
 import { TokenTransferProxyContract } from '../../src/contract_wrappers/generated/token_transfer_proxy';
 import { Balances } from '../../src/utils/balances';


### PR DESCRIPTION
<!--- Thank you for taking the time to submit a Pull Request -->

<!--- Provide a general summary of the issue in the Title above -->

## Description

<!--- Describe your changes in detail -->
- Adds a version of `marketFillOrders` where the taker can specify the amount of `makerTokens` to buy, rather than the amount of `takerTokens` to sell
- Renames a handful of order properties, function args, and return values for clarity

TODO:
- Does `makerFeePaid` need to be in the `FillResults` struct? I can't really think of a good use case for it

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOGs.
*   [ ] Updated the new versions of the changed packages in the relevant CHANGELOGs.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
