### PR TITLE
Improve README contributing sections in all packages

### DIFF
--- a/packages/0x.js/README.md
+++ b/packages/0x.js/README.md
@@ -46,7 +46,7 @@ Download the UMD module from our [releases page](https://github.com/0xProject/0x
 
 We strongly recommend that the community help us make improvements and determine the future direction of the protocol. To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
 
 ### Install dependencies
 

--- a/packages/0x.js/README.md
+++ b/packages/0x.js/README.md
@@ -1,5 +1,9 @@
 ## 0x.js
 
+A TypeScript/Javascript library for interacting with the 0x protocol.
+
+### Read the [Documentation](0xproject.com/docs/0xjs).
+
 ## Installation
 
 0x.js ships as both a [UMD](https://github.com/umdjs/umd) module and a [CommonJS](https://en.wikipedia.org/wiki/CommonJS) package.
@@ -38,10 +42,66 @@ Download the UMD module from our [releases page](https://github.com/0xProject/0x
 <script type="text/javascript" src="0x.js"></script>
 ```
 
-## Documentation
+## Contributing
 
-Extensive documentation of 0x.js can be found on [our website][docs-url].
+We strongly recommend that the community help us make improvements and determine the future direction of the protocol. To report bugs within this package, please create an issue in this repository.
 
-[website-url]: https://0xproject.com/
-[whitepaper-url]: https://0xproject.com/pdfs/0x_white_paper.pdf
-[docs-url]: https://0xproject.com/docs/0xjs
+Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
+
+### Install dependencies
+
+If you don't have yarn workspaces enabled (Yarn < v1.0) - enable them:
+
+```bash
+yarn config set workspaces-experimental true
+```
+
+Then install dependencies
+
+```bash
+yarn install
+```
+
+### Build
+
+If this is your **first** time building this package, you must first build **all** packages within the monorepo. This is because packages that depend on other packages located inside this monorepo are symlinked when run from **within** the monorepo. This allows you to make changes across multiple packages without first publishing dependent packages to NPM. To build all packages, run the following from the monorepo root directory:
+
+```bash
+yarn lerna:rebuild
+```
+
+Or continuously rebuild on change:
+
+```bash
+yarn dev
+```
+
+You can also build this specific package by running the following from within its directory:
+
+```bash
+yarn build
+```
+
+or continuously rebuild on change:
+
+```bash
+yarn build:watch
+```
+
+### Clean
+
+```bash
+yarn clean
+```
+
+### Lint
+
+```bash
+yarn lint
+```
+
+### Run Tests
+
+```bash
+yarn test
+```

--- a/packages/abi-gen/README.md
+++ b/packages/abi-gen/README.md
@@ -62,7 +62,7 @@ Output files will be generated within an output folder with names converted to c
 
 We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
 
 ### Install dependencies
 

--- a/packages/abi-gen/README.md
+++ b/packages/abi-gen/README.md
@@ -57,3 +57,61 @@ See the [type definition](https://github.com/0xProject/0x-monorepo/tree/developm
 ## Output files
 
 Output files will be generated within an output folder with names converted to camel case and taken from abi file names. If you already have some files in that folder they will be overwritten.
+
+## Contributing
+
+We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
+
+Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
+
+### Install dependencies
+
+If you don't have yarn workspaces enabled (Yarn < v1.0) - enable them:
+
+```bash
+yarn config set workspaces-experimental true
+```
+
+Then install dependencies
+
+```bash
+yarn install
+```
+
+### Build
+
+If this is your **first** time building this package, you must first build **all** packages within the monorepo. This is because packages that depend on other packages located inside this monorepo are symlinked when run from **within** the monorepo. This allows you to make changes across multiple packages without first publishing dependent packages to NPM. To build all packages, run the following from the monorepo root directory:
+
+```bash
+yarn lerna:rebuild
+```
+
+Or continuously rebuild on change:
+
+```bash
+yarn dev
+```
+
+You can also build this specific package by running the following from within its directory:
+
+```bash
+yarn build
+```
+
+or continuously rebuild on change:
+
+```bash
+yarn build:watch
+```
+
+### Clean
+
+```bash
+yarn clean
+```
+
+### Lint
+
+```bash
+yarn lint
+```

--- a/packages/assert/README.md
+++ b/packages/assert/README.md
@@ -26,11 +26,11 @@ If your project is in [TypeScript](https://www.typescriptlang.org/), add the fol
 
 ## Contributing
 
-We strongly encourage that the community help us make improvements and determine the future direction of the protocol. To report bugs within this package, please create an issue in this repository.
+We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
 
-### Install Dependencies
+### Install dependencies
 
 If you don't have yarn workspaces enabled (Yarn < v1.0) - enable them:
 
@@ -46,8 +46,34 @@ yarn install
 
 ### Build
 
+If this is your **first** time building this package, you must first build **all** packages within the monorepo. This is because packages that depend on other packages located inside this monorepo are symlinked when run from **within** the monorepo. This allows you to make changes across multiple packages without first publishing dependent packages to NPM. To build all packages, run the following from the monorepo root directory:
+
+```bash
+yarn lerna:rebuild
+```
+
+Or continuously rebuild on change:
+
+```bash
+yarn dev
+```
+
+You can also build this specific package by running the following from within its directory:
+
 ```bash
 yarn build
+```
+
+or continuously rebuild on change:
+
+```bash
+yarn build:watch
+```
+
+### Clean
+
+```bash
+yarn clean
 ```
 
 ### Lint

--- a/packages/assert/README.md
+++ b/packages/assert/README.md
@@ -28,7 +28,7 @@ If your project is in [TypeScript](https://www.typescriptlang.org/), add the fol
 
 We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
 
 ### Install dependencies
 

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -23,11 +23,11 @@ If your project is in [TypeScript](https://www.typescriptlang.org/), add the fol
 
 ## Contributing
 
-We strongly recommend that the community help us make improvements and determine the future direction of the protocol. To report bugs within this package, please create an issue in this repository.
+We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
 
-### Install Dependencies
+### Install dependencies
 
 If you don't have yarn workspaces enabled (Yarn < v1.0) - enable them:
 
@@ -43,8 +43,34 @@ yarn install
 
 ### Build
 
+If this is your **first** time building this package, you must first build **all** packages within the monorepo. This is because packages that depend on other packages located inside this monorepo are symlinked when run from **within** the monorepo. This allows you to make changes across multiple packages without first publishing dependent packages to NPM. To build all packages, run the following from the monorepo root directory:
+
+```bash
+yarn lerna:rebuild
+```
+
+Or continuously rebuild on change:
+
+```bash
+yarn dev
+```
+
+You can also build this specific package by running the following from within its directory:
+
 ```bash
 yarn build
+```
+
+or continuously rebuild on change:
+
+```bash
+yarn build:watch
+```
+
+### Clean
+
+```bash
+yarn clean
 ```
 
 ### Lint

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -25,7 +25,7 @@ If your project is in [TypeScript](https://www.typescriptlang.org/), add the fol
 
 We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
 
 ### Install dependencies
 

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -34,11 +34,25 @@ yarn install
 
 ### Build
 
+If this is your **first** time building this package, you must first build **all** packages within the monorepo. This is because packages that depend on other packages located inside this monorepo are symlinked when run from **within** the monorepo. This allows you to make changes across multiple packages without first publishing dependent packages to NPM. To build all packages, run the following from the monorepo root directory:
+
+```bash
+yarn lerna:rebuild
+```
+
+Or continuously rebuild on change:
+
+```bash
+yarn dev
+```
+
+You can also build this specific package by running the following from within its directory:
+
 ```bash
 yarn build
 ```
 
-or
+or continuously rebuild on change:
 
 ```bash
 yarn build:watch

--- a/packages/deployer/README.md
+++ b/packages/deployer/README.md
@@ -41,11 +41,11 @@ var Compiler = require('@0xproject/deployer').Compiler;
 
 ## Contributing
 
-We strongly recommend that the community help us make improvements and determine the future direction of the protocol. To report bugs within this package, please create an issue in this repository.
+We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
 
-### Install Dependencies
+### Install dependencies
 
 If you don't have yarn workspaces enabled (Yarn < v1.0) - enable them:
 
@@ -61,14 +61,34 @@ yarn install
 
 ### Build
 
+If this is your **first** time building this package, you must first build **all** packages within the monorepo. This is because packages that depend on other packages located inside this monorepo are symlinked when run from **within** the monorepo. This allows you to make changes across multiple packages without first publishing dependent packages to NPM. To build all packages, run the following from the monorepo root directory:
+
+```bash
+yarn lerna:rebuild
+```
+
+Or continuously rebuild on change:
+
+```bash
+yarn dev
+```
+
+You can also build this specific package by running the following from within its directory:
+
 ```bash
 yarn build
 ```
 
-or
+or continuously rebuild on change:
 
 ```bash
 yarn build:watch
+```
+
+### Clean
+
+```bash
+yarn clean
 ```
 
 ### Lint

--- a/packages/deployer/README.md
+++ b/packages/deployer/README.md
@@ -43,7 +43,7 @@ var Compiler = require('@0xproject/deployer').Compiler;
 
 We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
 
 ### Install dependencies
 

--- a/packages/dev-utils/README.md
+++ b/packages/dev-utils/README.md
@@ -26,3 +26,67 @@ If your project is in [TypeScript](https://www.typescriptlang.org/), add the fol
     "typeRoots": ["node_modules/@0xproject/typescript-typings/types", "node_modules/@types"],
 }
 ```
+
+## Contributing
+
+We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
+
+Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
+
+### Install dependencies
+
+If you don't have yarn workspaces enabled (Yarn < v1.0) - enable them:
+
+```bash
+yarn config set workspaces-experimental true
+```
+
+Then install dependencies
+
+```bash
+yarn install
+```
+
+### Build
+
+If this is your **first** time building this package, you must first build **all** packages within the monorepo. This is because packages that depend on other packages located inside this monorepo are symlinked when run from **within** the monorepo. This allows you to make changes across multiple packages without first publishing dependent packages to NPM. To build all packages, run the following from the monorepo root directory:
+
+```bash
+yarn lerna:rebuild
+```
+
+Or continuously rebuild on change:
+
+```bash
+yarn dev
+```
+
+You can also build this specific package by running the following from within its directory:
+
+```bash
+yarn build
+```
+
+or continuously rebuild on change:
+
+```bash
+yarn build:watch
+```
+
+### Clean
+
+```bash
+yarn clean
+```
+
+### Lint
+
+```bash
+yarn lint
+```
+
+### Run Tests
+
+```bash
+yarn test
+```

--- a/packages/dev-utils/README.md
+++ b/packages/dev-utils/README.md
@@ -31,7 +31,7 @@ If your project is in [TypeScript](https://www.typescriptlang.org/), add the fol
 
 We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
 
 ### Install dependencies
 

--- a/packages/json-schemas/README.md
+++ b/packages/json-schemas/README.md
@@ -34,7 +34,7 @@ If your project is in [TypeScript](https://www.typescriptlang.org/), add the fol
 
 We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
 
 ### Install dependencies
 

--- a/packages/json-schemas/README.md
+++ b/packages/json-schemas/README.md
@@ -32,11 +32,11 @@ If your project is in [TypeScript](https://www.typescriptlang.org/), add the fol
 
 ## Contributing
 
-We strongly encourage that the community help us make improvements and determine the future direction of the protocol. To report bugs within this package, please create an issue in this repository.
+We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
 
-### Install Dependencies
+### Install dependencies
 
 If you don't have yarn workspaces enabled (Yarn < v1.0) - enable them:
 
@@ -52,14 +52,34 @@ yarn install
 
 ### Build
 
+If this is your **first** time building this package, you must first build **all** packages within the monorepo. This is because packages that depend on other packages located inside this monorepo are symlinked when run from **within** the monorepo. This allows you to make changes across multiple packages without first publishing dependent packages to NPM. To build all packages, run the following from the monorepo root directory:
+
+```bash
+yarn lerna:rebuild
+```
+
+Or continuously rebuild on change:
+
+```bash
+yarn dev
+```
+
+You can also build this specific package by running the following from within its directory:
+
 ```bash
 yarn build
 ```
 
-or
+or continuously rebuild on change:
 
 ```bash
 yarn build:watch
+```
+
+### Clean
+
+```bash
+yarn clean
 ```
 
 ### Lint

--- a/packages/monorepo-scripts/README.md
+++ b/packages/monorepo-scripts/README.md
@@ -18,7 +18,7 @@ This will list out any dependencies that differ in versions between packages.
 
 We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
 
 ### Install dependencies
 

--- a/packages/monorepo-scripts/README.md
+++ b/packages/monorepo-scripts/README.md
@@ -16,11 +16,11 @@ This will list out any dependencies that differ in versions between packages.
 
 ## Contributing
 
-We strongly recommend that the community help us make improvements and determine the future direction of the protocol. To report bugs within this package, please create an issue in this repository.
+We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
 
-### Install Dependencies
+### Install dependencies
 
 If you don't have yarn workspaces enabled (Yarn < v1.0) - enable them:
 
@@ -36,11 +36,25 @@ yarn install
 
 ### Build
 
+If this is your **first** time building this package, you must first build **all** packages within the monorepo. This is because packages that depend on other packages located inside this monorepo are symlinked when run from **within** the monorepo. This allows you to make changes across multiple packages without first publishing dependent packages to NPM. To build all packages, run the following from the monorepo root directory:
+
+```bash
+yarn lerna:rebuild
+```
+
+Or continuously rebuild on change:
+
+```bash
+yarn dev
+```
+
+You can also build this specific package by running the following from within its directory:
+
 ```bash
 yarn build
 ```
 
-or
+or continuously rebuild on change:
 
 ```bash
 yarn build:watch
@@ -56,4 +70,10 @@ yarn clean
 
 ```bash
 yarn lint
+```
+
+### Run Tests
+
+```bash
+yarn test
 ```

--- a/packages/monorepo-scripts/src/find_unused_dependencies.ts
+++ b/packages/monorepo-scripts/src/find_unused_dependencies.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import * as depcheck from 'depcheck';
+import * as depcheckAsync from 'depcheck';
 import * as fs from 'fs';
 import lernaGetPackages = require('lerna-get-packages');
 import * as _ from 'lodash';
@@ -35,11 +35,3 @@ const IGNORE_PACKAGES = ['@0xproject/deployer'];
     utils.log(err);
     process.exit(1);
 });
-
-async function depcheckAsync(path: string, opts: any): Promise<depcheck.Results> {
-    return new Promise<depcheck.Results>((resolve, reject) => {
-        depcheck(path, opts, (unused: any) => {
-            resolve(unused);
-        });
-    });
-}

--- a/packages/react-docs-example/README.md
+++ b/packages/react-docs-example/README.md
@@ -35,7 +35,7 @@ Note: If you move this package out of the monorepo, it will work without this st
 The the `react-docs-example` root directory, run:
 
 ```bash
-yarn run dev
+yarn dev
 ```
 
 ### Deploy Example to S3 bucket

--- a/packages/react-docs-example/README.md
+++ b/packages/react-docs-example/README.md
@@ -20,10 +20,22 @@ Then install dependencies
 yarn install
 ```
 
-#### Start the dev server
+### Initial setup
+
+The **first** time you work with this package, you must build **all** packages within the monorepo. This is because packages that depend on other packages located inside this monorepo are symlinked when run from **within** the monorepo. This allows you to make changes across multiple packages without first publishing dependent packages to NPM. To build all packages, run the following from the monorepo root directory:
 
 ```bash
-yarn dev
+yarn lerna:rebuild
+```
+
+Note: If you move this package out of the monorepo, it will work without this step. Make sure you copy it out on the `master` branch since the `development` version might rely on not-yet published changes to other packages.
+
+### Run dev server
+
+The the `react-docs-example` root directory, run:
+
+```bash
+yarn run dev
 ```
 
 ### Deploy Example to S3 bucket
@@ -40,6 +52,12 @@ yarn deploy_example
 
 ```bash
 yarn build
+```
+
+### Clean
+
+```bash
+yarn clean
 ```
 
 ### Lint

--- a/packages/react-docs/README.md
+++ b/packages/react-docs/README.md
@@ -53,7 +53,7 @@ Feel free to contribute to these improvements!
 
 We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
 
 ### Install dependencies
 

--- a/packages/react-docs/README.md
+++ b/packages/react-docs/README.md
@@ -51,11 +51,11 @@ Feel free to contribute to these improvements!
 
 ## Contributing
 
-We strongly encourage the community to help us make improvements. To report bugs within this package, please create an issue in this repository.
+We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
 
-### Install Dependencies
+### Install dependencies
 
 If you don't have yarn workspaces enabled (Yarn < v1.0) - enable them:
 
@@ -71,8 +71,34 @@ yarn install
 
 ### Build
 
+If this is your **first** time building this package, you must first build **all** packages within the monorepo. This is because packages that depend on other packages located inside this monorepo are symlinked when run from **within** the monorepo. This allows you to make changes across multiple packages without first publishing dependent packages to NPM. To build all packages, run the following from the monorepo root directory:
+
+```bash
+yarn lerna:rebuild
+```
+
+Or continuously rebuild on change:
+
+```bash
+yarn dev
+```
+
+You can also build this specific package by running the following from within its directory:
+
 ```bash
 yarn build
+```
+
+or continuously rebuild on change:
+
+```bash
+yarn build:watch
+```
+
+### Clean
+
+```bash
+yarn clean
 ```
 
 ### Lint

--- a/packages/react-shared/README.md
+++ b/packages/react-shared/README.md
@@ -18,11 +18,11 @@ If your project is in [TypeScript](https://www.typescriptlang.org/), add the fol
 
 ## Contributing
 
-We strongly encourage that the community help us make improvements and determine the future direction of the protocol. To report bugs within this package, please create an issue in this repository.
+We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
 
-### Install Dependencies
+### Install dependencies
 
 If you don't have yarn workspaces enabled (Yarn < v1.0) - enable them:
 
@@ -38,18 +38,38 @@ yarn install
 
 ### Build
 
+If this is your **first** time building this package, you must first build **all** packages within the monorepo. This is because packages that depend on other packages located inside this monorepo are symlinked when run from **within** the monorepo. This allows you to make changes across multiple packages without first publishing dependent packages to NPM. To build all packages, run the following from the monorepo root directory:
+
+```bash
+yarn lerna:rebuild
+```
+
+Or continuously rebuild on change:
+
+```bash
+yarn dev
+```
+
+You can also build this specific package by running the following from within its directory:
+
 ```bash
 yarn build
+```
+
+or continuously rebuild on change:
+
+```bash
+yarn build:watch
+```
+
+### Clean
+
+```bash
+yarn clean
 ```
 
 ### Lint
 
 ```bash
 yarn lint
-```
-
-### Run Tests
-
-```bash
-yarn test
 ```

--- a/packages/react-shared/README.md
+++ b/packages/react-shared/README.md
@@ -20,7 +20,7 @@ If your project is in [TypeScript](https://www.typescriptlang.org/), add the fol
 
 We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
 
 ### Install dependencies
 

--- a/packages/sol-cov/README.md
+++ b/packages/sol-cov/README.md
@@ -26,7 +26,7 @@ var CoverageSubprovider = require('@0xproject/sol-cov').CoverageSubprovider;
 
 We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
 
 ### Install dependencies
 

--- a/packages/sol-cov/README.md
+++ b/packages/sol-cov/README.md
@@ -24,11 +24,11 @@ var CoverageSubprovider = require('@0xproject/sol-cov').CoverageSubprovider;
 
 ## Contributing
 
-We strongly encourage the community to help us make improvements. To report bugs within this package, please create an issue in this repository.
+We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
 
-### Install Dependencies
+### Install dependencies
 
 If you don't have yarn workspaces enabled (Yarn < v1.0) - enable them:
 
@@ -42,8 +42,46 @@ Then install dependencies
 yarn install
 ```
 
+### Build
+
+If this is your **first** time building this package, you must first build **all** packages within the monorepo. This is because packages that depend on other packages located inside this monorepo are symlinked when run from **within** the monorepo. This allows you to make changes across multiple packages without first publishing dependent packages to NPM. To build all packages, run the following from the monorepo root directory:
+
+```bash
+yarn lerna:rebuild
+```
+
+Or continuously rebuild on change:
+
+```bash
+yarn dev
+```
+
+You can also build this specific package by running the following from within its directory:
+
+```bash
+yarn build
+```
+
+or continuously rebuild on change:
+
+```bash
+yarn build:watch
+```
+
+### Clean
+
+```bash
+yarn clean
+```
+
 ### Lint
 
 ```bash
 yarn lint
+```
+
+### Run Tests
+
+```bash
+yarn test
 ```

--- a/packages/sra-report/README.md
+++ b/packages/sra-report/README.md
@@ -87,11 +87,11 @@ In order to provide a custom environment to the tool, perform the following step
 
 ## Contributing
 
-We strongly encourage that the community help us make improvements and determine the future direction of the protocol. To report bugs within this package, please create an issue in this repository.
+We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
 
-### Install Dependencies
+### Install dependencies
 
 If you don't have yarn workspaces enabled (Yarn < v1.0) - enable them:
 
@@ -107,8 +107,34 @@ yarn install
 
 ### Build
 
+If this is your **first** time building this package, you must first build **all** packages within the monorepo. This is because packages that depend on other packages located inside this monorepo are symlinked when run from **within** the monorepo. This allows you to make changes across multiple packages without first publishing dependent packages to NPM. To build all packages, run the following from the monorepo root directory:
+
+```bash
+yarn lerna:rebuild
+```
+
+Or continuously rebuild on change:
+
+```bash
+yarn dev
+```
+
+You can also build this specific package by running the following from within its directory:
+
 ```bash
 yarn build
+```
+
+or continuously rebuild on change:
+
+```bash
+yarn build:watch
+```
+
+### Clean
+
+```bash
+yarn clean
 ```
 
 ### Lint

--- a/packages/sra-report/README.md
+++ b/packages/sra-report/README.md
@@ -89,7 +89,7 @@ In order to provide a custom environment to the tool, perform the following step
 
 We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
 
 ### Install dependencies
 

--- a/packages/subproviders/README.md
+++ b/packages/subproviders/README.md
@@ -24,7 +24,7 @@ If your project is in [TypeScript](https://www.typescriptlang.org/), add the fol
 
 We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
 
 ### Install dependencies
 

--- a/packages/subproviders/README.md
+++ b/packages/subproviders/README.md
@@ -22,11 +22,11 @@ If your project is in [TypeScript](https://www.typescriptlang.org/), add the fol
 
 ## Contributing
 
-We strongly recommend that the community help us make improvements and determine the future direction of the protocol. To report bugs within this package, please create an issue in this repository.
+We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
 
-### Install Dependencies
+### Install dependencies
 
 If you don't have yarn workspaces enabled (Yarn < v1.0) - enable them:
 
@@ -34,17 +34,33 @@ If you don't have yarn workspaces enabled (Yarn < v1.0) - enable them:
 yarn config set workspaces-experimental true
 ```
 
+Then install dependencies
+
 ```bash
 yarn install
 ```
 
 ### Build
 
+If this is your **first** time building this package, you must first build **all** packages within the monorepo. This is because packages that depend on other packages located inside this monorepo are symlinked when run from **within** the monorepo. This allows you to make changes across multiple packages without first publishing dependent packages to NPM. To build all packages, run the following from the monorepo root directory:
+
+```bash
+yarn lerna:rebuild
+```
+
+Or continuously rebuild on change:
+
+```bash
+yarn dev
+```
+
+You can also build this specific package by running the following from within its directory:
+
 ```bash
 yarn build
 ```
 
-or
+or continuously rebuild on change:
 
 ```bash
 yarn build:watch

--- a/packages/testnet-faucets/README.md
+++ b/packages/testnet-faucets/README.md
@@ -4,15 +4,15 @@ This faucet dispenses 0.1 test ether to one recipient per second and 0.1 test ZR
 
 ## Installation
 
-This is a private package and therefore is not published to npm. In order to build and run this package locally, see the [Install Dependencies](#Install-Dependencies) section and onwards below.
+This is a private package and therefore is not published to npm. In order to build and run this package locally, see the contributing instructions below.
 
 ## Contributing
 
-We strongly recommend that the community help us make improvements and determine the future direction of the protocol. To report bugs within this package, please create an issue in this repository.
+We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
 
-### Install Dependencies
+### Install dependencies
 
 If you don't have yarn workspaces enabled (Yarn < v1.0) - enable them:
 
@@ -24,6 +24,44 @@ Then install dependencies
 
 ```bash
 yarn install
+```
+
+### Build
+
+If this is your **first** time building this package, you must first build **all** packages within the monorepo. This is because packages that depend on other packages located inside this monorepo are symlinked when run from **within** the monorepo. This allows you to make changes across multiple packages without first publishing dependent packages to NPM. To build all packages, run the following from the monorepo root directory:
+
+```bash
+yarn lerna:rebuild
+```
+
+Or continuously rebuild on change:
+
+```bash
+yarn dev
+```
+
+You can also build this specific package by running the following from within its directory:
+
+```bash
+yarn build
+```
+
+or continuously rebuild on change:
+
+```bash
+yarn build:watch
+```
+
+### Clean
+
+```bash
+yarn clean
+```
+
+### Lint
+
+```bash
+yarn lint
 ```
 
 ### Start
@@ -124,10 +162,4 @@ docker run -d \
 -e FAUCET_ENVIRONMENT=production \
 -e INFURA_API_KEY=$INFURA_API_KEY \
 testnet-faucets
-```
-
-### Lint
-
-```bash
-yarn lint
 ```

--- a/packages/testnet-faucets/README.md
+++ b/packages/testnet-faucets/README.md
@@ -10,7 +10,7 @@ This is a private package and therefore is not published to npm. In order to bui
 
 We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
 
 ### Install dependencies
 

--- a/packages/tslint-config/README.md
+++ b/packages/tslint-config/README.md
@@ -20,11 +20,11 @@ Add the following to your `tslint.json` file
 
 ## Contributing
 
-We strongly encourage that the community help us make improvements and determine the future direction of the protocol. To report bugs within this package, please create an issue in this repository.
+We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
 
-### Install Dependencies
+### Install dependencies
 
 If you don't have yarn workspaces enabled (Yarn < v1.0) - enable them:
 
@@ -40,14 +40,34 @@ yarn install
 
 ### Build
 
+If this is your **first** time building this package, you must first build **all** packages within the monorepo. This is because packages that depend on other packages located inside this monorepo are symlinked when run from **within** the monorepo. This allows you to make changes across multiple packages without first publishing dependent packages to NPM. To build all packages, run the following from the monorepo root directory:
+
+```bash
+yarn lerna:rebuild
+```
+
+Or continuously rebuild on change:
+
+```bash
+yarn dev
+```
+
+You can also build this specific package by running the following from within its directory:
+
 ```bash
 yarn build
 ```
 
-or
+or continuously rebuild on change:
 
 ```bash
 yarn build:watch
+```
+
+### Clean
+
+```bash
+yarn clean
 ```
 
 ### Lint

--- a/packages/tslint-config/README.md
+++ b/packages/tslint-config/README.md
@@ -22,7 +22,7 @@ Add the following to your `tslint.json` file
 
 We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
 
 ### Install dependencies
 

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -26,7 +26,7 @@ import { TransactionReceipt, TxData, TxDataPayable } from '@0xproject/types';
 
 We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
 
 ### Install dependencies
 

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -24,13 +24,13 @@ import { TransactionReceipt, TxData, TxDataPayable } from '@0xproject/types';
 
 ## Contributing
 
-We strongly recommend that the community help us make improvements and determine the future direction of the protocol. To report bugs within this package, please create an issue in this repository.
+We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
 
-### Install Dependencies
+### Install dependencies
 
-If you don't have yarn workspaces e`nabled (Yarn < v1.0) - enable them:
+If you don't have yarn workspaces enabled (Yarn < v1.0) - enable them:
 
 ```bash
 yarn config set workspaces-experimental true
@@ -44,14 +44,34 @@ yarn install
 
 ### Build
 
+If this is your **first** time building this package, you must first build **all** packages within the monorepo. This is because packages that depend on other packages located inside this monorepo are symlinked when run from **within** the monorepo. This allows you to make changes across multiple packages without first publishing dependent packages to NPM. To build all packages, run the following from the monorepo root directory:
+
+```bash
+yarn lerna:rebuild
+```
+
+Or continuously rebuild on change:
+
+```bash
+yarn dev
+```
+
+You can also build this specific package by running the following from within its directory:
+
 ```bash
 yarn build
 ```
 
-or
+or continuously rebuild on change:
 
 ```bash
 yarn build:watch
+```
+
+### Clean
+
+```bash
+yarn clean
 ```
 
 ### Lint

--- a/packages/typescript-typings/README.md
+++ b/packages/typescript-typings/README.md
@@ -22,7 +22,7 @@ This will allow the TS compiler to first look into that repo and then fallback t
 
 We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
 
 ### Install dependencies
 

--- a/packages/typescript-typings/README.md
+++ b/packages/typescript-typings/README.md
@@ -20,11 +20,11 @@ This will allow the TS compiler to first look into that repo and then fallback t
 
 ## Contributing
 
-We strongly encourage that the community help us make improvements and determine the future direction of the protocol. To report bugs within this package, please create an issue in this repository.
+We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
 
-### Install Dependencies
+### Install dependencies
 
 If you don't have yarn workspaces enabled (Yarn < v1.0) - enable them:
 
@@ -36,6 +36,38 @@ Then install dependencies
 
 ```bash
 yarn install
+```
+
+### Build
+
+If this is your **first** time building this package, you must first build **all** packages within the monorepo. This is because packages that depend on other packages located inside this monorepo are symlinked when run from **within** the monorepo. This allows you to make changes across multiple packages without first publishing dependent packages to NPM. To build all packages, run the following from the monorepo root directory:
+
+```bash
+yarn lerna:rebuild
+```
+
+Or continuously rebuild on change:
+
+```bash
+yarn dev
+```
+
+You can also build this specific package by running the following from within its directory:
+
+```bash
+yarn build
+```
+
+or continuously rebuild on change:
+
+```bash
+yarn build:watch
+```
+
+### Clean
+
+```bash
+yarn clean
 ```
 
 ### Lint

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -24,11 +24,11 @@ import { addressUtils, bigNumberConfigs, classUtils, intervalUtils, promisify } 
 
 ## Contributing
 
-We strongly recommend that the community help us make improvements and determine the future direction of the protocol. To report bugs within this package, please create an issue in this repository.
+We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
 
-### Install Dependencies
+### Install dependencies
 
 If you don't have yarn workspaces enabled (Yarn < v1.0) - enable them:
 
@@ -44,14 +44,34 @@ yarn install
 
 ### Build
 
+If this is your **first** time building this package, you must first build **all** packages within the monorepo. This is because packages that depend on other packages located inside this monorepo are symlinked when run from **within** the monorepo. This allows you to make changes across multiple packages without first publishing dependent packages to NPM. To build all packages, run the following from the monorepo root directory:
+
+```bash
+yarn lerna:rebuild
+```
+
+Or continuously rebuild on change:
+
+```bash
+yarn dev
+```
+
+You can also build this specific package by running the following from within its directory:
+
 ```bash
 yarn build
 ```
 
-or
+or continuously rebuild on change:
 
 ```bash
 yarn build:watch
+```
+
+### Clean
+
+```bash
+yarn clean
 ```
 
 ### Lint

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -26,7 +26,7 @@ import { addressUtils, bigNumberConfigs, classUtils, intervalUtils, promisify } 
 
 We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
 
 ### Install dependencies
 

--- a/packages/web3-wrapper/README.md
+++ b/packages/web3-wrapper/README.md
@@ -22,7 +22,7 @@ If your project is in [TypeScript](https://www.typescriptlang.org/), add the fol
 
 We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
 
 ### Install dependencies
 

--- a/packages/web3-wrapper/README.md
+++ b/packages/web3-wrapper/README.md
@@ -20,11 +20,11 @@ If your project is in [TypeScript](https://www.typescriptlang.org/), add the fol
 
 ## Contributing
 
-We strongly encourage that the community help us make improvements and determine the future direction of the protocol. To report bugs within this package, please create an issue in this repository.
+We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
 
-Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
+Please read our [contribution guidelines](./CONTRIBUTING.md) before getting started.
 
-### Install Dependencies
+### Install dependencies
 
 If you don't have yarn workspaces enabled (Yarn < v1.0) - enable them:
 
@@ -40,14 +40,34 @@ yarn install
 
 ### Build
 
+If this is your **first** time building this package, you must first build **all** packages within the monorepo. This is because packages that depend on other packages located inside this monorepo are symlinked when run from **within** the monorepo. This allows you to make changes across multiple packages without first publishing dependent packages to NPM. To build all packages, run the following from the monorepo root directory:
+
+```bash
+yarn lerna:rebuild
+```
+
+Or continuously rebuild on change:
+
+```bash
+yarn dev
+```
+
+You can also build this specific package by running the following from within its directory:
+
 ```bash
 yarn build
 ```
 
-or
+or continuously rebuild on change:
 
 ```bash
 yarn build:watch
+```
+
+### Clean
+
+```bash
+yarn clean
 ```
 
 ### Lint

--- a/packages/website/README.md
+++ b/packages/website/README.md
@@ -41,7 +41,7 @@ yarn lerna:rebuild
 The the `website` root directory, run:
 
 ```bash
-yarn run dev
+yarn dev
 ```
 
 Visit [0xproject.localhost:3572](http://0xproject.localhost:3572) in your browser.

--- a/packages/website/README.md
+++ b/packages/website/README.md
@@ -28,19 +28,23 @@ Add the following to your `/etc/hosts` file:
 yarn install
 ```
 
+### Initial setup
+
+The **first** time you work with this package, you must build **all** packages within the monorepo. This is because packages that depend on other packages located inside this monorepo are symlinked when run from **within** the monorepo. This allows you to make changes across multiple packages without first publishing dependent packages to NPM. To build all packages, run the following from the monorepo root directory:
+
+```bash
+yarn lerna:rebuild
+```
+
 ### Run dev server
+
+The the `website` root directory, run:
 
 ```bash
 yarn run dev
 ```
 
 Visit [0xproject.localhost:3572](http://0xproject.localhost:3572) in your browser.
-
-### Build
-
-```bash
-yarn build
-```
 
 ### Clean
 


### PR DESCRIPTION


<!--- Thank you for taking the time to submit a Pull Request -->

<!--- Provide a general summary of the issue in the Title above -->

## Description

- The first time a user builds a package, they must build all monorepo packages. This was missing from the package README instructions so I added it. (See issue: https://github.com/0xProject/0x-monorepo/issues/481)
- Added missing `clean` instruction.
- Standardized inclusion of `yarn build:watch` in all package README's.
- Add short description to 0x.js readme.

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOGs.
*   [ ] Updated the new versions of the changed packages in the relevant CHANGELOGs.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
