### PR TITLE
Check transaction receipt status

### DIFF
--- a/packages/contract-wrappers/test/ether_token_wrapper_test.ts
+++ b/packages/contract-wrappers/test/ether_token_wrapper_test.ts
@@ -95,7 +95,7 @@ describe('EtherTokenWrapper', () => {
                 depositWeiAmount,
                 addressWithETH,
             );
-            await web3Wrapper.awaitTransactionMinedAsync(txHash);
+            await web3Wrapper.awaitTransactionSuccessAsync(txHash);
 
             const postETHBalanceInWei = await web3Wrapper.getBalanceInWeiAsync(addressWithETH);
             const postWETHBalanceInBaseUnits = await contractWrappers.token.getBalanceAsync(
@@ -137,7 +137,7 @@ describe('EtherTokenWrapper', () => {
                 depositWeiAmount,
                 addressWithETH,
             );
-            await web3Wrapper.awaitTransactionMinedAsync(txHash);
+            await web3Wrapper.awaitTransactionSuccessAsync(txHash);
 
             const postETHBalance = await web3Wrapper.getBalanceInWeiAsync(addressWithETH);
             const postWETHBalanceInBaseUnits = await contractWrappers.token.getBalanceAsync(
@@ -347,7 +347,7 @@ describe('EtherTokenWrapper', () => {
         });
         it('should get logs with decoded args emitted by Approval', async () => {
             txHash = await contractWrappers.token.setUnlimitedProxyAllowanceAsync(etherTokenAddress, addressWithETH);
-            await web3Wrapper.awaitTransactionMinedAsync(txHash);
+            await web3Wrapper.awaitTransactionSuccessAsync(txHash);
             const eventName = EtherTokenEvents.Approval;
             const indexFilterValues = {};
             const logs = await contractWrappers.etherToken.getLogsAsync<ApprovalContractEventArgs>(
@@ -381,7 +381,7 @@ describe('EtherTokenWrapper', () => {
         });
         it('should only get the logs with the correct event name', async () => {
             txHash = await contractWrappers.token.setUnlimitedProxyAllowanceAsync(etherTokenAddress, addressWithETH);
-            await web3Wrapper.awaitTransactionMinedAsync(txHash);
+            await web3Wrapper.awaitTransactionSuccessAsync(txHash);
             const differentEventName = EtherTokenEvents.Transfer;
             const indexFilterValues = {};
             const logs = await contractWrappers.etherToken.getLogsAsync(
@@ -394,12 +394,12 @@ describe('EtherTokenWrapper', () => {
         });
         it('should only get the logs with the correct indexed fields', async () => {
             txHash = await contractWrappers.token.setUnlimitedProxyAllowanceAsync(etherTokenAddress, addressWithETH);
-            await web3Wrapper.awaitTransactionMinedAsync(txHash);
+            await web3Wrapper.awaitTransactionSuccessAsync(txHash);
             txHash = await contractWrappers.token.setUnlimitedProxyAllowanceAsync(
                 etherTokenAddress,
                 addressWithoutFunds,
             );
-            await web3Wrapper.awaitTransactionMinedAsync(txHash);
+            await web3Wrapper.awaitTransactionSuccessAsync(txHash);
             const eventName = EtherTokenEvents.Approval;
             const indexFilterValues = {
                 _owner: addressWithETH,

--- a/packages/contract-wrappers/test/exchange_transfer_simulator_test.ts
+++ b/packages/contract-wrappers/test/exchange_transfer_simulator_test.ts
@@ -60,7 +60,7 @@ describe('ExchangeTransferSimulator', () => {
         });
         it("throws if the user doesn't have enough balance", async () => {
             txHash = await contractWrappers.token.setProxyAllowanceAsync(exampleTokenAddress, sender, transferAmount);
-            await web3Wrapper.awaitTransactionMinedAsync(txHash);
+            await web3Wrapper.awaitTransactionSuccessAsync(txHash);
             return expect(
                 exchangeTransferSimulator.transferFromAsync(
                     exampleTokenAddress,
@@ -74,9 +74,9 @@ describe('ExchangeTransferSimulator', () => {
         });
         it('updates balances and proxyAllowance after transfer', async () => {
             txHash = await contractWrappers.token.transferAsync(exampleTokenAddress, coinbase, sender, transferAmount);
-            await web3Wrapper.awaitTransactionMinedAsync(txHash);
+            await web3Wrapper.awaitTransactionSuccessAsync(txHash);
             txHash = await contractWrappers.token.setProxyAllowanceAsync(exampleTokenAddress, sender, transferAmount);
-            await web3Wrapper.awaitTransactionMinedAsync(txHash);
+            await web3Wrapper.awaitTransactionSuccessAsync(txHash);
             await exchangeTransferSimulator.transferFromAsync(
                 exampleTokenAddress,
                 sender,
@@ -95,9 +95,9 @@ describe('ExchangeTransferSimulator', () => {
         });
         it("doesn't update proxyAllowance after transfer if unlimited", async () => {
             txHash = await contractWrappers.token.transferAsync(exampleTokenAddress, coinbase, sender, transferAmount);
-            await web3Wrapper.awaitTransactionMinedAsync(txHash);
+            await web3Wrapper.awaitTransactionSuccessAsync(txHash);
             txHash = await contractWrappers.token.setUnlimitedProxyAllowanceAsync(exampleTokenAddress, sender);
-            await web3Wrapper.awaitTransactionMinedAsync(txHash);
+            await web3Wrapper.awaitTransactionSuccessAsync(txHash);
             await exchangeTransferSimulator.transferFromAsync(
                 exampleTokenAddress,
                 sender,

--- a/packages/contract-wrappers/test/exchange_wrapper_test.ts
+++ b/packages/contract-wrappers/test/exchange_wrapper_test.ts
@@ -276,7 +276,7 @@ describe('ExchangeWrapper', () => {
                         shouldThrowOnInsufficientBalanceOrAllowance,
                         takerAddress,
                     );
-                    await web3Wrapper.awaitTransactionMinedAsync(txHash);
+                    await web3Wrapper.awaitTransactionSuccessAsync(txHash);
                     expect(
                         await contractWrappers.token.getBalanceAsync(makerTokenAddress, makerAddress),
                     ).to.be.bignumber.equal(fillableAmount.minus(takerTokenFillAmount));
@@ -305,7 +305,7 @@ describe('ExchangeWrapper', () => {
                         shouldThrowOnInsufficientBalanceOrAllowance,
                         takerAddress,
                     );
-                    await web3Wrapper.awaitTransactionMinedAsync(txHash);
+                    await web3Wrapper.awaitTransactionSuccessAsync(txHash);
                     expect(
                         await contractWrappers.token.getBalanceAsync(makerTokenAddress, makerAddress),
                     ).to.be.bignumber.equal(fillableAmount.minus(partialFillAmount));
@@ -338,7 +338,7 @@ describe('ExchangeWrapper', () => {
                         shouldThrowOnInsufficientBalanceOrAllowance,
                         takerAddress,
                     );
-                    await web3Wrapper.awaitTransactionMinedAsync(txHash);
+                    await web3Wrapper.awaitTransactionSuccessAsync(txHash);
                     expect(
                         await contractWrappers.token.getBalanceAsync(zrxTokenAddress, feeRecipient),
                     ).to.be.bignumber.equal(makerFee.plus(takerFee));
@@ -469,7 +469,7 @@ describe('ExchangeWrapper', () => {
                         shouldThrowOnInsufficientBalanceOrAllowance,
                         takerAddress,
                     );
-                    await web3Wrapper.awaitTransactionMinedAsync(txHash);
+                    await web3Wrapper.awaitTransactionSuccessAsync(txHash);
                     const filledAmount = await contractWrappers.exchange.getFilledTakerAmountAsync(signedOrderHashHex);
                     const anotherFilledAmount = await contractWrappers.exchange.getFilledTakerAmountAsync(
                         anotherOrderHashHex,
@@ -595,7 +595,7 @@ describe('ExchangeWrapper', () => {
                         shouldThrowOnInsufficientBalanceOrAllowance,
                         takerAddress,
                     );
-                    await web3Wrapper.awaitTransactionMinedAsync(txHash);
+                    await web3Wrapper.awaitTransactionSuccessAsync(txHash);
                     const filledAmount = await contractWrappers.exchange.getFilledTakerAmountAsync(signedOrderHashHex);
                     const anotherFilledAmount = await contractWrappers.exchange.getFilledTakerAmountAsync(
                         anotherOrderHashHex,
@@ -611,7 +611,7 @@ describe('ExchangeWrapper', () => {
                         shouldThrowOnInsufficientBalanceOrAllowance,
                         takerAddress,
                     );
-                    await web3Wrapper.awaitTransactionMinedAsync(txHash);
+                    await web3Wrapper.awaitTransactionSuccessAsync(txHash);
                     const filledAmount = await contractWrappers.exchange.getFilledTakerAmountAsync(signedOrderHashHex);
                     const zeroAmount = await contractWrappers.exchange.getFilledTakerAmountAsync(anotherOrderHashHex);
                     expect(filledAmount).to.be.bignumber.equal(fillableAmount);
@@ -632,7 +632,7 @@ describe('ExchangeWrapper', () => {
                         shouldThrowOnInsufficientBalanceOrAllowance,
                         takerAddress,
                     );
-                    await web3Wrapper.awaitTransactionMinedAsync(txHash);
+                    await web3Wrapper.awaitTransactionSuccessAsync(txHash);
                     const filledAmount = await contractWrappers.exchange.getFilledTakerAmountAsync(signedOrderHashHex);
                     const anotherFilledAmount = await contractWrappers.exchange.getFilledTakerAmountAsync(
                         anotherOrderHashHex,
@@ -730,7 +730,7 @@ describe('ExchangeWrapper', () => {
             describe('successful cancels', () => {
                 it('should cancel an order', async () => {
                     const txHash = await contractWrappers.exchange.cancelOrderAsync(signedOrder, cancelAmount);
-                    await web3Wrapper.awaitTransactionMinedAsync(txHash);
+                    await web3Wrapper.awaitTransactionSuccessAsync(txHash);
                     const cancelledAmount = await contractWrappers.exchange.getCancelledTakerAmountAsync(orderHashHex);
                     expect(cancelledAmount).to.be.bignumber.equal(cancelAmount);
                 });
@@ -1112,7 +1112,7 @@ describe('ExchangeWrapper', () => {
                 shouldThrowOnInsufficientBalanceOrAllowance,
                 takerAddress,
             );
-            await web3Wrapper.awaitTransactionMinedAsync(txHash);
+            await web3Wrapper.awaitTransactionSuccessAsync(txHash);
             const eventName = ExchangeEvents.LogFill;
             const indexFilterValues = {};
             const logs = await contractWrappers.exchange.getLogsAsync(eventName, blockRange, indexFilterValues);
@@ -1133,7 +1133,7 @@ describe('ExchangeWrapper', () => {
                 shouldThrowOnInsufficientBalanceOrAllowance,
                 takerAddress,
             );
-            await web3Wrapper.awaitTransactionMinedAsync(txHash);
+            await web3Wrapper.awaitTransactionSuccessAsync(txHash);
             const differentEventName = ExchangeEvents.LogCancel;
             const indexFilterValues = {};
             const logs = await contractWrappers.exchange.getLogsAsync(
@@ -1157,7 +1157,7 @@ describe('ExchangeWrapper', () => {
                 shouldThrowOnInsufficientBalanceOrAllowance,
                 takerAddress,
             );
-            await web3Wrapper.awaitTransactionMinedAsync(txHash);
+            await web3Wrapper.awaitTransactionSuccessAsync(txHash);
 
             const differentMakerAddress = userAddresses[2];
             const anotherSignedOrder = await fillScenarios.createFillableSignedOrderAsync(
@@ -1173,7 +1173,7 @@ describe('ExchangeWrapper', () => {
                 shouldThrowOnInsufficientBalanceOrAllowance,
                 takerAddress,
             );
-            await web3Wrapper.awaitTransactionMinedAsync(txHash);
+            await web3Wrapper.awaitTransactionSuccessAsync(txHash);
 
             const eventName = ExchangeEvents.LogFill;
             const indexFilterValues = {

--- a/packages/contract-wrappers/test/token_wrapper_test.ts
+++ b/packages/contract-wrappers/test/token_wrapper_test.ts
@@ -542,7 +542,7 @@ describe('TokenWrapper', () => {
         });
         it('should get logs with decoded args emitted by Approval', async () => {
             txHash = await contractWrappers.token.setUnlimitedProxyAllowanceAsync(tokenAddress, coinbase);
-            await web3Wrapper.awaitTransactionMinedAsync(txHash);
+            await web3Wrapper.awaitTransactionSuccessAsync(txHash);
             const eventName = TokenEvents.Approval;
             const indexFilterValues = {};
             const logs = await contractWrappers.token.getLogsAsync<ApprovalContractEventArgs>(
@@ -560,7 +560,7 @@ describe('TokenWrapper', () => {
         });
         it('should only get the logs with the correct event name', async () => {
             txHash = await contractWrappers.token.setUnlimitedProxyAllowanceAsync(tokenAddress, coinbase);
-            await web3Wrapper.awaitTransactionMinedAsync(txHash);
+            await web3Wrapper.awaitTransactionSuccessAsync(txHash);
             const differentEventName = TokenEvents.Transfer;
             const indexFilterValues = {};
             const logs = await contractWrappers.token.getLogsAsync(
@@ -573,9 +573,9 @@ describe('TokenWrapper', () => {
         });
         it('should only get the logs with the correct indexed fields', async () => {
             txHash = await contractWrappers.token.setUnlimitedProxyAllowanceAsync(tokenAddress, coinbase);
-            await web3Wrapper.awaitTransactionMinedAsync(txHash);
+            await web3Wrapper.awaitTransactionSuccessAsync(txHash);
             txHash = await contractWrappers.token.setUnlimitedProxyAllowanceAsync(tokenAddress, addressWithoutFunds);
-            await web3Wrapper.awaitTransactionMinedAsync(txHash);
+            await web3Wrapper.awaitTransactionSuccessAsync(txHash);
             const eventName = TokenEvents.Approval;
             const indexFilterValues = {
                 _owner: coinbase,

--- a/packages/contract_templates/contract.handlebars
+++ b/packages/contract_templates/contract.handlebars
@@ -76,7 +76,7 @@ export class {{contractName}}Contract extends BaseContract {
         );
         const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
         logUtils.log(`transactionHash: ${txHash}`);
-        const txReceipt = await web3Wrapper.awaitTransactionMinedAsync(txHash);
+        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
         logUtils.log(`{{contractName}} successfully deployed at ${txReceipt.contractAddress}`);
         const contractInstance = new {{contractName}}Contract(abi, txReceipt.contractAddress as string, provider, txDefaults);
         contractInstance.constructorArgs = [{{> params inputs=ctor.inputs}}];

--- a/packages/contracts/src/utils/exchange_wrapper.ts
+++ b/packages/contracts/src/utils/exchange_wrapper.ts
@@ -247,7 +247,7 @@ export class ExchangeWrapper {
         return tx;
     }
     private async _getTxWithDecodedExchangeLogsAsync(txHash: string): Promise<TransactionReceiptWithDecodedLogs> {
-        const tx = await this._web3Wrapper.awaitTransactionMinedAsync(txHash, constants.AWAIT_TRANSACTION_MINED_MS);
+        const tx = await this._web3Wrapper.awaitTransactionSuccessAsync(txHash, constants.AWAIT_TRANSACTION_MINED_MS);
         tx.logs = _.filter(tx.logs, log => log.address === this._exchange.address);
         tx.logs = _.map(tx.logs, log => this._logDecoder.decodeLogOrThrow(log));
         return tx;

--- a/packages/contracts/test/asset_proxy/authorizable.ts
+++ b/packages/contracts/test/asset_proxy/authorizable.ts
@@ -48,7 +48,7 @@ describe('Authorizable', () => {
             ).to.be.rejectedWith(constants.REVERT);
         });
         it('should allow owner to add an authorized address', async () => {
-            await web3Wrapper.awaitTransactionMinedAsync(
+            await web3Wrapper.awaitTransactionSuccessAsync(
                 await authorizable.addAuthorizedAddress.sendTransactionAsync(address, { from: owner }),
                 constants.AWAIT_TRANSACTION_MINED_MS,
             );
@@ -56,7 +56,7 @@ describe('Authorizable', () => {
             expect(isAuthorized).to.be.true();
         });
         it('should throw if owner attempts to authorize a duplicate address', async () => {
-            await web3Wrapper.awaitTransactionMinedAsync(
+            await web3Wrapper.awaitTransactionSuccessAsync(
                 await authorizable.addAuthorizedAddress.sendTransactionAsync(address, { from: owner }),
                 constants.AWAIT_TRANSACTION_MINED_MS,
             );
@@ -68,7 +68,7 @@ describe('Authorizable', () => {
 
     describe('removeAuthorizedAddress', () => {
         it('should throw if not called by owner', async () => {
-            await web3Wrapper.awaitTransactionMinedAsync(
+            await web3Wrapper.awaitTransactionSuccessAsync(
                 await authorizable.addAuthorizedAddress.sendTransactionAsync(address, { from: owner }),
                 constants.AWAIT_TRANSACTION_MINED_MS,
             );
@@ -80,11 +80,11 @@ describe('Authorizable', () => {
         });
 
         it('should allow owner to remove an authorized address', async () => {
-            await web3Wrapper.awaitTransactionMinedAsync(
+            await web3Wrapper.awaitTransactionSuccessAsync(
                 await authorizable.addAuthorizedAddress.sendTransactionAsync(address, { from: owner }),
                 constants.AWAIT_TRANSACTION_MINED_MS,
             );
-            await web3Wrapper.awaitTransactionMinedAsync(
+            await web3Wrapper.awaitTransactionSuccessAsync(
                 await authorizable.removeAuthorizedAddress.sendTransactionAsync(address, {
                     from: owner,
                 }),
@@ -107,7 +107,7 @@ describe('Authorizable', () => {
         it('should return all authorized addresses', async () => {
             const initial = await authorizable.getAuthorizedAddresses.callAsync();
             expect(initial).to.have.length(0);
-            await web3Wrapper.awaitTransactionMinedAsync(
+            await web3Wrapper.awaitTransactionSuccessAsync(
                 await authorizable.addAuthorizedAddress.sendTransactionAsync(address, {
                     from: owner,
                 }),
@@ -117,7 +117,7 @@ describe('Authorizable', () => {
             expect(afterAdd).to.have.length(1);
             expect(afterAdd).to.include(address);
 
-            await web3Wrapper.awaitTransactionMinedAsync(
+            await web3Wrapper.awaitTransactionSuccessAsync(
                 await authorizable.removeAuthorizedAddress.sendTransactionAsync(address, {
                     from: owner,
                 }),

--- a/packages/contracts/test/asset_proxy/proxies.ts
+++ b/packages/contracts/test/asset_proxy/proxies.ts
@@ -52,7 +52,7 @@ describe('Asset Transfer Proxies', () => {
         [zrxToken] = await erc20Wrapper.deployDummyTokensAsync();
         erc20Proxy = await erc20Wrapper.deployProxyAsync();
         await erc20Wrapper.setBalancesAndAllowancesAsync();
-        await web3Wrapper.awaitTransactionMinedAsync(
+        await web3Wrapper.awaitTransactionSuccessAsync(
             await erc20Proxy.addAuthorizedAddress.sendTransactionAsync(exchangeAddress, {
                 from: owner,
             }),
@@ -64,7 +64,7 @@ describe('Asset Transfer Proxies', () => {
         await erc721Wrapper.setBalancesAndAllowancesAsync();
         const erc721Balances = await erc721Wrapper.getBalancesAsync();
         erc721MakerTokenId = erc721Balances[makerAddress][erc721Token.address][0];
-        await web3Wrapper.awaitTransactionMinedAsync(
+        await web3Wrapper.awaitTransactionSuccessAsync(
             await erc721Proxy.addAuthorizedAddress.sendTransactionAsync(exchangeAddress, {
                 from: owner,
             }),
@@ -85,7 +85,7 @@ describe('Asset Transfer Proxies', () => {
                 // Perform a transfer from makerAddress to takerAddress
                 const erc20Balances = await erc20Wrapper.getBalancesAsync();
                 const amount = new BigNumber(10);
-                await web3Wrapper.awaitTransactionMinedAsync(
+                await web3Wrapper.awaitTransactionSuccessAsync(
                     await erc20Proxy.transferFrom.sendTransactionAsync(
                         encodedProxyMetadata,
                         makerAddress,
@@ -111,7 +111,7 @@ describe('Asset Transfer Proxies', () => {
                 // Perform a transfer from makerAddress to takerAddress
                 const erc20Balances = await erc20Wrapper.getBalancesAsync();
                 const amount = new BigNumber(0);
-                await web3Wrapper.awaitTransactionMinedAsync(
+                await web3Wrapper.awaitTransactionSuccessAsync(
                     await erc20Proxy.transferFrom.sendTransactionAsync(
                         encodedProxyMetadata,
                         makerAddress,
@@ -137,7 +137,7 @@ describe('Asset Transfer Proxies', () => {
                 // Create allowance less than transfer amount. Set allowance on proxy.
                 const allowance = new BigNumber(0);
                 const transferAmount = new BigNumber(10);
-                await web3Wrapper.awaitTransactionMinedAsync(
+                await web3Wrapper.awaitTransactionSuccessAsync(
                     await zrxToken.approve.sendTransactionAsync(erc20Proxy.address, allowance, {
                         from: makerAddress,
                     }),
@@ -193,7 +193,10 @@ describe('Asset Transfer Proxies', () => {
                     amounts,
                     { from: exchangeAddress },
                 );
-                const res = await web3Wrapper.awaitTransactionMinedAsync(txHash, constants.AWAIT_TRANSACTION_MINED_MS);
+                const res = await web3Wrapper.awaitTransactionSuccessAsync(
+                    txHash,
+                    constants.AWAIT_TRANSACTION_MINED_MS,
+                );
                 const newBalances = await erc20Wrapper.getBalancesAsync();
 
                 expect(res.logs.length).to.equal(numTransfers);
@@ -246,7 +249,7 @@ describe('Asset Transfer Proxies', () => {
                 // Perform a transfer from makerAddress to takerAddress
                 const erc20Balances = await erc20Wrapper.getBalancesAsync();
                 const amount = new BigNumber(1);
-                await web3Wrapper.awaitTransactionMinedAsync(
+                await web3Wrapper.awaitTransactionSuccessAsync(
                     await erc721Proxy.transferFrom.sendTransactionAsync(
                         encodedProxyMetadata,
                         makerAddress,
@@ -314,7 +317,7 @@ describe('Asset Transfer Proxies', () => {
                     erc721MakerTokenId,
                 );
                 // Remove transfer approval for makerAddress.
-                await web3Wrapper.awaitTransactionMinedAsync(
+                await web3Wrapper.awaitTransactionSuccessAsync(
                     await erc721Token.setApprovalForAll.sendTransactionAsync(erc721Proxy.address, false, {
                         from: makerAddress,
                     }),
@@ -376,7 +379,10 @@ describe('Asset Transfer Proxies', () => {
                     amounts,
                     { from: exchangeAddress },
                 );
-                const res = await web3Wrapper.awaitTransactionMinedAsync(txHash, constants.AWAIT_TRANSACTION_MINED_MS);
+                const res = await web3Wrapper.awaitTransactionSuccessAsync(
+                    txHash,
+                    constants.AWAIT_TRANSACTION_MINED_MS,
+                );
                 expect(res.logs.length).to.equal(numTransfers);
 
                 const newOwnerMakerAssetA = await erc721Token.ownerOf.callAsync(makerTokenIdA);

--- a/packages/contracts/test/ether_token.ts
+++ b/packages/contracts/test/ether_token.ts
@@ -61,7 +61,10 @@ describe('EtherToken', () => {
             const ethToDeposit = new BigNumber(Web3Wrapper.toWei(new BigNumber(1)));
 
             const txHash = await contractWrappers.etherToken.depositAsync(etherTokenAddress, ethToDeposit, account);
-            const receipt = await web3Wrapper.awaitTransactionMinedAsync(txHash, constants.AWAIT_TRANSACTION_MINED_MS);
+            const receipt = await web3Wrapper.awaitTransactionSuccessAsync(
+                txHash,
+                constants.AWAIT_TRANSACTION_MINED_MS,
+            );
 
             const ethSpentOnGas = gasPrice.times(receipt.gasUsed);
             const finalEthBalance = await web3Wrapper.getBalanceInWeiAsync(account);
@@ -97,7 +100,10 @@ describe('EtherToken', () => {
                     gasLimit: constants.MAX_ETHERTOKEN_WITHDRAW_GAS,
                 },
             );
-            const receipt = await web3Wrapper.awaitTransactionMinedAsync(txHash, constants.AWAIT_TRANSACTION_MINED_MS);
+            const receipt = await web3Wrapper.awaitTransactionSuccessAsync(
+                txHash,
+                constants.AWAIT_TRANSACTION_MINED_MS,
+            );
 
             const ethSpentOnGas = gasPrice.times(receipt.gasUsed);
             const finalEthBalance = await web3Wrapper.getBalanceInWeiAsync(account);
@@ -124,7 +130,10 @@ describe('EtherToken', () => {
                 gasPrice,
             });
 
-            const receipt = await web3Wrapper.awaitTransactionMinedAsync(txHash, constants.AWAIT_TRANSACTION_MINED_MS);
+            const receipt = await web3Wrapper.awaitTransactionSuccessAsync(
+                txHash,
+                constants.AWAIT_TRANSACTION_MINED_MS,
+            );
 
             const ethSpentOnGas = gasPrice.times(receipt.gasUsed);
             const finalEthBalance = await web3Wrapper.getBalanceInWeiAsync(account);

--- a/packages/contracts/test/exchange/core.ts
+++ b/packages/contracts/test/exchange/core.ts
@@ -94,13 +94,13 @@ describe('Exchange core', () => {
         await exchangeWrapper.registerAssetProxyAsync(AssetProxyId.ERC20, erc20Proxy.address, owner);
         await exchangeWrapper.registerAssetProxyAsync(AssetProxyId.ERC721, erc721Proxy.address, owner);
 
-        await web3Wrapper.awaitTransactionMinedAsync(
+        await web3Wrapper.awaitTransactionSuccessAsync(
             await erc20Proxy.addAuthorizedAddress.sendTransactionAsync(exchange.address, {
                 from: owner,
             }),
             constants.AWAIT_TRANSACTION_MINED_MS,
         );
-        await web3Wrapper.awaitTransactionMinedAsync(
+        await web3Wrapper.awaitTransactionSuccessAsync(
             await erc721Proxy.addAuthorizedAddress.sendTransactionAsync(exchange.address, {
                 from: owner,
             }),
@@ -527,7 +527,7 @@ describe('Exchange core', () => {
         });
 
         it('should throw if maker allowances are too low to fill order', async () => {
-            await web3Wrapper.awaitTransactionMinedAsync(
+            await web3Wrapper.awaitTransactionSuccessAsync(
                 await erc20TokenA.approve.sendTransactionAsync(erc20Proxy.address, new BigNumber(0), {
                     from: makerAddress,
                 }),
@@ -539,7 +539,7 @@ describe('Exchange core', () => {
             await expect(exchangeWrapper.fillOrderAsync(signedOrder, takerAddress)).to.be.rejectedWith(
                 constants.REVERT,
             );
-            await web3Wrapper.awaitTransactionMinedAsync(
+            await web3Wrapper.awaitTransactionSuccessAsync(
                 await erc20TokenA.approve.sendTransactionAsync(erc20Proxy.address, constants.INITIAL_ERC20_ALLOWANCE, {
                     from: makerAddress,
                 }),
@@ -548,7 +548,7 @@ describe('Exchange core', () => {
         });
 
         it('should throw if taker allowances are too low to fill order', async () => {
-            await web3Wrapper.awaitTransactionMinedAsync(
+            await web3Wrapper.awaitTransactionSuccessAsync(
                 await erc20TokenB.approve.sendTransactionAsync(erc20Proxy.address, new BigNumber(0), {
                     from: takerAddress,
                 }),
@@ -560,7 +560,7 @@ describe('Exchange core', () => {
             await expect(exchangeWrapper.fillOrderAsync(signedOrder, takerAddress)).to.be.rejectedWith(
                 constants.REVERT,
             );
-            await web3Wrapper.awaitTransactionMinedAsync(
+            await web3Wrapper.awaitTransactionSuccessAsync(
                 await erc20TokenB.approve.sendTransactionAsync(erc20Proxy.address, constants.INITIAL_ERC20_ALLOWANCE, {
                     from: takerAddress,
                 }),

--- a/packages/contracts/test/exchange/dispatcher.ts
+++ b/packages/contracts/test/exchange/dispatcher.ts
@@ -61,13 +61,13 @@ describe('AssetProxyDispatcher', () => {
             provider,
             txDefaults,
         );
-        await web3Wrapper.awaitTransactionMinedAsync(
+        await web3Wrapper.awaitTransactionSuccessAsync(
             await erc20Proxy.addAuthorizedAddress.sendTransactionAsync(assetProxyDispatcher.address, {
                 from: owner,
             }),
             constants.AWAIT_TRANSACTION_MINED_MS,
         );
-        await web3Wrapper.awaitTransactionMinedAsync(
+        await web3Wrapper.awaitTransactionSuccessAsync(
             await erc721Proxy.addAuthorizedAddress.sendTransactionAsync(assetProxyDispatcher.address, {
                 from: owner,
             }),
@@ -83,7 +83,7 @@ describe('AssetProxyDispatcher', () => {
     describe('registerAssetProxy', () => {
         it('should record proxy upon registration', async () => {
             const prevProxyAddress = constants.NULL_ADDRESS;
-            await web3Wrapper.awaitTransactionMinedAsync(
+            await web3Wrapper.awaitTransactionSuccessAsync(
                 await assetProxyDispatcher.registerAssetProxy.sendTransactionAsync(
                     AssetProxyId.ERC20,
                     erc20Proxy.address,
@@ -99,7 +99,7 @@ describe('AssetProxyDispatcher', () => {
         it('should be able to record multiple proxies', async () => {
             // Record first proxy
             const prevERC20ProxyAddress = constants.NULL_ADDRESS;
-            await web3Wrapper.awaitTransactionMinedAsync(
+            await web3Wrapper.awaitTransactionSuccessAsync(
                 await assetProxyDispatcher.registerAssetProxy.sendTransactionAsync(
                     AssetProxyId.ERC20,
                     erc20Proxy.address,
@@ -112,7 +112,7 @@ describe('AssetProxyDispatcher', () => {
             expect(proxyAddress).to.be.equal(erc20Proxy.address);
             // Record another proxy
             const prevERC721ProxyAddress = constants.NULL_ADDRESS;
-            await web3Wrapper.awaitTransactionMinedAsync(
+            await web3Wrapper.awaitTransactionSuccessAsync(
                 await assetProxyDispatcher.registerAssetProxy.sendTransactionAsync(
                     AssetProxyId.ERC721,
                     erc721Proxy.address,
@@ -128,7 +128,7 @@ describe('AssetProxyDispatcher', () => {
         it('should replace proxy address upon re-registration', async () => {
             // Initial registration
             const prevProxyAddress = constants.NULL_ADDRESS;
-            await web3Wrapper.awaitTransactionMinedAsync(
+            await web3Wrapper.awaitTransactionSuccessAsync(
                 await assetProxyDispatcher.registerAssetProxy.sendTransactionAsync(
                     AssetProxyId.ERC20,
                     erc20Proxy.address,
@@ -148,7 +148,7 @@ describe('AssetProxyDispatcher', () => {
             // Register new ERC20 Transfer Proxy contract
             const newAddress = newErc20TransferProxy.address;
             const currentAddress = erc20Proxy.address;
-            await web3Wrapper.awaitTransactionMinedAsync(
+            await web3Wrapper.awaitTransactionSuccessAsync(
                 await assetProxyDispatcher.registerAssetProxy.sendTransactionAsync(
                     AssetProxyId.ERC20,
                     newAddress,
@@ -165,7 +165,7 @@ describe('AssetProxyDispatcher', () => {
         it('should throw if registering with incorrect "currentAssetProxyAddress" field', async () => {
             // Initial registration
             const prevProxyAddress = constants.NULL_ADDRESS;
-            await web3Wrapper.awaitTransactionMinedAsync(
+            await web3Wrapper.awaitTransactionSuccessAsync(
                 await assetProxyDispatcher.registerAssetProxy.sendTransactionAsync(
                     AssetProxyId.ERC20,
                     erc20Proxy.address,
@@ -190,7 +190,7 @@ describe('AssetProxyDispatcher', () => {
         it('should be able to reset proxy address to NULL', async () => {
             // Initial registration
             const prevProxyAddress = constants.NULL_ADDRESS;
-            await web3Wrapper.awaitTransactionMinedAsync(
+            await web3Wrapper.awaitTransactionSuccessAsync(
                 await assetProxyDispatcher.registerAssetProxy.sendTransactionAsync(
                     AssetProxyId.ERC20,
                     erc20Proxy.address,
@@ -203,7 +203,7 @@ describe('AssetProxyDispatcher', () => {
             expect(proxyAddress).to.be.equal(erc20Proxy.address);
             // The following transaction will reset the proxy address
             const newProxyAddress = constants.NULL_ADDRESS;
-            await web3Wrapper.awaitTransactionMinedAsync(
+            await web3Wrapper.awaitTransactionSuccessAsync(
                 await assetProxyDispatcher.registerAssetProxy.sendTransactionAsync(
                     AssetProxyId.ERC20,
                     newProxyAddress,
@@ -244,7 +244,7 @@ describe('AssetProxyDispatcher', () => {
     describe('getAssetProxy', () => {
         it('should return correct address of registered proxy', async () => {
             const prevProxyAddress = constants.NULL_ADDRESS;
-            await web3Wrapper.awaitTransactionMinedAsync(
+            await web3Wrapper.awaitTransactionSuccessAsync(
                 await assetProxyDispatcher.registerAssetProxy.sendTransactionAsync(
                     AssetProxyId.ERC20,
                     erc20Proxy.address,
@@ -267,7 +267,7 @@ describe('AssetProxyDispatcher', () => {
         it('should dispatch transfer to registered proxy', async () => {
             // Register ERC20 proxy
             const prevProxyAddress = constants.NULL_ADDRESS;
-            await web3Wrapper.awaitTransactionMinedAsync(
+            await web3Wrapper.awaitTransactionSuccessAsync(
                 await assetProxyDispatcher.registerAssetProxy.sendTransactionAsync(
                     AssetProxyId.ERC20,
                     erc20Proxy.address,
@@ -281,7 +281,7 @@ describe('AssetProxyDispatcher', () => {
             // Perform a transfer from makerAddress to takerAddress
             const erc20Balances = await erc20Wrapper.getBalancesAsync();
             const amount = new BigNumber(10);
-            await web3Wrapper.awaitTransactionMinedAsync(
+            await web3Wrapper.awaitTransactionSuccessAsync(
                 await assetProxyDispatcher.publicDispatchTransferFrom.sendTransactionAsync(
                     encodedProxyMetadata,
                     makerAddress,

--- a/packages/contracts/test/exchange/match_orders.ts
+++ b/packages/contracts/test/exchange/match_orders.ts
@@ -120,13 +120,13 @@ describe('matchOrders', () => {
         await exchangeWrapper.registerAssetProxyAsync(AssetProxyId.ERC20, erc20Proxy.address, owner);
         await exchangeWrapper.registerAssetProxyAsync(AssetProxyId.ERC721, erc721Proxy.address, owner);
         // Authorize ERC20 and ERC721 trades by exchange
-        await web3Wrapper.awaitTransactionMinedAsync(
+        await web3Wrapper.awaitTransactionSuccessAsync(
             await erc20Proxy.addAuthorizedAddress.sendTransactionAsync(exchange.address, {
                 from: owner,
             }),
             constants.AWAIT_TRANSACTION_MINED_MS,
         );
-        await web3Wrapper.awaitTransactionMinedAsync(
+        await web3Wrapper.awaitTransactionSuccessAsync(
             await erc721Proxy.addAuthorizedAddress.sendTransactionAsync(exchange.address, {
                 from: owner,
             }),

--- a/packages/contracts/test/exchange/transactions.ts
+++ b/packages/contracts/test/exchange/transactions.ts
@@ -82,7 +82,7 @@ describe('Exchange transactions', () => {
         exchangeWrapper = new ExchangeWrapper(exchange, provider);
         await exchangeWrapper.registerAssetProxyAsync(AssetProxyId.ERC20, erc20Proxy.address, owner);
 
-        await web3Wrapper.awaitTransactionMinedAsync(
+        await web3Wrapper.awaitTransactionSuccessAsync(
             await erc20Proxy.addAuthorizedAddress.sendTransactionAsync(exchange.address, { from: owner }),
             constants.AWAIT_TRANSACTION_MINED_MS,
         );

--- a/packages/contracts/test/exchange/wrapper.ts
+++ b/packages/contracts/test/exchange/wrapper.ts
@@ -87,13 +87,13 @@ describe('Exchange wrappers', () => {
         await exchangeWrapper.registerAssetProxyAsync(AssetProxyId.ERC20, erc20Proxy.address, owner);
         await exchangeWrapper.registerAssetProxyAsync(AssetProxyId.ERC721, erc721Proxy.address, owner);
 
-        await web3Wrapper.awaitTransactionMinedAsync(
+        await web3Wrapper.awaitTransactionSuccessAsync(
             await erc20Proxy.addAuthorizedAddress.sendTransactionAsync(exchange.address, {
                 from: owner,
             }),
             constants.AWAIT_TRANSACTION_MINED_MS,
         );
-        await web3Wrapper.awaitTransactionMinedAsync(
+        await web3Wrapper.awaitTransactionSuccessAsync(
             await erc721Proxy.addAuthorizedAddress.sendTransactionAsync(exchange.address, {
                 from: owner,
             }),
@@ -256,14 +256,14 @@ describe('Exchange wrappers', () => {
 
         it('should not change erc20Balances if maker allowances are too low to fill order', async () => {
             const signedOrder = orderFactory.newSignedOrder();
-            await web3Wrapper.awaitTransactionMinedAsync(
+            await web3Wrapper.awaitTransactionSuccessAsync(
                 await erc20TokenA.approve.sendTransactionAsync(erc20Proxy.address, new BigNumber(0), {
                     from: makerAddress,
                 }),
                 constants.AWAIT_TRANSACTION_MINED_MS,
             );
             await exchangeWrapper.fillOrderNoThrowAsync(signedOrder, takerAddress);
-            await web3Wrapper.awaitTransactionMinedAsync(
+            await web3Wrapper.awaitTransactionSuccessAsync(
                 await erc20TokenA.approve.sendTransactionAsync(erc20Proxy.address, constants.INITIAL_ERC20_ALLOWANCE, {
                     from: makerAddress,
                 }),
@@ -276,14 +276,14 @@ describe('Exchange wrappers', () => {
 
         it('should not change erc20Balances if taker allowances are too low to fill order', async () => {
             const signedOrder = orderFactory.newSignedOrder();
-            await web3Wrapper.awaitTransactionMinedAsync(
+            await web3Wrapper.awaitTransactionSuccessAsync(
                 await erc20TokenB.approve.sendTransactionAsync(erc20Proxy.address, new BigNumber(0), {
                     from: takerAddress,
                 }),
                 constants.AWAIT_TRANSACTION_MINED_MS,
             );
             await exchangeWrapper.fillOrderNoThrowAsync(signedOrder, takerAddress);
-            await web3Wrapper.awaitTransactionMinedAsync(
+            await web3Wrapper.awaitTransactionSuccessAsync(
                 await erc20TokenB.approve.sendTransactionAsync(erc20Proxy.address, constants.INITIAL_ERC20_ALLOWANCE, {
                     from: takerAddress,
                 }),

--- a/packages/contracts/test/multi_sig_with_time_lock.ts
+++ b/packages/contracts/test/multi_sig_with_time_lock.ts
@@ -79,7 +79,7 @@ describe('MultiSigWalletWithTimeLock', () => {
                     args: [SECONDS_TIME_LOCKED.toNumber()],
                 };
                 const txHash = await multiSigWrapper.submitTransactionAsync(destination, from, dataParams);
-                const txReceipt = await web3Wrapper.awaitTransactionMinedAsync(
+                const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(
                     txHash,
                     constants.AWAIT_TRANSACTION_MINED_MS,
                 );
@@ -102,7 +102,7 @@ describe('MultiSigWalletWithTimeLock', () => {
                     args: [SECONDS_TIME_LOCKED.toNumber()],
                 };
                 let txHash = await multiSigWrapper.submitTransactionAsync(destination, from, dataParams);
-                const txReceipt = await web3Wrapper.awaitTransactionMinedAsync(
+                const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(
                     txHash,
                     constants.AWAIT_TRANSACTION_MINED_MS,
                 );
@@ -112,7 +112,10 @@ describe('MultiSigWalletWithTimeLock', () => {
 
                 txId = log.args.transactionId;
                 txHash = await multiSig.confirmTransaction.sendTransactionAsync(txId, { from: owners[1] });
-                const res = await web3Wrapper.awaitTransactionMinedAsync(txHash, constants.AWAIT_TRANSACTION_MINED_MS);
+                const res = await web3Wrapper.awaitTransactionSuccessAsync(
+                    txHash,
+                    constants.AWAIT_TRANSACTION_MINED_MS,
+                );
                 expect(res.logs).to.have.length(2);
 
                 const blockNum = await web3Wrapper.getBlockNumberAsync();
@@ -132,7 +135,7 @@ describe('MultiSigWalletWithTimeLock', () => {
                     args: [SECONDS_TIME_LOCKED.toNumber()],
                 };
                 let txHash = await multiSigWrapper.submitTransactionAsync(destination, from, dataParams);
-                const txReceipt = await web3Wrapper.awaitTransactionMinedAsync(
+                const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(
                     txHash,
                     constants.AWAIT_TRANSACTION_MINED_MS,
                 );
@@ -142,12 +145,15 @@ describe('MultiSigWalletWithTimeLock', () => {
 
                 txId = log.args.transactionId;
                 txHash = await multiSig.confirmTransaction.sendTransactionAsync(txId, { from: owners[1] });
-                await web3Wrapper.awaitTransactionMinedAsync(txHash, constants.AWAIT_TRANSACTION_MINED_MS);
+                await web3Wrapper.awaitTransactionSuccessAsync(txHash, constants.AWAIT_TRANSACTION_MINED_MS);
 
                 expect(initialSecondsTimeLocked).to.be.equal(0);
 
                 txHash = await multiSig.executeTransaction.sendTransactionAsync(txId, { from: owners[0] });
-                const res = await web3Wrapper.awaitTransactionMinedAsync(txHash, constants.AWAIT_TRANSACTION_MINED_MS);
+                const res = await web3Wrapper.awaitTransactionSuccessAsync(
+                    txHash,
+                    constants.AWAIT_TRANSACTION_MINED_MS,
+                );
                 expect(res.logs).to.have.length(2);
 
                 const secondsTimeLocked = new BigNumber(await multiSig.secondsTimeLocked.callAsync());
@@ -182,7 +188,7 @@ describe('MultiSigWalletWithTimeLock', () => {
                     args: [newSecondsTimeLocked],
                 };
                 let txHash = await multiSigWrapper.submitTransactionAsync(destination, from, dataParams);
-                let txReceipt = await web3Wrapper.awaitTransactionMinedAsync(
+                let txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(
                     txHash,
                     constants.AWAIT_TRANSACTION_MINED_MS,
                 );
@@ -193,7 +199,10 @@ describe('MultiSigWalletWithTimeLock', () => {
                 txHash = await multiSig.confirmTransaction.sendTransactionAsync(txId, {
                     from: owners[1],
                 });
-                txReceipt = await web3Wrapper.awaitTransactionMinedAsync(txHash, constants.AWAIT_TRANSACTION_MINED_MS);
+                txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(
+                    txHash,
+                    constants.AWAIT_TRANSACTION_MINED_MS,
+                );
                 expect(txReceipt.logs).to.have.length(2);
             });
             const newSecondsTimeLocked = 0;
@@ -205,7 +214,7 @@ describe('MultiSigWalletWithTimeLock', () => {
 
             it('should execute if it has enough confirmations and is past the time lock', async () => {
                 await web3Wrapper.increaseTimeAsync(SECONDS_TIME_LOCKED.toNumber());
-                await web3Wrapper.awaitTransactionMinedAsync(
+                await web3Wrapper.awaitTransactionSuccessAsync(
                     await multiSig.executeTransaction.sendTransactionAsync(txId, { from: owners[0] }),
                     constants.AWAIT_TRANSACTION_MINED_MS,
                 );

--- a/packages/contracts/test/token_registry.ts
+++ b/packages/contracts/test/token_registry.ts
@@ -142,7 +142,7 @@ describe('TokenRegistry', () => {
             });
 
             it('should change the token name when called by owner', async () => {
-                await web3Wrapper.awaitTransactionMinedAsync(
+                await web3Wrapper.awaitTransactionSuccessAsync(
                     await tokenReg.setTokenName.sendTransactionAsync(token1.address, token2.name, {
                         from: owner,
                     }),
@@ -184,7 +184,7 @@ describe('TokenRegistry', () => {
             });
 
             it('should change the token symbol when called by owner', async () => {
-                await web3Wrapper.awaitTransactionMinedAsync(
+                await web3Wrapper.awaitTransactionSuccessAsync(
                     await tokenReg.setTokenSymbol.sendTransactionAsync(token1.address, token2.symbol, { from: owner }),
                     constants.AWAIT_TRANSACTION_MINED_MS,
                 );
@@ -228,7 +228,7 @@ describe('TokenRegistry', () => {
 
             it('should remove token metadata when called by owner', async () => {
                 const index = new BigNumber(0);
-                await web3Wrapper.awaitTransactionMinedAsync(
+                await web3Wrapper.awaitTransactionSuccessAsync(
                     await tokenReg.removeToken.sendTransactionAsync(token1.address, index, {
                         from: owner,
                     }),

--- a/packages/contracts/test/unlimited_allowance_token.ts
+++ b/packages/contracts/test/unlimited_allowance_token.ts
@@ -46,7 +46,7 @@ describe('UnlimitedAllowanceToken', () => {
             constants.DUMMY_TOKEN_DECIMALS,
             constants.DUMMY_TOKEN_TOTAL_SUPPLY,
         );
-        await web3Wrapper.awaitTransactionMinedAsync(
+        await web3Wrapper.awaitTransactionSuccessAsync(
             await token.mint.sendTransactionAsync(MAX_MINT_VALUE, { from: owner }),
             constants.AWAIT_TRANSACTION_MINED_MS,
         );

--- a/packages/fill-scenarios/src/index.ts
+++ b/packages/fill-scenarios/src/index.ts
@@ -49,7 +49,7 @@ export class FillScenarios {
                 const txHash = await dummyToken.setBalance.sendTransactionAsync(this._coinbase, tokenSupply, {
                     from: this._coinbase,
                 });
-                await this._web3Wrapper.awaitTransactionMinedAsync(txHash);
+                await this._web3Wrapper.awaitTransactionSuccessAsync(txHash);
             }
         }
     }

--- a/packages/metacoin/test/metacoin_test.ts
+++ b/packages/metacoin/test/metacoin_test.ts
@@ -52,7 +52,7 @@ describe('Metacoin', () => {
                 },
                 { from: devConstants.TESTRPC_FIRST_ADDRESS },
             );
-            const txReceipt = await web3Wrapper.awaitTransactionMinedAsync(txHash);
+            const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
             const transferLogs = txReceipt.logs[0] as LogWithDecodedArgs<TransferContractEventArgs>;
             expect(transferLogs.args).to.be.deep.equal({
                 _to: ZERO_ADDRESS,
@@ -77,7 +77,7 @@ describe('Metacoin', () => {
                 callback,
                 { from: devConstants.TESTRPC_FIRST_ADDRESS },
             );
-            const txReceipt = await web3Wrapper.awaitTransactionMinedAsync(txHash);
+            const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
             const transferLogs = txReceipt.logs[0] as LogWithDecodedArgs<TransferContractEventArgs>;
             expect(transferLogs.args).to.be.deep.equal({
                 _to: ZERO_ADDRESS,
@@ -104,7 +104,7 @@ describe('Metacoin', () => {
                 },
                 { from: devConstants.TESTRPC_FIRST_ADDRESS },
             );
-            const txReceipt = await web3Wrapper.awaitTransactionMinedAsync(txHash);
+            const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
             const transferLogs = txReceipt.logs[0] as LogWithDecodedArgs<TransferContractEventArgs>;
             expect(transferLogs.args).to.be.deep.equal({
                 _to: ZERO_ADDRESS,

--- a/packages/web3-wrapper/src/web3_wrapper.ts
+++ b/packages/web3-wrapper/src/web3_wrapper.ts
@@ -328,6 +328,10 @@ export class Web3Wrapper {
     }
     /**
      * Waits for a transaction to be mined and returns the transaction receipt.
+     * Note that just because a transaction was mined does not mean it was
+     * successful. You need to check the status code of the transaction receipt
+     * to find out if it was successful, or use the helper method
+     * awaitTransactionSuccessAsync.
      * @param   txHash            Transaction hash
      * @param   pollingIntervalMs How often (in ms) should we check if the transaction is mined.
      * @param   timeoutMs         How long (in ms) to poll for transaction mined until aborting.
@@ -376,6 +380,28 @@ export class Web3Wrapper {
         );
         const txReceipt = await txReceiptPromise;
         return txReceipt;
+    }
+    /**
+     * Waits for a transaction to be mined and returns the transaction receipt.
+     * Unlike awaitTransactionMinedAsync, it will throw if the receipt has a
+     * status that is not equal to 1. A status of 0 or null indicates that the
+     * transaction was mined, but failed. See:
+     * https://github.com/ethereum/wiki/wiki/JavaScript-API#web3ethgettransactionreceipt
+     * @param   txHash            Transaction hash
+     * @param   pollingIntervalMs How often (in ms) should we check if the transaction is mined.
+     * @param   timeoutMs         How long (in ms) to poll for transaction mined until aborting.
+     * @return  Transaction receipt with decoded log args.
+     */
+    public async awaitTransactionSuccessAsync(
+        txHash: string,
+        pollingIntervalMs: number = 1000,
+        timeoutMs?: number,
+    ): Promise<TransactionReceiptWithDecodedLogs> {
+        const receipt = await this.awaitTransactionMinedAsync(txHash, pollingIntervalMs, timeoutMs);
+        if (receipt.status !== 1) {
+            throw new Error('Transaction failed (transaction receipt did not have a status of 1)');
+        }
+        return receipt;
     }
     private async _sendRawPayloadAsync<A>(payload: Partial<JSONRPCRequestPayload>): Promise<A> {
         const sendAsync = this._web3.currentProvider.sendAsync.bind(this._web3.currentProvider);

--- a/packages/web3-wrapper/src/web3_wrapper.ts
+++ b/packages/web3-wrapper/src/web3_wrapper.ts
@@ -399,7 +399,7 @@ export class Web3Wrapper {
     ): Promise<TransactionReceiptWithDecodedLogs> {
         const receipt = await this.awaitTransactionMinedAsync(txHash, pollingIntervalMs, timeoutMs);
         if (receipt.status !== 1) {
-            throw new Error('Transaction failed (transaction receipt did not have a status of 1)');
+            throw new Error(`Transaction failed: ${txHash}`);
         }
         return receipt;
     }

--- a/packages/website/ts/blockchain.ts
+++ b/packages/website/ts/blockchain.ts
@@ -623,7 +623,7 @@ export class Blockchain {
         );
         const provider = this._contractWrappers.getProvider();
         const web3Wrapper = new Web3Wrapper(provider);
-        const receipt = await web3Wrapper.awaitTransactionMinedAsync(txHash);
+        const receipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
         return receipt;
     }
     private _doesUserAddressExist(): boolean {


### PR DESCRIPTION
## Description

This PR introduces an `awaitTransactionSuccessAsync` method in `Web3Wrapper`. It works similarly to `awaitTransactionMinedAsync` but checks the transaction receipt and throws if it has a status not equal to 1.

## Motivation and Context

In lots of different places in our tests, we call `awaitTransactionMinedAsync` to wait for a transaction to be added to the blockchain. However, in Ethereum, just because a transaction was mined doesn't mean it was successful. Failed transactions are still mined (though don't affect any state in the blockchain).

To check if a transaction was successful, you need to check the `status` field of the [transaction receipt](https://github.com/ethereum/wiki/wiki/JavaScript-API#web3ethgettransactionreceipt). The `awaitTransactionSuccessAsync` method does this and throws if it is not 1. Clients are inconsistent about how they report a failure; it's either 0, null, or undefined. However, they appear to be consistent in representing success with a status of 1.

When I was trying to debug some intermittent failures on my Geth branch, I noticed we were sometimes getting a transaction receipt status of `null`. This led to failures later on in the test which were difficult to track down. I still don't know why these intermittent transaction failures are happening but with this change we will at least be able to fail fast and see the error closer to where the problem actually occurred.

## How Has This Been Tested?

I confirmed the existing tests still pass (save for a known issue with the 0x.js package) after replacing all `awaitTransactionMinedAsync` calls with `awaitTransactionSuccessAsync`.

I'm not sure how to construct a test case for the `awaitTransactionSuccessAsync` method. Usually, Ganache throws at `sendTransactionAsync` if the transaction fails, before we even call `awaitTransactionSuccessAsync`. As mentioned above, I have seen transaction receipts with a status of `null`, but it didn't happen every time and I only saw it with Geth. Even with Geth, it usually fails at the gas estimation step, before we call `awaitTransactionSuccessAsync`. I can't reliably reproduce the `null` case.

If someone has a suggestion, I'd love to hear it.

## Types of changes

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
