### PR TITLE
Add hard coded proxyId into each AssetProxy

### DIFF
--- a/packages/contracts/src/contracts/current/protocol/AssetProxy/IAssetProxy.sol
+++ b/packages/contracts/src/contracts/current/protocol/AssetProxy/IAssetProxy.sol
@@ -33,4 +33,11 @@ contract IAssetProxy is IAuthorizable {
         address to,
         uint256 amount)
         external;
+    
+    /// @dev Gets the proxy id associated with the proxy address.
+    /// @return Proxy id.
+    function getProxyId()
+        external
+        view
+        returns (uint8);
 }

--- a/packages/contracts/src/contracts/current/protocol/AssetProxy/proxies/ERC20Proxy.sol
+++ b/packages/contracts/src/contracts/current/protocol/AssetProxy/proxies/ERC20Proxy.sol
@@ -29,6 +29,8 @@ contract ERC20Proxy is
     IAssetProxy
 {
 
+    uint8 constant PROXY_ID = 1;
+
     /// @dev Transfers ERC20 tokens. Either succeeds or throws.
     /// @param assetMetadata ERC20-encoded byte array.
     /// @param from Address to transfer token from.
@@ -42,9 +44,25 @@ contract ERC20Proxy is
         external
         onlyAuthorized
     {
+        // Data must be intended for this proxy.
+        require(uint8(assetMetadata[0]) == PROXY_ID);
+
+        // Decode metadata.
         require(assetMetadata.length == 21);
         address token = readAddress(assetMetadata, 1);
+
+        // Transfer tokens.
         bool success = IERC20Token(token).transferFrom(from, to, amount);
         require(success == true);
+    }
+
+    /// @dev Gets the proxy id associated with the proxy address.
+    /// @return Proxy id.
+    function getProxyId()
+        external
+        view
+        returns (uint8)
+    {
+        return PROXY_ID;
     }
 }

--- a/packages/contracts/src/contracts/current/protocol/AssetProxy/proxies/ERC721Proxy.sol
+++ b/packages/contracts/src/contracts/current/protocol/AssetProxy/proxies/ERC721Proxy.sol
@@ -29,6 +29,8 @@ contract ERC721Proxy is
     IAssetProxy
 {
 
+    uint8 constant PROXY_ID = 2;
+
     /// @dev Transfers ERC721 tokens. Either succeeds or throws.
     /// @param assetMetadata ERC721-encoded byte array
     /// @param from Address to transfer token from.
@@ -42,17 +44,31 @@ contract ERC721Proxy is
         external
         onlyAuthorized
     {
+        // Data must be intended for this proxy.
+        require(uint8(assetMetadata[0]) == PROXY_ID);
+
         // There exists only 1 of each token.
         require(amount == 1);
 
-        // Decode metadata
+        // Decode metadata.
         require(assetMetadata.length == 53);
         address token = readAddress(assetMetadata, 1);
         uint256 tokenId = readUint256(assetMetadata, 21);
 
+        // Transfer token.
         // Either succeeds or throws.
         // @TODO: Call safeTransferFrom if there is additional
         //        data stored in `assetMetadata`.
         ERC721Token(token).transferFrom(from, to, tokenId);
+    }
+
+    /// @dev Gets the proxy id associated with the proxy address.
+    /// @return Proxy id.
+    function getProxyId()
+        external
+        view
+        returns (uint8)
+    {
+        return PROXY_ID;
     }
 }

--- a/packages/contracts/src/contracts/current/protocol/Exchange/MixinAssetProxyDispatcher.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/MixinAssetProxyDispatcher.sol
@@ -54,8 +54,7 @@ contract MixinAssetProxyDispatcher is
     }
 
     /// @dev Registers an asset proxy to an asset proxy id.
-    ///      An id can only be assigned to a single proxy at a given time,
-    ///      however, an asset proxy may be registered to multiple ids.
+    ///      An id can only be assigned to a single proxy at a given time.
     /// @param assetProxyId Id to register`newAssetProxy` under.
     /// @param newAssetProxy Address of new asset proxy to register, or 0x0 to unset assetProxyId.
     /// @param oldAssetProxy Existing asset proxy to overwrite, or 0x0 if assetProxyId is currently unused.

--- a/packages/contracts/src/contracts/current/protocol/Exchange/MixinAssetProxyDispatcher.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/MixinAssetProxyDispatcher.sol
@@ -43,7 +43,7 @@ contract MixinAssetProxyDispatcher is
     {
         // Do nothing if no amount should be transferred.
         if (amount > 0) {
-            // Lookup asset proxy
+            // Lookup asset proxy.
             require(assetMetadata.length >= 1);
             uint8 assetProxyId = uint8(assetMetadata[0]);
             IAssetProxy assetProxy = assetProxies[assetProxyId];
@@ -66,11 +66,19 @@ contract MixinAssetProxyDispatcher is
         external
         onlyOwner
     {
-        // Ensure the existing asset proxy is not unintentionally overwritten
+        // Ensure the existing asset proxy is not unintentionally overwritten.
         require(oldAssetProxy == address(assetProxies[assetProxyId]));
 
-        // Add asset proxy and log registration
-        assetProxies[assetProxyId] = IAssetProxy(newAssetProxy);
+        IAssetProxy assetProxy = IAssetProxy(newAssetProxy);
+
+        // Ensure that the id of newAssetProxy matches the passed in assetProxyId, unless it is being reset to 0.
+        if (newAssetProxy != address(0)) {
+            uint8 newAssetProxyId = assetProxy.getProxyId();
+            require(newAssetProxyId == assetProxyId);
+        }
+
+        // Add asset proxy and log registration.
+        assetProxies[assetProxyId] = assetProxy;
         emit AssetProxySet(assetProxyId, newAssetProxy, oldAssetProxy);
     }
 

--- a/packages/contracts/src/contracts/current/protocol/Exchange/mixins/MAssetProxyDispatcher.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/mixins/MAssetProxyDispatcher.sol
@@ -40,8 +40,7 @@ contract MAssetProxyDispatcher {
         internal;
 
     /// @dev Registers an asset proxy to an asset proxy id.
-    ///      An id can only be assigned to a single proxy at a given time,
-    ///      however, an asset proxy may be registered to multiple ids.
+    ///      An id can only be assigned to a single proxy at a given time.
     /// @param assetProxyId Id to register`newAssetProxy` under.
     /// @param newAssetProxy Address of new asset proxy to register, or 0x0 to unset assetProxyId.
     /// @param oldAssetProxy Existing asset proxy to overwrite, or 0x0 if assetProxyId is currently unused.

--- a/packages/contracts/test/asset_proxy/proxies.ts
+++ b/packages/contracts/test/asset_proxy/proxies.ts
@@ -145,6 +145,11 @@ describe('Asset Transfer Proxies', () => {
                 }),
             ).to.be.rejectedWith(constants.REVERT);
         });
+
+        it('should have an id of 1', async () => {
+            const proxyId = await erc20Proxy.getProxyId.callAsync();
+            expect(proxyId).to.equal(1);
+        });
     });
 
     describe('Transfer Proxy - ERC721', () => {
@@ -239,6 +244,11 @@ describe('Asset Transfer Proxies', () => {
                     { from: notAuthorized },
                 ),
             ).to.be.rejectedWith(constants.REVERT);
+        });
+
+        it('should have an id of 2', async () => {
+            const proxyId = await erc721Proxy.getProxyId.callAsync();
+            expect(proxyId).to.equal(2);
         });
     });
 });

--- a/packages/contracts/test/exchange/dispatcher.ts
+++ b/packages/contracts/test/exchange/dispatcher.ts
@@ -194,6 +194,18 @@ describe('AssetProxyDispatcher', () => {
                 ),
             ).to.be.rejectedWith(constants.REVERT);
         });
+
+        it('should throw if attempting to register a proxy to the incorrect id', async () => {
+            const prevProxyAddress = ZeroEx.NULL_ADDRESS;
+            return expect(
+                assetProxyDispatcher.registerAssetProxy.sendTransactionAsync(
+                    AssetProxyId.ERC721,
+                    erc20Proxy.address,
+                    prevProxyAddress,
+                    { from: owner },
+                ),
+            ).to.be.rejectedWith(constants.REVERT);
+        });
     });
 
     describe('getAssetProxy', () => {


### PR DESCRIPTION
<!--- Thank you for taking the time to submit a Pull Request -->

<!--- Provide a general summary of the issue in the Title above -->

## Description

- Hard codes a proxyId into each AssetProxy
- Check that the metadata being passed in is intended for the receiving proxy
- Check the that ids match when registering a new proxy, unless the proxy is being removed

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
