### PR TITLE
Make erc20_wrapper and erc721_wrapper serial and increase contract expiration time

### DIFF
--- a/packages/contracts/src/utils/erc20_wrapper.ts
+++ b/packages/contracts/src/utils/erc20_wrapper.ts
@@ -52,8 +52,6 @@ export class ERC20Wrapper {
     public async setBalancesAndAllowancesAsync(): Promise<void> {
         this._validateDummyTokenContractsExistOrThrow();
         this._validateProxyContractExistsOrThrow();
-        const setBalancePromises: Array<Promise<string>> = [];
-        const setAllowancePromises: Array<Promise<string>> = [];
         for (const dummyTokenContract of this._dummyTokenContracts) {
             for (const tokenOwnerAddress of this._tokenOwnerAddresses) {
                 await this._web3Wrapper.awaitTransactionSuccessAsync(
@@ -79,7 +77,6 @@ export class ERC20Wrapper {
         this._validateDummyTokenContractsExistOrThrow();
         const balancesByOwner: ERC20BalancesByOwner = {};
         const balances: BigNumber[] = [];
-        const balancePromises: Array<Promise<BigNumber>> = [];
         const balanceInfo: Array<{ tokenOwnerAddress: string; tokenAddress: string }> = [];
         for (const dummyTokenContract of this._dummyTokenContracts) {
             for (const tokenOwnerAddress of this._tokenOwnerAddresses) {

--- a/packages/contracts/src/utils/erc721_wrapper.ts
+++ b/packages/contracts/src/utils/erc721_wrapper.ts
@@ -52,8 +52,6 @@ export class ERC721Wrapper {
     public async setBalancesAndAllowancesAsync(): Promise<void> {
         this._validateDummyTokenContractsExistOrThrow();
         this._validateProxyContractExistsOrThrow();
-        const setBalancePromises: Array<Promise<string>> = [];
-        const setAllowancePromises: Array<Promise<string>> = [];
         this._initialTokenIdsByOwner = {};
         for (const dummyTokenContract of this._dummyTokenContracts) {
             for (const tokenOwnerAddress of this._tokenOwnerAddresses) {
@@ -92,7 +90,6 @@ export class ERC721Wrapper {
         this._validateBalancesAndAllowancesSetOrThrow();
         const tokenIdsByOwner: ERC721TokenIdsByOwner = {};
         const tokenOwnerAddresses: string[] = [];
-        const tokenOwnerPromises: Array<Promise<string>> = [];
         const tokenInfo: Array<{ tokenId: BigNumber; tokenAddress: string }> = [];
         for (const dummyTokenContract of this._dummyTokenContracts) {
             for (const tokenOwnerAddress of this._tokenOwnerAddresses) {

--- a/packages/contracts/src/utils/order_factory.ts
+++ b/packages/contracts/src/utils/order_factory.ts
@@ -19,7 +19,8 @@ export class OrderFactory {
         customOrderParams: Partial<UnsignedOrder> = {},
         signatureType: SignatureType = SignatureType.Ecrecover,
     ): SignedOrder {
-        const randomExpiration = new BigNumber(Math.floor((Date.now() + Math.random() * 100000000000) / 1000));
+        const tenMinutes = 10 * 60 * 1000;
+        const randomExpiration = new BigNumber(Date.now() + tenMinutes);
         const order = ({
             senderAddress: constants.NULL_ADDRESS,
             expirationTimeSeconds: randomExpiration,


### PR DESCRIPTION
This PR changes some functions in __erc20_wrapper.ts__ and __erc721_wrapper.ts__ in the contracts package to run serially instead of concurrently. That means we're sending out each transaction one at a time and waiting for it to be successfully mined before continuing.

We also noticed contracts were expiring in CI because the tests sometimes take too long. It's a separate issue, but we wanted to see if we could get the tests to pass in CI for this PR so we also addressed that.

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

This is an attempt to solve the race condition(s) that have been disrupting our tests. We're not entirely sure if it solves the issue, but we believe at this time it is good to rule out the concurrent portions of these contract wrappers.

This change does make our tests slower, so if it turns out not to be necessary we should revert it in the future.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
