### PR TITLE
[WIP] Default order params

### DIFF
--- a/packages/contracts/src/contracts/current/protocol/Exchange/MixinExchangeCore.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/MixinExchangeCore.sol
@@ -49,6 +49,15 @@ contract MixinExchangeCore is
     // Orders with a salt less than their maker's epoch are considered cancelled
     mapping (address => uint256) public makerEpoch;
 
+    // Mapping of id => default order params
+    mapping (uint256 => Order) public defaultOrderParams;
+
+    // Mapping of default order params orderHash => default order params id
+    mapping (bytes32 => uint256) public defaultOrderParamsIds;
+
+    // Last default order params id set
+    uint256 currentOrderParamsId = 0;
+
     event Fill(
         address indexed makerAddress,
         address takerAddress,
@@ -75,6 +84,11 @@ contract MixinExchangeCore is
         uint256 makerEpoch
     );
 
+    event DefaultOrderParamsRegistered(
+        bytes32 indexed orderHash,
+        uint256 defaultOrderParamsId
+    );
+
     /*
     * Core exchange functions
     */
@@ -82,15 +96,20 @@ contract MixinExchangeCore is
     /// @dev Fills the input order.
     /// @param order Order struct containing order specifications.
     /// @param takerTokenFillAmount Desired amount of takerToken to sell.
+    /// @param defaultParamsId Id of the default order parameters to use.
     /// @param signature Proof that order has been created by maker.
     /// @return Amounts filled and fees paid by maker and taker.
     function fillOrder(
         Order memory order,
         uint256 takerTokenFillAmount,
+        uint256 defaultParamsId,
         bytes memory signature)
         public
         returns (FillResults memory fillResults)
     {
+        // Overwrite null order params with defaults
+        applyDefaultOrderParams(order, defaultParamsId);
+
         // Compute the order hash
         bytes32 orderHash = getOrderHash(order);
 
@@ -166,12 +185,16 @@ contract MixinExchangeCore is
 
     /// @dev After calling, the order can not be filled anymore.
     /// @param order Order struct containing order specifications.
+    /// @param defaultParamsId Id of the default order parameters to use.
     /// @return True if the order state changed to cancelled.
     ///         False if the transaction was already cancelled or expired.
-    function cancelOrder(Order memory order)
+    function cancelOrder(Order memory order, uint256 defaultParamsId)
         public
         returns (bool)
     {
+        // Overwrite null order params with defaults
+        applyDefaultOrderParams(order, defaultParamsId);
+
         // Compute the order hash
         bytes32 orderHash = getOrderHash(order);
 
@@ -202,6 +225,7 @@ contract MixinExchangeCore is
         return true;
     }
 
+    /// @dev Cancels orders created with a salt that is less than or equal to specified salt.
     /// @param salt Orders created with a salt less or equal to this value will be cancelled.
     function cancelOrdersUpTo(uint256 salt)
         external
@@ -212,13 +236,41 @@ contract MixinExchangeCore is
         emit CancelUpTo(msg.sender, newMakerEpoch);
     }
 
+    /// @dev Stores a set of default order parameters in contract state.
+    ///      The parameters can be looked up by id. The id can be looked up by hash of the entire order struct.
+    /// @param order Order struct containing order specifications.
+    /// @return The id that the order parameters are registered to in the defaultOrderParams mapping.
+    function registerDefaultOrderParams(Order memory order)
+        public
+        returns (uint256)
+    {
+        bytes32 orderHash = getOrderHash(order);
+
+        // Order params must not already be registered
+        require(defaultOrderParamsIds[orderHash] == 0);
+
+        // Increment id
+        currentOrderParamsId++;
+
+        // Map order params to id
+        defaultOrderParams[currentOrderParamsId] = order;
+
+        // Map id to orderHash
+        defaultOrderParamsIds[orderHash] = currentOrderParamsId;
+
+        // Log registration
+        emit DefaultOrderParamsRegistered(orderHash, currentOrderParamsId);
+        return currentOrderParamsId;
+    }
+
     /// @dev Checks if rounding error > 0.1%.
     /// @param numerator Numerator.
     /// @param denominator Denominator.
     /// @param target Value to multiply with numerator/denominator.
     /// @return Rounding error is present.
     function isRoundingError(uint256 numerator, uint256 denominator, uint256 target)
-        public pure
+        public
+        pure
         returns (bool isError)
     {
         uint256 remainder = mulmod(target, numerator, denominator);
@@ -232,5 +284,75 @@ contract MixinExchangeCore is
         );
         isError = errPercentageTimes1000000 > 1000;
         return isError;
+    }
+
+    /// @dev Overwrites all 0 values of order if default paramters for the specified id exist.
+    /// @param order Order struct containing order specifications.
+    /// @param defaultParamsId Id of the default order parameters to use.
+    function applyDefaultOrderParams(Order memory order, uint256 defaultParamsId)
+        internal
+        view
+    {
+        // Do nothing if id not specified
+        if (defaultParamsId != 0) {
+
+            // Load default order params
+            Order storage orderParams = defaultOrderParams[defaultParamsId];
+
+            // Overwrite null makerAddress
+            if (order.makerAddress == address(0)) {
+                order.makerAddress = orderParams.makerAddress;
+            }
+
+            // Overwrite null takerAddress
+            if (order.takerAddress == address(0)) {
+                order.takerAddress = orderParams.takerAddress;
+            }
+
+            // Overwrite null makerTokenAddress
+            if (order.makerTokenAddress == address(0)) {
+                order.makerTokenAddress = orderParams.makerTokenAddress;
+            }
+
+            // Overwrite null takerTokenAddress
+            if (order.takerTokenAddress == address(0)) {
+                order.takerTokenAddress = orderParams.takerTokenAddress;
+            }
+
+            // Overwrite null feeRecipientAddress
+            if (order.feeRecipientAddress == address(0)) {
+                order.feeRecipientAddress = orderParams.feeRecipientAddress;
+            }
+
+            // Overwrite 0 makerTokenAmount
+            if (order.makerTokenAmount == 0) {
+                order.makerTokenAmount = orderParams.makerTokenAmount;
+            }
+
+            // Overwrite 0 takerTokenAmount
+            if (order.takerTokenAmount == 0) {
+                order.takerTokenAmount = orderParams.takerTokenAmount;
+            }
+
+            // Overwrite 0 makerFeeAmount
+            if (order.makerFee == 0) {
+                order.makerFee = orderParams.makerFee;
+            }
+
+            // Overwrite 0 takerFeeAmount
+            if (order.takerFee == 0) {
+                order.takerFee = orderParams.takerFee;
+            }
+
+            // Overwrtie 0 expirationTimeSeconds
+            if (order.expirationTimeSeconds == 0) {
+                order.expirationTimeSeconds = orderParams.expirationTimeSeconds;
+            }
+
+            // Overwrite 0 salt
+            if (order.salt == 0) {
+                order.salt = orderParams.salt;
+            }
+        }
     }
 }

--- a/packages/contracts/src/contracts/current/protocol/Exchange/mixins/MExchangeCore.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/mixins/MExchangeCore.sol
@@ -33,11 +33,12 @@ contract MExchangeCore is LibOrder {
     function fillOrder(
         Order memory order,
         uint256 takerTokenFillAmount,
+        uint256 defaultParamsId,
         bytes memory signature)
         public
         returns (FillResults memory fillResults);
 
-    function cancelOrder(Order memory order)
+    function cancelOrder(Order memory order, uint256 defaultParamsId)
         public
         returns (bool);
 

--- a/packages/contracts/src/utils/exchange_wrapper.ts
+++ b/packages/contracts/src/utils/exchange_wrapper.ts
@@ -22,33 +22,41 @@ export class ExchangeWrapper {
     public async fillOrderAsync(
         signedOrder: SignedOrder,
         from: string,
-        opts: { takerTokenFillAmount?: BigNumber } = {},
+        opts: { takerTokenFillAmount?: BigNumber; defaultParamsId?: BigNumber } = {},
     ): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = orderUtils.createFill(signedOrder, opts.takerTokenFillAmount);
+        const params = orderUtils.createFill(signedOrder, opts.takerTokenFillAmount, opts.defaultParamsId);
         const txHash = await this._exchange.fillOrder.sendTransactionAsync(
             params.order,
             params.takerTokenFillAmount,
+            params.defaultParamsId,
             params.signature,
             { from },
         );
         const tx = await this._getTxWithDecodedExchangeLogsAsync(txHash);
         return tx;
     }
-    public async cancelOrderAsync(signedOrder: SignedOrder, from: string): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = orderUtils.createCancel(signedOrder);
-        const txHash = await this._exchange.cancelOrder.sendTransactionAsync(params.order, { from });
+    public async cancelOrderAsync(
+        signedOrder: SignedOrder,
+        from: string,
+        opts: { defaultParamsId?: BigNumber } = {},
+    ): Promise<TransactionReceiptWithDecodedLogs> {
+        const params = orderUtils.createCancel(signedOrder, opts.defaultParamsId);
+        const txHash = await this._exchange.cancelOrder.sendTransactionAsync(params.order, params.defaultParamsIds, {
+            from,
+        });
         const tx = await this._getTxWithDecodedExchangeLogsAsync(txHash);
         return tx;
     }
     public async fillOrKillOrderAsync(
         signedOrder: SignedOrder,
         from: string,
-        opts: { takerTokenFillAmount?: BigNumber } = {},
+        opts: { takerTokenFillAmount?: BigNumber; defaultParamsId?: BigNumber } = {},
     ): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = orderUtils.createFill(signedOrder, opts.takerTokenFillAmount);
+        const params = orderUtils.createFill(signedOrder, opts.takerTokenFillAmount, opts.defaultParamsId);
         const txHash = await this._exchange.fillOrKillOrder.sendTransactionAsync(
             params.order,
             params.takerTokenFillAmount,
+            params.defaultParamsId,
             params.signature,
             { from },
         );
@@ -58,12 +66,13 @@ export class ExchangeWrapper {
     public async fillOrderNoThrowAsync(
         signedOrder: SignedOrder,
         from: string,
-        opts: { takerTokenFillAmount?: BigNumber } = {},
+        opts: { takerTokenFillAmount?: BigNumber; defaultParamsId?: BigNumber } = {},
     ): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = orderUtils.createFill(signedOrder, opts.takerTokenFillAmount);
+        const params = orderUtils.createFill(signedOrder, opts.takerTokenFillAmount, opts.defaultParamsId);
         const txHash = await this._exchange.fillOrderNoThrow.sendTransactionAsync(
             params.order,
             params.takerTokenFillAmount,
+            params.defaultParamsId,
             params.signature,
             { from },
         );
@@ -73,12 +82,13 @@ export class ExchangeWrapper {
     public async batchFillOrdersAsync(
         orders: SignedOrder[],
         from: string,
-        opts: { takerTokenFillAmounts?: BigNumber[] } = {},
+        opts: { takerTokenFillAmounts?: BigNumber[]; defaultParamsIds?: BigNumber[] } = {},
     ): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = formatters.createBatchFill(orders, opts.takerTokenFillAmounts);
+        const params = formatters.createBatchFill(orders, opts.takerTokenFillAmounts, opts.defaultParamsIds);
         const txHash = await this._exchange.batchFillOrders.sendTransactionAsync(
             params.orders,
             params.takerTokenFillAmounts,
+            params.defaultParamsIds,
             params.signatures,
             { from },
         );
@@ -88,12 +98,13 @@ export class ExchangeWrapper {
     public async batchFillOrKillOrdersAsync(
         orders: SignedOrder[],
         from: string,
-        opts: { takerTokenFillAmounts?: BigNumber[] } = {},
+        opts: { takerTokenFillAmounts?: BigNumber[]; defaultParamsIds?: BigNumber[] } = {},
     ): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = formatters.createBatchFill(orders, opts.takerTokenFillAmounts);
+        const params = formatters.createBatchFill(orders, opts.takerTokenFillAmounts, opts.defaultParamsIds);
         const txHash = await this._exchange.batchFillOrKillOrders.sendTransactionAsync(
             params.orders,
             params.takerTokenFillAmounts,
+            params.defaultParamsIds,
             params.signatures,
             { from },
         );
@@ -103,12 +114,13 @@ export class ExchangeWrapper {
     public async batchFillOrdersNoThrowAsync(
         orders: SignedOrder[],
         from: string,
-        opts: { takerTokenFillAmounts?: BigNumber[] } = {},
+        opts: { takerTokenFillAmounts?: BigNumber[]; defaultParamsIds?: BigNumber[] } = {},
     ): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = formatters.createBatchFill(orders, opts.takerTokenFillAmounts);
+        const params = formatters.createBatchFill(orders, opts.takerTokenFillAmounts, opts.defaultParamsIds);
         const txHash = await this._exchange.batchFillOrdersNoThrow.sendTransactionAsync(
             params.orders,
             params.takerTokenFillAmounts,
+            params.defaultParamsIds,
             params.signatures,
             { from },
         );
@@ -118,12 +130,13 @@ export class ExchangeWrapper {
     public async marketSellOrdersAsync(
         orders: SignedOrder[],
         from: string,
-        opts: { takerTokenFillAmount: BigNumber },
+        opts: { takerTokenFillAmount: BigNumber; defaultParamsIds?: BigNumber[] },
     ): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = formatters.createMarketSellOrders(orders, opts.takerTokenFillAmount);
+        const params = formatters.createMarketSellOrders(orders, opts.takerTokenFillAmount, opts.defaultParamsIds);
         const txHash = await this._exchange.marketSellOrders.sendTransactionAsync(
             params.orders,
             params.takerTokenFillAmount,
+            params.defaultParamsIds,
             params.signatures,
             { from },
         );
@@ -133,12 +146,13 @@ export class ExchangeWrapper {
     public async marketSellOrdersNoThrowAsync(
         orders: SignedOrder[],
         from: string,
-        opts: { takerTokenFillAmount: BigNumber },
+        opts: { takerTokenFillAmount: BigNumber; defaultParamsIds?: BigNumber[] },
     ): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = formatters.createMarketSellOrders(orders, opts.takerTokenFillAmount);
+        const params = formatters.createMarketSellOrders(orders, opts.takerTokenFillAmount, opts.defaultParamsIds);
         const txHash = await this._exchange.marketSellOrdersNoThrow.sendTransactionAsync(
             params.orders,
             params.takerTokenFillAmount,
+            params.defaultParamsIds,
             params.signatures,
             { from },
         );
@@ -148,12 +162,13 @@ export class ExchangeWrapper {
     public async marketBuyOrdersAsync(
         orders: SignedOrder[],
         from: string,
-        opts: { makerTokenFillAmount: BigNumber },
+        opts: { makerTokenFillAmount: BigNumber; defaultParamsIds?: BigNumber[] },
     ): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = formatters.createMarketBuyOrders(orders, opts.makerTokenFillAmount);
+        const params = formatters.createMarketBuyOrders(orders, opts.makerTokenFillAmount, opts.defaultParamsIds);
         const txHash = await this._exchange.marketBuyOrders.sendTransactionAsync(
             params.orders,
             params.makerTokenFillAmount,
+            params.defaultParamsIds,
             params.signatures,
             { from },
         );
@@ -163,12 +178,13 @@ export class ExchangeWrapper {
     public async marketBuyOrdersNoThrowAsync(
         orders: SignedOrder[],
         from: string,
-        opts: { makerTokenFillAmount: BigNumber },
+        opts: { makerTokenFillAmount: BigNumber; defaultParamsIds?: BigNumber[] },
     ): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = formatters.createMarketBuyOrders(orders, opts.makerTokenFillAmount);
+        const params = formatters.createMarketBuyOrders(orders, opts.makerTokenFillAmount, opts.defaultParamsIds);
         const txHash = await this._exchange.marketBuyOrdersNoThrow.sendTransactionAsync(
             params.orders,
             params.makerTokenFillAmount,
+            params.defaultParamsIds,
             params.signatures,
             { from },
         );
@@ -178,9 +194,14 @@ export class ExchangeWrapper {
     public async batchCancelOrdersAsync(
         orders: SignedOrder[],
         from: string,
+        opts: { defaultParamsIds?: BigNumber[] } = {},
     ): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = formatters.createBatchCancel(orders);
-        const txHash = await this._exchange.batchCancelOrders.sendTransactionAsync(params.orders, { from });
+        const params = formatters.createBatchCancel(orders, opts.defaultParamsIds);
+        const txHash = await this._exchange.batchCancelOrders.sendTransactionAsync(
+            params.orders,
+            params.defaultParamsIds,
+            { from },
+        );
         const tx = await this._getTxWithDecodedExchangeLogsAsync(txHash);
         return tx;
     }
@@ -221,7 +242,7 @@ export class ExchangeWrapper {
         );
         return partialAmount;
     }
-    public async getTakerTokenFilledAmount(orderHashHex: string): Promise<BigNumber> {
+    public async getTakerTokenFilledAmountAsync(orderHashHex: string): Promise<BigNumber> {
         const filledAmount = new BigNumber(await this._exchange.filled.callAsync(orderHashHex));
         return filledAmount;
     }

--- a/packages/contracts/src/utils/formatters.ts
+++ b/packages/contracts/src/utils/formatters.ts
@@ -5,11 +5,16 @@ import { orderUtils } from './order_utils';
 import { BatchCancelOrders, BatchFillOrders, MarketBuyOrders, MarketSellOrders, SignedOrder } from './types';
 
 export const formatters = {
-    createBatchFill(signedOrders: SignedOrder[], takerTokenFillAmounts: BigNumber[] = []) {
+    createBatchFill(
+        signedOrders: SignedOrder[],
+        takerTokenFillAmounts: BigNumber[] = [],
+        defaultParamsIds: BigNumber[] = [],
+    ) {
         const batchFill: BatchFillOrders = {
             orders: [],
             signatures: [],
             takerTokenFillAmounts,
+            defaultParamsIds,
         };
         _.forEach(signedOrders, signedOrder => {
             const orderStruct = orderUtils.getOrderStruct(signedOrder);
@@ -18,42 +23,69 @@ export const formatters = {
             if (takerTokenFillAmounts.length < signedOrders.length) {
                 batchFill.takerTokenFillAmounts.push(signedOrder.takerTokenAmount);
             }
+            if (defaultParamsIds.length < signedOrders.length) {
+                const nullId = new BigNumber(0);
+                batchFill.defaultParamsIds.push(nullId);
+            }
         });
         return batchFill;
     },
-    createMarketSellOrders(signedOrders: SignedOrder[], takerTokenFillAmount: BigNumber) {
+    createMarketSellOrders(
+        signedOrders: SignedOrder[],
+        takerTokenFillAmount: BigNumber,
+        defaultParamsIds: BigNumber[] = [],
+    ) {
         const marketSellOrders: MarketSellOrders = {
             orders: [],
             signatures: [],
             takerTokenFillAmount,
+            defaultParamsIds,
         };
         _.forEach(signedOrders, signedOrder => {
             const orderStruct = orderUtils.getOrderStruct(signedOrder);
             marketSellOrders.orders.push(orderStruct);
             marketSellOrders.signatures.push(signedOrder.signature);
+            if (defaultParamsIds.length < signedOrders.length) {
+                const nullId = new BigNumber(0);
+                marketSellOrders.defaultParamsIds.push(nullId);
+            }
         });
         return marketSellOrders;
     },
-    createMarketBuyOrders(signedOrders: SignedOrder[], makerTokenFillAmount: BigNumber) {
+    createMarketBuyOrders(
+        signedOrders: SignedOrder[],
+        makerTokenFillAmount: BigNumber,
+        defaultParamsIds: BigNumber[] = [],
+    ) {
         const marketBuyOrders: MarketBuyOrders = {
             orders: [],
             signatures: [],
             makerTokenFillAmount,
+            defaultParamsIds,
         };
         _.forEach(signedOrders, signedOrder => {
             const orderStruct = orderUtils.getOrderStruct(signedOrder);
             marketBuyOrders.orders.push(orderStruct);
             marketBuyOrders.signatures.push(signedOrder.signature);
+            if (defaultParamsIds.length < signedOrders.length) {
+                const nullId = new BigNumber(0);
+                marketBuyOrders.defaultParamsIds.push(nullId);
+            }
         });
         return marketBuyOrders;
     },
-    createBatchCancel(signedOrders: SignedOrder[]) {
+    createBatchCancel(signedOrders: SignedOrder[], defaultParamsIds: BigNumber[] = []) {
         const batchCancel: BatchCancelOrders = {
             orders: [],
+            defaultParamsIds,
         };
         _.forEach(signedOrders, signedOrder => {
             const orderStruct = orderUtils.getOrderStruct(signedOrder);
             batchCancel.orders.push(orderStruct);
+            if (defaultParamsIds.length < signedOrders.length) {
+                const nullId = new BigNumber(0);
+                batchCancel.defaultParamsIds.push(nullId);
+            }
         });
         return batchCancel;
     },

--- a/packages/contracts/src/utils/order_utils.ts
+++ b/packages/contracts/src/utils/order_utils.ts
@@ -7,18 +7,19 @@ import { crypto } from './crypto';
 import { OrderStruct, SignatureType, SignedOrder, UnsignedOrder } from './types';
 
 export const orderUtils = {
-    createFill: (signedOrder: SignedOrder, takerTokenFillAmount?: BigNumber) => {
+    createFill: (signedOrder: SignedOrder, takerTokenFillAmount?: BigNumber, defaultParamsIds?: BigNumber) => {
         const fill = {
             order: orderUtils.getOrderStruct(signedOrder),
             takerTokenFillAmount: takerTokenFillAmount || signedOrder.takerTokenAmount,
+            defaultParamsId: defaultParamsIds || new BigNumber(0),
             signature: signedOrder.signature,
         };
         return fill;
     },
-    createCancel(signedOrder: SignedOrder, takerTokenCancelAmount?: BigNumber) {
+    createCancel(signedOrder: SignedOrder, defaultParamsIds?: BigNumber) {
         const cancel = {
             order: orderUtils.getOrderStruct(signedOrder),
-            takerTokenCancelAmount: takerTokenCancelAmount || signedOrder.takerTokenAmount,
+            defaultParamsIds: defaultParamsIds || new BigNumber(0),
         };
         return cancel;
     },

--- a/packages/contracts/src/utils/types.ts
+++ b/packages/contracts/src/utils/types.ts
@@ -15,22 +15,26 @@ export interface BatchFillOrders {
     orders: OrderStruct[];
     signatures: string[];
     takerTokenFillAmounts: BigNumber[];
+    defaultParamsIds: BigNumber[];
 }
 
 export interface MarketSellOrders {
     orders: OrderStruct[];
     signatures: string[];
     takerTokenFillAmount: BigNumber;
+    defaultParamsIds: BigNumber[];
 }
 
 export interface MarketBuyOrders {
     orders: OrderStruct[];
     signatures: string[];
     makerTokenFillAmount: BigNumber;
+    defaultParamsIds: BigNumber[];
 }
 
 export interface BatchCancelOrders {
     orders: OrderStruct[];
+    defaultParamsIds: BigNumber[];
 }
 
 export interface CancelOrdersBefore {

--- a/packages/contracts/test/exchange/core.ts
+++ b/packages/contracts/test/exchange/core.ts
@@ -147,7 +147,7 @@ describe('Exchange', () => {
                 takerTokenAmount: new BigNumber(3),
             });
 
-            const takerTokenFilledAmountBefore = await exWrapper.getTakerTokenFilledAmount(
+            const takerTokenFilledAmountBefore = await exWrapper.getTakerTokenFilledAmountAsync(
                 orderUtils.getOrderHashHex(signedOrder),
             );
             expect(takerTokenFilledAmountBefore).to.be.bignumber.equal(0);
@@ -157,7 +157,7 @@ describe('Exchange', () => {
                 takerTokenFillAmount: fillTakerTokenAmount1,
             });
 
-            const takerTokenFilledAmountAfter1 = await exWrapper.getTakerTokenFilledAmount(
+            const takerTokenFilledAmountAfter1 = await exWrapper.getTakerTokenFilledAmountAsync(
                 orderUtils.getOrderHashHex(signedOrder),
             );
             expect(takerTokenFilledAmountAfter1).to.be.bignumber.equal(fillTakerTokenAmount1);
@@ -167,7 +167,7 @@ describe('Exchange', () => {
                 takerTokenFillAmount: fillTakerTokenAmount2,
             });
 
-            const takerTokenFilledAmountAfter2 = await exWrapper.getTakerTokenFilledAmount(
+            const takerTokenFilledAmountAfter2 = await exWrapper.getTakerTokenFilledAmountAsync(
                 orderUtils.getOrderHashHex(signedOrder),
             );
             expect(takerTokenFilledAmountAfter2).to.be.bignumber.equal(takerTokenFilledAmountAfter1);
@@ -179,7 +179,7 @@ describe('Exchange', () => {
                 takerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(100), 18),
             });
 
-            const takerTokenFilledAmountBefore = await exWrapper.getTakerTokenFilledAmount(
+            const takerTokenFilledAmountBefore = await exWrapper.getTakerTokenFilledAmountAsync(
                 orderUtils.getOrderHashHex(signedOrder),
             );
             expect(takerTokenFilledAmountBefore).to.be.bignumber.equal(0);
@@ -187,7 +187,7 @@ describe('Exchange', () => {
             const takerTokenFillAmount = signedOrder.takerTokenAmount.div(2);
             await exWrapper.fillOrderAsync(signedOrder, takerAddress, { takerTokenFillAmount });
 
-            const makerAmountBoughtAfter = await exWrapper.getTakerTokenFilledAmount(
+            const makerAmountBoughtAfter = await exWrapper.getTakerTokenFilledAmountAsync(
                 orderUtils.getOrderHashHex(signedOrder),
             );
             expect(makerAmountBoughtAfter).to.be.bignumber.equal(takerTokenFillAmount);
@@ -232,7 +232,7 @@ describe('Exchange', () => {
                 takerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(100), 18),
             });
 
-            const takerTokenFilledAmountBefore = await exWrapper.getTakerTokenFilledAmount(
+            const takerTokenFilledAmountBefore = await exWrapper.getTakerTokenFilledAmountAsync(
                 orderUtils.getOrderHashHex(signedOrder),
             );
             expect(takerTokenFilledAmountBefore).to.be.bignumber.equal(0);
@@ -240,7 +240,7 @@ describe('Exchange', () => {
             const takerTokenFillAmount = signedOrder.takerTokenAmount.div(2);
             await exWrapper.fillOrderAsync(signedOrder, takerAddress, { takerTokenFillAmount });
 
-            const makerAmountBoughtAfter = await exWrapper.getTakerTokenFilledAmount(
+            const makerAmountBoughtAfter = await exWrapper.getTakerTokenFilledAmountAsync(
                 orderUtils.getOrderHashHex(signedOrder),
             );
             expect(makerAmountBoughtAfter).to.be.bignumber.equal(takerTokenFillAmount);
@@ -285,7 +285,7 @@ describe('Exchange', () => {
                 takerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(200), 18),
             });
 
-            const takerTokenFilledAmountBefore = await exWrapper.getTakerTokenFilledAmount(
+            const takerTokenFilledAmountBefore = await exWrapper.getTakerTokenFilledAmountAsync(
                 orderUtils.getOrderHashHex(signedOrder),
             );
             expect(takerTokenFilledAmountBefore).to.be.bignumber.equal(0);
@@ -293,7 +293,7 @@ describe('Exchange', () => {
             const takerTokenFillAmount = signedOrder.takerTokenAmount.div(2);
             await exWrapper.fillOrderAsync(signedOrder, takerAddress, { takerTokenFillAmount });
 
-            const makerAmountBoughtAfter = await exWrapper.getTakerTokenFilledAmount(
+            const makerAmountBoughtAfter = await exWrapper.getTakerTokenFilledAmountAsync(
                 orderUtils.getOrderHashHex(signedOrder),
             );
             expect(makerAmountBoughtAfter).to.be.bignumber.equal(takerTokenFillAmount);
@@ -339,7 +339,7 @@ describe('Exchange', () => {
                 takerTokenAmount: ZeroEx.toBaseUnitAmount(new BigNumber(200), 18),
             });
 
-            const takerTokenFilledAmountBefore = await exWrapper.getTakerTokenFilledAmount(
+            const takerTokenFilledAmountBefore = await exWrapper.getTakerTokenFilledAmountAsync(
                 orderUtils.getOrderHashHex(signedOrder),
             );
             expect(takerTokenFilledAmountBefore).to.be.bignumber.equal(0);
@@ -347,7 +347,7 @@ describe('Exchange', () => {
             const takerTokenFillAmount = signedOrder.takerTokenAmount.div(2);
             await exWrapper.fillOrderAsync(signedOrder, takerAddress, { takerTokenFillAmount });
 
-            const makerAmountBoughtAfter = await exWrapper.getTakerTokenFilledAmount(
+            const makerAmountBoughtAfter = await exWrapper.getTakerTokenFilledAmountAsync(
                 orderUtils.getOrderHashHex(signedOrder),
             );
             const expectedMakerAmountBoughtAfter = takerTokenFillAmount.add(takerTokenFilledAmountBefore);


### PR DESCRIPTION
<!--- Thank you for taking the time to submit a Pull Request -->

<!--- Provide a general summary of the issue in the Title above -->

## Description

This PR adds the ability to register default order parameters on-chain, which can be specified when filling an order.

<!--- Describe your changes in detail -->

## Motivation and Context

This change let's users remove non-zero bytes from calldata (by registering those parameters as defaults), which can result in a lot of gas savings for frequent users.

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Current tests all pass. Need to add tests for when defaults are actually specified.

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [x] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOGs.
*   [ ] Updated the new versions of the changed packages in the relevant CHANGELOGs.
*   [x] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
