### PR TITLE
Fix redundant expired order removal bug

### DIFF
--- a/packages/0x.js/CHANGELOG.json
+++ b/packages/0x.js/CHANGELOG.json
@@ -4,6 +4,10 @@
         "changes": [
             {
                 "note": "Internal changes and refactoring"
+            },
+            {
+                "note": "Fix redundant expired order removal bug",
+                "pr": 527
             }
         ]
     },

--- a/packages/0x.js/src/order_watcher/expiration_watcher.ts
+++ b/packages/0x.js/src/order_watcher/expiration_watcher.ts
@@ -48,6 +48,9 @@ export class ExpirationWatcher {
         this._orderHashByExpirationRBTree.insert(orderHash);
     }
     public removeOrder(orderHash: string): void {
+        if (_.isUndefined(this._expiration[orderHash])) {
+            return; // noop since order already removed
+        }
         this._orderHashByExpirationRBTree.remove(orderHash);
         delete this._expiration[orderHash];
     }

--- a/packages/0x.js/src/order_watcher/order_state_watcher.ts
+++ b/packages/0x.js/src/order_watcher/order_state_watcher.ts
@@ -123,7 +123,7 @@ export class OrderStateWatcher {
      * Removes an order from the orderStateWatcher
      * @param   orderHash     The orderHash of the order you wish to stop watching.
      */
-    public removeOrder(orderHash: string): void {
+    public removeOrder(orderHash: string, removeFromExpirationWatcher: boolean = true): void {
         assert.doesConformToSchema('orderHash', orderHash, schemas.orderHashSchema);
         const signedOrder = this._orderByOrderHash[orderHash];
         if (_.isUndefined(signedOrder)) {
@@ -139,7 +139,9 @@ export class OrderStateWatcher {
             this._removeFromDependentOrderHashes(signedOrder.maker, signedOrder.makerTokenAddress, orderHash);
         }
 
-        this._expirationWatcher.removeOrder(orderHash);
+        if (removeFromExpirationWatcher) {
+            this._expirationWatcher.removeOrder(orderHash);
+        }
     }
     /**
      * Starts an orderStateWatcher subscription. The callback will be called every time a watched order's
@@ -212,7 +214,7 @@ export class OrderStateWatcher {
             error: ExchangeContractErrs.OrderFillExpired,
         };
         if (!_.isUndefined(this._orderByOrderHash[orderHash])) {
-            this.removeOrder(orderHash);
+            this.removeOrder(orderHash, false);
             if (!_.isUndefined(this._callbackIfExists)) {
                 this._callbackIfExists(null, orderState);
             }

--- a/packages/0x.js/src/order_watcher/order_state_watcher.ts
+++ b/packages/0x.js/src/order_watcher/order_state_watcher.ts
@@ -123,7 +123,7 @@ export class OrderStateWatcher {
      * Removes an order from the orderStateWatcher
      * @param   orderHash     The orderHash of the order you wish to stop watching.
      */
-    public removeOrder(orderHash: string, removeFromExpirationWatcher: boolean = true): void {
+    public removeOrder(orderHash: string): void {
         assert.doesConformToSchema('orderHash', orderHash, schemas.orderHashSchema);
         const signedOrder = this._orderByOrderHash[orderHash];
         if (_.isUndefined(signedOrder)) {
@@ -139,9 +139,7 @@ export class OrderStateWatcher {
             this._removeFromDependentOrderHashes(signedOrder.maker, signedOrder.makerTokenAddress, orderHash);
         }
 
-        if (removeFromExpirationWatcher) {
-            this._expirationWatcher.removeOrder(orderHash);
-        }
+        this._expirationWatcher.removeOrder(orderHash);
     }
     /**
      * Starts an orderStateWatcher subscription. The callback will be called every time a watched order's
@@ -214,7 +212,7 @@ export class OrderStateWatcher {
             error: ExchangeContractErrs.OrderFillExpired,
         };
         if (!_.isUndefined(this._orderByOrderHash[orderHash])) {
-            this.removeOrder(orderHash, false);
+            this.removeOrder(orderHash);
             if (!_.isUndefined(this._callbackIfExists)) {
                 this._callbackIfExists(null, orderState);
             }


### PR DESCRIPTION
<!--- Thank you for taking the time to submit a Pull Request -->

<!--- Provide a general summary of the issue in the Title above -->

## Description
There appears to be a bug related to recursive attempts to remove orders from expiration_watcher.

What happens is that `_pruneExpiredOrders` removes the order from both the RBtree and the expiration stack, but when the `_onOrderExpired` callback executes at the end, it invokes `expiration_watcher.removeOrder()`, but since the order was already removed, it blows up in the scoreFunction (see this [screenshot](https://i.imgur.com/t3ltrpp.png) from my debugger).

This is a fix to ensure that the `_onOrderExpired` skips `expiration_watcher.removeOrder()` when `expiration_watcher` has already handled the order removal.

<!--- Describe your changes in detail -->

## Motivation and Context
When testing OrderStateWatcher for expired orders I identified an issue where when I had multiple orders in the stack, the first expiration would fail to execute the `OnOrderStateChangeCallback`.

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

When you add two orders to OrderStateWatcher, when the first one expires, it fails to execute the callback but doesn't display an error since it get's caught in the `intervalUtils.setInterval` try/catch (see this [screenshot](https://i.imgur.com/t3ltrpp.png) from my debugger)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOGs.
*   [ ] Updated the new versions of the changed packages in the relevant CHANGELOGs.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.