### PR TITLE
Add awaitTransactionSuccess where needed

### DIFF
--- a/packages/contracts/src/utils/token_registry_wrapper.ts
+++ b/packages/contracts/src/utils/token_registry_wrapper.ts
@@ -4,13 +4,16 @@ import { TokenRegistryContract } from '../contract_wrappers/generated/token_regi
 
 import { Token } from './types';
 
+import { constants } from './constants';
+import { web3Wrapper } from './web3_wrapper';
+
 export class TokenRegWrapper {
     private _tokenReg: TokenRegistryContract;
     constructor(tokenRegContract: TokenRegistryContract) {
         this._tokenReg = tokenRegContract;
     }
     public async addTokenAsync(token: Token, from: string): Promise<string> {
-        const tx = this._tokenReg.addToken.sendTransactionAsync(
+        const txHash = await this._tokenReg.addToken.sendTransactionAsync(
             token.address as string,
             token.name,
             token.symbol,
@@ -19,7 +22,8 @@ export class TokenRegWrapper {
             token.swarmHash,
             { from },
         );
-        return tx;
+        await web3Wrapper.awaitTransactionSuccessAsync(txHash, constants.AWAIT_TRANSACTION_MINED_MS);
+        return txHash;
     }
     public async getTokenMetaDataAsync(tokenAddress: string): Promise<Token> {
         const data = await this._tokenReg.getTokenMetaData.callAsync(tokenAddress);

--- a/packages/contracts/src/utils/token_registry_wrapper.ts
+++ b/packages/contracts/src/utils/token_registry_wrapper.ts
@@ -1,16 +1,18 @@
-import * as Web3 from 'web3';
+import { Provider } from '@0xproject/types';
+import { Web3Wrapper } from '@0xproject/web3-wrapper';
 
 import { TokenRegistryContract } from '../contract_wrappers/generated/token_registry';
 
 import { Token } from './types';
 
 import { constants } from './constants';
-import { web3Wrapper } from './web3_wrapper';
 
 export class TokenRegWrapper {
     private _tokenReg: TokenRegistryContract;
-    constructor(tokenRegContract: TokenRegistryContract) {
+    private _web3Wrapper: Web3Wrapper;
+    constructor(tokenRegContract: TokenRegistryContract, provider: Provider) {
         this._tokenReg = tokenRegContract;
+        this._web3Wrapper = new Web3Wrapper(provider);
     }
     public async addTokenAsync(token: Token, from: string): Promise<string> {
         const txHash = await this._tokenReg.addToken.sendTransactionAsync(
@@ -22,7 +24,7 @@ export class TokenRegWrapper {
             token.swarmHash,
             { from },
         );
-        await web3Wrapper.awaitTransactionSuccessAsync(txHash, constants.AWAIT_TRANSACTION_MINED_MS);
+        await this._web3Wrapper.awaitTransactionSuccessAsync(txHash, constants.AWAIT_TRANSACTION_MINED_MS);
         return txHash;
     }
     public async getTokenMetaDataAsync(tokenAddress: string): Promise<Token> {

--- a/packages/contracts/test/asset_proxy_owner.ts
+++ b/packages/contracts/test/asset_proxy_owner.ts
@@ -60,8 +60,14 @@ describe('AssetProxyOwner', () => {
             SECONDS_TIME_LOCKED,
         );
         multiSigWrapper = new MultiSigWrapper(multiSig, provider);
-        await erc20Proxy.transferOwnership.sendTransactionAsync(multiSig.address, { from: initialOwner });
-        await erc721Proxy.transferOwnership.sendTransactionAsync(multiSig.address, { from: initialOwner });
+        await web3Wrapper.awaitTransactionSuccessAsync(
+            await erc20Proxy.transferOwnership.sendTransactionAsync(multiSig.address, { from: initialOwner }),
+            constants.AWAIT_TRANSACTION_MINED_MS,
+        );
+        await web3Wrapper.awaitTransactionSuccessAsync(
+            await erc721Proxy.transferOwnership.sendTransactionAsync(multiSig.address, { from: initialOwner }),
+            constants.AWAIT_TRANSACTION_MINED_MS,
+        );
     });
     beforeEach(async () => {
         await blockchainLifecycle.startAsync();

--- a/packages/contracts/test/ether_token.ts
+++ b/packages/contracts/test/ether_token.ts
@@ -83,7 +83,10 @@ describe('EtherToken', () => {
 
         it('should convert ether tokens to ether with sufficient balance', async () => {
             const ethToDeposit = new BigNumber(Web3Wrapper.toWei(new BigNumber(1)));
-            await etherToken.deposit.sendTransactionAsync({ value: ethToDeposit });
+            await web3Wrapper.awaitTransactionSuccessAsync(
+                await etherToken.deposit.sendTransactionAsync({ value: ethToDeposit }),
+                constants.AWAIT_TRANSACTION_MINED_MS,
+            );
             const initEthTokenBalance = await etherToken.balanceOf.callAsync(account);
             const initEthBalance = await web3Wrapper.getBalanceInWeiAsync(account);
             const ethTokensToWithdraw = initEthTokenBalance;

--- a/packages/contracts/test/token_registry.ts
+++ b/packages/contracts/test/token_registry.ts
@@ -34,7 +34,7 @@ describe('TokenRegistry', () => {
         owner = accounts[0];
         notOwner = accounts[1];
         tokenReg = await TokenRegistryContract.deployFrom0xArtifactAsync(artifacts.TokenRegistry, provider, txDefaults);
-        tokenRegWrapper = new TokenRegWrapper(tokenReg);
+        tokenRegWrapper = new TokenRegWrapper(tokenReg, provider);
     });
     beforeEach(async () => {
         await blockchainLifecycle.startAsync();

--- a/packages/contracts/test/unlimited_allowance_token.ts
+++ b/packages/contracts/test/unlimited_allowance_token.ts
@@ -64,7 +64,10 @@ describe('UnlimitedAllowanceToken', () => {
             const receiver = spender;
             const initOwnerBalance = await token.balanceOf.callAsync(owner);
             const amountToTransfer = new BigNumber(1);
-            await token.transfer.sendTransactionAsync(receiver, amountToTransfer, { from: owner });
+            await web3Wrapper.awaitTransactionSuccessAsync(
+                await token.transfer.sendTransactionAsync(receiver, amountToTransfer, { from: owner }),
+                constants.AWAIT_TRANSACTION_MINED_MS,
+            );
             const finalOwnerBalance = await token.balanceOf.callAsync(owner);
             const finalReceiverBalance = await token.balanceOf.callAsync(receiver);
 
@@ -86,7 +89,10 @@ describe('UnlimitedAllowanceToken', () => {
         it('should throw if owner has insufficient balance', async () => {
             const ownerBalance = await token.balanceOf.callAsync(owner);
             const amountToTransfer = ownerBalance.plus(1);
-            await token.approve.sendTransactionAsync(spender, amountToTransfer, { from: owner });
+            await web3Wrapper.awaitTransactionSuccessAsync(
+                await token.approve.sendTransactionAsync(spender, amountToTransfer, { from: owner }),
+                constants.AWAIT_TRANSACTION_MINED_MS,
+            );
             return expect(
                 token.transferFrom.callAsync(owner, spender, amountToTransfer, {
                     from: spender,
@@ -121,11 +127,17 @@ describe('UnlimitedAllowanceToken', () => {
             const initOwnerBalance = await token.balanceOf.callAsync(owner);
             const amountToTransfer = initOwnerBalance;
             const initSpenderAllowance = constants.UNLIMITED_ALLOWANCE_IN_BASE_UNITS;
-            await token.approve.sendTransactionAsync(spender, initSpenderAllowance, { from: owner });
-            await token.transferFrom.sendTransactionAsync(owner, spender, amountToTransfer, {
-                from: spender,
-                gas: constants.MAX_TOKEN_TRANSFERFROM_GAS,
-            });
+            await web3Wrapper.awaitTransactionSuccessAsync(
+                await token.approve.sendTransactionAsync(spender, initSpenderAllowance, { from: owner }),
+                constants.AWAIT_TRANSACTION_MINED_MS,
+            );
+            await web3Wrapper.awaitTransactionSuccessAsync(
+                await token.transferFrom.sendTransactionAsync(owner, spender, amountToTransfer, {
+                    from: spender,
+                    gas: constants.MAX_TOKEN_TRANSFERFROM_GAS,
+                }),
+                constants.AWAIT_TRANSACTION_MINED_MS,
+            );
 
             const newSpenderAllowance = await token.allowance.callAsync(owner, spender);
             expect(initSpenderAllowance).to.be.bignumber.equal(newSpenderAllowance);
@@ -135,11 +147,17 @@ describe('UnlimitedAllowanceToken', () => {
             const initOwnerBalance = await token.balanceOf.callAsync(owner);
             const amountToTransfer = initOwnerBalance;
             const initSpenderAllowance = initOwnerBalance;
-            await token.approve.sendTransactionAsync(spender, initSpenderAllowance, { from: owner });
-            await token.transferFrom.sendTransactionAsync(owner, spender, amountToTransfer, {
-                from: spender,
-                gas: constants.MAX_TOKEN_TRANSFERFROM_GAS,
-            });
+            await web3Wrapper.awaitTransactionSuccessAsync(
+                await token.approve.sendTransactionAsync(spender, initSpenderAllowance, { from: owner }),
+                constants.AWAIT_TRANSACTION_MINED_MS,
+            );
+            await web3Wrapper.awaitTransactionSuccessAsync(
+                await token.transferFrom.sendTransactionAsync(owner, spender, amountToTransfer, {
+                    from: spender,
+                    gas: constants.MAX_TOKEN_TRANSFERFROM_GAS,
+                }),
+                constants.AWAIT_TRANSACTION_MINED_MS,
+            );
 
             const newOwnerBalance = await token.balanceOf.callAsync(owner);
             const newSpenderBalance = await token.balanceOf.callAsync(spender);
@@ -152,11 +170,17 @@ describe('UnlimitedAllowanceToken', () => {
             const initOwnerBalance = await token.balanceOf.callAsync(owner);
             const amountToTransfer = initOwnerBalance;
             const initSpenderAllowance = initOwnerBalance;
-            await token.approve.sendTransactionAsync(spender, initSpenderAllowance, { from: owner });
-            await token.transferFrom.sendTransactionAsync(owner, spender, amountToTransfer, {
-                from: spender,
-                gas: constants.MAX_TOKEN_TRANSFERFROM_GAS,
-            });
+            await web3Wrapper.awaitTransactionSuccessAsync(
+                await token.approve.sendTransactionAsync(spender, initSpenderAllowance, { from: owner }),
+                constants.AWAIT_TRANSACTION_MINED_MS,
+            );
+            await web3Wrapper.awaitTransactionSuccessAsync(
+                await token.transferFrom.sendTransactionAsync(owner, spender, amountToTransfer, {
+                    from: spender,
+                    gas: constants.MAX_TOKEN_TRANSFERFROM_GAS,
+                }),
+                constants.AWAIT_TRANSACTION_MINED_MS,
+            );
 
             const newSpenderAllowance = await token.allowance.callAsync(owner, spender);
             expect(newSpenderAllowance).to.be.bignumber.equal(0);


### PR DESCRIPTION
See #601 and #613 for some background. We had some code pushed in the last few days that didn't follow the practice of calling `awaitTransactionSuccess` when needed.

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
