### PR TITLE
[WIP] Add BrowserWebSocketOrderbookChannel for browser compatibility

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -67,7 +67,7 @@
         "@types/lodash": "4.14.104",
         "@types/mocha": "^2.2.42",
         "@types/query-string": "^5.0.1",
-        "@types/websocket": "^0.0.34",
+        "@types/websocket": "^0.0.39",
         "async-child-process": "^1.1.1",
         "chai": "^4.0.1",
         "chai-as-promised": "^7.1.0",

--- a/packages/connect/src/browser_ws_orderbook_channel.ts
+++ b/packages/connect/src/browser_ws_orderbook_channel.ts
@@ -1,0 +1,140 @@
+import * as _ from 'lodash';
+import * as WebSocket from 'websocket';
+
+import {
+    OrderbookChannel,
+    OrderbookChannelHandler,
+    OrderbookChannelMessageTypes,
+    OrderbookChannelSubscriptionOpts,
+    WebsocketClientEventType,
+    WebsocketConnectionEventType,
+} from './types';
+import { assert } from './utils/assert';
+import { orderbookChannelMessageParser } from './utils/orderbook_channel_message_parser';
+
+interface Subscription {
+    subscriptionOpts: OrderbookChannelSubscriptionOpts;
+    handler: OrderbookChannelHandler;
+}
+
+/**
+ * This class includes all the functionality related to interacting with a websocket endpoint
+ * that implements the standard relayer API v0 in a browser environment
+ */
+export class BrowserWebSocketOrderbookChannel implements OrderbookChannel {
+    private _apiEndpointUrl: string;
+    private _clientIfExists?: WebSocket.w3cwebsocket;
+    private _subscriptions: Subscription[] = [];
+    /**
+     * Instantiates a new WebSocketOrderbookChannel instance
+     * @param   url                 The relayer API base WS url you would like to interact with
+     * @return  An instance of WebSocketOrderbookChannel
+     */
+    constructor(url: string) {
+        assert.isUri('url', url);
+        this._apiEndpointUrl = url;
+    }
+    /**
+     * Subscribe to orderbook snapshots and updates from the websocket
+     * @param   subscriptionOpts     An OrderbookChannelSubscriptionOpts instance describing which
+     *                               token pair to subscribe to
+     * @param   handler              An OrderbookChannelHandler instance that responds to various
+     *                               channel updates
+     */
+    public subscribe(subscriptionOpts: OrderbookChannelSubscriptionOpts, handler: OrderbookChannelHandler): void {
+        assert.isOrderbookChannelSubscriptionOpts('subscriptionOpts', subscriptionOpts);
+        assert.isOrderbookChannelHandler('handler', handler);
+        const newSubscription: Subscription = {
+            subscriptionOpts,
+            handler,
+        };
+        this._subscriptions.push(newSubscription);
+        const subscribeMessage = {
+            type: 'subscribe',
+            channel: 'orderbook',
+            requestId: this._subscriptions.length - 1,
+            payload: subscriptionOpts,
+        };
+        if (_.isUndefined(this._clientIfExists)) {
+            this._clientIfExists = new WebSocket.w3cwebsocket(this._apiEndpointUrl);
+            this._clientIfExists.onopen = () => {
+                this._sendMessage(subscribeMessage);
+            };
+            this._clientIfExists.onerror = error => {
+                this._alertAllHandlersToError(error);
+            };
+            this._clientIfExists.onclose = () => {
+                _.forEach(this._subscriptions, subscription => {
+                    subscription.handler.onClose(this, subscription.subscriptionOpts);
+                });
+            };
+            this._clientIfExists.onmessage = message => {
+                this._handleWebSocketMessage(message);
+            };
+        } else {
+            this._sendMessage(subscribeMessage);
+        }
+    }
+    /**
+     * Close the websocket and stop receiving updates
+     */
+    public close(): void {
+        if (!_.isUndefined(this._clientIfExists)) {
+            this._clientIfExists.close();
+        }
+    }
+    /**
+     * Send a message to the client if it has been instantiated and it is open
+     */
+    private _sendMessage(message: any): void {
+        if (!_.isUndefined(this._clientIfExists) && this._clientIfExists.readyState === WebSocket.w3cwebsocket.OPEN) {
+            this._clientIfExists.send(JSON.stringify(message));
+        }
+    }
+    /**
+     * For use in cases where we need to alert all handlers of an error
+     */
+    private _alertAllHandlersToError(error: Error): void {
+        _.forEach(this._subscriptions, subscription => {
+            subscription.handler.onError(this, subscription.subscriptionOpts, error);
+        });
+    }
+    private _handleWebSocketMessage(message: any): void {
+        // if we get a message with no data, alert all handlers and return
+        if (_.isUndefined(message.data)) {
+            this._alertAllHandlersToError(new Error(`Message does not contain utf8Data`));
+            return;
+        }
+        // try to parse the message data and route it to the correct handler
+        try {
+            const utf8Data = message.data;
+            const parserResult = orderbookChannelMessageParser.parse(utf8Data);
+            const subscription = this._subscriptions[parserResult.requestId];
+            if (_.isUndefined(subscription)) {
+                this._alertAllHandlersToError(new Error(`Message has unknown requestId: ${utf8Data}`));
+                return;
+            }
+            const handler = subscription.handler;
+            const subscriptionOpts = subscription.subscriptionOpts;
+            switch (parserResult.type) {
+                case OrderbookChannelMessageTypes.Snapshot: {
+                    handler.onSnapshot(this, subscriptionOpts, parserResult.payload);
+                    break;
+                }
+                case OrderbookChannelMessageTypes.Update: {
+                    handler.onUpdate(this, subscriptionOpts, parserResult.payload);
+                    break;
+                }
+                default: {
+                    handler.onError(
+                        this,
+                        subscriptionOpts,
+                        new Error(`Message has unknown type parameter: ${utf8Data}`),
+                    );
+                }
+            }
+        } catch (error) {
+            this._alertAllHandlersToError(error);
+        }
+    }
+}

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -1,9 +1,11 @@
 export { HttpClient } from './http_client';
-export { WebSocketOrderbookChannel } from './ws_orderbook_channel';
+export { BrowserWebSocketOrderbookChannel } from './browser_ws_orderbook_channel';
+export { NodeWebSocketOrderbookChannel } from './node_ws_orderbook_channel';
 export {
     Client,
     FeesRequest,
     FeesResponse,
+    NodeWebSocketOrderbookChannelConfig,
     OrderbookChannel,
     OrderbookChannelHandler,
     OrderbookChannelSubscriptionOpts,
@@ -14,7 +16,5 @@ export {
     TokenPairsItem,
     TokenPairsRequestOpts,
     TokenTradeInfo,
-    WebSocketOrderbookChannelConfig,
 } from './types';
-
 export { ECSignature, Order, SignedOrder } from '@0xproject/types';

--- a/packages/connect/src/schemas/node_websocket_orderbook_channel_config_schema.ts
+++ b/packages/connect/src/schemas/node_websocket_orderbook_channel_config_schema.ts
@@ -1,5 +1,5 @@
-export const webSocketOrderbookChannelConfigSchema = {
-    id: '/WebSocketOrderbookChannelConfig',
+export const nodeWebSocketOrderbookChannelConfigSchema = {
+    id: '/NodeWebSocketOrderbookChannelConfig',
     type: 'object',
     properties: {
         heartbeatIntervalMs: {

--- a/packages/connect/src/schemas/schemas.ts
+++ b/packages/connect/src/schemas/schemas.ts
@@ -1,15 +1,15 @@
 import { feesRequestSchema } from './fees_request_schema';
+import { nodeWebSocketOrderbookChannelConfigSchema } from './node_websocket_orderbook_channel_config_schema';
 import { orderBookRequestSchema } from './orderbook_request_schema';
 import { ordersRequestOptsSchema } from './orders_request_opts_schema';
 import { pagedRequestOptsSchema } from './paged_request_opts_schema';
 import { tokenPairsRequestOptsSchema } from './token_pairs_request_opts_schema';
-import { webSocketOrderbookChannelConfigSchema } from './websocket_orderbook_channel_config_schema';
 
 export const schemas = {
     feesRequestSchema,
+    nodeWebSocketOrderbookChannelConfigSchema,
     orderBookRequestSchema,
     ordersRequestOptsSchema,
     pagedRequestOptsSchema,
     tokenPairsRequestOptsSchema,
-    webSocketOrderbookChannelConfigSchema,
 };

--- a/packages/connect/src/types.ts
+++ b/packages/connect/src/types.ts
@@ -18,7 +18,7 @@ export interface OrderbookChannel {
 /**
  * heartbeatInterval: Interval in milliseconds that the orderbook channel should ping the underlying websocket. Default: 15000
  */
-export interface WebSocketOrderbookChannelConfig {
+export interface NodeWebSocketOrderbookChannelConfig {
     heartbeatIntervalMs?: number;
 }
 

--- a/packages/connect/src/utils/assert.ts
+++ b/packages/connect/src/utils/assert.ts
@@ -1,0 +1,25 @@
+import { assert as sharedAssert } from '@0xproject/assert';
+// We need those two unused imports because they're actually used by sharedAssert which gets injected here
+// tslint:disable-next-line:no-unused-variable
+import { Schema, schemas } from '@0xproject/json-schemas';
+// tslint:disable-next-line:no-unused-variable
+import { ECSignature } from '@0xproject/types';
+import { BigNumber } from '@0xproject/utils';
+import * as _ from 'lodash';
+
+export const assert = {
+    ...sharedAssert,
+    isOrderbookChannelSubscriptionOpts(variableName: string, subscriptionOpts: any): void {
+        sharedAssert.doesConformToSchema(
+            'subscriptionOpts',
+            subscriptionOpts,
+            schemas.relayerApiOrderbookChannelSubscribePayload,
+        );
+    },
+    isOrderbookChannelHandler(variableName: string, handler: any): void {
+        sharedAssert.isFunction(`${variableName}.onSnapshot`, _.get(handler, 'onSnapshot'));
+        sharedAssert.isFunction(`${variableName}.onUpdate`, _.get(handler, 'onUpdate'));
+        sharedAssert.isFunction(`${variableName}.onError`, _.get(handler, 'onError'));
+        sharedAssert.isFunction(`${variableName}.onClose`, _.get(handler, 'onClose'));
+    },
+};

--- a/packages/connect/src/utils/orderbook_channel_message_parser.ts
+++ b/packages/connect/src/utils/orderbook_channel_message_parser.ts
@@ -8,10 +8,16 @@ import { relayerResponseJsonParsers } from './relayer_response_json_parsers';
 
 export const orderbookChannelMessageParser = {
     parse(utf8Data: string): OrderbookChannelMessage {
+        // parse the message
         const messageObj = JSON.parse(utf8Data);
+        // ensure we have a type parameter to switch on
         const type: string = _.get(messageObj, 'type');
         assert.assert(!_.isUndefined(type), `Message is missing a type parameter: ${utf8Data}`);
         assert.isString('type', type);
+        // ensure we have a request id for the resulting message
+        const requestId: number = _.get(messageObj, 'requestId');
+        assert.assert(!_.isUndefined(requestId), `Message is missing a requestId parameter: ${utf8Data}`);
+        assert.isNumber('requestId', requestId);
         switch (type) {
             case OrderbookChannelMessageTypes.Snapshot: {
                 assert.doesConformToSchema('message', messageObj, schemas.relayerApiOrderbookChannelSnapshotSchema);
@@ -28,7 +34,7 @@ export const orderbookChannelMessageParser = {
             default: {
                 return {
                     type: OrderbookChannelMessageTypes.Unknown,
-                    requestId: 0,
+                    requestId,
                     payload: undefined,
                 };
             }

--- a/packages/connect/test/browser_ws_orderbook_channel_test.ts
+++ b/packages/connect/test/browser_ws_orderbook_channel_test.ts
@@ -3,15 +3,15 @@ import * as dirtyChai from 'dirty-chai';
 import * as _ from 'lodash';
 import 'mocha';
 
-import { WebSocketOrderbookChannel } from '../src/ws_orderbook_channel';
+import { BrowserWebSocketOrderbookChannel } from '../src/browser_ws_orderbook_channel';
 
 chai.config.includeStack = true;
 chai.use(dirtyChai);
 const expect = chai.expect;
 
-describe('WebSocketOrderbookChannel', () => {
+describe('BrowserWebSocketOrderbookChannel', () => {
     const websocketUrl = 'ws://localhost:8080';
-    const orderbookChannel = new WebSocketOrderbookChannel(websocketUrl);
+    const orderbookChannel = new BrowserWebSocketOrderbookChannel(websocketUrl);
     const subscriptionOpts = {
         baseTokenAddress: '0x323b5d4c32345ced77393b3530b1eed0f346429d',
         quoteTokenAddress: '0xef7fff64389b814a946f3e92105513705ca6b990',

--- a/packages/connect/test/node_ws_orderbook_channel_test.ts
+++ b/packages/connect/test/node_ws_orderbook_channel_test.ts
@@ -1,0 +1,61 @@
+import * as chai from 'chai';
+import * as dirtyChai from 'dirty-chai';
+import * as _ from 'lodash';
+import 'mocha';
+
+import { NodeWebSocketOrderbookChannel } from '../src/node_ws_orderbook_channel';
+
+chai.config.includeStack = true;
+chai.use(dirtyChai);
+const expect = chai.expect;
+
+describe('NodeWebSocketOrderbookChannel', () => {
+    const websocketUrl = 'ws://localhost:8080';
+    const orderbookChannel = new NodeWebSocketOrderbookChannel(websocketUrl);
+    const subscriptionOpts = {
+        baseTokenAddress: '0x323b5d4c32345ced77393b3530b1eed0f346429d',
+        quoteTokenAddress: '0xef7fff64389b814a946f3e92105513705ca6b990',
+        snapshot: true,
+        limit: 100,
+    };
+    const emptyOrderbookChannelHandler = {
+        onSnapshot: () => {
+            _.noop();
+        },
+        onUpdate: () => {
+            _.noop();
+        },
+        onError: () => {
+            _.noop();
+        },
+        onClose: () => {
+            _.noop();
+        },
+    };
+    describe('#subscribe', () => {
+        it('throws when subscriptionOpts does not conform to schema', () => {
+            const badSubscribeCall = orderbookChannel.subscribe.bind(
+                orderbookChannel,
+                {},
+                emptyOrderbookChannelHandler,
+            );
+            expect(badSubscribeCall).throws(
+                'Expected subscriptionOpts to conform to schema /RelayerApiOrderbookChannelSubscribePayload\nEncountered: {}\nValidation errors: instance requires property "baseTokenAddress", instance requires property "quoteTokenAddress"',
+            );
+        });
+        it('throws when handler has the incorrect members', () => {
+            const badSubscribeCall = orderbookChannel.subscribe.bind(orderbookChannel, subscriptionOpts, {});
+            expect(badSubscribeCall).throws(
+                'Expected handler.onSnapshot to be of type function, encountered: undefined',
+            );
+        });
+        it('does not throw when inputs are of correct types', () => {
+            const goodSubscribeCall = orderbookChannel.subscribe.bind(
+                orderbookChannel,
+                subscriptionOpts,
+                emptyOrderbookChannelHandler,
+            );
+            expect(goodSubscribeCall).to.not.throw();
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -354,10 +354,11 @@
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@types/valid-url/-/valid-url-1.0.2.tgz#60fa435ce24bfd5ba107b8d2a80796aeaf3a8f45"
 
-"@types/websocket@^0.0.34":
-  version "0.0.34"
-  resolved "https://registry.yarnpkg.com/@types/websocket/-/websocket-0.0.34.tgz#25596764cec885eda070fdb6d19cd76fe582747c"
+"@types/websocket@^0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/websocket/-/websocket-0.0.39.tgz#aa971e24f9c1455fe2a57ee3e69c7d395016b12a"
   dependencies:
+    "@types/events" "*"
     "@types/node" "*"
 
 "@types/yargs@^10.0.0":


### PR DESCRIPTION
<!--- Thank you for taking the time to submit a Pull Request -->

<!--- Provide a general summary of the issue in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds a new `BrowserWebSocketOrderbookChannel` class  and `NodeWebSocketOrderbookChannel` class that both implement the `OrderbookChannel` interface. New tests are included as well as some refactored common functionality between them.

## Motivation and Context

The browser API for WebSockets are slightly different than those available for node and offer less functionality than the node apis. Separating the previous `WebSocketOrderbookChannel` class into two different classes allows us to pass additional configuration into `NodeWebSocketOrderbookChannel` for node-only behavior such as sending ping frames.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [x] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [x] Change requires a change to the documentation.
*   [x] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [x] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [x] Labeled this PR with the labels corresponding to the changed package.
