### PR TITLE
Apply prettier to some files which were not formatted correctly

### DIFF
--- a/packages/monorepo-scripts/src/postpublish_utils.ts
+++ b/packages/monorepo-scripts/src/postpublish_utils.ts
@@ -164,7 +164,12 @@ export const postpublishUtils = {
         });
         return fileIncludesAdjusted;
     },
-    async generateAndUploadDocsAsync(cwd: string, fileIncludes: string[], version: string, S3BucketPath: string): Promise<void> {
+    async generateAndUploadDocsAsync(
+        cwd: string,
+        fileIncludes: string[],
+        version: string,
+        S3BucketPath: string,
+    ): Promise<void> {
         const fileIncludesAdjusted = this.adjustFileIncludePaths(fileIncludes, cwd);
         const projectFiles = fileIncludesAdjusted.join(' ');
         const jsonFilePath = `${cwd}/${generatedDocsDirectoryName}/index.json`;

--- a/packages/monorepo-scripts/src/utils.ts
+++ b/packages/monorepo-scripts/src/utils.ts
@@ -43,7 +43,7 @@ export const utils = {
         }
         return updatedPackages;
     },
-    getChangelogJSONIfExists(changelogPath: string): string|undefined {
+    getChangelogJSONIfExists(changelogPath: string): string | undefined {
         try {
             const changelogJSON = fs.readFileSync(changelogPath, 'utf-8');
             return changelogJSON;


### PR DESCRIPTION
## Description

This PR applies prettier to the following files:

- __packages/monorepo-scripts/src/utils.ts__
- __packages/monorepo-scripts/src/postpublish_utils.ts__

Prior to this change, CI was failing at the `yarn prettier:ci` step.

## Motivation and Context

(Pretty self-explanatory).

## How Has This Been Tested?

I ran `yarn prettier:ci` locally and verified it did not spit out an error. We can also observe the output of CI on this PR.

## Types of changes

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
