### PR TITLE
don't thow if contractData not found and look for sourceCodes in artifacts

### DIFF
--- a/packages/sol-cov/src/collect_contract_data.ts
+++ b/packages/sol-cov/src/collect_contract_data.ts
@@ -14,7 +14,7 @@ export const collectContractsData = (artifactsPath: string, sourcesPath: string)
         const sources = _.keys(artifact.sources);
         const contractName = artifact.contractName;
         // We don't compute coverage for dependencies
-        const sourceCodes = _.map(sources, (source: string) =>
+        const sourceCodes = artifact.sourceCodes || _.map(sources, (source: string) => 
             fs.readFileSync(path.join(sourcesPath, source)).toString(),
         );
         const contractData = {

--- a/packages/sol-cov/src/coverage_subprovider.ts
+++ b/packages/sol-cov/src/coverage_subprovider.ts
@@ -29,12 +29,13 @@ export class CoverageSubprovider extends Subprovider {
      * @param artifactsPath Path to the smart contract artifacts
      * @param sourcesPath Path to the smart contract source files
      * @param defaultFromAddress default from address to use when sending transactions
+     * @param verbose If true, we will log any unknown transactions. Otherwise we will ignore them
      */
-    constructor(artifactsPath: string, sourcesPath: string, defaultFromAddress: string) {
+    constructor(artifactsPath: string, sourcesPath: string, defaultFromAddress: string, verbose: boolean = false) {
         super();
         this._lock = new Lock();
         this._defaultFromAddress = defaultFromAddress;
-        this._coverageManager = new CoverageManager(artifactsPath, sourcesPath, this._getContractCodeAsync.bind(this));
+        this._coverageManager = new CoverageManager(artifactsPath, sourcesPath, this._getContractCodeAsync.bind(this), verbose);
     }
     /**
      * Write the test coverage results to a file in Istanbul format.


### PR DESCRIPTION
<!--- Thank you for taking the time to submit a Pull Request -->

<!--- Provide a general summary of the issue in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

We have contract A & contract B. They are independent projects/repos. Contract A interacts with contract B. We want to cover contract A, however contract B artifacts are not in contract A's repo. This change makes sol-cov ignore errors when it can't find a contract for a tx to contract B.

Also look for `sourceCodes` in the artifact when collecting contract data.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [X] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [X] Labeled this PR with the labels corresponding to the changed package.
