### PR TITLE
Execute Taker side in trade simulation

### DIFF
--- a/packages/0x.js/src/utils/exchange_transfer_simulator.ts
+++ b/packages/0x.js/src/utils/exchange_transfer_simulator.ts
@@ -67,7 +67,9 @@ export class ExchangeTransferSimulator {
         tradeSide: TradeSide,
         transferType: TransferType,
     ): Promise<void> {
-        // If we are simulating an open order then 0x0 will have no balance or allowance
+        // HACK: When simulating an open order (e.g taker is NULL_ADDRESS), we don't want to adjust balances/
+        // allowances for the taker. We do however, want to increase the balance of the maker since the maker
+        // might be relying on those funds to fill subsequent orders or pay the order's fees.
         if (from === constants.NULL_ADDRESS && tradeSide === TradeSide.Taker) {
             await this._increaseBalanceAsync(tokenAddress, to, amountInBaseUnits);
             return;

--- a/packages/0x.js/src/utils/order_validation_utils.ts
+++ b/packages/0x.js/src/utils/order_validation_utils.ts
@@ -124,31 +124,12 @@ export class OrderValidationUtils {
         if (!_.isUndefined(expectedFillTakerTokenAmount)) {
             fillTakerTokenAmount = expectedFillTakerTokenAmount;
         }
-        const fillMakerTokenAmount = OrderValidationUtils._getPartialAmount(
+        await OrderValidationUtils.validateFillOrderBalancesAllowancesThrowIfInvalidAsync(
+            exchangeTradeEmulator,
+            signedOrder,
             fillTakerTokenAmount,
-            signedOrder.takerTokenAmount,
-            signedOrder.makerTokenAmount,
-        );
-        await exchangeTradeEmulator.transferFromAsync(
-            signedOrder.makerTokenAddress,
-            signedOrder.maker,
             signedOrder.taker,
-            fillMakerTokenAmount,
-            TradeSide.Maker,
-            TransferType.Trade,
-        );
-        const makerFeeAmount = OrderValidationUtils._getPartialAmount(
-            fillTakerTokenAmount,
-            signedOrder.takerTokenAmount,
-            signedOrder.makerFee,
-        );
-        await exchangeTradeEmulator.transferFromAsync(
             zrxTokenAddress,
-            signedOrder.maker,
-            signedOrder.feeRecipient,
-            makerFeeAmount,
-            TradeSide.Maker,
-            TransferType.Fee,
         );
     }
     public async validateFillOrderThrowIfInvalidAsync(

--- a/packages/0x.js/test/order_validation_test.ts
+++ b/packages/0x.js/test/order_validation_test.ts
@@ -68,6 +68,40 @@ describe('OrderValidation', () => {
             );
             await zeroEx.exchange.validateOrderFillableOrThrowAsync(signedOrder);
         });
+        it('should succeed if the maker is buying ZRX and has no ZRX balance', async () => {
+            const makerFee = new BigNumber(2);
+            const takerFee = new BigNumber(2);
+            const signedOrder = await fillScenarios.createFillableSignedOrderWithFeesAsync(
+                makerTokenAddress,
+                zrxTokenAddress,
+                makerFee,
+                takerFee,
+                makerAddress,
+                takerAddress,
+                fillableAmount,
+                feeRecipient,
+            );
+            const zrxMakerBalance = await zeroEx.token.getBalanceAsync(zrxTokenAddress, makerAddress);
+            await zeroEx.token.transferAsync(zrxTokenAddress, makerAddress, takerAddress, zrxMakerBalance);
+            await zeroEx.exchange.validateOrderFillableOrThrowAsync(signedOrder);
+        });
+        it('should succeed if the maker is buying ZRX and has no ZRX balance and there is no specified taker', async () => {
+            const makerFee = new BigNumber(2);
+            const takerFee = new BigNumber(2);
+            const signedOrder = await fillScenarios.createFillableSignedOrderWithFeesAsync(
+                makerTokenAddress,
+                zrxTokenAddress,
+                makerFee,
+                takerFee,
+                makerAddress,
+                constants.NULL_ADDRESS,
+                fillableAmount,
+                feeRecipient,
+            );
+            const zrxMakerBalance = await zeroEx.token.getBalanceAsync(zrxTokenAddress, makerAddress);
+            await zeroEx.token.transferAsync(zrxTokenAddress, makerAddress, takerAddress, zrxMakerBalance);
+            await zeroEx.exchange.validateOrderFillableOrThrowAsync(signedOrder);
+        });
         it('should succeed if the order is asymmetric and fillable', async () => {
             const makerFillableAmount = fillableAmount;
             const takerFillableAmount = fillableAmount.minus(4);
@@ -469,4 +503,4 @@ describe('OrderValidation', () => {
             expect(partialTakerFee).to.be.bignumber.equal(takerPartialFee);
         });
     });
-});
+}); // tslint:disable-line:max-file-line-count


### PR DESCRIPTION
#567

## Description

Simulate both sides of the trade in the exchange simulator

## Motivation and Context

It's possible to just in time fill for fees when buying ZRX. Exchange simulator was only trading the maker side to the taker, as such it would fail the fee simulation as the maker did not receive any ZRX.

The current order state validation code looks intentional to not execute the Taker side (as its likely the order is open to any taker). The exchange simulator now allows for open orders to be simulated. It is assumed there will be further verification with a real taker using `validateFillOrderBalancesAllowancesThrowIfInvalidAsync` or that the taker will have sufficient balance and allowance.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [x] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
