### PR TITLE
fix: typescript type of web3.eth.filter.get

### DIFF
--- a/packages/typescript-typings/types/web3/index.d.ts
+++ b/packages/typescript-typings/types/web3/index.d.ts
@@ -73,7 +73,7 @@ declare module 'web3' {
         }
 
         interface FilterResult {
-            get(callback: () => void): void;
+            get(callback: (err: Error, result: LogEntryEvent[]) => void): void;
             watch(callback: (err: Error, result: LogEntryEvent) => void): void;
             stopWatching(callback?: () => void): void;
         }


### PR DESCRIPTION
## Description
filter.get() is the synchronous variant of filter.watch().

## Motivation and Context
While filter.watch() already has a full type declaration in your index.d.ts, filter.get() has not. So far I was using a timer in my typescript app that called filter.get(), so I needed the correct type declaration.
However I'm currently moving away from the timer and will use filter.watch() in the future... but anyway, maybe some other users will need this PR.

This PR solves #471 .

## How Has This Been Tested?
In my app... which is closed source, unfortunately. I changed index.d.ts in node_modules (after "yarn install") and tslint was happy with my change.

## Types of changes

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
