### PR TITLE
Order Watcher validate order on addOrder

### DIFF
--- a/packages/0x.js/CHANGELOG.json
+++ b/packages/0x.js/CHANGELOG.json
@@ -9,6 +9,10 @@
             {
                 "note": "Update Web3 Provider Engine to 14.0.4",
                 "pr": 555
+            },
+            {
+                "note": "Order Watcher config to validate order when calling addOrder",
+                "pr": 566
             }
         ]
     },

--- a/packages/0x.js/src/order_watcher/order_state_watcher.ts
+++ b/packages/0x.js/src/order_watcher/order_state_watcher.ts
@@ -75,6 +75,7 @@ export class OrderStateWatcher {
     private _balanceAndProxyAllowanceLazyStore: BalanceAndProxyAllowanceLazyStore;
     private _cleanupJobInterval: number;
     private _cleanupJobIntervalIdIfExists?: NodeJS.Timer;
+    private _validateOnAddOrder: boolean;
     constructor(
         web3Wrapper: Web3Wrapper,
         token: TokenWrapper,
@@ -104,6 +105,8 @@ export class OrderStateWatcher {
             _.isUndefined(config) || _.isUndefined(config.cleanupJobIntervalMs)
                 ? DEFAULT_CLEANUP_JOB_INTERVAL_MS
                 : config.cleanupJobIntervalMs;
+        this._validateOnAddOrder =
+            _.isUndefined(config) || _.isUndefined(config.validateOnAddOrder) ? false : config.validateOnAddOrder;
     }
     /**
      * Add an order to the orderStateWatcher. Before the order is added, it's
@@ -118,6 +121,9 @@ export class OrderStateWatcher {
         this._addToDependentOrderHashes(signedOrder, orderHash);
         const expirationUnixTimestampMs = signedOrder.expirationUnixTimestampSec.times(1000);
         this._expirationWatcher.addOrder(orderHash, expirationUnixTimestampMs);
+        if (this._validateOnAddOrder) {
+            void this._emitRevalidateOrdersAsync([orderHash]);
+        }
     }
     /**
      * Removes an order from the orderStateWatcher

--- a/packages/0x.js/src/types.ts
+++ b/packages/0x.js/src/types.ts
@@ -161,6 +161,7 @@ export type SyncMethod = (...args: any[]) => any;
  * of an orders expiration. Default=0.
  * cleanupJobIntervalMs: How often to run a cleanup job which revalidates all the orders. Default=1hr.
  * stateLayer: Optional blockchain state layer OrderWatcher will monitor for new events. Default=latest.
+ * validateOnAddOrder: Optional validate the order when the order is added. Default=false.
  */
 export interface OrderStateWatcherConfig {
     orderExpirationCheckingIntervalMs?: number;
@@ -168,6 +169,7 @@ export interface OrderStateWatcherConfig {
     expirationMarginMs?: number;
     cleanupJobIntervalMs?: number;
     stateLayer: BlockParamLiteral;
+    validateOnAddOrder?: boolean;
 }
 
 /**

--- a/packages/0x.js/src/utils/order_state_utils.ts
+++ b/packages/0x.js/src/utils/order_state_utils.ts
@@ -83,27 +83,44 @@ export class OrderStateUtils {
         const exchange = (this._orderFilledCancelledFetcher as any)._exchangeWrapper as ExchangeWrapper;
         const zrxTokenAddress = exchange.getZRXTokenAddress();
         const orderHash = ZeroEx.getOrderHashHex(signedOrder);
-        const makerBalance = await this._balanceAndProxyAllowanceFetcher.getBalanceAsync(
+        const makerBalancePromise = this._balanceAndProxyAllowanceFetcher.getBalanceAsync(
             signedOrder.makerTokenAddress,
             signedOrder.maker,
         );
-        const makerProxyAllowance = await this._balanceAndProxyAllowanceFetcher.getProxyAllowanceAsync(
+        const makerProxyAllowancePromise = this._balanceAndProxyAllowanceFetcher.getProxyAllowanceAsync(
             signedOrder.makerTokenAddress,
             signedOrder.maker,
         );
-        const makerFeeBalance = await this._balanceAndProxyAllowanceFetcher.getBalanceAsync(
+        const makerFeeBalancePromise = this._balanceAndProxyAllowanceFetcher.getBalanceAsync(
             zrxTokenAddress,
             signedOrder.maker,
         );
-        const makerFeeProxyAllowance = await this._balanceAndProxyAllowanceFetcher.getProxyAllowanceAsync(
+        const makerFeeProxyAllowancePromise = this._balanceAndProxyAllowanceFetcher.getProxyAllowanceAsync(
             zrxTokenAddress,
             signedOrder.maker,
         );
-        const filledTakerTokenAmount = await this._orderFilledCancelledFetcher.getFilledTakerAmountAsync(orderHash);
-        const cancelledTakerTokenAmount = await this._orderFilledCancelledFetcher.getCancelledTakerAmountAsync(
+        const filledTakerTokenAmountPromise = this._orderFilledCancelledFetcher.getFilledTakerAmountAsync(orderHash);
+        const cancelledTakerTokenAmountPromise = this._orderFilledCancelledFetcher.getCancelledTakerAmountAsync(
             orderHash,
         );
-        const unavailableTakerTokenAmount = await exchange.getUnavailableTakerAmountAsync(orderHash);
+        const unavailableTakerTokenAmountPromise = exchange.getUnavailableTakerAmountAsync(orderHash);
+        const [
+            makerBalance,
+            makerProxyAllowance,
+            makerFeeBalance,
+            makerFeeProxyAllowance,
+            filledTakerTokenAmount,
+            cancelledTakerTokenAmount,
+            unavailableTakerTokenAmount,
+        ] = await Promise.all([
+            makerBalancePromise,
+            makerProxyAllowancePromise,
+            makerFeeBalancePromise,
+            makerFeeProxyAllowancePromise,
+            filledTakerTokenAmountPromise,
+            cancelledTakerTokenAmountPromise,
+            unavailableTakerTokenAmountPromise,
+        ]);
         const totalMakerTokenAmount = signedOrder.makerTokenAmount;
         const totalTakerTokenAmount = signedOrder.takerTokenAmount;
         const remainingTakerTokenAmount = totalTakerTokenAmount.minus(unavailableTakerTokenAmount);


### PR DESCRIPTION

<!--- Thank you for taking the time to submit a Pull Request -->

<!--- Provide a general summary of the issue in the Title above -->

## Description

Allow a user to specify whether they would like to receive an order state update when the order is added to order state watcher

<!--- Describe your changes in detail -->

## Motivation and Context

When pulling orders from SRA it's beneficial to get the order state before adding to the internal order book. 

It's a bit of wasted effort to do this outside of the order watcher through order state utils as you could have to create a couple of lazy stores out of band.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [x] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [x] Added tests to cover my changes.
*   [x] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
