### PR TITLE
ERC721Proxy Pad to 32 if asset ids are small

### DIFF
--- a/packages/contracts/src/utils/asset_proxy_utils.ts
+++ b/packages/contracts/src/utils/asset_proxy_utils.ts
@@ -18,7 +18,8 @@ export const assetProxyUtils = {
     encodeUint256(value: BigNumber): Buffer {
         const formattedValue = new BN(value.toString(10));
         const encodedValue = ethUtil.toBuffer(formattedValue);
-        return encodedValue;
+        const paddedValue = ethUtil.setLengthLeft(encodedValue, 32);
+        return paddedValue;
     },
     encodeERC20ProxyData(tokenAddress: string): string {
         const encodedAssetProxyId = assetProxyUtils.encodeAssetProxyId(AssetProxyId.ERC20);


### PR DESCRIPTION
<!--- Thank you for taking the time to submit a Pull Request -->

<!--- Provide a general summary of the issue in the Title above -->

## Description

Pad to the full 32 bytes for ERC721 encoding

## Motivation and Context
Some ERC721 token ids are incremental ID's and start small. The ERC721 proxy expects a full 32 byte token id, and our current encoding doesn't pad to 32 bytes. This results in a failure to decode in the erc721 proxy.

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
