### PR TITLE
Prevent multiple connections in 0x Connect websocket

### DIFF
--- a/packages/connect/src/types.ts
+++ b/packages/connect/src/types.ts
@@ -11,7 +11,6 @@ export interface Client {
 }
 
 export interface OrderbookChannel {
-    connectAsync: () => Promise<void>;
     subscribe: (subscriptionOpts: OrderbookChannelSubscriptionOpts, handler: OrderbookChannelHandler) => void;
     close: () => void;
 }

--- a/packages/connect/src/types.ts
+++ b/packages/connect/src/types.ts
@@ -11,6 +11,7 @@ export interface Client {
 }
 
 export interface OrderbookChannel {
+    connectAsync: () => Promise<void>;
     subscribe: (subscriptionOpts: OrderbookChannelSubscriptionOpts, handler: OrderbookChannelHandler) => void;
     close: () => void;
 }

--- a/packages/connect/src/ws_orderbook_channel.ts
+++ b/packages/connect/src/ws_orderbook_channel.ts
@@ -17,6 +17,8 @@ import { orderbookChannelMessageParser } from './utils/orderbook_channel_message
 
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 15000;
 const MINIMUM_HEARTBEAT_INTERVAL_MS = 10;
+const CONNECTION_POLL_INTERVAL = 100;
+const FAILED_TO_POLL_CONNECTION_ERROR = 'Failed to establish a connection';
 
 /**
  * This class includes all the functionality related to interacting with a websocket endpoint
@@ -26,6 +28,7 @@ export class WebSocketOrderbookChannel implements OrderbookChannel {
     private _apiEndpointUrl: string;
     private _client: WebSocket.client;
     private _connectionIfExists?: WebSocket.connection;
+    private _isConnecting: boolean = false;
     private _heartbeatTimerIfExists?: NodeJS.Timer;
     private _subscriptionCounter = 0;
     private _heartbeatIntervalMs: number;
@@ -91,16 +94,6 @@ export class WebSocketOrderbookChannel implements OrderbookChannel {
         });
     }
     /**
-     * Opens a Websocket connection ensuring the underlying socket is connected for future subscribe calls
-     */
-    public async connectAsync(): Promise<void> {
-        return new Promise<void>((resolve, reject) => {
-            this._getConnection((error, connection) => {
-                _.isUndefined(error) ? resolve() : reject(error);
-            });
-        });
-    }
-    /**
      * Close the websocket and stop receiving updates
      */
     public close() {
@@ -115,29 +108,50 @@ export class WebSocketOrderbookChannel implements OrderbookChannel {
         if (!_.isUndefined(this._connectionIfExists) && this._connectionIfExists.connected) {
             callback(undefined, this._connectionIfExists);
         } else {
-            this._client.on(WebsocketClientEventType.Connect, connection => {
-                this._connectionIfExists = connection;
-                if (this._heartbeatIntervalMs >= MINIMUM_HEARTBEAT_INTERVAL_MS) {
-                    this._heartbeatTimerIfExists = setInterval(() => {
-                        connection.ping('');
-                    }, this._heartbeatIntervalMs);
-                } else {
-                    callback(
-                        new Error(
-                            `Heartbeat interval is ${
-                                this._heartbeatIntervalMs
-                            }ms which is less than the required minimum of ${MINIMUM_HEARTBEAT_INTERVAL_MS}ms`,
-                        ),
-                        undefined,
-                    );
-                }
-                callback(undefined, this._connectionIfExists);
-            });
-            this._client.on(WebsocketClientEventType.ConnectFailed, error => {
-                callback(error, undefined);
-            });
-            this._client.connect(this._apiEndpointUrl);
+            if (!this._isConnecting) {
+                this._connect(callback);
+            } else {
+                // Since we're hitting the network it's possible that multiple getConnections are called before we are connected
+                // this can result in multiple connections established and multiple connection handlers registered
+                const awaitingConnectionInterval = setInterval(() => {
+                    if (!_.isUndefined(this._connectionIfExists) && this._connectionIfExists.connected) {
+                        clearInterval(awaitingConnectionInterval);
+                        return callback(undefined, this._connectionIfExists);
+                    }
+                    if (!this._isConnecting) {
+                        clearInterval(awaitingConnectionInterval);
+                        return callback(new Error(FAILED_TO_POLL_CONNECTION_ERROR));
+                    }
+                }, CONNECTION_POLL_INTERVAL);
+            }
         }
+    }
+    private _connect(callback: (error?: Error, connection?: WebSocket.connection) => void) {
+        this._isConnecting = true;
+        this._client.on(WebsocketClientEventType.Connect, connection => {
+            this._connectionIfExists = connection;
+            if (this._heartbeatIntervalMs >= MINIMUM_HEARTBEAT_INTERVAL_MS) {
+                this._heartbeatTimerIfExists = setInterval(() => {
+                    connection.ping('');
+                }, this._heartbeatIntervalMs);
+            } else {
+                callback(
+                    new Error(
+                        `Heartbeat interval is ${
+                            this._heartbeatIntervalMs
+                        }ms which is less than the required minimum of ${MINIMUM_HEARTBEAT_INTERVAL_MS}ms`,
+                    ),
+                    undefined,
+                );
+            }
+            this._isConnecting = false;
+            callback(undefined, this._connectionIfExists);
+        });
+        this._client.on(WebsocketClientEventType.ConnectFailed, error => {
+            this._isConnecting = false;
+            callback(error, undefined);
+        });
+        this._client.connect(this._apiEndpointUrl);
     }
     private _handleWebSocketMessage(
         requestId: number,

--- a/packages/connect/src/ws_orderbook_channel.ts
+++ b/packages/connect/src/ws_orderbook_channel.ts
@@ -75,6 +75,8 @@ export class WebSocketOrderbookChannel implements OrderbookChannel {
             if (!_.isUndefined(error)) {
                 handler.onError(this, subscriptionOpts, error);
             } else if (!_.isUndefined(connection) && connection.connected) {
+                // Bump up the max listeners otherwise a warning will be printed
+                connection.setMaxListeners(this._subscriptionCounter);
                 connection.on(WebsocketConnectionEventType.Error, wsError => {
                     handler.onError(this, subscriptionOpts, wsError);
                 });
@@ -86,6 +88,16 @@ export class WebSocketOrderbookChannel implements OrderbookChannel {
                 });
                 connection.sendUTF(JSON.stringify(subscribeMessage));
             }
+        });
+    }
+    /**
+     * Opens a Websocket connection ensuring the underlying socket is connected for future subscribe calls
+     */
+    public async connectAsync(): Promise<void> {
+        return new Promise<void>((resolve, reject) => {
+            this._getConnection((error, connection) => {
+                _.isUndefined(error) ? resolve() : reject(error);
+            });
         });
     }
     /**


### PR DESCRIPTION

<!--- Thank you for taking the time to submit a Pull Request -->

<!--- Provide a general summary of the issue in the Title above -->

## Description

<!--- Describe your changes in detail -->

Prevents multiple connections from being created (and their respective connection handlers)

## Motivation and Context

In practice, calling a large number of subscribes asynchronously can cause connect to open multiple websocket connections as there is no locking mechanism. Rather than introduce a lock and queue we can introduce internal state and an interval.
<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
