### PR TITLE
Update MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress

### DIFF
--- a/packages/contracts/src/contracts/current/multisig/MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress/MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress.sol
+++ b/packages/contracts/src/contracts/current/multisig/MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress/MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress.sol
@@ -18,15 +18,19 @@
 
 pragma solidity ^0.4.10;
 
-import { MultiSigWalletWithTimeLock } from "../MultiSigWalletWithTimeLock/MultiSigWalletWithTimeLock.sol";
+import "../MultiSigWalletWithTimeLock/MultiSigWalletWithTimeLock.sol";
 
-contract MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress is MultiSigWalletWithTimeLock {
+contract MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress is
+    MultiSigWalletWithTimeLock
+{
+    event AssetProxyRegistration(address assetProxyContract, bool isRegistered);
 
-    address public TOKEN_TRANSFER_PROXY_CONTRACT;
+    // Mapping of AssetProxy contract address => approved to execute removeAuthorizedAddress without time lock.
+    mapping (address => bool) public isAssetProxyRegistered;
 
-    modifier validRemoveAuthorizedAddressTx(uint transactionId) {
+    modifier validRemoveAuthorizedAddressTx(uint256 transactionId) {
         Transaction storage tx = transactions[transactionId];
-        require(tx.destination == TOKEN_TRANSFER_PROXY_CONTRACT);
+        require(isAssetProxyRegistered[tx.destination]);
         require(isFunctionRemoveAuthorizedAddress(tx.data));
         _;
     }
@@ -35,21 +39,36 @@ contract MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress is MultiSigWall
     /// @param _owners List of initial owners.
     /// @param _required Number of required confirmations.
     /// @param _secondsTimeLocked Duration needed after a transaction is confirmed and before it becomes executable, in seconds.
-    /// @param _tokenTransferProxy Address of TokenTransferProxy contract.
+    /// @param _assetProxyContracts Array of AssetProxy contract addresses.
     function MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress(
-        address[] _owners,
-        uint _required,
-        uint _secondsTimeLocked,
-        address _tokenTransferProxy)
+        address[] memory _owners,
+        uint256 _required,
+        uint256 _secondsTimeLocked,
+        address[] memory _assetProxyContracts)
         public
         MultiSigWalletWithTimeLock(_owners, _required, _secondsTimeLocked)
     {
-        TOKEN_TRANSFER_PROXY_CONTRACT = _tokenTransferProxy;
+        for (uint256 i = 0; i < _assetProxyContracts.length; i++) {
+            require(_assetProxyContracts[i] != address(0));
+            isAssetProxyRegistered[_assetProxyContracts[i]] = true;
+        }
+    }
+
+    /// @dev Sets approval for calling removeAuthorizedAddress on an AssetProxy contract without a timelock.
+    /// @param assetProxyContract Address of AssetProxy contract.
+    /// @param isRegistered Status of approval for AssetProxy contract.
+    function registerAssetProxy(address assetProxyContract, bool isRegistered)
+        public
+        onlyWallet
+        notNull(assetProxyContract)
+    {
+        isAssetProxyRegistered[assetProxyContract] = isRegistered;
+        AssetProxyRegistration(assetProxyContract, isRegistered);
     }
 
     /// @dev Allows execution of removeAuthorizedAddress without time lock.
     /// @param transactionId Transaction ID.
-    function executeRemoveAuthorizedAddress(uint transactionId)
+    function executeRemoveAuthorizedAddress(uint256 transactionId)
         public
         notExecuted(transactionId)
         fullyConfirmed(transactionId)
@@ -68,15 +87,26 @@ contract MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress is MultiSigWall
     /// @dev Compares first 4 bytes of byte array to removeAuthorizedAddress function signature.
     /// @param data Transaction data.
     /// @return Successful if data is a call to removeAuthorizedAddress.
-    function isFunctionRemoveAuthorizedAddress(bytes data)
+    function isFunctionRemoveAuthorizedAddress(bytes memory data)
         public
-        constant
+        pure
         returns (bool)
     {
-        bytes4 removeAuthorizedAddressSignature = bytes4(sha3("removeAuthorizedAddress(address)"));
-        for (uint i = 0; i < 4; i++) {
-            require(data[i] == removeAuthorizedAddressSignature[i]);
-        }
+        bytes4 removeAuthorizedAddressSelector = bytes4(keccak256("removeAuthorizedAddress(address)"));
+        bytes4 first4Bytes = readFirst4(data);
+        require(removeAuthorizedAddressSelector == first4Bytes);
         return true;
+    }
+
+    function readFirst4(bytes memory data)
+        public
+        pure
+        returns (bytes4 result)
+    {
+        require(data.length >= 4);
+        assembly {
+            result := mload(add(data, 32))
+        }
+        return result;
     }
 }

--- a/packages/contracts/src/utils/multi_sig_wrapper.ts
+++ b/packages/contracts/src/utils/multi_sig_wrapper.ts
@@ -1,43 +1,61 @@
-import { AbiDefinition, MethodAbi } from '@0xproject/types';
+import { TransactionReceiptWithDecodedLogs, ZeroEx } from '0x.js';
 import { BigNumber } from '@0xproject/utils';
-import ABI = require('ethereumjs-abi');
-import ethUtil = require('ethereumjs-util');
 import * as _ from 'lodash';
 import * as Web3 from 'web3';
 
 import { MultiSigWalletContract } from '../contract_wrappers/generated/multi_sig_wallet';
+import { MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddressContract } from '../contract_wrappers/generated/multi_sig_wallet_with_time_lock_except_remove_authorized_address';
 
-import { TransactionDataParams } from './types';
+import { constants } from './constants';
+import { LogDecoder } from './log_decoder';
 
 export class MultiSigWrapper {
     private _multiSig: MultiSigWalletContract;
-    public static encodeFnArgs(name: string, abi: AbiDefinition[], args: any[]) {
-        const abiEntity = _.find(abi, { name }) as MethodAbi;
-        if (_.isUndefined(abiEntity)) {
-            throw new Error(`Did not find abi entry for name: ${name}`);
-        }
-        const types = _.map(abiEntity.inputs, input => input.type);
-        const funcSig = ethUtil.bufferToHex(ABI.methodID(name, types));
-        const argsData = _.map(args, arg => {
-            const target = _.isBoolean(arg) ? +arg : arg;
-            const targetBuff = ethUtil.toBuffer(target);
-            return ethUtil.setLengthLeft(targetBuff, 32).toString('hex');
-        });
-        return funcSig + argsData.join('');
-    }
-    constructor(multiSigContract: MultiSigWalletContract) {
+    private _logDecoder: LogDecoder = new LogDecoder(constants.TESTRPC_NETWORK_ID);
+    private _zeroEx: ZeroEx;
+    constructor(multiSigContract: MultiSigWalletContract, zeroEx: ZeroEx) {
         this._multiSig = multiSigContract;
+        this._zeroEx = zeroEx;
     }
     public async submitTransactionAsync(
         destination: string,
+        data: string,
         from: string,
-        dataParams: TransactionDataParams,
-        value: BigNumber = new BigNumber(0),
-    ) {
-        const { name, abi, args = [] } = dataParams;
-        const encoded = MultiSigWrapper.encodeFnArgs(name, abi, args);
-        return this._multiSig.submitTransaction.sendTransactionAsync(destination, value, encoded, {
+        opts: { value?: BigNumber } = {},
+    ): Promise<TransactionReceiptWithDecodedLogs> {
+        const value = _.isUndefined(opts.value) ? new BigNumber(0) : opts.value;
+        const txHash = await this._multiSig.submitTransaction.sendTransactionAsync(destination, value, data, {
             from,
         });
+        const tx = await this._getTxWithDecodedMultiSigLogs(txHash);
+        return tx;
+    }
+    public async confirmTransactionAsync(txId: BigNumber, from: string): Promise<TransactionReceiptWithDecodedLogs> {
+        const txHash = await this._multiSig.confirmTransaction.sendTransactionAsync(txId, { from });
+        const tx = await this._getTxWithDecodedMultiSigLogs(txHash);
+        return tx;
+    }
+    public async executeTransactionAsync(txId: BigNumber, from: string): Promise<TransactionReceiptWithDecodedLogs> {
+        const txHash = await this._multiSig.executeTransaction.sendTransactionAsync(txId, { from });
+        const tx = await this._getTxWithDecodedMultiSigLogs(txHash);
+        return tx;
+    }
+    public async executeRemoveAuthorizedAddressAsync(
+        txId: BigNumber,
+        from: string,
+    ): Promise<TransactionReceiptWithDecodedLogs> {
+        const txHash = await (this
+            ._multiSig as MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddressContract).executeRemoveAuthorizedAddress.sendTransactionAsync(
+            txId,
+            { from },
+        );
+        const tx = await this._getTxWithDecodedMultiSigLogs(txHash);
+        return tx;
+    }
+    private async _getTxWithDecodedMultiSigLogs(txHash: string) {
+        const tx = await this._zeroEx.awaitTransactionMinedAsync(txHash);
+        tx.logs = _.filter(tx.logs, log => log.address === this._multiSig.address);
+        tx.logs = _.map(tx.logs, log => this._logDecoder.decodeLogOrThrow(log));
+        return tx;
     }
 }

--- a/packages/contracts/test/exchange/core.ts
+++ b/packages/contracts/test/exchange/core.ts
@@ -124,11 +124,6 @@ describe('Exchange core', () => {
     afterEach(async () => {
         await blockchainLifecycle.revertAsync();
     });
-    describe('internal functions', () => {
-        it('should include transferViaTokenTransferProxy', () => {
-            expect((exchange as any).transferViaTokenTransferProxy).to.be.undefined();
-        });
-    });
 
     describe('fillOrder', () => {
         beforeEach(async () => {

--- a/packages/contracts/test/multi_sig_with_time_lock.ts
+++ b/packages/contracts/test/multi_sig_with_time_lock.ts
@@ -1,42 +1,40 @@
 import { LogWithDecodedArgs, ZeroEx } from '0x.js';
-import { BlockchainLifecycle, web3Factory } from '@0xproject/dev-utils';
-import { AbiDecoder, BigNumber } from '@0xproject/utils';
-import { Web3Wrapper } from '@0xproject/web3-wrapper';
+import { BlockchainLifecycle } from '@0xproject/dev-utils';
+import { BigNumber } from '@0xproject/utils';
 import * as chai from 'chai';
+import * as _ from 'lodash';
 import * as Web3 from 'web3';
 
-import * as multiSigWalletJSON from '../../build/contracts/MultiSigWalletWithTimeLock.json';
-import { MultiSigWalletContract } from '../src/contract_wrappers/generated/multi_sig_wallet';
-import { MultiSigWalletWithTimeLockContract } from '../src/contract_wrappers/generated/multi_sig_wallet_with_time_lock';
-import { artifacts } from '../src/utils/artifacts';
+import {
+    MultiSigWalletWithTimeLockContract,
+    SubmissionContractEventArgs,
+} from '../src/contract_wrappers/generated/multi_sig_wallet_with_time_lock';
 import { constants } from '../src/utils/constants';
 import { MultiSigWrapper } from '../src/utils/multi_sig_wrapper';
-import { ContractName, SubmissionContractEventArgs } from '../src/utils/types';
+import { ContractName } from '../src/utils/types';
 
 import { chaiSetup } from './utils/chai_setup';
 import { deployer } from './utils/deployer';
 import { provider, web3Wrapper } from './utils/web3_wrapper';
 
-const MULTI_SIG_ABI = artifacts.MultiSigWalletWithTimeLockArtifact.networks[constants.TESTRPC_NETWORK_ID].abi;
 chaiSetup.configure();
 const expect = chai.expect;
 const blockchainLifecycle = new BlockchainLifecycle(web3Wrapper);
 const zeroEx = new ZeroEx(provider, { networkId: constants.TESTRPC_NETWORK_ID });
-const abiDecoder = new AbiDecoder([MULTI_SIG_ABI]);
 
 describe('MultiSigWalletWithTimeLock', () => {
     let owners: string[];
+    const requiredApprovals = new BigNumber(2);
+    const SECONDS_TIME_LOCKED = new BigNumber(1000000);
+
     before(async () => {
         const accounts = await web3Wrapper.getAvailableAddressesAsync();
         owners = [accounts[0], accounts[1]];
     });
-    const SIGNATURES_REQUIRED = new BigNumber(2);
-    const SECONDS_TIME_LOCKED = new BigNumber(10000);
 
     let multiSig: MultiSigWalletWithTimeLockContract;
     let multiSigWrapper: MultiSigWrapper;
-    let txId: BigNumber;
-    let initialSecondsTimeLocked: number;
+
     beforeEach(async () => {
         await blockchainLifecycle.startAsync();
     });
@@ -47,21 +45,20 @@ describe('MultiSigWalletWithTimeLock', () => {
     describe('changeTimeLock', () => {
         describe('initially non-time-locked', async () => {
             before('deploy a wallet', async () => {
+                const secondsTimeLocked = new BigNumber(0);
                 const multiSigInstance = await deployer.deployAsync(ContractName.MultiSigWalletWithTimeLock, [
                     owners,
-                    SIGNATURES_REQUIRED,
-                    0,
+                    requiredApprovals,
+                    secondsTimeLocked,
                 ]);
                 multiSig = new MultiSigWalletWithTimeLockContract(
                     multiSigInstance.abi,
                     multiSigInstance.address,
                     provider,
                 );
-                multiSigWrapper = new MultiSigWrapper((multiSig as any) as MultiSigWalletContract);
-
-                const secondsTimeLocked = await multiSig.secondsTimeLocked.callAsync();
-                initialSecondsTimeLocked = secondsTimeLocked.toNumber();
+                multiSigWrapper = new MultiSigWrapper(multiSig, zeroEx);
             });
+
             it('should throw when not called by wallet', async () => {
                 return expect(
                     multiSig.changeTimeLock.sendTransactionAsync(SECONDS_TIME_LOCKED, { from: owners[0] }),
@@ -70,19 +67,11 @@ describe('MultiSigWalletWithTimeLock', () => {
 
             it('should throw without enough confirmations', async () => {
                 const destination = multiSig.address;
-                const from = owners[0];
-                const dataParams = {
-                    name: 'changeTimeLock',
-                    abi: MULTI_SIG_ABI,
-                    args: [SECONDS_TIME_LOCKED.toNumber()],
-                };
-                const txHash = await multiSigWrapper.submitTransactionAsync(destination, from, dataParams);
-                const subRes = await zeroEx.awaitTransactionMinedAsync(txHash);
-                const log = abiDecoder.tryToDecodeLogOrNoop(subRes.logs[0]) as LogWithDecodedArgs<
-                    SubmissionContractEventArgs
-                >;
+                const changeTimeLockData = multiSig.changeTimeLock.getABIEncodedTransactionData(SECONDS_TIME_LOCKED);
+                const res = await multiSigWrapper.submitTransactionAsync(destination, changeTimeLockData, owners[0]);
+                const log = res.logs[0] as LogWithDecodedArgs<SubmissionContractEventArgs>;
+                const txId = log.args.transactionId;
 
-                txId = log.args.transactionId;
                 return expect(
                     multiSig.executeTransaction.sendTransactionAsync(txId, { from: owners[0] }),
                 ).to.be.rejectedWith(constants.REVERT);
@@ -90,22 +79,13 @@ describe('MultiSigWalletWithTimeLock', () => {
 
             it('should set confirmation time with enough confirmations', async () => {
                 const destination = multiSig.address;
-                const from = owners[0];
-                const dataParams = {
-                    name: 'changeTimeLock',
-                    abi: MULTI_SIG_ABI,
-                    args: [SECONDS_TIME_LOCKED.toNumber()],
-                };
-                let txHash = await multiSigWrapper.submitTransactionAsync(destination, from, dataParams);
-                const subRes = await zeroEx.awaitTransactionMinedAsync(txHash);
-                const log = abiDecoder.tryToDecodeLogOrNoop(subRes.logs[0]) as LogWithDecodedArgs<
-                    SubmissionContractEventArgs
-                >;
+                const changeTimeLockData = multiSig.changeTimeLock.getABIEncodedTransactionData(SECONDS_TIME_LOCKED);
+                const subRes = await multiSigWrapper.submitTransactionAsync(destination, changeTimeLockData, owners[0]);
+                const subLog = subRes.logs[0] as LogWithDecodedArgs<SubmissionContractEventArgs>;
+                const txId = subLog.args.transactionId;
 
-                txId = log.args.transactionId;
-                txHash = await multiSig.confirmTransaction.sendTransactionAsync(txId, { from: owners[1] });
-                const res = await zeroEx.awaitTransactionMinedAsync(txHash);
-                expect(res.logs).to.have.length(2);
+                const confirmRes = await multiSigWrapper.confirmTransactionAsync(txId, owners[1]);
+                expect(confirmRes.logs).to.have.length(2);
 
                 const blockNum = await web3Wrapper.getBlockNumberAsync();
                 const blockInfo = await web3Wrapper.getBlockAsync(blockNum);
@@ -117,36 +97,25 @@ describe('MultiSigWalletWithTimeLock', () => {
 
             it('should be executable with enough confirmations and secondsTimeLocked of 0', async () => {
                 const destination = multiSig.address;
-                const from = owners[0];
-                const dataParams = {
-                    name: 'changeTimeLock',
-                    abi: MULTI_SIG_ABI,
-                    args: [SECONDS_TIME_LOCKED.toNumber()],
-                };
-                let txHash = await multiSigWrapper.submitTransactionAsync(destination, from, dataParams);
-                const subRes = await zeroEx.awaitTransactionMinedAsync(txHash);
-                const log = abiDecoder.tryToDecodeLogOrNoop(subRes.logs[0]) as LogWithDecodedArgs<
-                    SubmissionContractEventArgs
-                >;
+                const changeTimeLockData = multiSig.changeTimeLock.getABIEncodedTransactionData(SECONDS_TIME_LOCKED);
+                const subRes = await multiSigWrapper.submitTransactionAsync(destination, changeTimeLockData, owners[0]);
+                const subLog = subRes.logs[0] as LogWithDecodedArgs<SubmissionContractEventArgs>;
+                const txId = subLog.args.transactionId;
 
-                txId = log.args.transactionId;
-                txHash = await multiSig.confirmTransaction.sendTransactionAsync(txId, { from: owners[1] });
-
-                expect(initialSecondsTimeLocked).to.be.equal(0);
-
-                txHash = await multiSig.executeTransaction.sendTransactionAsync(txId, { from: owners[0] });
-                const res = await zeroEx.awaitTransactionMinedAsync(txHash);
-                expect(res.logs).to.have.length(2);
+                await multiSigWrapper.confirmTransactionAsync(txId, owners[1]);
+                await multiSigWrapper.executeTransactionAsync(txId, owners[1]);
 
                 const secondsTimeLocked = new BigNumber(await multiSig.secondsTimeLocked.callAsync());
                 expect(secondsTimeLocked).to.be.bignumber.equal(SECONDS_TIME_LOCKED);
             });
         });
         describe('initially time-locked', async () => {
-            before('deploy a wallet', async () => {
+            let txId: BigNumber;
+            const newSecondsTimeLocked = new BigNumber(0);
+            before('deploy a wallet, submit transaction to change timelock, and confirm the transaction', async () => {
                 const multiSigInstance = await deployer.deployAsync(ContractName.MultiSigWalletWithTimeLock, [
                     owners,
-                    SIGNATURES_REQUIRED,
+                    requiredApprovals,
                     SECONDS_TIME_LOCKED,
                 ]);
                 multiSig = new MultiSigWalletWithTimeLockContract(
@@ -154,30 +123,18 @@ describe('MultiSigWalletWithTimeLock', () => {
                     multiSigInstance.address,
                     provider,
                 );
-                multiSigWrapper = new MultiSigWrapper((multiSig as any) as MultiSigWalletContract);
+                multiSigWrapper = new MultiSigWrapper(multiSig, zeroEx);
 
-                const secondsTimeLocked = await multiSig.secondsTimeLocked.callAsync();
-                initialSecondsTimeLocked = secondsTimeLocked.toNumber();
-                const destination = multiSig.address;
-                const from = owners[0];
-                const dataParams = {
-                    name: 'changeTimeLock',
-                    abi: MULTI_SIG_ABI,
-                    args: [newSecondsTimeLocked],
-                };
-                let txHash = await multiSigWrapper.submitTransactionAsync(destination, from, dataParams);
-                const subRes = await zeroEx.awaitTransactionMinedAsync(txHash);
-                const log = abiDecoder.tryToDecodeLogOrNoop(subRes.logs[0]) as LogWithDecodedArgs<
-                    SubmissionContractEventArgs
-                >;
+                const changeTimeLockData = multiSig.changeTimeLock.getABIEncodedTransactionData(newSecondsTimeLocked);
+                const res = await multiSigWrapper.submitTransactionAsync(
+                    multiSig.address,
+                    changeTimeLockData,
+                    owners[0],
+                );
+                const log = res.logs[0] as LogWithDecodedArgs<SubmissionContractEventArgs>;
                 txId = log.args.transactionId;
-                txHash = await multiSig.confirmTransaction.sendTransactionAsync(txId, {
-                    from: owners[1],
-                });
-                const confRes = await zeroEx.awaitTransactionMinedAsync(txHash);
-                expect(confRes.logs).to.have.length(2);
+                await multiSigWrapper.confirmTransactionAsync(txId, owners[1]);
             });
-            const newSecondsTimeLocked = 0;
             it('should throw if it has enough confirmations but is not past the time lock', async () => {
                 return expect(
                     multiSig.executeTransaction.sendTransactionAsync(txId, { from: owners[0] }),

--- a/packages/contracts/test/multi_sig_with_time_lock_except_remove_auth_addr.ts
+++ b/packages/contracts/test/multi_sig_with_time_lock_except_remove_auth_addr.ts
@@ -1,81 +1,63 @@
-/*
- *
- * @TODO:   Before deploying, the MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress contract must be updated
- *          to have a mapping of all approved addresses. These tests must be updated appropriately.
- *          For now, these tests have been commented out by @hysz (greg@0xproject.com).
- *
 import { LogWithDecodedArgs, ZeroEx } from '0x.js';
-import { BlockchainLifecycle, devConstants, web3Factory } from '@0xproject/dev-utils';
-import { AbiDecoder } from '@0xproject/utils';
-import { Web3Wrapper } from '@0xproject/web3-wrapper';
+import { BlockchainLifecycle } from '@0xproject/dev-utils';
+import { BigNumber } from '@0xproject/utils';
 import * as chai from 'chai';
+import * as _ from 'lodash';
 import * as Web3 from 'web3';
 
-import { MultiSigWalletContract } from '../src/contract_wrappers/generated/multi_sig_wallet';
-import { MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddressContract } from '../src/contract_wrappers/generated/multi_sig_wallet_with_time_lock_except_remove_authorized_address';
-import { TokenTransferProxyContract } from '../src/contract_wrappers/generated/token_transfer_proxy';
-import { artifacts } from '../src/utils/artifacts';
+import { AuthorizableContract } from '../src/contract_wrappers/generated/authorizable';
+import {
+    AssetProxyRegistrationContractEventArgs,
+    ExecutionContractEventArgs,
+    ExecutionFailureContractEventArgs,
+    MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddressContract,
+    SubmissionContractEventArgs,
+} from '../src/contract_wrappers/generated/multi_sig_wallet_with_time_lock_except_remove_authorized_address';
 import { constants } from '../src/utils/constants';
-import { crypto } from '../src/utils/crypto';
 import { MultiSigWrapper } from '../src/utils/multi_sig_wrapper';
-import { ContractName, SubmissionContractEventArgs, TransactionDataParams } from '../src/utils/types';
+import { ContractName } from '../src/utils/types';
 
 import { chaiSetup } from './utils/chai_setup';
 import { deployer } from './utils/deployer';
 import { provider, web3Wrapper } from './utils/web3_wrapper';
-const PROXY_ABI = artifacts.TokenTransferProxyArtifact.networks[constants.TESTRPC_NETWORK_ID].abi;
-const MUTISIG_WALLET_WITH_TIME_LOCK_EXCEPT_REMOVE_AUTHORIZED_ADDRESS_ABI =
-    artifacts.MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddressArtifact.networks[constants.TESTRPC_NETWORK_ID]
-        .abi;
 
 chaiSetup.configure();
 const expect = chai.expect;
 const blockchainLifecycle = new BlockchainLifecycle(web3Wrapper);
-const abiDecoder = new AbiDecoder([MUTISIG_WALLET_WITH_TIME_LOCK_EXCEPT_REMOVE_AUTHORIZED_ADDRESS_ABI]);
+const zeroEx = new ZeroEx(provider, { networkId: constants.TESTRPC_NETWORK_ID });
 
 describe('MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress', () => {
-    const zeroEx = new ZeroEx(provider, { networkId: constants.TESTRPC_NETWORK_ID });
     let owners: string[];
-    const requiredApprovals = 2;
-    const SECONDS_TIME_LOCKED = 1000000;
+    let authorized: string;
+    const requiredApprovals = new BigNumber(2);
+    const SECONDS_TIME_LOCKED = new BigNumber(1000000);
 
-    // initialize fake addresses
-    let authorizedAddress: string;
-    let unauthorizedAddress: string;
-
-    let tokenTransferProxy: TokenTransferProxyContract;
+    let erc20Proxy: AuthorizableContract;
+    let erc721Proxy: AuthorizableContract;
     let multiSig: MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddressContract;
     let multiSigWrapper: MultiSigWrapper;
 
-    let validDestination: string;
     before(async () => {
         const accounts = await web3Wrapper.getAvailableAddressesAsync();
         owners = [accounts[0], accounts[1]];
-        [authorizedAddress, unauthorizedAddress] = accounts;
-        const initialOwner = accounts[0];
-        const tokenTransferProxyInstance = await deployer.deployAsync(ContractName.TokenTransferProxy);
-        tokenTransferProxy = new TokenTransferProxyContract(
-            tokenTransferProxyInstance.abi,
-            tokenTransferProxyInstance.address,
-            provider,
-        );
-        await tokenTransferProxy.addAuthorizedAddress.sendTransactionAsync(authorizedAddress, {
-            from: initialOwner,
-        });
+        const initialOwner = (authorized = accounts[0]);
+        const erc20ProxyInstance = await deployer.deployAsync(ContractName.Authorizable);
+        const erc721ProxyInstance = await deployer.deployAsync(ContractName.Authorizable);
+        erc20Proxy = new AuthorizableContract(erc20ProxyInstance.abi, erc20ProxyInstance.address, provider);
+        erc721Proxy = new AuthorizableContract(erc721ProxyInstance.abi, erc721ProxyInstance.address, provider);
+        const defaultAssetProxyContractAddresses: string[] = [];
         const multiSigInstance = await deployer.deployAsync(
             ContractName.MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress,
-            [owners, requiredApprovals, SECONDS_TIME_LOCKED, tokenTransferProxy.address],
+            [owners, requiredApprovals, SECONDS_TIME_LOCKED, defaultAssetProxyContractAddresses],
         );
         multiSig = new MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddressContract(
             multiSigInstance.abi,
             multiSigInstance.address,
             provider,
         );
-        await tokenTransferProxy.transferOwnership.sendTransactionAsync(multiSig.address, {
-            from: initialOwner,
-        });
-        multiSigWrapper = new MultiSigWrapper((multiSig as any) as MultiSigWalletContract);
-        validDestination = tokenTransferProxy.address;
+        multiSigWrapper = new MultiSigWrapper(multiSig, zeroEx);
+        await erc20Proxy.transferOwnership.sendTransactionAsync(multiSig.address, { from: initialOwner });
+        await erc721Proxy.transferOwnership.sendTransactionAsync(multiSig.address, { from: initialOwner });
     });
     beforeEach(async () => {
         await blockchainLifecycle.startAsync();
@@ -84,31 +66,192 @@ describe('MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress', () => {
         await blockchainLifecycle.revertAsync();
     });
 
+    describe('constructor', () => {
+        it('should register passed in assetProxyContracts', async () => {
+            const assetProxyContractAddresses = [erc20Proxy.address, erc721Proxy.address];
+            const multiSigInstance = await deployer.deployAsync(
+                ContractName.MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress,
+                [owners, requiredApprovals, SECONDS_TIME_LOCKED, assetProxyContractAddresses],
+            );
+            const newMultiSig = new MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddressContract(
+                multiSigInstance.abi,
+                multiSigInstance.address,
+                provider,
+            );
+            const isErc20ProxyRegistered = await newMultiSig.isAssetProxyRegistered.callAsync(erc20Proxy.address);
+            const isErc721ProxyRegistered = await newMultiSig.isAssetProxyRegistered.callAsync(erc721Proxy.address);
+            expect(isErc20ProxyRegistered).to.equal(true);
+            expect(isErc721ProxyRegistered).to.equal(true);
+        });
+        it('should throw if a null address is included in assetProxyContracts', async () => {
+            const assetProxyContractAddresses = [erc20Proxy.address, ZeroEx.NULL_ADDRESS];
+            expect(
+                deployer.deployAsync(ContractName.MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress, [
+                    owners,
+                    requiredApprovals,
+                    SECONDS_TIME_LOCKED,
+                    assetProxyContractAddresses,
+                ]),
+            ).to.be.rejectedWith(constants.REVERT);
+        });
+    });
+    describe('readFirst4', () => {
+        it('should return the first 4 bytes of a byte array of arbitrary length', async () => {
+            const addAuthorizedAddressData = erc20Proxy.addAuthorizedAddress.getABIEncodedTransactionData(owners[0]);
+            const removeAuthorizedAddressData = erc20Proxy.removeAuthorizedAddress.getABIEncodedTransactionData(
+                owners[0],
+            );
+            const expectedAddAuthorizedAddressSelector = addAuthorizedAddressData.slice(0, 10);
+            const expectedRemoveAuthorizedAddressSelector = removeAuthorizedAddressData.slice(0, 10);
+            const [addAuthorizedAddressSelector, removeAuthorizedAddressSelector] = await Promise.all([
+                multiSig.readFirst4.callAsync(addAuthorizedAddressData),
+                multiSig.readFirst4.callAsync(removeAuthorizedAddressData),
+            ]);
+            expect(expectedAddAuthorizedAddressSelector).to.equal(addAuthorizedAddressSelector);
+            expect(expectedRemoveAuthorizedAddressSelector).to.equal(removeAuthorizedAddressSelector);
+        });
+    });
+
     describe('isFunctionRemoveAuthorizedAddress', () => {
         it('should throw if data is not for removeAuthorizedAddress', async () => {
-            const data = MultiSigWrapper.encodeFnArgs('addAuthorizedAddress', PROXY_ABI, [owners[0]]);
-            return expect(multiSig.isFunctionRemoveAuthorizedAddress.callAsync(data)).to.be.rejectedWith(
-                constants.REVERT,
+            const notRemoveAuthorizedAddressData = erc20Proxy.addAuthorizedAddress.getABIEncodedTransactionData(
+                owners[0],
             );
+            return expect(
+                multiSig.isFunctionRemoveAuthorizedAddress.callAsync(notRemoveAuthorizedAddressData),
+            ).to.be.rejectedWith(constants.REVERT);
         });
 
         it('should return true if data is for removeAuthorizedAddress', async () => {
-            const data = MultiSigWrapper.encodeFnArgs('removeAuthorizedAddress', PROXY_ABI, [owners[0]]);
-            const isFunctionRemoveAuthorizedAddress = await multiSig.isFunctionRemoveAuthorizedAddress.callAsync(data);
+            const removeAuthorizedAddressData = erc20Proxy.removeAuthorizedAddress.getABIEncodedTransactionData(
+                owners[0],
+            );
+            const isFunctionRemoveAuthorizedAddress = await multiSig.isFunctionRemoveAuthorizedAddress.callAsync(
+                removeAuthorizedAddressData,
+            );
             expect(isFunctionRemoveAuthorizedAddress).to.be.true();
         });
     });
 
+    describe('registerAssetProxy', () => {
+        it('should throw if not called by multisig', async () => {
+            const isRegistered = true;
+            expect(
+                multiSig.registerAssetProxy.sendTransactionAsync(erc20Proxy.address, isRegistered, { from: owners[0] }),
+            ).to.be.rejectedWith(constants.REVERT);
+        });
+
+        it('should register an address if called by multisig after timelock', async () => {
+            const addressToRegister = erc20Proxy.address;
+            const isRegistered = true;
+            const registerAssetProxyData = multiSig.registerAssetProxy.getABIEncodedTransactionData(
+                addressToRegister,
+                isRegistered,
+            );
+            const submitTxRes = await multiSigWrapper.submitTransactionAsync(
+                multiSig.address,
+                registerAssetProxyData,
+                owners[0],
+            );
+            const log = submitTxRes.logs[0] as LogWithDecodedArgs<SubmissionContractEventArgs>;
+            const txId = log.args.transactionId;
+
+            await multiSigWrapper.confirmTransactionAsync(txId, owners[1]);
+            await web3Wrapper.increaseTimeAsync(SECONDS_TIME_LOCKED.toNumber());
+
+            const executeTxRes = await multiSigWrapper.executeTransactionAsync(txId, owners[0]);
+            const registerLog = executeTxRes.logs[0] as LogWithDecodedArgs<AssetProxyRegistrationContractEventArgs>;
+            expect(registerLog.args.assetProxyContract).to.equal(addressToRegister);
+            expect(registerLog.args.isRegistered).to.equal(isRegistered);
+
+            const isAssetProxyRegistered = await multiSig.isAssetProxyRegistered.callAsync(addressToRegister);
+            expect(isAssetProxyRegistered).to.equal(isRegistered);
+        });
+
+        it('should fail if registering a null address', async () => {
+            const addressToRegister = ZeroEx.NULL_ADDRESS;
+            const isRegistered = true;
+            const registerAssetProxyData = multiSig.registerAssetProxy.getABIEncodedTransactionData(
+                addressToRegister,
+                isRegistered,
+            );
+            const submitTxRes = await multiSigWrapper.submitTransactionAsync(
+                multiSig.address,
+                registerAssetProxyData,
+                owners[0],
+            );
+            const log = submitTxRes.logs[0] as LogWithDecodedArgs<SubmissionContractEventArgs>;
+            const txId = log.args.transactionId;
+
+            await multiSigWrapper.confirmTransactionAsync(txId, owners[1]);
+            await web3Wrapper.increaseTimeAsync(SECONDS_TIME_LOCKED.toNumber());
+
+            const executeTxRes = await multiSigWrapper.executeTransactionAsync(txId, owners[0]);
+            const failureLog = executeTxRes.logs[0] as LogWithDecodedArgs<ExecutionFailureContractEventArgs>;
+            expect(failureLog.args.transactionId).to.be.bignumber.equal(txId);
+
+            const isAssetProxyRegistered = await multiSig.isAssetProxyRegistered.callAsync(addressToRegister);
+            expect(isAssetProxyRegistered).to.equal(false);
+        });
+    });
+
     describe('executeRemoveAuthorizedAddress', () => {
+        before('authorize both proxies and register erc20 proxy', async () => {
+            // Only register ERC20 proxy
+            const addressToRegister = erc20Proxy.address;
+            const isRegistered = true;
+            const registerAssetProxyData = multiSig.registerAssetProxy.getABIEncodedTransactionData(
+                addressToRegister,
+                isRegistered,
+            );
+            const registerAssetProxySubmitRes = await multiSigWrapper.submitTransactionAsync(
+                multiSig.address,
+                registerAssetProxyData,
+                owners[0],
+            );
+            const registerAssetProxySubmitLog = registerAssetProxySubmitRes.logs[0] as LogWithDecodedArgs<
+                SubmissionContractEventArgs
+            >;
+            const registerAssetProxyTxId = registerAssetProxySubmitLog.args.transactionId;
+            await multiSigWrapper.confirmTransactionAsync(registerAssetProxyTxId, owners[1]);
+
+            const addAuthorizedAddressData = erc20Proxy.addAuthorizedAddress.getABIEncodedTransactionData(authorized);
+            const erc20AddAuthorizedAddressSubmitRes = await multiSigWrapper.submitTransactionAsync(
+                erc20Proxy.address,
+                addAuthorizedAddressData,
+                owners[0],
+            );
+            const erc721AddAuthorizedAddressSubmitRes = await multiSigWrapper.submitTransactionAsync(
+                erc721Proxy.address,
+                addAuthorizedAddressData,
+                owners[0],
+            );
+            const erc20AddAuthorizedAddressSubmitLog = erc20AddAuthorizedAddressSubmitRes.logs[0] as LogWithDecodedArgs<
+                SubmissionContractEventArgs
+            >;
+            const erc721AddAuthorizedAddressSubmitLog = erc721AddAuthorizedAddressSubmitRes
+                .logs[0] as LogWithDecodedArgs<SubmissionContractEventArgs>;
+            const erc20AddAuthorizedAddressTxId = erc20AddAuthorizedAddressSubmitLog.args.transactionId;
+            const erc721AddAuthorizedAddressTxId = erc721AddAuthorizedAddressSubmitLog.args.transactionId;
+
+            await multiSigWrapper.confirmTransactionAsync(erc20AddAuthorizedAddressTxId, owners[1]);
+            await multiSigWrapper.confirmTransactionAsync(erc721AddAuthorizedAddressTxId, owners[1]);
+            await web3Wrapper.increaseTimeAsync(SECONDS_TIME_LOCKED.toNumber());
+            await multiSigWrapper.executeTransactionAsync(registerAssetProxyTxId, owners[0]);
+            await multiSigWrapper.executeTransactionAsync(erc20AddAuthorizedAddressTxId, owners[0]);
+            await multiSigWrapper.executeTransactionAsync(erc721AddAuthorizedAddressTxId, owners[0]);
+        });
+
         it('should throw without the required confirmations', async () => {
-            const dataParams: TransactionDataParams = {
-                name: 'removeAuthorizedAddress',
-                abi: PROXY_ABI,
-                args: [authorizedAddress],
-            };
-            const txHash = await multiSigWrapper.submitTransactionAsync(validDestination, owners[0], dataParams);
-            const res = await zeroEx.awaitTransactionMinedAsync(txHash);
-            const log = abiDecoder.tryToDecodeLogOrNoop(res.logs[0]) as LogWithDecodedArgs<SubmissionContractEventArgs>;
+            const removeAuthorizedAddressData = erc20Proxy.removeAuthorizedAddress.getABIEncodedTransactionData(
+                authorized,
+            );
+            const res = await multiSigWrapper.submitTransactionAsync(
+                erc20Proxy.address,
+                removeAuthorizedAddressData,
+                owners[0],
+            );
+            const log = res.logs[0] as LogWithDecodedArgs<SubmissionContractEventArgs>;
             const txId = log.args.transactionId;
 
             return expect(
@@ -116,21 +259,19 @@ describe('MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress', () => {
             ).to.be.rejectedWith(constants.REVERT);
         });
 
-        it('should throw if tx destination is not the tokenTransferProxy', async () => {
-            const invalidTokenTransferProxy = await deployer.deployAsync(ContractName.TokenTransferProxy);
-            const invalidDestination = invalidTokenTransferProxy.address;
-            const dataParams: TransactionDataParams = {
-                name: 'removeAuthorizedAddress',
-                abi: PROXY_ABI,
-                args: [authorizedAddress],
-            };
-            const txHash = await multiSigWrapper.submitTransactionAsync(invalidDestination, owners[0], dataParams);
-            const res = await zeroEx.awaitTransactionMinedAsync(txHash);
-            const log = abiDecoder.tryToDecodeLogOrNoop(res.logs[0]) as LogWithDecodedArgs<SubmissionContractEventArgs>;
+        it('should throw if tx destination is not registered', async () => {
+            const removeAuthorizedAddressData = erc721Proxy.removeAuthorizedAddress.getABIEncodedTransactionData(
+                authorized,
+            );
+            const res = await multiSigWrapper.submitTransactionAsync(
+                erc721Proxy.address,
+                removeAuthorizedAddressData,
+                owners[0],
+            );
+            const log = res.logs[0] as LogWithDecodedArgs<SubmissionContractEventArgs>;
             const txId = log.args.transactionId;
-            await multiSig.confirmTransaction.sendTransactionAsync(txId, { from: owners[1] });
-            const isConfirmed = await multiSig.isConfirmed.callAsync(txId);
-            expect(isConfirmed).to.be.true();
+
+            await multiSigWrapper.confirmTransactionAsync(txId, owners[1]);
 
             return expect(
                 multiSig.executeRemoveAuthorizedAddress.sendTransactionAsync(txId, { from: owners[1] }),
@@ -138,64 +279,76 @@ describe('MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress', () => {
         });
 
         it('should throw if tx data is not for removeAuthorizedAddress', async () => {
-            const dataParams: TransactionDataParams = {
-                name: 'addAuthorizedAddress',
-                abi: PROXY_ABI,
-                args: [unauthorizedAddress],
-            };
-            const txHash = await multiSigWrapper.submitTransactionAsync(validDestination, owners[0], dataParams);
-            const res = await zeroEx.awaitTransactionMinedAsync(txHash);
-            const log = abiDecoder.tryToDecodeLogOrNoop(res.logs[0]) as LogWithDecodedArgs<SubmissionContractEventArgs>;
+            const newAuthorized = owners[1];
+            const addAuthorizedAddressData = erc20Proxy.addAuthorizedAddress.getABIEncodedTransactionData(
+                newAuthorized,
+            );
+            const res = await multiSigWrapper.submitTransactionAsync(
+                erc20Proxy.address,
+                addAuthorizedAddressData,
+                owners[0],
+            );
+            const log = res.logs[0] as LogWithDecodedArgs<SubmissionContractEventArgs>;
             const txId = log.args.transactionId;
-            await multiSig.confirmTransaction.sendTransactionAsync(txId, { from: owners[1] });
-            const isConfirmed = await multiSig.isConfirmed.callAsync(txId);
-            expect(isConfirmed).to.be.true();
+
+            await multiSigWrapper.confirmTransactionAsync(txId, owners[1]);
 
             return expect(
                 multiSig.executeRemoveAuthorizedAddress.sendTransactionAsync(txId, { from: owners[1] }),
             ).to.be.rejectedWith(constants.REVERT);
         });
 
-        it('should execute removeAuthorizedAddress for valid tokenTransferProxy if fully confirmed', async () => {
-            const dataParams: TransactionDataParams = {
-                name: 'removeAuthorizedAddress',
-                abi: PROXY_ABI,
-                args: [authorizedAddress],
-            };
-            const txHash = await multiSigWrapper.submitTransactionAsync(validDestination, owners[0], dataParams);
-            const res = await zeroEx.awaitTransactionMinedAsync(txHash);
-            const log = abiDecoder.tryToDecodeLogOrNoop(res.logs[0]) as LogWithDecodedArgs<SubmissionContractEventArgs>;
-            const txId = log.args.transactionId;
-            await multiSig.confirmTransaction.sendTransactionAsync(txId, { from: owners[1] });
-            const isConfirmed = await multiSig.isConfirmed.callAsync(txId);
-            expect(isConfirmed).to.be.true();
-            await multiSig.executeRemoveAuthorizedAddress.sendTransactionAsync(txId, { from: owners[1] });
-            const isAuthorized = await tokenTransferProxy.authorized.callAsync(authorizedAddress);
-            expect(isAuthorized).to.be.false();
+        it('should execute removeAuthorizedAddress for registered address if fully confirmed', async () => {
+            const removeAuthorizedAddressData = erc20Proxy.removeAuthorizedAddress.getABIEncodedTransactionData(
+                authorized,
+            );
+            const submitRes = await multiSigWrapper.submitTransactionAsync(
+                erc20Proxy.address,
+                removeAuthorizedAddressData,
+                owners[0],
+            );
+            const submitLog = submitRes.logs[0] as LogWithDecodedArgs<SubmissionContractEventArgs>;
+            const txId = submitLog.args.transactionId;
+
+            await multiSigWrapper.confirmTransactionAsync(txId, owners[1]);
+
+            const execRes = await multiSigWrapper.executeRemoveAuthorizedAddressAsync(txId, owners[0]);
+            const execLog = execRes.logs[0] as LogWithDecodedArgs<ExecutionContractEventArgs>;
+            expect(execLog.args.transactionId).to.be.bignumber.equal(txId);
+
+            const tx = await multiSig.transactions.callAsync(txId);
+            const isExecuted = tx[3];
+            expect(isExecuted).to.equal(true);
+
+            const isAuthorized = await erc20Proxy.authorized.callAsync(authorized);
+            expect(isAuthorized).to.equal(false);
         });
 
         it('should throw if already executed', async () => {
-            const dataParams: TransactionDataParams = {
-                name: 'removeAuthorizedAddress',
-                abi: PROXY_ABI,
-                args: [authorizedAddress],
-            };
-            const txHash = await multiSigWrapper.submitTransactionAsync(validDestination, owners[0], dataParams);
-            const res = await zeroEx.awaitTransactionMinedAsync(txHash);
-            const log = abiDecoder.tryToDecodeLogOrNoop(res.logs[0]) as LogWithDecodedArgs<SubmissionContractEventArgs>;
-            const txId = log.args.transactionId;
-            await multiSig.confirmTransaction.sendTransactionAsync(txId, { from: owners[1] });
-            const isConfirmed = await multiSig.isConfirmed.callAsync(txId);
-            expect(isConfirmed).to.be.true();
-            await multiSig.executeRemoveAuthorizedAddress.sendTransactionAsync(txId, { from: owners[1] });
+            const removeAuthorizedAddressData = erc20Proxy.removeAuthorizedAddress.getABIEncodedTransactionData(
+                authorized,
+            );
+            const submitRes = await multiSigWrapper.submitTransactionAsync(
+                erc20Proxy.address,
+                removeAuthorizedAddressData,
+                owners[0],
+            );
+            const submitLog = submitRes.logs[0] as LogWithDecodedArgs<SubmissionContractEventArgs>;
+            const txId = submitLog.args.transactionId;
+
+            await multiSigWrapper.confirmTransactionAsync(txId, owners[1]);
+
+            const execRes = await multiSigWrapper.executeRemoveAuthorizedAddressAsync(txId, owners[0]);
+            const execLog = execRes.logs[0] as LogWithDecodedArgs<ExecutionContractEventArgs>;
+            expect(execLog.args.transactionId).to.be.bignumber.equal(txId);
+
             const tx = await multiSig.transactions.callAsync(txId);
             const isExecuted = tx[3];
-            expect(isExecuted).to.be.true();
+            expect(isExecuted).to.equal(true);
+
             return expect(
                 multiSig.executeRemoveAuthorizedAddress.sendTransactionAsync(txId, { from: owners[1] }),
             ).to.be.rejectedWith(constants.REVERT);
         });
     });
 });
-
-*/


### PR DESCRIPTION
<!--- Thank you for taking the time to submit a Pull Request -->

<!--- Provide a general summary of the issue in the Title above -->

## Description

<!--- Describe your changes in detail -->
Rather than hard coding in the `tokenTransferProxy` as the only address that can call `removeAuthorizedAddress` with no timelock, the multisig now maintains a mapping of multiple proxy addresses that are approved to do so.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->
This change needed to be made to support the new AssetProxy architecture. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
