### PR TITLE
Fix relative link

### DIFF
--- a/packages/json-schemas/README.md
+++ b/packages/json-schemas/README.md
@@ -2,7 +2,7 @@
 
 Contains 0x-related json schemas
 
-### Read the [Documentation](0xproject.com/docs/json-schemas).
+### Read the [Documentation](https://0xproject.com/docs/json-schemas).
 
 ## Installation
 


### PR DESCRIPTION
0xproject.com/docs/json-schemas  -->  https://0xproject.com/docs/json-schemas

## Description

Converte relative link to absolute.

## Motivation and Context

Relative links are appended to github.com and 404.

## How Has This Been Tested?

I clicked the link and it worked.

## Types of changes

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOGs.
*   [ ] Updated the new versions of the changed packages in the relevant CHANGELOGs.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
