### PR TITLE
Manage your wallet section of portal

### DIFF
--- a/packages/website/ts/components/legacy_portal/legacy_portal.tsx
+++ b/packages/website/ts/components/legacy_portal/legacy_portal.tsx
@@ -217,7 +217,7 @@ export class LegacyPortal extends React.Component<LegacyPortalProps, LegacyPorta
                                                 />
                                                 <Route
                                                     path={`${WebsitePaths.Portal}/trades`}
-                                                    component={this._renderTradeHistory.bind(this)}
+                                                    render={this._renderTradeHistory.bind(this)}
                                                 />
                                                 <Route
                                                     path={`${WebsitePaths.Home}`}

--- a/packages/website/ts/components/portal/back_button.tsx
+++ b/packages/website/ts/components/portal/back_button.tsx
@@ -1,0 +1,41 @@
+import { colors, Styles } from '@0xproject/react-shared';
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+
+export interface BackButtonProps {
+    to: string;
+    labelText: string;
+}
+
+const BACK_BUTTON_HEIGHT = 28;
+
+const styles: Styles = {
+    backButton: {
+        height: BACK_BUTTON_HEIGHT,
+        paddingTop: 10,
+        backgroundColor: colors.white,
+        borderRadius: BACK_BUTTON_HEIGHT,
+        boxShadow: `0px 4px 6px ${colors.walletBoxShadow}`,
+    },
+    backButtonIcon: {
+        color: colors.mediumBlue,
+        fontSize: 20,
+    },
+};
+
+export const BackButton = (props: BackButtonProps) => {
+    return (
+        <div style={{ height: 65, paddingTop: 25 }}>
+            <Link to={props.to} style={{ textDecoration: 'none' }}>
+                <div className="flex right" style={styles.backButton}>
+                    <div style={{ marginLeft: 12 }}>
+                        <i style={styles.backButtonIcon} className={`zmdi zmdi-arrow-left`} />
+                    </div>
+                    <div style={{ marginLeft: 12, marginRight: 12 }}>
+                        <div style={{ fontSize: 16, color: colors.lightGrey }}>{props.labelText}</div>
+                    </div>
+                </div>
+            </Link>
+        </div>
+    );
+};

--- a/packages/website/ts/components/portal/loading.tsx
+++ b/packages/website/ts/components/portal/loading.tsx
@@ -1,0 +1,21 @@
+import CircularProgress from 'material-ui/CircularProgress';
+import * as React from 'react';
+
+const CIRCULAR_PROGRESS_SIZE = 40;
+const CIRCULAR_PROGRESS_THICKNESS = 5;
+
+export interface LoadingProps {
+    isLoading: boolean;
+    content: React.ReactNode;
+}
+export const Loading = (props: LoadingProps) => {
+    if (props.isLoading) {
+        return (
+            <div className="center">
+                <CircularProgress size={CIRCULAR_PROGRESS_SIZE} thickness={CIRCULAR_PROGRESS_THICKNESS} />
+            </div>
+        );
+    } else {
+        return <div>{props.content}</div>;
+    }
+};

--- a/packages/website/ts/components/portal/menu.tsx
+++ b/packages/website/ts/components/portal/menu.tsx
@@ -5,7 +5,7 @@ import { MenuItem } from 'ts/components/ui/menu_item';
 import { Environments, WebsitePaths } from 'ts/types';
 import { configs } from 'ts/utils/configs';
 
-export interface PortalMenuProps {
+export interface MenuProps {
     selectedPath?: string;
 }
 
@@ -44,14 +44,14 @@ const SELECTED_ICON_COLOR = colors.yellow900;
 
 const LEFT_PADDING = 185;
 
-export const PortalMenu: React.StatelessComponent<PortalMenuProps> = (props: PortalMenuProps) => {
+export const Menu: React.StatelessComponent<MenuProps> = (props: MenuProps) => {
     return (
         <div style={{ paddingLeft: LEFT_PADDING }}>
             {_.map(menuItemEntries, entry => {
                 const selected = entry.to === props.selectedPath;
                 return (
                     <MenuItem key={entry.to} className="py2" to={entry.to}>
-                        <PortalMenuItemLabel title={entry.labelText} iconName={entry.iconName} selected={selected} />
+                        <MenuItemLabel title={entry.labelText} iconName={entry.iconName} selected={selected} />
                     </MenuItem>
                 );
             })}
@@ -59,12 +59,12 @@ export const PortalMenu: React.StatelessComponent<PortalMenuProps> = (props: Por
     );
 };
 
-interface PortalMenuItemLabelProps {
+interface MenuItemLabelProps {
     title: string;
     iconName: string;
     selected: boolean;
 }
-const PortalMenuItemLabel: React.StatelessComponent<PortalMenuItemLabelProps> = (props: PortalMenuItemLabelProps) => {
+const MenuItemLabel: React.StatelessComponent<MenuItemLabelProps> = (props: MenuItemLabelProps) => {
     const styles: Styles = {
         iconStyle: {
             color: props.selected ? SELECTED_ICON_COLOR : DEFAULT_ICON_COLOR,

--- a/packages/website/ts/components/portal/portal.tsx
+++ b/packages/website/ts/components/portal/portal.tsx
@@ -275,7 +275,7 @@ export class Portal extends React.Component<PortalProps, PortalState> {
     private _renderMenu(routeComponentProps: RouteComponentProps<any>) {
         return (
             <div>
-                <BackButton />
+                <BackButton to={`${WebsitePaths.Portal}`} labelText={'back to Relayers'} />
                 <PortalMenu selectedPath={routeComponentProps.location.pathname} />
             </div>
         );
@@ -285,7 +285,7 @@ export class Portal extends React.Component<PortalProps, PortalState> {
         const trackedTokens = _.filter(allTokens, t => t.isTracked);
         return (
             <div>
-                <Title titleText={'Your Account'} />
+                <Title labelText={'Your Account'} />
                 <Wallet
                     userAddress={this.props.userAddress}
                     networkId={this.props.networkId}
@@ -333,7 +333,7 @@ export class Portal extends React.Component<PortalProps, PortalState> {
         const trackedTokens = _.filter(allTokens, t => t.isTracked);
         return (
             <div>
-                <Title titleText={'Your Account'} />
+                <Title labelText={'Your Account'} />
                 <TokenBalances
                     blockchain={this._blockchain}
                     blockchainErr={this.props.blockchainErr}
@@ -381,7 +381,7 @@ export class Portal extends React.Component<PortalProps, PortalState> {
     private _renderRelayerIndex() {
         return (
             <div>
-                <Title titleText={'Explore 0x Relayers'} />
+                <Title labelText={'Explore 0x Relayers'} />
                 <RelayerIndex networkId={this.props.networkId} />
             </div>
         );
@@ -442,26 +442,30 @@ export class Portal extends React.Component<PortalProps, PortalState> {
 }
 
 interface TitleProps {
-    titleText: string;
+    labelText: string;
 }
 const Title = (props: TitleProps) => {
     return (
         <div className="py3" style={styles.title}>
-            {props.titleText}
+            {props.labelText}
         </div>
     );
 };
 
-const BackButton = () => {
+interface BackButtonProps {
+    to: string;
+    labelText: string;
+}
+const BackButton = (props: BackButtonProps) => {
     return (
         <div style={{ height: 65, paddingTop: 25 }}>
-            <Link to={`${WebsitePaths.Portal}`} style={{ textDecoration: 'none' }}>
+            <Link to={props.to} style={{ textDecoration: 'none' }}>
                 <div className="flex right" style={{ ...styles.backButton, paddingTop: 10 }}>
                     <div style={{ marginLeft: 12 }}>
                         <i style={styles.backButtonIcon} className={`zmdi zmdi-arrow-left`} />
                     </div>
                     <div style={{ marginLeft: 12, marginRight: 12 }}>
-                        <div style={{ fontSize: 16, color: colors.lightGrey }}>back to Relayers</div>
+                        <div style={{ fontSize: 16, color: colors.lightGrey }}>{props.labelText}</div>
                     </div>
                 </div>
             </Link>

--- a/packages/website/ts/components/portal/portal.tsx
+++ b/packages/website/ts/components/portal/portal.tsx
@@ -221,7 +221,6 @@ export class Portal extends React.Component<PortalProps, PortalState> {
                                     path={`${WebsitePaths.Portal}/weth`}
                                     render={this._renderEthWrapper.bind(this)}
                                 />
-                                <Route path={`${WebsitePaths.Portal}/fill`} render={this._renderFillOrder.bind(this)} />
                                 <Route
                                     path={`${WebsitePaths.Portal}/account`}
                                     render={this._renderTokenBalances.bind(this)}
@@ -229,6 +228,10 @@ export class Portal extends React.Component<PortalProps, PortalState> {
                                 <Route
                                     path={`${WebsitePaths.Portal}/trades`}
                                     component={this._renderTradeHistory.bind(this)}
+                                />
+                                <Route
+                                    path={`${WebsitePaths.Portal}/direct`}
+                                    component={this._renderTradeDirect.bind(this)}
                                 />
                                 <Route path={`${WebsitePaths.Home}`} component={this._renderRelayerIndex.bind(this)} />
                             </Switch>
@@ -308,24 +311,42 @@ export class Portal extends React.Component<PortalProps, PortalState> {
     }
     private _renderEthWrapper() {
         return (
-            <EthWrappers
-                networkId={this.props.networkId}
-                blockchain={this._blockchain}
-                dispatcher={this.props.dispatcher}
-                tokenByAddress={this.props.tokenByAddress}
-                userAddress={this.props.userAddress}
-                userEtherBalanceInWei={this.props.userEtherBalanceInWei}
-                lastForceTokenStateRefetch={this.props.lastForceTokenStateRefetch}
-            />
+            <div>
+                <Title labelText={'Wrapped ETH'} />
+                <EthWrappers
+                    networkId={this.props.networkId}
+                    blockchain={this._blockchain}
+                    dispatcher={this.props.dispatcher}
+                    tokenByAddress={this.props.tokenByAddress}
+                    userAddress={this.props.userAddress}
+                    userEtherBalanceInWei={this.props.userEtherBalanceInWei}
+                    lastForceTokenStateRefetch={this.props.lastForceTokenStateRefetch}
+                />
+            </div>
         );
     }
     private _renderTradeHistory() {
         return (
-            <TradeHistory
-                tokenByAddress={this.props.tokenByAddress}
-                userAddress={this.props.userAddress}
-                networkId={this.props.networkId}
-            />
+            <div>
+                <Title labelText={'Trade History'} />
+                <TradeHistory
+                    tokenByAddress={this.props.tokenByAddress}
+                    userAddress={this.props.userAddress}
+                    networkId={this.props.networkId}
+                />
+            </div>
+        );
+    }
+    private _renderTradeDirect(match: any, location: Location, history: History) {
+        return (
+            <div>
+                <Title labelText={'Trade Direct'} />
+                <GenerateOrderForm
+                    blockchain={this._blockchain}
+                    hashData={this.props.hashData}
+                    dispatcher={this.props.dispatcher}
+                />
+            </div>
         );
     }
     private _renderTokenBalances() {
@@ -348,34 +369,6 @@ export class Portal extends React.Component<PortalProps, PortalState> {
                     lastForceTokenStateRefetch={this.props.lastForceTokenStateRefetch}
                 />
             </div>
-        );
-    }
-    private _renderFillOrder(match: any, location: Location, history: History) {
-        const initialFillOrder = !_.isUndefined(this.props.userSuppliedOrderCache)
-            ? this.props.userSuppliedOrderCache
-            : this._sharedOrderIfExists;
-        return (
-            <FillOrder
-                blockchain={this._blockchain}
-                blockchainErr={this.props.blockchainErr}
-                initialOrder={initialFillOrder}
-                isOrderInUrl={!_.isUndefined(this._sharedOrderIfExists)}
-                orderFillAmount={this.props.orderFillAmount}
-                networkId={this.props.networkId}
-                userAddress={this.props.userAddress}
-                tokenByAddress={this.props.tokenByAddress}
-                dispatcher={this.props.dispatcher}
-                lastForceTokenStateRefetch={this.props.lastForceTokenStateRefetch}
-            />
-        );
-    }
-    private _renderGenerateOrderForm(match: any, location: Location, history: History) {
-        return (
-            <GenerateOrderForm
-                blockchain={this._blockchain}
-                hashData={this.props.hashData}
-                dispatcher={this.props.dispatcher}
-            />
         );
     }
     private _renderRelayerIndex() {

--- a/packages/website/ts/components/portal/portal.tsx
+++ b/packages/website/ts/components/portal/portal.tsx
@@ -210,7 +210,7 @@ export class Portal extends React.Component<PortalProps, PortalState> {
                                     <Route
                                         exact={true}
                                         path={`${WebsitePaths.Portal}`}
-                                        component={this._renderWallet.bind(this)}
+                                        render={this._renderWallet.bind(this)}
                                     />
                                 </Switch>
                             </div>
@@ -227,13 +227,17 @@ export class Portal extends React.Component<PortalProps, PortalState> {
                                 />
                                 <Route
                                     path={`${WebsitePaths.Portal}/trades`}
-                                    component={this._renderTradeHistory.bind(this)}
+                                    render={this._renderTradeHistory.bind(this)}
                                 />
                                 <Route
                                     path={`${WebsitePaths.Portal}/direct`}
-                                    component={this._renderTradeDirect.bind(this)}
+                                    render={this._renderTradeDirect.bind(this)}
                                 />
-                                <Route path={`${WebsitePaths.Home}`} component={this._renderRelayerIndex.bind(this)} />
+                                <Route
+                                    exact={true}
+                                    path={`${WebsitePaths.Portal}/`}
+                                    render={this._renderRelayerIndex.bind(this)}
+                                />
                             </Switch>
                         </div>
                     </div>
@@ -275,7 +279,7 @@ export class Portal extends React.Component<PortalProps, PortalState> {
             </div>
         );
     }
-    private _renderMenu(routeComponentProps: RouteComponentProps<any>) {
+    private _renderMenu(routeComponentProps: RouteComponentProps<any>): React.ReactNode {
         return (
             <div>
                 <BackButton to={`${WebsitePaths.Portal}`} labelText={'back to Relayers'} />
@@ -283,7 +287,7 @@ export class Portal extends React.Component<PortalProps, PortalState> {
             </div>
         );
     }
-    private _renderWallet() {
+    private _renderWallet(): React.ReactNode {
         const allTokens = _.values(this.props.tokenByAddress);
         const trackedTokens = _.filter(allTokens, t => t.isTracked);
         return (
@@ -309,7 +313,7 @@ export class Portal extends React.Component<PortalProps, PortalState> {
             </div>
         );
     }
-    private _renderEthWrapper() {
+    private _renderEthWrapper(): React.ReactNode {
         return (
             <div>
                 <Title labelText={'Wrapped ETH'} />
@@ -325,7 +329,7 @@ export class Portal extends React.Component<PortalProps, PortalState> {
             </div>
         );
     }
-    private _renderTradeHistory() {
+    private _renderTradeHistory(): React.ReactNode {
         return (
             <div>
                 <Title labelText={'Trade History'} />
@@ -337,7 +341,7 @@ export class Portal extends React.Component<PortalProps, PortalState> {
             </div>
         );
     }
-    private _renderTradeDirect(match: any, location: Location, history: History) {
+    private _renderTradeDirect(match: any, location: Location, history: History): React.ReactNode {
         return (
             <div>
                 <Title labelText={'Trade Direct'} />
@@ -349,7 +353,7 @@ export class Portal extends React.Component<PortalProps, PortalState> {
             </div>
         );
     }
-    private _renderTokenBalances() {
+    private _renderTokenBalances(): React.ReactNode {
         const allTokens = _.values(this.props.tokenByAddress);
         const trackedTokens = _.filter(allTokens, t => t.isTracked);
         return (
@@ -371,7 +375,7 @@ export class Portal extends React.Component<PortalProps, PortalState> {
             </div>
         );
     }
-    private _renderRelayerIndex() {
+    private _renderRelayerIndex(): React.ReactNode {
         return (
             <div>
                 <Title labelText={'Explore 0x Relayers'} />

--- a/packages/website/ts/components/portal/portal.tsx
+++ b/packages/website/ts/components/portal/portal.tsx
@@ -1,7 +1,6 @@
 import { colors, Styles } from '@0xproject/react-shared';
 import { BigNumber } from '@0xproject/utils';
 import * as _ from 'lodash';
-import CircularProgress from 'material-ui/CircularProgress';
 import * as React from 'react';
 import * as DocumentTitle from 'react-document-title';
 import { Link, Route, RouteComponentProps, Switch } from 'react-router-dom';
@@ -13,6 +12,7 @@ import { PortalDisclaimerDialog } from 'ts/components/dialogs/portal_disclaimer_
 import { EthWrappers } from 'ts/components/eth_wrappers';
 import { AssetPicker } from 'ts/components/generate_order/asset_picker';
 import { BackButton } from 'ts/components/portal/back_button';
+import { Loading } from 'ts/components/portal/loading';
 import { Menu } from 'ts/components/portal/menu';
 import { Section } from 'ts/components/portal/section';
 import { TextHeader } from 'ts/components/portal/text_header';
@@ -283,7 +283,7 @@ export class Portal extends React.Component<PortalProps, PortalState> {
         );
     }
     private _renderAccountManagement(): React.ReactNode {
-        return this.props.blockchainIsLoaded ? (
+        return (
             <Switch>
                 <Route path={`${WebsitePaths.Portal}/weth`} render={this._renderEthWrapper.bind(this)} />
                 <Route path={`${WebsitePaths.Portal}/account`} render={this._renderTokenBalances.bind(this)} />
@@ -291,18 +291,6 @@ export class Portal extends React.Component<PortalProps, PortalState> {
                 <Route path={`${WebsitePaths.Portal}/direct`} render={this._renderTradeDirect.bind(this)} />
                 <Route render={this._renderNotFoundMessage.bind(this)} />
             </Switch>
-        ) : (
-            // TODO: consolidate this loading component with the one in relayer_index
-            <div className="pt4 sm-px2 sm-pt2 sm-m1" style={{ height: 500 }}>
-                <div
-                    className="relative sm-px2 sm-pt2 sm-m1"
-                    style={{ height: 122, top: '50%', transform: 'translateY(-50%)' }}
-                >
-                    <div className="center pb2">
-                        <CircularProgress size={40} thickness={5} />
-                    </div>
-                </div>
-            </div>
         );
     }
     private _renderEthWrapper(): React.ReactNode {
@@ -310,14 +298,19 @@ export class Portal extends React.Component<PortalProps, PortalState> {
             <Section
                 header={<TextHeader labelText="Wrapped ETH" />}
                 body={
-                    <EthWrappers
-                        networkId={this.props.networkId}
-                        blockchain={this._blockchain}
-                        dispatcher={this.props.dispatcher}
-                        tokenByAddress={this.props.tokenByAddress}
-                        userAddress={this.props.userAddress}
-                        userEtherBalanceInWei={this.props.userEtherBalanceInWei}
-                        lastForceTokenStateRefetch={this.props.lastForceTokenStateRefetch}
+                    <Loading
+                        isLoading={!this.props.blockchainIsLoaded}
+                        content={
+                            <EthWrappers
+                                networkId={this.props.networkId}
+                                blockchain={this._blockchain}
+                                dispatcher={this.props.dispatcher}
+                                tokenByAddress={this.props.tokenByAddress}
+                                userAddress={this.props.userAddress}
+                                userEtherBalanceInWei={this.props.userEtherBalanceInWei}
+                                lastForceTokenStateRefetch={this.props.lastForceTokenStateRefetch}
+                            />
+                        }
                     />
                 }
             />
@@ -328,10 +321,15 @@ export class Portal extends React.Component<PortalProps, PortalState> {
             <Section
                 header={<TextHeader labelText="Trade History" />}
                 body={
-                    <TradeHistory
-                        tokenByAddress={this.props.tokenByAddress}
-                        userAddress={this.props.userAddress}
-                        networkId={this.props.networkId}
+                    <Loading
+                        isLoading={!this.props.blockchainIsLoaded}
+                        content={
+                            <TradeHistory
+                                tokenByAddress={this.props.tokenByAddress}
+                                userAddress={this.props.userAddress}
+                                networkId={this.props.networkId}
+                            />
+                        }
                     />
                 }
             />
@@ -342,10 +340,15 @@ export class Portal extends React.Component<PortalProps, PortalState> {
             <Section
                 header={<TextHeader labelText="Trade Direct" />}
                 body={
-                    <GenerateOrderForm
-                        blockchain={this._blockchain}
-                        hashData={this.props.hashData}
-                        dispatcher={this.props.dispatcher}
+                    <Loading
+                        isLoading={!this.props.blockchainIsLoaded}
+                        content={
+                            <GenerateOrderForm
+                                blockchain={this._blockchain}
+                                hashData={this.props.hashData}
+                                dispatcher={this.props.dispatcher}
+                            />
+                        }
                     />
                 }
             />
@@ -358,18 +361,23 @@ export class Portal extends React.Component<PortalProps, PortalState> {
             <Section
                 header={<TextHeader labelText="Your Account" />}
                 body={
-                    <TokenBalances
-                        blockchain={this._blockchain}
-                        blockchainErr={this.props.blockchainErr}
-                        blockchainIsLoaded={this.props.blockchainIsLoaded}
-                        dispatcher={this.props.dispatcher}
-                        screenWidth={this.props.screenWidth}
-                        tokenByAddress={this.props.tokenByAddress}
-                        trackedTokens={trackedTokens}
-                        userAddress={this.props.userAddress}
-                        userEtherBalanceInWei={this.props.userEtherBalanceInWei}
-                        networkId={this.props.networkId}
-                        lastForceTokenStateRefetch={this.props.lastForceTokenStateRefetch}
+                    <Loading
+                        isLoading={!this.props.blockchainIsLoaded}
+                        content={
+                            <TokenBalances
+                                blockchain={this._blockchain}
+                                blockchainErr={this.props.blockchainErr}
+                                blockchainIsLoaded={this.props.blockchainIsLoaded}
+                                dispatcher={this.props.dispatcher}
+                                screenWidth={this.props.screenWidth}
+                                tokenByAddress={this.props.tokenByAddress}
+                                trackedTokens={trackedTokens}
+                                userAddress={this.props.userAddress}
+                                userEtherBalanceInWei={this.props.userEtherBalanceInWei}
+                                networkId={this.props.networkId}
+                                lastForceTokenStateRefetch={this.props.lastForceTokenStateRefetch}
+                            />
+                        }
                     />
                 }
             />

--- a/packages/website/ts/components/portal/portal.tsx
+++ b/packages/website/ts/components/portal/portal.tsx
@@ -105,6 +105,7 @@ const styles: Styles = {
     },
     backButton: {
         height: BACK_BUTTON_HEIGHT,
+        paddingTop: 10,
         backgroundColor: colors.white,
         borderRadius: BACK_BUTTON_HEIGHT,
         boxShadow: `0px 4px 6px ${colors.walletBoxShadow}`,
@@ -203,36 +204,17 @@ export class Portal extends React.Component<PortalProps, PortalState> {
                     style={{ backgroundColor: colors.lightestGrey }}
                 />
                 <div id="portal" style={styles.body}>
-                    <div className="sm-flex flex-center">
-                        <div className="flex-last px3">
-                            <div style={styles.leftColumn}>
-                                <Switch>
-                                    <Route
-                                        path={`${WebsitePaths.Portal}/:route`}
-                                        render={this._renderMenu.bind(this)}
-                                    />
-                                    <Route
-                                        exact={true}
-                                        path={`${WebsitePaths.Portal}`}
-                                        render={this._renderWallet.bind(this)}
-                                    />
-                                </Switch>
-                            </div>
-                        </div>
-                        <div className="flex-auto px3" style={styles.scrollContainer}>
-                            <Switch>
-                                <Route
-                                    path={`${WebsitePaths.Portal}/:route`}
-                                    render={this._renderAccountManagement.bind(this)}
-                                />
-                                <Route
-                                    exact={true}
-                                    path={`${WebsitePaths.Portal}/`}
-                                    render={this._renderRelayerIndex.bind(this)}
-                                />
-                            </Switch>
-                        </div>
-                    </div>
+                    <Switch>
+                        <Route
+                            path={`${WebsitePaths.Portal}/:route`}
+                            render={this._renderMenuAndAccountManagement.bind(this)}
+                        />
+                        <Route
+                            exact={true}
+                            path={`${WebsitePaths.Portal}/`}
+                            render={this._renderWalletAndRelayerIndex.bind(this)}
+                        />
+                    </Switch>
                     <BlockchainErrDialog
                         blockchain={this._blockchain}
                         blockchainErr={this.props.blockchainErr}
@@ -270,6 +252,12 @@ export class Portal extends React.Component<PortalProps, PortalState> {
                 </div>
             </div>
         );
+    }
+    private _renderWalletAndRelayerIndex(): React.ReactNode {
+        return <PortalLayout left={this._renderWallet()} right={this._renderRelayerIndex()} />;
+    }
+    private _renderMenuAndAccountManagement(routeComponentProps: RouteComponentProps<any>): React.ReactNode {
+        return <PortalLayout left={this._renderMenu(routeComponentProps)} right={this._renderAccountManagement()} />;
     }
     private _renderMenu(routeComponentProps: RouteComponentProps<any>): React.ReactNode {
         return (
@@ -480,7 +468,7 @@ const BackButton = (props: BackButtonProps) => {
     return (
         <div style={{ height: 65, paddingTop: 25 }}>
             <Link to={props.to} style={{ textDecoration: 'none' }}>
-                <div className="flex right" style={{ ...styles.backButton, paddingTop: 10 }}>
+                <div className="flex right" style={styles.backButton}>
                     <div style={{ marginLeft: 12 }}>
                         <i style={styles.backButtonIcon} className={`zmdi zmdi-arrow-left`} />
                     </div>
@@ -489,6 +477,23 @@ const BackButton = (props: BackButtonProps) => {
                     </div>
                 </div>
             </Link>
+        </div>
+    );
+};
+
+interface PortalLayoutProps {
+    left: React.ReactNode;
+    right: React.ReactNode;
+}
+const PortalLayout = (props: PortalLayoutProps) => {
+    return (
+        <div className="sm-flex flex-center">
+            <div className="flex-last px3">
+                <div style={styles.leftColumn}>{props.left}</div>
+            </div>
+            <div className="flex-auto px3" style={styles.scrollContainer}>
+                {props.right}
+            </div>
         </div>
     );
 };

--- a/packages/website/ts/components/portal/portal.tsx
+++ b/packages/website/ts/components/portal/portal.tsx
@@ -274,7 +274,7 @@ export class Portal extends React.Component<PortalProps, PortalState> {
     private _renderMenu(routeComponentProps: RouteComponentProps<any>): React.ReactNode {
         return (
             <div>
-                <BackButton to={`${WebsitePaths.Portal}`} labelText={'back to Relayers'} />
+                <BackButton to={`${WebsitePaths.Portal}`} labelText="back to Relayers" />
                 <PortalMenu selectedPath={routeComponentProps.location.pathname} />
             </div>
         );
@@ -284,7 +284,7 @@ export class Portal extends React.Component<PortalProps, PortalState> {
         const trackedTokens = _.filter(allTokens, t => t.isTracked);
         return (
             <div>
-                <Title labelText={'Your Account'} />
+                <Title labelText="Your Account" />
                 <Wallet
                     userAddress={this.props.userAddress}
                     networkId={this.props.networkId}
@@ -331,7 +331,7 @@ export class Portal extends React.Component<PortalProps, PortalState> {
     private _renderEthWrapper(): React.ReactNode {
         return (
             <div>
-                <Title labelText={'Wrapped ETH'} />
+                <Title labelText="Wrapped ETH" />
                 <EthWrappers
                     networkId={this.props.networkId}
                     blockchain={this._blockchain}
@@ -347,7 +347,7 @@ export class Portal extends React.Component<PortalProps, PortalState> {
     private _renderTradeHistory(): React.ReactNode {
         return (
             <div>
-                <Title labelText={'Trade History'} />
+                <Title labelText="Trade History" />
                 <TradeHistory
                     tokenByAddress={this.props.tokenByAddress}
                     userAddress={this.props.userAddress}
@@ -359,7 +359,7 @@ export class Portal extends React.Component<PortalProps, PortalState> {
     private _renderTradeDirect(match: any, location: Location, history: History): React.ReactNode {
         return (
             <div>
-                <Title labelText={'Trade Direct'} />
+                <Title labelText="Trade Direct" />
                 <GenerateOrderForm
                     blockchain={this._blockchain}
                     hashData={this.props.hashData}
@@ -373,7 +373,7 @@ export class Portal extends React.Component<PortalProps, PortalState> {
         const trackedTokens = _.filter(allTokens, t => t.isTracked);
         return (
             <div>
-                <Title labelText={'Your Account'} />
+                <Title labelText="Your Account" />
                 <TokenBalances
                     blockchain={this._blockchain}
                     blockchainErr={this.props.blockchainErr}
@@ -393,7 +393,7 @@ export class Portal extends React.Component<PortalProps, PortalState> {
     private _renderRelayerIndex(): React.ReactNode {
         return (
             <div>
-                <Title labelText={'Explore 0x Relayers'} />
+                <Title labelText="Explore 0x Relayers" />
                 <RelayerIndex networkId={this.props.networkId} />
             </div>
         );
@@ -401,8 +401,8 @@ export class Portal extends React.Component<PortalProps, PortalState> {
     private _renderNotFoundMessage(): React.ReactNode {
         return (
             <FullscreenMessage
-                headerText={'404 Not Found'}
-                bodyText={"Hm... looks like we couldn't find what you are looking for."}
+                headerText="404 Not Found"
+                bodyText="Hm... looks like we couldn't find what you are looking for."
             />
         );
     }

--- a/packages/website/ts/components/portal/portal.tsx
+++ b/packages/website/ts/components/portal/portal.tsx
@@ -12,6 +12,7 @@ import { PortalDisclaimerDialog } from 'ts/components/dialogs/portal_disclaimer_
 import { EthWrappers } from 'ts/components/eth_wrappers';
 import { FillOrder } from 'ts/components/fill_order';
 import { AssetPicker } from 'ts/components/generate_order/asset_picker';
+import { LegacyPortalMenu } from 'ts/components/legacy_portal/legacy_portal_menu';
 import { RelayerIndex } from 'ts/components/relayer_index/relayer_index';
 import { TokenBalances } from 'ts/components/token_balances';
 import { TopBar, TopBarDisplayType } from 'ts/components/top_bar/top_bar';
@@ -164,8 +165,6 @@ export class Portal extends React.Component<PortalProps, PortalState> {
         const updateShouldBlockchainErrDialogBeOpen = this.props.dispatcher.updateShouldBlockchainErrDialogBeOpen.bind(
             this.props.dispatcher,
         );
-        const allTokens = _.values(this.props.tokenByAddress);
-        const trackedTokens = _.filter(allTokens, t => t.isTracked);
         const isAssetPickerDialogOpen = this.state.tokenManagementState !== TokenManagementState.None;
         const tokenVisibility =
             this.state.tokenManagementState === TokenManagementState.Add
@@ -194,23 +193,19 @@ export class Portal extends React.Component<PortalProps, PortalState> {
                             <div className="py3" style={styles.title}>
                                 Your Account
                             </div>
-                            <Wallet
-                                userAddress={this.props.userAddress}
-                                networkId={this.props.networkId}
-                                blockchain={this._blockchain}
-                                blockchainIsLoaded={this.props.blockchainIsLoaded}
-                                blockchainErr={this.props.blockchainErr}
-                                dispatcher={this.props.dispatcher}
-                                tokenByAddress={this.props.tokenByAddress}
-                                trackedTokens={trackedTokens}
-                                userEtherBalanceInWei={this.props.userEtherBalanceInWei}
-                                lastForceTokenStateRefetch={this.props.lastForceTokenStateRefetch}
-                                injectedProviderName={this.props.injectedProviderName}
-                                providerType={this.props.providerType}
-                                onToggleLedgerDialog={this._onToggleLedgerDialog.bind(this)}
-                                onAddToken={this._onAddToken.bind(this)}
-                                onRemoveToken={this._onRemoveToken.bind(this)}
-                            />
+                            <div style={{ width: 346 }}>
+                                <Switch>
+                                    <Route
+                                        path={`${WebsitePaths.Portal}/:route`}
+                                        render={this._renderMenu.bind(this)}
+                                    />
+                                    <Route
+                                        exact={true}
+                                        path={`${WebsitePaths.Portal}`}
+                                        component={this._renderWallet.bind(this)}
+                                    />
+                                </Switch>
+                            </div>
                         </div>
                         <div className="flex-auto px3" style={styles.scrollContainer}>
                             <div className="py3" style={styles.title}>
@@ -270,6 +265,32 @@ export class Portal extends React.Component<PortalProps, PortalState> {
                     />
                 </div>
             </div>
+        );
+    }
+    private _renderMenu() {
+        return <LegacyPortalMenu menuItemStyle={{ color: colors.darkerGrey }} />;
+    }
+    private _renderWallet() {
+        const allTokens = _.values(this.props.tokenByAddress);
+        const trackedTokens = _.filter(allTokens, t => t.isTracked);
+        return (
+            <Wallet
+                userAddress={this.props.userAddress}
+                networkId={this.props.networkId}
+                blockchain={this._blockchain}
+                blockchainIsLoaded={this.props.blockchainIsLoaded}
+                blockchainErr={this.props.blockchainErr}
+                dispatcher={this.props.dispatcher}
+                tokenByAddress={this.props.tokenByAddress}
+                trackedTokens={trackedTokens}
+                userEtherBalanceInWei={this.props.userEtherBalanceInWei}
+                lastForceTokenStateRefetch={this.props.lastForceTokenStateRefetch}
+                injectedProviderName={this.props.injectedProviderName}
+                providerType={this.props.providerType}
+                onToggleLedgerDialog={this._onToggleLedgerDialog.bind(this)}
+                onAddToken={this._onAddToken.bind(this)}
+                onRemoveToken={this._onRemoveToken.bind(this)}
+            />
         );
     }
     private _renderEthWrapper() {

--- a/packages/website/ts/components/portal/portal.tsx
+++ b/packages/website/ts/components/portal/portal.tsx
@@ -12,7 +12,10 @@ import { LedgerConfigDialog } from 'ts/components/dialogs/ledger_config_dialog';
 import { PortalDisclaimerDialog } from 'ts/components/dialogs/portal_disclaimer_dialog';
 import { EthWrappers } from 'ts/components/eth_wrappers';
 import { AssetPicker } from 'ts/components/generate_order/asset_picker';
-import { PortalMenu } from 'ts/components/portal/portal_menu';
+import { BackButton } from 'ts/components/portal/back_button';
+import { Menu } from 'ts/components/portal/menu';
+import { Section } from 'ts/components/portal/section';
+import { TextHeader } from 'ts/components/portal/text_header';
 import { RelayerIndex } from 'ts/components/relayer_index/relayer_index';
 import { TokenBalances } from 'ts/components/token_balances';
 import { TopBar, TopBarDisplayType } from 'ts/components/top_bar/top_bar';
@@ -79,7 +82,6 @@ enum TokenManagementState {
 
 const THROTTLE_TIMEOUT = 100;
 const TOP_BAR_HEIGHT = TopBar.heightForDisplayType(TopBarDisplayType.Expanded);
-const BACK_BUTTON_HEIGHT = 28;
 const LEFT_COLUMN_WIDTH = 346;
 
 const styles: Styles = {
@@ -98,21 +100,6 @@ const styles: Styles = {
         height: `calc(100vh - ${TOP_BAR_HEIGHT}px)`,
         WebkitOverflowScrolling: 'touch',
         overflow: 'auto',
-    },
-    title: {
-        fontWeight: 'bold',
-        fontSize: 20,
-    },
-    backButton: {
-        height: BACK_BUTTON_HEIGHT,
-        paddingTop: 10,
-        backgroundColor: colors.white,
-        borderRadius: BACK_BUTTON_HEIGHT,
-        boxShadow: `0px 4px 6px ${colors.walletBoxShadow}`,
-    },
-    backButtonIcon: {
-        color: colors.mediumBlue,
-        fontSize: 20,
     },
 };
 
@@ -261,36 +248,38 @@ export class Portal extends React.Component<PortalProps, PortalState> {
     }
     private _renderMenu(routeComponentProps: RouteComponentProps<any>): React.ReactNode {
         return (
-            <div>
-                <BackButton to={`${WebsitePaths.Portal}`} labelText="back to Relayers" />
-                <PortalMenu selectedPath={routeComponentProps.location.pathname} />
-            </div>
+            <Section
+                header={<BackButton to={`${WebsitePaths.Portal}`} labelText="back to Relayers" />}
+                body={<Menu selectedPath={routeComponentProps.location.pathname} />}
+            />
         );
     }
     private _renderWallet(): React.ReactNode {
         const allTokens = _.values(this.props.tokenByAddress);
         const trackedTokens = _.filter(allTokens, t => t.isTracked);
         return (
-            <div>
-                <Title labelText="Your Account" />
-                <Wallet
-                    userAddress={this.props.userAddress}
-                    networkId={this.props.networkId}
-                    blockchain={this._blockchain}
-                    blockchainIsLoaded={this.props.blockchainIsLoaded}
-                    blockchainErr={this.props.blockchainErr}
-                    dispatcher={this.props.dispatcher}
-                    tokenByAddress={this.props.tokenByAddress}
-                    trackedTokens={trackedTokens}
-                    userEtherBalanceInWei={this.props.userEtherBalanceInWei}
-                    lastForceTokenStateRefetch={this.props.lastForceTokenStateRefetch}
-                    injectedProviderName={this.props.injectedProviderName}
-                    providerType={this.props.providerType}
-                    onToggleLedgerDialog={this._onToggleLedgerDialog.bind(this)}
-                    onAddToken={this._onAddToken.bind(this)}
-                    onRemoveToken={this._onRemoveToken.bind(this)}
-                />
-            </div>
+            <Section
+                header={<TextHeader labelText="Your Account" />}
+                body={
+                    <Wallet
+                        userAddress={this.props.userAddress}
+                        networkId={this.props.networkId}
+                        blockchain={this._blockchain}
+                        blockchainIsLoaded={this.props.blockchainIsLoaded}
+                        blockchainErr={this.props.blockchainErr}
+                        dispatcher={this.props.dispatcher}
+                        tokenByAddress={this.props.tokenByAddress}
+                        trackedTokens={trackedTokens}
+                        userEtherBalanceInWei={this.props.userEtherBalanceInWei}
+                        lastForceTokenStateRefetch={this.props.lastForceTokenStateRefetch}
+                        injectedProviderName={this.props.injectedProviderName}
+                        providerType={this.props.providerType}
+                        onToggleLedgerDialog={this._onToggleLedgerDialog.bind(this)}
+                        onAddToken={this._onAddToken.bind(this)}
+                        onRemoveToken={this._onRemoveToken.bind(this)}
+                    />
+                }
+            />
         );
     }
     private _renderAccountManagement(): React.ReactNode {
@@ -318,72 +307,80 @@ export class Portal extends React.Component<PortalProps, PortalState> {
     }
     private _renderEthWrapper(): React.ReactNode {
         return (
-            <div>
-                <Title labelText="Wrapped ETH" />
-                <EthWrappers
-                    networkId={this.props.networkId}
-                    blockchain={this._blockchain}
-                    dispatcher={this.props.dispatcher}
-                    tokenByAddress={this.props.tokenByAddress}
-                    userAddress={this.props.userAddress}
-                    userEtherBalanceInWei={this.props.userEtherBalanceInWei}
-                    lastForceTokenStateRefetch={this.props.lastForceTokenStateRefetch}
-                />
-            </div>
+            <Section
+                header={<TextHeader labelText="Wrapped ETH" />}
+                body={
+                    <EthWrappers
+                        networkId={this.props.networkId}
+                        blockchain={this._blockchain}
+                        dispatcher={this.props.dispatcher}
+                        tokenByAddress={this.props.tokenByAddress}
+                        userAddress={this.props.userAddress}
+                        userEtherBalanceInWei={this.props.userEtherBalanceInWei}
+                        lastForceTokenStateRefetch={this.props.lastForceTokenStateRefetch}
+                    />
+                }
+            />
         );
     }
     private _renderTradeHistory(): React.ReactNode {
         return (
-            <div>
-                <Title labelText="Trade History" />
-                <TradeHistory
-                    tokenByAddress={this.props.tokenByAddress}
-                    userAddress={this.props.userAddress}
-                    networkId={this.props.networkId}
-                />
-            </div>
+            <Section
+                header={<TextHeader labelText="Trade History" />}
+                body={
+                    <TradeHistory
+                        tokenByAddress={this.props.tokenByAddress}
+                        userAddress={this.props.userAddress}
+                        networkId={this.props.networkId}
+                    />
+                }
+            />
         );
     }
     private _renderTradeDirect(match: any, location: Location, history: History): React.ReactNode {
         return (
-            <div>
-                <Title labelText="Trade Direct" />
-                <GenerateOrderForm
-                    blockchain={this._blockchain}
-                    hashData={this.props.hashData}
-                    dispatcher={this.props.dispatcher}
-                />
-            </div>
+            <Section
+                header={<TextHeader labelText="Trade Direct" />}
+                body={
+                    <GenerateOrderForm
+                        blockchain={this._blockchain}
+                        hashData={this.props.hashData}
+                        dispatcher={this.props.dispatcher}
+                    />
+                }
+            />
         );
     }
     private _renderTokenBalances(): React.ReactNode {
         const allTokens = _.values(this.props.tokenByAddress);
         const trackedTokens = _.filter(allTokens, t => t.isTracked);
         return (
-            <div>
-                <Title labelText="Your Account" />
-                <TokenBalances
-                    blockchain={this._blockchain}
-                    blockchainErr={this.props.blockchainErr}
-                    blockchainIsLoaded={this.props.blockchainIsLoaded}
-                    dispatcher={this.props.dispatcher}
-                    screenWidth={this.props.screenWidth}
-                    tokenByAddress={this.props.tokenByAddress}
-                    trackedTokens={trackedTokens}
-                    userAddress={this.props.userAddress}
-                    userEtherBalanceInWei={this.props.userEtherBalanceInWei}
-                    networkId={this.props.networkId}
-                    lastForceTokenStateRefetch={this.props.lastForceTokenStateRefetch}
-                />
-            </div>
+            <Section
+                header={<TextHeader labelText="Your Account" />}
+                body={
+                    <TokenBalances
+                        blockchain={this._blockchain}
+                        blockchainErr={this.props.blockchainErr}
+                        blockchainIsLoaded={this.props.blockchainIsLoaded}
+                        dispatcher={this.props.dispatcher}
+                        screenWidth={this.props.screenWidth}
+                        tokenByAddress={this.props.tokenByAddress}
+                        trackedTokens={trackedTokens}
+                        userAddress={this.props.userAddress}
+                        userEtherBalanceInWei={this.props.userEtherBalanceInWei}
+                        networkId={this.props.networkId}
+                        lastForceTokenStateRefetch={this.props.lastForceTokenStateRefetch}
+                    />
+                }
+            />
         );
     }
     private _renderRelayerIndex(): React.ReactNode {
         return (
-            <div>
-                <Title labelText="Explore 0x Relayers" />
-                <RelayerIndex networkId={this.props.networkId} />
-            </div>
+            <Section
+                header={<TextHeader labelText="Explore 0x Relayers" />}
+                body={<RelayerIndex networkId={this.props.networkId} />}
+            />
         );
     }
     private _renderNotFoundMessage(): React.ReactNode {
@@ -449,38 +446,6 @@ export class Portal extends React.Component<PortalProps, PortalState> {
     }
 }
 
-interface TitleProps {
-    labelText: string;
-}
-const Title = (props: TitleProps) => {
-    return (
-        <div className="py3" style={styles.title}>
-            {props.labelText}
-        </div>
-    );
-};
-
-interface BackButtonProps {
-    to: string;
-    labelText: string;
-}
-const BackButton = (props: BackButtonProps) => {
-    return (
-        <div style={{ height: 65, paddingTop: 25 }}>
-            <Link to={props.to} style={{ textDecoration: 'none' }}>
-                <div className="flex right" style={styles.backButton}>
-                    <div style={{ marginLeft: 12 }}>
-                        <i style={styles.backButtonIcon} className={`zmdi zmdi-arrow-left`} />
-                    </div>
-                    <div style={{ marginLeft: 12, marginRight: 12 }}>
-                        <div style={{ fontSize: 16, color: colors.lightGrey }}>{props.labelText}</div>
-                    </div>
-                </div>
-            </Link>
-        </div>
-    );
-};
-
 interface PortalLayoutProps {
     left: React.ReactNode;
     right: React.ReactNode;
@@ -496,4 +461,4 @@ const PortalLayout = (props: PortalLayoutProps) => {
             </div>
         </div>
     );
-};
+}; // tslint:disable:max-file-line-count

--- a/packages/website/ts/components/portal/portal.tsx
+++ b/packages/website/ts/components/portal/portal.tsx
@@ -3,7 +3,7 @@ import { BigNumber } from '@0xproject/utils';
 import * as _ from 'lodash';
 import * as React from 'react';
 import * as DocumentTitle from 'react-document-title';
-import { Route, Switch } from 'react-router-dom';
+import { Route, RouteComponentProps, Switch } from 'react-router-dom';
 
 import { Blockchain } from 'ts/blockchain';
 import { BlockchainErrDialog } from 'ts/components/dialogs/blockchain_err_dialog';
@@ -12,7 +12,7 @@ import { PortalDisclaimerDialog } from 'ts/components/dialogs/portal_disclaimer_
 import { EthWrappers } from 'ts/components/eth_wrappers';
 import { FillOrder } from 'ts/components/fill_order';
 import { AssetPicker } from 'ts/components/generate_order/asset_picker';
-import { LegacyPortalMenu } from 'ts/components/legacy_portal/legacy_portal_menu';
+import { PortalMenu } from 'ts/components/portal/portal_menu';
 import { RelayerIndex } from 'ts/components/relayer_index/relayer_index';
 import { TokenBalances } from 'ts/components/token_balances';
 import { TopBar, TopBarDisplayType } from 'ts/components/top_bar/top_bar';
@@ -267,8 +267,8 @@ export class Portal extends React.Component<PortalProps, PortalState> {
             </div>
         );
     }
-    private _renderMenu() {
-        return <LegacyPortalMenu menuItemStyle={{ color: colors.darkerGrey }} />;
+    private _renderMenu(routeComponentProps: RouteComponentProps<any>) {
+        return <PortalMenu selectedPath={routeComponentProps.location.pathname} />;
     }
     private _renderWallet() {
         const allTokens = _.values(this.props.tokenByAddress);

--- a/packages/website/ts/components/portal/portal.tsx
+++ b/packages/website/ts/components/portal/portal.tsx
@@ -3,7 +3,7 @@ import { BigNumber } from '@0xproject/utils';
 import * as _ from 'lodash';
 import * as React from 'react';
 import * as DocumentTitle from 'react-document-title';
-import { Route, RouteComponentProps, Switch } from 'react-router-dom';
+import { Link, Route, RouteComponentProps, Switch } from 'react-router-dom';
 
 import { Blockchain } from 'ts/blockchain';
 import { BlockchainErrDialog } from 'ts/components/dialogs/blockchain_err_dialog';
@@ -78,6 +78,7 @@ enum TokenManagementState {
 
 const THROTTLE_TIMEOUT = 100;
 const TOP_BAR_HEIGHT = TopBar.heightForDisplayType(TopBarDisplayType.Expanded);
+const BACK_BUTTON_HEIGHT = 28;
 
 const styles: Styles = {
     root: {
@@ -95,6 +96,16 @@ const styles: Styles = {
     },
     title: {
         fontWeight: 'bold',
+        fontSize: 20,
+    },
+    backButton: {
+        height: BACK_BUTTON_HEIGHT,
+        backgroundColor: colors.white,
+        borderRadius: BACK_BUTTON_HEIGHT,
+        boxShadow: `0px 4px 6px ${colors.walletBoxShadow}`,
+    },
+    backButtonIcon: {
+        color: colors.mediumBlue,
         fontSize: 20,
     },
 };
@@ -190,9 +201,6 @@ export class Portal extends React.Component<PortalProps, PortalState> {
                 <div id="portal" style={styles.body}>
                     <div className="sm-flex flex-center">
                         <div className="flex-last px3">
-                            <div className="py3" style={styles.title}>
-                                Your Account
-                            </div>
                             <div style={{ width: 346 }}>
                                 <Switch>
                                     <Route
@@ -208,9 +216,6 @@ export class Portal extends React.Component<PortalProps, PortalState> {
                             </div>
                         </div>
                         <div className="flex-auto px3" style={styles.scrollContainer}>
-                            <div className="py3" style={styles.title}>
-                                Explore 0x Ecosystem
-                            </div>
                             <Switch>
                                 <Route
                                     path={`${WebsitePaths.Portal}/weth`}
@@ -218,7 +223,7 @@ export class Portal extends React.Component<PortalProps, PortalState> {
                                 />
                                 <Route path={`${WebsitePaths.Portal}/fill`} render={this._renderFillOrder.bind(this)} />
                                 <Route
-                                    path={`${WebsitePaths.Portal}/balances`}
+                                    path={`${WebsitePaths.Portal}/account`}
                                     render={this._renderTokenBalances.bind(this)}
                                 />
                                 <Route
@@ -268,29 +273,37 @@ export class Portal extends React.Component<PortalProps, PortalState> {
         );
     }
     private _renderMenu(routeComponentProps: RouteComponentProps<any>) {
-        return <PortalMenu selectedPath={routeComponentProps.location.pathname} />;
+        return (
+            <div>
+                <BackButton />
+                <PortalMenu selectedPath={routeComponentProps.location.pathname} />
+            </div>
+        );
     }
     private _renderWallet() {
         const allTokens = _.values(this.props.tokenByAddress);
         const trackedTokens = _.filter(allTokens, t => t.isTracked);
         return (
-            <Wallet
-                userAddress={this.props.userAddress}
-                networkId={this.props.networkId}
-                blockchain={this._blockchain}
-                blockchainIsLoaded={this.props.blockchainIsLoaded}
-                blockchainErr={this.props.blockchainErr}
-                dispatcher={this.props.dispatcher}
-                tokenByAddress={this.props.tokenByAddress}
-                trackedTokens={trackedTokens}
-                userEtherBalanceInWei={this.props.userEtherBalanceInWei}
-                lastForceTokenStateRefetch={this.props.lastForceTokenStateRefetch}
-                injectedProviderName={this.props.injectedProviderName}
-                providerType={this.props.providerType}
-                onToggleLedgerDialog={this._onToggleLedgerDialog.bind(this)}
-                onAddToken={this._onAddToken.bind(this)}
-                onRemoveToken={this._onRemoveToken.bind(this)}
-            />
+            <div>
+                <Title titleText={'Your Account'} />
+                <Wallet
+                    userAddress={this.props.userAddress}
+                    networkId={this.props.networkId}
+                    blockchain={this._blockchain}
+                    blockchainIsLoaded={this.props.blockchainIsLoaded}
+                    blockchainErr={this.props.blockchainErr}
+                    dispatcher={this.props.dispatcher}
+                    tokenByAddress={this.props.tokenByAddress}
+                    trackedTokens={trackedTokens}
+                    userEtherBalanceInWei={this.props.userEtherBalanceInWei}
+                    lastForceTokenStateRefetch={this.props.lastForceTokenStateRefetch}
+                    injectedProviderName={this.props.injectedProviderName}
+                    providerType={this.props.providerType}
+                    onToggleLedgerDialog={this._onToggleLedgerDialog.bind(this)}
+                    onAddToken={this._onAddToken.bind(this)}
+                    onRemoveToken={this._onRemoveToken.bind(this)}
+                />
+            </div>
         );
     }
     private _renderEthWrapper() {
@@ -319,19 +332,22 @@ export class Portal extends React.Component<PortalProps, PortalState> {
         const allTokens = _.values(this.props.tokenByAddress);
         const trackedTokens = _.filter(allTokens, t => t.isTracked);
         return (
-            <TokenBalances
-                blockchain={this._blockchain}
-                blockchainErr={this.props.blockchainErr}
-                blockchainIsLoaded={this.props.blockchainIsLoaded}
-                dispatcher={this.props.dispatcher}
-                screenWidth={this.props.screenWidth}
-                tokenByAddress={this.props.tokenByAddress}
-                trackedTokens={trackedTokens}
-                userAddress={this.props.userAddress}
-                userEtherBalanceInWei={this.props.userEtherBalanceInWei}
-                networkId={this.props.networkId}
-                lastForceTokenStateRefetch={this.props.lastForceTokenStateRefetch}
-            />
+            <div>
+                <Title titleText={'Your Account'} />
+                <TokenBalances
+                    blockchain={this._blockchain}
+                    blockchainErr={this.props.blockchainErr}
+                    blockchainIsLoaded={this.props.blockchainIsLoaded}
+                    dispatcher={this.props.dispatcher}
+                    screenWidth={this.props.screenWidth}
+                    tokenByAddress={this.props.tokenByAddress}
+                    trackedTokens={trackedTokens}
+                    userAddress={this.props.userAddress}
+                    userEtherBalanceInWei={this.props.userEtherBalanceInWei}
+                    networkId={this.props.networkId}
+                    lastForceTokenStateRefetch={this.props.lastForceTokenStateRefetch}
+                />
+            </div>
         );
     }
     private _renderFillOrder(match: any, location: Location, history: History) {
@@ -363,7 +379,12 @@ export class Portal extends React.Component<PortalProps, PortalState> {
         );
     }
     private _renderRelayerIndex() {
-        return <RelayerIndex networkId={this.props.networkId} />;
+        return (
+            <div>
+                <Title titleText={'Explore 0x Relayers'} />
+                <RelayerIndex networkId={this.props.networkId} />
+            </div>
+        );
     }
     private _onTokenChosen(tokenAddress: string): void {
         if (_.isEmpty(tokenAddress)) {
@@ -419,3 +440,31 @@ export class Portal extends React.Component<PortalProps, PortalState> {
         this.props.dispatcher.updateScreenWidth(newScreenWidth);
     }
 }
+
+interface TitleProps {
+    titleText: string;
+}
+const Title = (props: TitleProps) => {
+    return (
+        <div className="py3" style={styles.title}>
+            {props.titleText}
+        </div>
+    );
+};
+
+const BackButton = () => {
+    return (
+        <div style={{ height: 65, paddingTop: 25 }}>
+            <Link to={`${WebsitePaths.Portal}`} style={{ textDecoration: 'none' }}>
+                <div className="flex right" style={{ ...styles.backButton, paddingTop: 10 }}>
+                    <div style={{ marginLeft: 12 }}>
+                        <i style={styles.backButtonIcon} className={`zmdi zmdi-arrow-left`} />
+                    </div>
+                    <div style={{ marginLeft: 12, marginRight: 12 }}>
+                        <div style={{ fontSize: 16, color: colors.lightGrey }}>back to Relayers</div>
+                    </div>
+                </div>
+            </Link>
+        </div>
+    );
+};

--- a/packages/website/ts/components/portal/portal.tsx
+++ b/packages/website/ts/components/portal/portal.tsx
@@ -11,7 +11,6 @@ import { BlockchainErrDialog } from 'ts/components/dialogs/blockchain_err_dialog
 import { LedgerConfigDialog } from 'ts/components/dialogs/ledger_config_dialog';
 import { PortalDisclaimerDialog } from 'ts/components/dialogs/portal_disclaimer_dialog';
 import { EthWrappers } from 'ts/components/eth_wrappers';
-import { FillOrder } from 'ts/components/fill_order';
 import { AssetPicker } from 'ts/components/generate_order/asset_picker';
 import { PortalMenu } from 'ts/components/portal/portal_menu';
 import { RelayerIndex } from 'ts/components/relayer_index/relayer_index';
@@ -81,6 +80,7 @@ enum TokenManagementState {
 const THROTTLE_TIMEOUT = 100;
 const TOP_BAR_HEIGHT = TopBar.heightForDisplayType(TopBarDisplayType.Expanded);
 const BACK_BUTTON_HEIGHT = 28;
+const LEFT_COLUMN_WIDTH = 346;
 
 const styles: Styles = {
     root: {
@@ -90,6 +90,9 @@ const styles: Styles = {
     },
     body: {
         height: `calc(100vh - ${TOP_BAR_HEIGHT}px)`,
+    },
+    leftColumn: {
+        width: LEFT_COLUMN_WIDTH,
     },
     scrollContainer: {
         height: `calc(100vh - ${TOP_BAR_HEIGHT}px)`,
@@ -114,7 +117,6 @@ const styles: Styles = {
 
 export class Portal extends React.Component<PortalProps, PortalState> {
     private _blockchain: Blockchain;
-    private _sharedOrderIfExists: Order;
     private _throttledScreenWidthUpdate: () => void;
     constructor(props: PortalProps) {
         super(props);
@@ -203,7 +205,7 @@ export class Portal extends React.Component<PortalProps, PortalState> {
                 <div id="portal" style={styles.body}>
                     <div className="sm-flex flex-center">
                         <div className="flex-last px3">
-                            <div style={{ width: 346 }}>
+                            <div style={styles.leftColumn}>
                                 <Switch>
                                     <Route
                                         path={`${WebsitePaths.Portal}/:route`}
@@ -313,6 +315,7 @@ export class Portal extends React.Component<PortalProps, PortalState> {
                 <Route render={this._renderNotFoundMessage.bind(this)} />
             </Switch>
         ) : (
+            // TODO: consolidate this loading component with the one in relayer_index
             <div className="pt4 sm-px2 sm-pt2 sm-m1" style={{ height: 500 }}>
                 <div
                     className="relative sm-px2 sm-pt2 sm-m1"

--- a/packages/website/ts/components/portal/portal.tsx
+++ b/packages/website/ts/components/portal/portal.tsx
@@ -1,6 +1,7 @@
 import { colors, Styles } from '@0xproject/react-shared';
 import { BigNumber } from '@0xproject/utils';
 import * as _ from 'lodash';
+import CircularProgress from 'material-ui/CircularProgress';
 import * as React from 'react';
 import * as DocumentTitle from 'react-document-title';
 import { Link, Route, RouteComponentProps, Switch } from 'react-router-dom';
@@ -22,6 +23,7 @@ import { Wallet } from 'ts/components/wallet/wallet';
 import { GenerateOrderForm } from 'ts/containers/generate_order_form';
 import { localStorage } from 'ts/local_storage/local_storage';
 import { trackedTokenStorage } from 'ts/local_storage/tracked_token_storage';
+import { FullscreenMessage } from 'ts/pages/fullscreen_message';
 import { Dispatcher } from 'ts/redux/dispatcher';
 import {
     BlockchainErrs,
@@ -218,20 +220,8 @@ export class Portal extends React.Component<PortalProps, PortalState> {
                         <div className="flex-auto px3" style={styles.scrollContainer}>
                             <Switch>
                                 <Route
-                                    path={`${WebsitePaths.Portal}/weth`}
-                                    render={this._renderEthWrapper.bind(this)}
-                                />
-                                <Route
-                                    path={`${WebsitePaths.Portal}/account`}
-                                    render={this._renderTokenBalances.bind(this)}
-                                />
-                                <Route
-                                    path={`${WebsitePaths.Portal}/trades`}
-                                    render={this._renderTradeHistory.bind(this)}
-                                />
-                                <Route
-                                    path={`${WebsitePaths.Portal}/direct`}
-                                    render={this._renderTradeDirect.bind(this)}
+                                    path={`${WebsitePaths.Portal}/:route`}
+                                    render={this._renderAccountManagement.bind(this)}
                                 />
                                 <Route
                                     exact={true}
@@ -313,6 +303,28 @@ export class Portal extends React.Component<PortalProps, PortalState> {
             </div>
         );
     }
+    private _renderAccountManagement(): React.ReactNode {
+        return this.props.blockchainIsLoaded ? (
+            <Switch>
+                <Route path={`${WebsitePaths.Portal}/weth`} render={this._renderEthWrapper.bind(this)} />
+                <Route path={`${WebsitePaths.Portal}/account`} render={this._renderTokenBalances.bind(this)} />
+                <Route path={`${WebsitePaths.Portal}/trades`} render={this._renderTradeHistory.bind(this)} />
+                <Route path={`${WebsitePaths.Portal}/direct`} render={this._renderTradeDirect.bind(this)} />
+                <Route render={this._renderNotFoundMessage.bind(this)} />
+            </Switch>
+        ) : (
+            <div className="pt4 sm-px2 sm-pt2 sm-m1" style={{ height: 500 }}>
+                <div
+                    className="relative sm-px2 sm-pt2 sm-m1"
+                    style={{ height: 122, top: '50%', transform: 'translateY(-50%)' }}
+                >
+                    <div className="center pb2">
+                        <CircularProgress size={40} thickness={5} />
+                    </div>
+                </div>
+            </div>
+        );
+    }
     private _renderEthWrapper(): React.ReactNode {
         return (
             <div>
@@ -381,6 +393,14 @@ export class Portal extends React.Component<PortalProps, PortalState> {
                 <Title labelText={'Explore 0x Relayers'} />
                 <RelayerIndex networkId={this.props.networkId} />
             </div>
+        );
+    }
+    private _renderNotFoundMessage(): React.ReactNode {
+        return (
+            <FullscreenMessage
+                headerText={'404 Not Found'}
+                bodyText={"Hm... looks like we couldn't find what you are looking for."}
+            />
         );
     }
     private _onTokenChosen(tokenAddress: string): void {

--- a/packages/website/ts/components/portal/portal_menu.tsx
+++ b/packages/website/ts/components/portal/portal_menu.tsx
@@ -18,7 +18,7 @@ interface MenuItemEntry {
 const menuItemEntries: MenuItemEntry[] = [
     {
         to: `${WebsitePaths.Portal}/account`,
-        labelText: 'Account Overview',
+        labelText: 'Account overview',
         iconName: 'zmdi-balance-wallet',
     },
     {

--- a/packages/website/ts/components/portal/portal_menu.tsx
+++ b/packages/website/ts/components/portal/portal_menu.tsx
@@ -17,39 +17,34 @@ interface MenuItemEntry {
 
 const menuItemEntries: MenuItemEntry[] = [
     {
-        to: `${WebsitePaths.Portal}`,
-        labelText: 'Generate order',
-        iconName: 'zmdi-arrow-right-top',
-    },
-    {
-        to: `${WebsitePaths.Portal}/fill`,
-        labelText: 'Fill order',
-        iconName: 'zmdi-arrow-left-bottom',
-    },
-    {
-        to: `${WebsitePaths.Portal}/balances`,
-        labelText: 'Balances',
+        to: `${WebsitePaths.Portal}/account`,
+        labelText: 'Account Overview',
         iconName: 'zmdi-balance-wallet',
     },
     {
         to: `${WebsitePaths.Portal}/trades`,
-        labelText: 'Trade History',
+        labelText: 'Trade history',
         iconName: 'zmdi-format-list-bulleted',
     },
     {
         to: `${WebsitePaths.Portal}/weth`,
-        labelText: 'Wrap ETH',
+        labelText: 'Wrapped ETH',
         iconName: 'zmdi-circle-o',
+    },
+    {
+        to: `${WebsitePaths.Portal}/direct`,
+        labelText: 'Trade direct',
+        iconName: 'zmdi-swap',
     },
 ];
 
 const DEFAULT_LABEL_COLOR = colors.darkerGrey;
 const DEFAULT_ICON_COLOR = colors.darkerGrey;
-const SELECTED_ICON_COLOR = colors.yellow800;
+const SELECTED_ICON_COLOR = colors.yellow900;
 
 export const PortalMenu: React.StatelessComponent<PortalMenuProps> = (props: PortalMenuProps) => {
     return (
-        <div>
+        <div style={{ paddingLeft: 185 }}>
             {_.map(menuItemEntries, entry => {
                 const selected = entry.to === props.selectedPath;
                 return (
@@ -80,7 +75,7 @@ const PortalMenuItemLabel: React.StatelessComponent<PortalMenuItemLabelProps> = 
     };
     return (
         <div className="flex">
-            <div className="pr1 pl2">
+            <div className="pr1">
                 <i style={styles.iconStyle} className={`zmdi ${props.iconName}`} />
             </div>
             <div className="pl1" style={styles.textStyle}>

--- a/packages/website/ts/components/portal/portal_menu.tsx
+++ b/packages/website/ts/components/portal/portal_menu.tsx
@@ -1,0 +1,91 @@
+import { colors, Styles } from '@0xproject/react-shared';
+import * as _ from 'lodash';
+import * as React from 'react';
+import { MenuItem } from 'ts/components/ui/menu_item';
+import { Environments, WebsitePaths } from 'ts/types';
+import { configs } from 'ts/utils/configs';
+
+export interface PortalMenuProps {
+    selectedPath?: string;
+}
+
+interface MenuItemEntry {
+    to: string;
+    labelText: string;
+    iconName: string;
+}
+
+const menuItemEntries: MenuItemEntry[] = [
+    {
+        to: `${WebsitePaths.Portal}`,
+        labelText: 'Generate order',
+        iconName: 'zmdi-arrow-right-top',
+    },
+    {
+        to: `${WebsitePaths.Portal}/fill`,
+        labelText: 'Fill order',
+        iconName: 'zmdi-arrow-left-bottom',
+    },
+    {
+        to: `${WebsitePaths.Portal}/balances`,
+        labelText: 'Balances',
+        iconName: 'zmdi-balance-wallet',
+    },
+    {
+        to: `${WebsitePaths.Portal}/trades`,
+        labelText: 'Trade History',
+        iconName: 'zmdi-format-list-bulleted',
+    },
+    {
+        to: `${WebsitePaths.Portal}/weth`,
+        labelText: 'Wrap ETH',
+        iconName: 'zmdi-circle-o',
+    },
+];
+
+const DEFAULT_LABEL_COLOR = colors.darkerGrey;
+const DEFAULT_ICON_COLOR = colors.darkerGrey;
+const SELECTED_ICON_COLOR = colors.yellow800;
+
+export const PortalMenu: React.StatelessComponent<PortalMenuProps> = (props: PortalMenuProps) => {
+    return (
+        <div>
+            {_.map(menuItemEntries, entry => {
+                const selected = entry.to === props.selectedPath;
+                return (
+                    <MenuItem key={entry.to} className="py2" to={entry.to}>
+                        <PortalMenuItemLabel title={entry.labelText} iconName={entry.iconName} selected={selected} />
+                    </MenuItem>
+                );
+            })}
+        </div>
+    );
+};
+
+interface PortalMenuItemLabelProps {
+    title: string;
+    iconName: string;
+    selected: boolean;
+}
+const PortalMenuItemLabel: React.StatelessComponent<PortalMenuItemLabelProps> = (props: PortalMenuItemLabelProps) => {
+    const styles: Styles = {
+        iconStyle: {
+            color: props.selected ? SELECTED_ICON_COLOR : DEFAULT_ICON_COLOR,
+            fontSize: 20,
+        },
+        textStyle: {
+            color: DEFAULT_LABEL_COLOR,
+            fontWeight: props.selected ? 'bold' : 'normal',
+        },
+    };
+    return (
+        <div className="flex">
+            <div className="pr1 pl2">
+                <i style={styles.iconStyle} className={`zmdi ${props.iconName}`} />
+            </div>
+            <div className="pl1" style={styles.textStyle}>
+                {props.title}
+            </div>
+        </div>
+    );
+};

--- a/packages/website/ts/components/portal/portal_menu.tsx
+++ b/packages/website/ts/components/portal/portal_menu.tsx
@@ -42,9 +42,11 @@ const DEFAULT_LABEL_COLOR = colors.darkerGrey;
 const DEFAULT_ICON_COLOR = colors.darkerGrey;
 const SELECTED_ICON_COLOR = colors.yellow900;
 
+const LEFT_PADDING = 185;
+
 export const PortalMenu: React.StatelessComponent<PortalMenuProps> = (props: PortalMenuProps) => {
     return (
-        <div style={{ paddingLeft: 185 }}>
+        <div style={{ paddingLeft: LEFT_PADDING }}>
             {_.map(menuItemEntries, entry => {
                 const selected = entry.to === props.selectedPath;
                 return (

--- a/packages/website/ts/components/portal/section.tsx
+++ b/packages/website/ts/components/portal/section.tsx
@@ -1,0 +1,15 @@
+import { Styles } from '@0xproject/react-shared';
+import * as React from 'react';
+
+export interface SectionProps {
+    header: React.ReactNode;
+    body: React.ReactNode;
+}
+export const Section = (props: SectionProps) => {
+    return (
+        <div className="flex flex-column" style={{ height: '100%' }}>
+            {props.header}
+            <div className="flex-auto">{props.body}</div>
+        </div>
+    );
+};

--- a/packages/website/ts/components/portal/text_header.tsx
+++ b/packages/website/ts/components/portal/text_header.tsx
@@ -1,0 +1,21 @@
+import { Styles } from '@0xproject/react-shared';
+import * as React from 'react';
+
+export interface TextHeaderProps {
+    labelText: string;
+}
+
+const styles: Styles = {
+    title: {
+        fontWeight: 'bold',
+        fontSize: 20,
+    },
+};
+
+export const TextHeader = (props: TextHeaderProps) => {
+    return (
+        <div className="py3" style={styles.title}>
+            {props.labelText}
+        </div>
+    );
+};

--- a/packages/website/ts/components/relayer_index/relayer_index.tsx
+++ b/packages/website/ts/components/relayer_index/relayer_index.tsx
@@ -59,10 +59,10 @@ export class RelayerIndex extends React.Component<RelayerIndexProps, RelayerInde
         const readyToRender = _.isUndefined(this.state.error) && !_.isUndefined(this.state.relayerInfos);
         if (!readyToRender) {
             return (
-                <div className="col col-12" style={{ ...styles.root, height: '100%' }}>
+                <div className="pt4 sm-px2 sm-pt2 sm-m1" style={{ height: 500 }}>
                     <div
                         className="relative sm-px2 sm-pt2 sm-m1"
-                        style={{ height: 122, top: '33%', transform: 'translateY(-50%)' }}
+                        style={{ height: 122, top: '50%', transform: 'translateY(-50%)' }}
                     >
                         <div className="center pb2">
                             {_.isUndefined(this.state.error) ? (

--- a/packages/website/ts/components/relayer_index/relayer_index.tsx
+++ b/packages/website/ts/components/relayer_index/relayer_index.tsx
@@ -59,6 +59,7 @@ export class RelayerIndex extends React.Component<RelayerIndexProps, RelayerInde
         const readyToRender = _.isUndefined(this.state.error) && !_.isUndefined(this.state.relayerInfos);
         if (!readyToRender) {
             return (
+                // TODO: consolidate this loading component with the one in portal
                 <div className="pt4 sm-px2 sm-pt2 sm-m1" style={{ height: 500 }}>
                     <div
                         className="relative sm-px2 sm-pt2 sm-m1"

--- a/packages/website/ts/components/relayer_index/relayer_index.tsx
+++ b/packages/website/ts/components/relayer_index/relayer_index.tsx
@@ -60,18 +60,13 @@ export class RelayerIndex extends React.Component<RelayerIndexProps, RelayerInde
         if (!readyToRender) {
             return (
                 // TODO: consolidate this loading component with the one in portal
-                <div className="pt4 sm-px2 sm-pt2 sm-m1" style={{ height: 500 }}>
-                    <div
-                        className="relative sm-px2 sm-pt2 sm-m1"
-                        style={{ height: 122, top: '50%', transform: 'translateY(-50%)' }}
-                    >
-                        <div className="center pb2">
-                            {_.isUndefined(this.state.error) ? (
-                                <CircularProgress size={40} thickness={5} />
-                            ) : (
-                                <Retry onRetry={this._fetchRelayerInfosAsync.bind(this)} />
-                            )}
-                        </div>
+                <div style={styles.root}>
+                    <div className="center">
+                        {_.isUndefined(this.state.error) ? (
+                            <CircularProgress size={40} thickness={5} />
+                        ) : (
+                            <Retry onRetry={this._fetchRelayerInfosAsync.bind(this)} />
+                        )}
                     </div>
                 </div>
             );

--- a/packages/website/ts/components/relayer_index/relayer_index.tsx
+++ b/packages/website/ts/components/relayer_index/relayer_index.tsx
@@ -60,14 +60,12 @@ export class RelayerIndex extends React.Component<RelayerIndexProps, RelayerInde
         if (!readyToRender) {
             return (
                 // TODO: consolidate this loading component with the one in portal
-                <div style={styles.root}>
-                    <div className="center">
-                        {_.isUndefined(this.state.error) ? (
-                            <CircularProgress size={40} thickness={5} />
-                        ) : (
-                            <Retry onRetry={this._fetchRelayerInfosAsync.bind(this)} />
-                        )}
-                    </div>
+                <div className="center">
+                    {_.isUndefined(this.state.error) ? (
+                        <CircularProgress size={40} thickness={5} />
+                    ) : (
+                        <Retry onRetry={this._fetchRelayerInfosAsync.bind(this)} />
+                    )}
                 </div>
             );
         } else {

--- a/packages/website/ts/components/wallet/wallet.tsx
+++ b/packages/website/ts/components/wallet/wallet.tsx
@@ -80,7 +80,7 @@ interface AccessoryItemConfig {
 
 const styles: Styles = {
     root: {
-        width: 346,
+        width: '100%',
         backgroundColor: colors.white,
         borderBottomRightRadius: 10,
         borderBottomLeftRadius: 10,

--- a/packages/website/ts/components/wallet/wallet.tsx
+++ b/packages/website/ts/components/wallet/wallet.tsx
@@ -314,8 +314,7 @@ export class Wallet extends React.Component<WalletProps, WalletState> {
                         primaryText={
                             <div className="flex right" style={{ color: colors.mediumBlue, fontWeight: 'bold' }}>
                                 {'manage your wallet'}
-                            </div>
-                        }
+                            </div>}
                         style={{ ...styles.paddedItem, ...styles.borderedItem }}
                     />
                 </Link>

--- a/packages/website/ts/components/wallet/wallet.tsx
+++ b/packages/website/ts/components/wallet/wallet.tsx
@@ -18,6 +18,7 @@ import NavigationArrowDownward from 'material-ui/svg-icons/navigation/arrow-down
 import NavigationArrowUpward from 'material-ui/svg-icons/navigation/arrow-upward';
 import Close from 'material-ui/svg-icons/navigation/close';
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import ReactTooltip = require('react-tooltip');
 import firstBy = require('thenby');
 
@@ -38,6 +39,7 @@ import {
     TokenByAddress,
     TokenState,
     TokenStateByAddress,
+    WebsitePaths,
 } from 'ts/types';
 import { backendClient } from 'ts/utils/backend_client';
 import { constants } from 'ts/utils/constants';
@@ -237,13 +239,15 @@ export class Wallet extends React.Component<WalletProps, WalletState> {
         const userAddress = this.props.userAddress;
         const primaryText = utils.getAddressBeginAndEnd(userAddress);
         return (
-            <ListItem
-                key={HEADER_ITEM_KEY}
-                primaryText={primaryText}
-                leftIcon={<Identicon address={userAddress} diameter={ICON_DIMENSION} />}
-                style={{ ...styles.paddedItem, ...styles.borderedItem }}
-                innerDivStyle={styles.headerItemInnerDiv}
-            />
+            <Link to={`${WebsitePaths.Portal}/account`} style={{ textDecoration: 'none' }}>
+                <ListItem
+                    key={HEADER_ITEM_KEY}
+                    primaryText={primaryText}
+                    leftIcon={<Identicon address={userAddress} diameter={ICON_DIMENSION} />}
+                    style={{ ...styles.paddedItem, ...styles.borderedItem }}
+                    innerDivStyle={styles.headerItemInnerDiv}
+                />
+            </Link>
         );
     }
     private _renderBody(): React.ReactElement<{}> {

--- a/packages/website/ts/components/wallet/wallet.tsx
+++ b/packages/website/ts/components/wallet/wallet.tsx
@@ -136,6 +136,10 @@ const styles: Styles = {
         overflow: 'auto',
         WebkitOverflowScrolling: 'touch',
     },
+    manageYourWalletText: {
+        color: colors.mediumBlue,
+        fontWeight: 'bold',
+    },
 };
 
 const ETHER_ICON_PATH = '/images/ether.png';
@@ -312,9 +316,12 @@ export class Wallet extends React.Component<WalletProps, WalletState> {
                 <Link to={`${WebsitePaths.Portal}/account`} style={{ textDecoration: 'none' }}>
                     <ListItem
                         primaryText={
-                            <div className="flex right" style={{ color: colors.mediumBlue, fontWeight: 'bold' }}>
+                            <div className="flex right" style={styles.manageYourWalletText}>
                                 {'manage your wallet'}
-                            </div>}
+                            </div>
+                            // https://github.com/palantir/tslint-react/issues/140
+                            // tslint:disable-next-line:jsx-curly-spacing
+                        }
                         style={{ ...styles.paddedItem, ...styles.borderedItem }}
                     />
                 </Link>

--- a/packages/website/ts/components/wallet/wallet.tsx
+++ b/packages/website/ts/components/wallet/wallet.tsx
@@ -279,31 +279,48 @@ export class Wallet extends React.Component<WalletProps, WalletState> {
     }
     private _renderFooterRows(): React.ReactElement<{}> {
         return (
-            <ListItem
-                key={FOOTER_ITEM_KEY}
-                primaryText={
-                    <div className="flex">
-                        <FloatingActionButton mini={true} zDepth={0} onClick={this.props.onAddToken}>
-                            <ContentAdd />
-                        </FloatingActionButton>
-                        <FloatingActionButton mini={true} zDepth={0} className="px1" onClick={this.props.onRemoveToken}>
-                            <ContentRemove />
-                        </FloatingActionButton>
-                        <div
-                            style={{
-                                paddingLeft: 10,
-                                position: 'relative',
-                                top: '50%',
-                                transform: 'translateY(33%)',
-                            }}
-                        >
-                            add/remove tokens
+            <div key={FOOTER_ITEM_KEY}>
+                <ListItem
+                    primaryText={
+                        <div className="flex">
+                            <FloatingActionButton mini={true} zDepth={0} onClick={this.props.onAddToken}>
+                                <ContentAdd />
+                            </FloatingActionButton>
+                            <FloatingActionButton
+                                mini={true}
+                                zDepth={0}
+                                className="px1"
+                                onClick={this.props.onRemoveToken}
+                            >
+                                <ContentRemove />
+                            </FloatingActionButton>
+                            <div
+                                style={{
+                                    paddingLeft: 10,
+                                    position: 'relative',
+                                    top: '50%',
+                                    transform: 'translateY(33%)',
+                                }}
+                            >
+                                add/remove tokens
+                            </div>
                         </div>
-                    </div>
-                }
-                disabled={true}
-                innerDivStyle={styles.footerItemInnerDiv}
-            />
+                    }
+                    disabled={true}
+                    innerDivStyle={styles.footerItemInnerDiv}
+                    style={styles.borderedItem}
+                />
+                <Link to={`${WebsitePaths.Portal}/account`} style={{ textDecoration: 'none' }}>
+                    <ListItem
+                        primaryText={
+                            <div className="flex right" style={{ color: colors.mediumBlue, fontWeight: 'bold' }}>
+                                {'manage your wallet'}
+                            </div>
+                        }
+                        style={{ ...styles.paddedItem, ...styles.borderedItem }}
+                    />
+                </Link>
+            </div>
         );
     }
     private _renderEthRows(): React.ReactNode {

--- a/packages/website/ts/components/wallet/wallet.tsx
+++ b/packages/website/ts/components/wallet/wallet.tsx
@@ -239,9 +239,8 @@ export class Wallet extends React.Component<WalletProps, WalletState> {
         const userAddress = this.props.userAddress;
         const primaryText = utils.getAddressBeginAndEnd(userAddress);
         return (
-            <Link to={`${WebsitePaths.Portal}/account`} style={{ textDecoration: 'none' }}>
+            <Link key={HEADER_ITEM_KEY} to={`${WebsitePaths.Portal}/account`} style={{ textDecoration: 'none' }}>
                 <ListItem
-                    key={HEADER_ITEM_KEY}
                     primaryText={primaryText}
                     leftIcon={<Identicon address={userAddress} diameter={ICON_DIMENSION} />}
                     style={{ ...styles.paddedItem, ...styles.borderedItem }}

--- a/packages/website/ts/pages/fullscreen_message.tsx
+++ b/packages/website/ts/pages/fullscreen_message.tsx
@@ -1,0 +1,30 @@
+import { Styles } from '@0xproject/react-shared';
+import * as React from 'react';
+
+export interface FullscreenMessageProps {
+    headerText: string;
+    bodyText: string;
+}
+
+const styles: Styles = {
+    thin: {
+        fontWeight: 100,
+    },
+};
+
+export const FullscreenMessage = (props: FullscreenMessageProps) => {
+    return (
+        <div className="mx-auto max-width-4 py4">
+            <div className="center py4">
+                <div className="py4">
+                    <div className="py4">
+                        <h1 style={{ ...styles.thin }}>{props.headerText}</h1>
+                        <div className="py1">
+                            <div className="py3">{props.bodyText}</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/packages/website/ts/pages/fullscreen_message.tsx
+++ b/packages/website/ts/pages/fullscreen_message.tsx
@@ -18,7 +18,7 @@ export const FullscreenMessage = (props: FullscreenMessageProps) => {
             <div className="center py4">
                 <div className="py4">
                     <div className="py4">
-                        <h1 style={{ ...styles.thin }}>{props.headerText}</h1>
+                        <h1 style={styles.thin}>{props.headerText}</h1>
                         <div className="py1">
                             <div className="py3">{props.bodyText}</div>
                         </div>

--- a/packages/website/ts/pages/not_found.tsx
+++ b/packages/website/ts/pages/not_found.tsx
@@ -3,6 +3,7 @@ import * as _ from 'lodash';
 import * as React from 'react';
 import { Footer } from 'ts/components/footer';
 import { TopBar } from 'ts/components/top_bar/top_bar';
+import { FullscreenMessage } from 'ts/pages/fullscreen_message';
 import { Dispatcher } from 'ts/redux/dispatcher';
 import { Translate } from 'ts/utils/translate';
 
@@ -12,35 +13,15 @@ export interface NotFoundProps {
     dispatcher: Dispatcher;
 }
 
-interface NotFoundState {}
-
-const styles: Styles = {
-    thin: {
-        fontWeight: 100,
-    },
+export const NotFound = (props: NotFoundProps) => {
+    return (
+        <div>
+            <TopBar blockchainIsLoaded={false} location={this.props.location} translate={this.props.translate} />
+            <FullscreenMessage
+                headerText={'404 Not Found'}
+                bodyText={"Hm... looks like we couldn't find what you are looking for."}
+            />
+            <Footer translate={this.props.translate} dispatcher={this.props.dispatcher} />
+        </div>
+    );
 };
-
-export class NotFound extends React.Component<NotFoundProps, NotFoundState> {
-    public render(): React.ReactNode {
-        return (
-            <div>
-                <TopBar blockchainIsLoaded={false} location={this.props.location} translate={this.props.translate} />
-                <div className="mx-auto max-width-4 py4">
-                    <div className="center py4">
-                        <div className="py4">
-                            <div className="py4">
-                                <h1 style={{ ...styles.thin }}>404 Not Found</h1>
-                                <div className="py1">
-                                    <div className="py3">
-                                        Hm... looks like we couldn't find what you are looking for.
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <Footer translate={this.props.translate} dispatcher={this.props.dispatcher} />
-            </div>
-        );
-    }
-}


### PR DESCRIPTION

![screen shot 2018-05-15 at 10 40 21 am](https://user-images.githubusercontent.com/1141340/40073694-6ef68e3e-582c-11e8-96a8-967e504313d2.png)


Provide the functionality from the old portal in a "manage your wallet" section. This includes viewing account balances, trade history, dedicated wrap / unwrap ETH section, and trading direct

<!--- Describe your changes in detail -->

## Motivation and Context

N/A

## How Has This Been Tested?

Manually.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [x] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
