### PR TITLE
Rename Portal component to PortalDetails 

### DIFF
--- a/packages/website/ts/components/portal_details.tsx
+++ b/packages/website/ts/components/portal_details.tsx
@@ -14,7 +14,7 @@ import { WrappedEthSectionNoticeDialog } from 'ts/components/dialogs/wrapped_eth
 import { EthWrappers } from 'ts/components/eth_wrappers';
 import { FillOrder } from 'ts/components/fill_order';
 import { Footer } from 'ts/components/footer';
-import { PortalMenu } from 'ts/components/portal_menu';
+import { PortalDetailsMenu } from 'ts/components/portal_details_menu';
 import { RelayerIndex } from 'ts/components/relayer_index/relayer_index';
 import { TokenBalances } from 'ts/components/token_balances';
 import { TopBar } from 'ts/components/top_bar/top_bar';
@@ -43,9 +43,7 @@ import { utils } from 'ts/utils/utils';
 
 const THROTTLE_TIMEOUT = 100;
 
-export interface PortalPassedProps {}
-
-export interface PortalAllProps {
+export interface PortalDetailsProps {
     blockchainErr: BlockchainErrs;
     blockchainIsLoaded: boolean;
     dispatcher: Dispatcher;
@@ -67,7 +65,7 @@ export interface PortalAllProps {
     translate: Translate;
 }
 
-interface PortalAllState {
+interface PortalDetailsState {
     prevNetworkId: number;
     prevNodeVersion: string;
     prevUserAddress: string;
@@ -77,7 +75,7 @@ interface PortalAllState {
     isLedgerDialogOpen: boolean;
 }
 
-export class Portal extends React.Component<PortalAllProps, PortalAllState> {
+export class PortalDetails extends React.Component<PortalDetailsProps, PortalDetailsState> {
     private _blockchain: Blockchain;
     private _sharedOrderIfExists: Order;
     private _throttledScreenWidthUpdate: () => void;
@@ -86,13 +84,13 @@ export class Portal extends React.Component<PortalAllProps, PortalAllState> {
         const hasAlreadyDismissedWethNotice = !_.isUndefined(didDismissWethNotice) && !_.isEmpty(didDismissWethNotice);
         return hasAlreadyDismissedWethNotice;
     }
-    constructor(props: PortalAllProps) {
+    constructor(props: PortalDetailsProps) {
         super(props);
         this._sharedOrderIfExists = this._getSharedOrderIfExists();
         this._throttledScreenWidthUpdate = _.throttle(this._updateScreenWidth.bind(this), THROTTLE_TIMEOUT);
 
         const isViewingBalances = _.includes(props.location.pathname, `${WebsitePaths.Portal}/balances`);
-        const hasAlreadyDismissedWethNotice = Portal.hasAlreadyDismissedWethNotice();
+        const hasAlreadyDismissedWethNotice = PortalDetails.hasAlreadyDismissedWethNotice();
 
         const didAcceptPortalDisclaimer = localStorage.getItemIfExists(constants.LOCAL_STORAGE_KEY_ACCEPT_DISCLAIMER);
         const hasAcceptedDisclaimer =
@@ -123,7 +121,7 @@ export class Portal extends React.Component<PortalAllProps, PortalAllState> {
         // become disconnected from their backing Ethereum node, changes user accounts, etc...)
         this.props.dispatcher.resetState();
     }
-    public componentWillReceiveProps(nextProps: PortalAllProps) {
+    public componentWillReceiveProps(nextProps: PortalDetailsProps) {
         if (nextProps.networkId !== this.state.prevNetworkId) {
             // tslint:disable-next-line:no-floating-promises
             this._blockchain.networkIdUpdatedFireAndForgetAsync(nextProps.networkId);
@@ -145,7 +143,7 @@ export class Portal extends React.Component<PortalAllProps, PortalAllState> {
         }
         if (nextProps.location.pathname !== this.state.prevPathname) {
             const isViewingBalances = _.includes(nextProps.location.pathname, `${WebsitePaths.Portal}/balances`);
-            const hasAlreadyDismissedWethNotice = Portal.hasAlreadyDismissedWethNotice();
+            const hasAlreadyDismissedWethNotice = PortalDetails.hasAlreadyDismissedWethNotice();
             this.setState({
                 prevPathname: nextProps.location.pathname,
                 isWethNoticeDialogOpen: !hasAlreadyDismissedWethNotice && isViewingBalances,
@@ -200,7 +198,7 @@ export class Portal extends React.Component<PortalAllProps, PortalAllState> {
                         ) : (
                             <div className="mx-auto flex">
                                 <div className="col col-2 pr2 pt1 sm-hide xs-hide" style={portalMenuContainerStyle}>
-                                    <PortalMenu menuItemStyle={{ color: colors.white }} />
+                                    <PortalDetailsMenu menuItemStyle={{ color: colors.white }} />
                                 </div>
                                 <div className="col col-12 lg-col-10 md-col-10 sm-col sm-col-12">
                                     <div className="py2" style={{ backgroundColor: colors.grey50 }}>

--- a/packages/website/ts/components/portal_details_menu.tsx
+++ b/packages/website/ts/components/portal_details_menu.tsx
@@ -4,15 +4,15 @@ import { MenuItem } from 'ts/components/ui/menu_item';
 import { Environments, WebsitePaths } from 'ts/types';
 import { configs } from 'ts/utils/configs';
 
-export interface PortalMenuProps {
+export interface PortalDetailsMenuProps {
     menuItemStyle: React.CSSProperties;
     onClick?: () => void;
 }
 
-interface PortalMenuState {}
+interface PortalDetailsMenuState {}
 
-export class PortalMenu extends React.Component<PortalMenuProps, PortalMenuState> {
-    public static defaultProps: Partial<PortalMenuProps> = {
+export class PortalDetailsMenu extends React.Component<PortalDetailsMenuProps, PortalDetailsMenuState> {
+    public static defaultProps: Partial<PortalDetailsMenuProps> = {
         onClick: _.noop,
     };
     public render() {

--- a/packages/website/ts/components/top_bar/top_bar.tsx
+++ b/packages/website/ts/components/top_bar/top_bar.tsx
@@ -8,7 +8,7 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 import ReactTooltip = require('react-tooltip');
 import { Blockchain } from 'ts/blockchain';
-import { PortalMenu } from 'ts/components/portal_menu';
+import { PortalDetailsMenu } from 'ts/components/portal_details_menu';
 import { SidebarHeader } from 'ts/components/sidebar_header';
 import { ProviderDisplay } from 'ts/components/top_bar/provider_display';
 import { TopBarMenuItem } from 'ts/components/top_bar/top_bar_menu_item';
@@ -431,7 +431,7 @@ export class TopBar extends React.Component<TopBarProps, TopBarState> {
                 <div className="pl1 py1" style={{ backgroundColor: colors.lightGrey }}>
                     {this.props.translate.get(Key.PortalDApp, Deco.CapWords)}
                 </div>
-                <PortalMenu menuItemStyle={{ color: 'black' }} onClick={this._onMenuButtonClick.bind(this)} />
+                <PortalDetailsMenu menuItemStyle={{ color: 'black' }} onClick={this._onMenuButtonClick.bind(this)} />
             </div>
         );
     }

--- a/packages/website/ts/containers/portal.ts
+++ b/packages/website/ts/containers/portal.ts
@@ -3,7 +3,7 @@ import * as _ from 'lodash';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
-import { Portal as PortalComponent, PortalAllProps as PortalComponentAllProps } from 'ts/components/portal';
+import { PortalDetails, PortalDetailsProps } from 'ts/components/portal_details';
 import { Dispatcher } from 'ts/redux/dispatcher';
 import { State } from 'ts/redux/reducer';
 import { BlockchainErrs, HashData, Order, ProviderType, ScreenWidths, Side, TokenByAddress } from 'ts/types';
@@ -34,7 +34,7 @@ interface ConnectedDispatch {
     dispatcher: Dispatcher;
 }
 
-const mapStateToProps = (state: State, ownProps: PortalComponentAllProps): ConnectedState => {
+const mapStateToProps = (state: State, ownProps: PortalDetailsProps): ConnectedState => {
     const receiveAssetToken = state.sideToAssetToken[Side.Receive];
     const depositAssetToken = state.sideToAssetToken[Side.Deposit];
     const receiveAddress = !_.isUndefined(receiveAssetToken.address)
@@ -83,6 +83,6 @@ const mapDispatchToProps = (dispatch: Dispatch<State>): ConnectedDispatch => ({
     dispatcher: new Dispatcher(dispatch),
 });
 
-export const Portal: React.ComponentClass<PortalComponentAllProps> = connect(mapStateToProps, mapDispatchToProps)(
-    PortalComponent,
+export const Portal: React.ComponentClass<PortalDetailsProps> = connect(mapStateToProps, mapDispatchToProps)(
+    PortalDetails,
 );


### PR DESCRIPTION
<!--- Thank you for taking the time to submit a Pull Request -->

<!--- Provide a general summary of the issue in the Title above -->

## Description

In preparation for moving to a new main portal component, this refactor simply renames the existing `Portal` and `PortalMenu` components to `PortalDetails` and `PortalDetailsMenu` respectively. This component will still live in a separate screen reachable from the main portal interface (click on the "manage your wallet" button beneath the wallet component).

## Motivation and Context

See above.

## How Has This Been Tested?

Manually.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
