### PR TITLE
Fix expiration watcher comparator

### DIFF
--- a/packages/0x.js/CHANGELOG.json
+++ b/packages/0x.js/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "0.36.2",
+        "changes": [
+            {
+                "note": "Fixed expiration watcher comparator to handle orders with equal expiration times",
+                "pr": 526
+            }
+        ]
+    },
+    {
         "version": "0.36.1",
         "changes": [
             {

--- a/packages/0x.js/package.json
+++ b/packages/0x.js/package.json
@@ -26,7 +26,7 @@
         "build:umd:prod": "NODE_ENV=production webpack",
         "build:commonjs": "tsc && yarn update_artifacts && copyfiles -u 2 './src/compact_artifacts/**/*.json' ./lib/src/compact_artifacts && copyfiles -u 3 './lib/src/monorepo_scripts/**/*' ./scripts",
         "test:commonjs": "run-s build:commonjs run_mocha",
-        "run_mocha": "mocha lib/test/**/*_test.js --timeout 10000 --bail --exit",
+        "run_mocha": "mocha lib/test/**/*_test.js lib/test/global_hooks.js --timeout 10000 --bail --exit",
         "manual:postpublish": "yarn build; node ./scripts/postpublish.js",
         "docs:stage": "yarn build && node ./scripts/stage_docs.js",
         "docs:json": "typedoc --excludePrivate --excludeExternals --target ES5 --json $JSON_FILE_PATH $PROJECT_FILES",
@@ -115,7 +115,7 @@
         "web3": "^0.20.0"
     },
     "optionalDependencies": {
-        "@0xproject/migrations": "^0.0.1"
+        "@0xproject/migrations": "^0.0.2"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/0x.js/test/0x.js_test.ts
+++ b/packages/0x.js/test/0x.js_test.ts
@@ -1,9 +1,4 @@
-import { Deployer } from '@0xproject/deployer';
 import { BlockchainLifecycle, devConstants, web3Factory } from '@0xproject/dev-utils';
-// HACK: This dependency is optional since it is only available when run from within
-// the monorepo. tslint doesn't handle optional dependencies
-// tslint:disable-next-line:no-implicit-dependencies
-import { runMigrationsAsync } from '@0xproject/migrations';
 import { BigNumber } from '@0xproject/utils';
 import * as chai from 'chai';
 import * as _ from 'lodash';
@@ -15,7 +10,6 @@ import { ApprovalContractEventArgs, LogWithDecodedArgs, Order, TokenEvents, Zero
 
 import { chaiSetup } from './utils/chai_setup';
 import { constants } from './utils/constants';
-import { deployer } from './utils/deployer';
 import { TokenUtils } from './utils/token_utils';
 import { provider, web3Wrapper } from './utils/web3_wrapper';
 
@@ -28,7 +22,6 @@ const SHOULD_ADD_PERSONAL_MESSAGE_PREFIX = false;
 describe('ZeroEx library', () => {
     let zeroEx: ZeroEx;
     before(async () => {
-        await runMigrationsAsync(deployer);
         const config = {
             networkId: constants.TESTRPC_NETWORK_ID,
         };

--- a/packages/0x.js/test/global_hooks.ts
+++ b/packages/0x.js/test/global_hooks.ts
@@ -1,0 +1,10 @@
+// HACK: This dependency is optional since it is only available when run from within
+// the monorepo. tslint doesn't handle optional dependencies
+// tslint:disable-next-line:no-implicit-dependencies
+import { runMigrationsAsync } from '@0xproject/migrations';
+
+import { deployer } from './utils/deployer';
+
+before('migrate contracts', async () => {
+    await runMigrationsAsync(deployer);
+});

--- a/packages/0x.js/test/global_hooks.ts
+++ b/packages/0x.js/test/global_hooks.ts
@@ -1,6 +1,3 @@
-// HACK: This dependency is optional since it is only available when run from within
-// the monorepo. tslint doesn't handle optional dependencies
-// tslint:disable-next-line:no-implicit-dependencies
 import { runMigrationsAsync } from '@0xproject/migrations';
 
 import { deployer } from './utils/deployer';

--- a/packages/migrations/src/migration.ts
+++ b/packages/migrations/src/migration.ts
@@ -69,7 +69,7 @@ export const runMigrationsAsync = async (deployer: Deployer) => {
         },
     );
     for (const token of tokenInfo) {
-        const totalSupply = new BigNumber(0);
+        const totalSupply = new BigNumber(100000000000000000000);
         const args = [token.name, token.symbol, token.decimals, totalSupply];
         const dummyToken = await deployer.deployAsync(ContractName.DummyToken, args);
         await tokenReg.addToken.sendTransactionAsync(


### PR DESCRIPTION
## Description

RB tree is unable to store values with the same key. Before - we user expiraration time as a key.
This PR changes that and adds order hash as a secondary key

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Added a regression test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOGs.
*   [ ] Updated the new versions of the changed packages in the relevant CHANGELOGs.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
