### PR TITLE
Add a documentation page for ethereum-types package

### DIFF
--- a/packages/ethereum-types/package.json
+++ b/packages/ethereum-types/package.json
@@ -12,7 +12,18 @@
         "build": "tsc && copyfiles -u 2 './lib/monorepo_scripts/**/*' ./scripts",
         "clean": "shx rm -rf lib scripts",
         "lint": "tslint --project .",
-        "manual:postpublish": "yarn build; node ./scripts/postpublish.js"
+        "manual:postpublish": "yarn build; node ./scripts/postpublish.js",
+        "docs:stage": "node scripts/stage_docs.js",
+        "docs:json": "typedoc --excludePrivate --excludeExternals --target ES5 --json $JSON_FILE_PATH $PROJECT_FILES",
+        "upload_docs_json": "aws s3 cp generated_docs/index.json $S3_URL --profile 0xproject --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers --content-type application/json"
+    },
+    "config": {
+        "postpublish": {
+            "docPublishConfigs": {
+                "s3BucketPath": "s3://doc-jsons/ethereum-types/",
+                "s3StagingBucketPath": "s3://staging-doc-jsons/ethereum-types/"
+            }
+        }
     },
     "license": "Apache-2.0",
     "repository": {

--- a/packages/ethereum-types/src/monorepo_scripts/stage_docs.ts
+++ b/packages/ethereum-types/src/monorepo_scripts/stage_docs.ts
@@ -1,0 +1,8 @@
+import { postpublishUtils } from '@0xproject/monorepo-scripts';
+
+import * as packageJSON from '../package.json';
+import * as tsConfigJSON from '../tsconfig.json';
+
+const cwd = `${__dirname}/..`;
+// tslint:disable-next-line:no-floating-promises
+postpublishUtils.publishDocsToStagingAsync(packageJSON, tsConfigJSON, cwd);

--- a/packages/website/md/docs/ethereum_types/installation.md
+++ b/packages/website/md/docs/ethereum_types/installation.md
@@ -1,0 +1,11 @@
+**Install**
+
+```bash
+yarn add ethereum-types
+```
+
+**Import**
+
+```typescript
+import { Provider } from 'ethereum-types';
+```

--- a/packages/website/md/docs/ethereum_types/introduction.md
+++ b/packages/website/md/docs/ethereum_types/introduction.md
@@ -1,0 +1,1 @@
+Welcome to the [ethereum-types](https://github.com/0xProject/0x-monorepo/packages/ethereum-types) documentation! This package provides ethereum specific (but not library-specific) types that are meant to be shared between other ethereum packages.

--- a/packages/website/translations/chinese.json
+++ b/packages/website/translations/chinese.json
@@ -59,6 +59,7 @@
     "SOL_COMPILER": "Solidity Compiler",
     "JSON_SCHEMAS": "JSON Schemas",
     "SOL_COV": "Solidity Coverage",
+    "ETHEREUM_TYPES": "Ethereum Types",
     "SUBPROVIDERS": "Subproviders",
     "BLOG": "博客",
     "FORUM": "论坛",

--- a/packages/website/translations/english.json
+++ b/packages/website/translations/english.json
@@ -60,6 +60,7 @@
     "SOL_COMPILER": "Solidity Compiler",
     "JSON_SCHEMAS": "JSON Schemas",
     "SOL_COV": "Solidity Coverage",
+    "ETHEREUM_TYPES": "Ethereum Types",
     "SUBPROVIDERS": "Subproviders",
     "BLOG": "blog",
     "FORUM": "forum",

--- a/packages/website/translations/korean.json
+++ b/packages/website/translations/korean.json
@@ -59,6 +59,7 @@
     "SOL_COMPILER": "Solidity Compiler",
     "JSON_SCHEMAS": "JSON Schemas",
     "SOL_COV": "Solidity Coverage",
+    "ETHEREUM_TYPES": "Ethereum Types",
     "SUBPROVIDERS": "Subproviders",
     "BLOG": "블로그",
     "FORUM": "포럼",

--- a/packages/website/translations/russian.json
+++ b/packages/website/translations/russian.json
@@ -59,6 +59,7 @@
     "SOL_COMPILER": "Solidity Compiler",
     "JSON_SCHEMAS": "JSON Schemas",
     "SOL_COV": "Solidity Coverage",
+    "ETHEREUM_TYPES": "Ethereum Types",
     "SUBPROVIDERS": "Subproviders",
     "BLOG": "Блог",
     "FORUM": "Форум",

--- a/packages/website/translations/spanish.json
+++ b/packages/website/translations/spanish.json
@@ -60,6 +60,7 @@
     "SOL_COMPILER": "Solidity Compiler",
     "JSON_SCHEMAS": "JSON Schemas",
     "SOL_COV": "Solidity Coverage",
+    "ETHEREUM_TYPES": "Ethereum Types",
     "SUBPROVIDERS": "Subproviders",
     "BLOG": "blog",
     "FORUM": "foro",

--- a/packages/website/ts/components/top_bar/top_bar.tsx
+++ b/packages/website/ts/components/top_bar/top_bar.tsx
@@ -165,6 +165,12 @@ export class TopBar extends React.Component<TopBarProps, TopBarState> {
                     primaryText={this.props.translate.get(Key.SolCov, Deco.CapWords)}
                 />
             </Link>,
+            <Link key="subMenuItem-ethereum-types" to={WebsitePaths.EthereumTypes} className="text-decoration-none">
+                <MenuItem
+                    style={{ fontSize: styles.menuItem.fontSize }}
+                    primaryText={this.props.translate.get(Key.EthereumTypes, Deco.CapWords)}
+                />
+            </Link>,
             <a
                 key="subMenuItem-whitePaper"
                 target="_blank"

--- a/packages/website/ts/components/top_bar/top_bar.tsx
+++ b/packages/website/ts/components/top_bar/top_bar.tsx
@@ -385,6 +385,14 @@ export class TopBar extends React.Component<TopBarProps, TopBarState> {
                             </MenuItem>
                         </Link>
                     )}
+                    {!this._isViewingEthereumTypesDocs() && (
+                        <Link to={WebsitePaths.EthereumTypes} className="text-decoration-none">
+                            <MenuItem className="py2">
+                                {this.props.translate.get(Key.EthereumTypes, Deco.Cap)}{' '}
+                                {this.props.translate.get(Key.Docs, Deco.Cap)}
+                            </MenuItem>
+                        </Link>
+                    )}
                     {!this._isViewingPortal() && (
                         <Link to={`${WebsitePaths.Portal}`} className="text-decoration-none">
                             <MenuItem className="py2">
@@ -512,6 +520,9 @@ export class TopBar extends React.Component<TopBarProps, TopBarState> {
     }
     private _isViewingSubprovidersDocs(): boolean {
         return _.includes(this.props.location.pathname, WebsitePaths.Subproviders);
+    }
+    private _isViewingEthereumTypesDocs(): boolean {
+        return _.includes(this.props.location.pathname, WebsitePaths.EthereumTypes);
     }
     private _isViewingWiki(): boolean {
         return _.includes(this.props.location.pathname, WebsitePaths.Wiki);

--- a/packages/website/ts/containers/ethereum_types_documentation.ts
+++ b/packages/website/ts/containers/ethereum_types_documentation.ts
@@ -61,7 +61,7 @@ const docsInfoConfig: DocsInfoConfig = {
             'EventAbi',
             'DataItem',
             'OpCode',
-            // 'StructLog',
+            // 'StructLog', // TODO: This type breaks the docs so we don't render it for now
             'TransactionTrace',
             'Unit',
             'JSONRPCRequestPayload',

--- a/packages/website/ts/containers/ethereum_types_documentation.ts
+++ b/packages/website/ts/containers/ethereum_types_documentation.ts
@@ -1,0 +1,124 @@
+import { constants as docConstants, DocsInfo, DocsInfoConfig, SupportedDocJson } from '@0xproject/react-docs';
+import * as _ from 'lodash';
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { Dispatch } from 'redux';
+import { DocPage as DocPageComponent, DocPageProps } from 'ts/pages/documentation/doc_page';
+import { Dispatcher } from 'ts/redux/dispatcher';
+import { State } from 'ts/redux/reducer';
+import { DocPackages, Environments, WebsitePaths } from 'ts/types';
+import { configs } from 'ts/utils/configs';
+import { constants } from 'ts/utils/constants';
+import { Translate } from 'ts/utils/translate';
+
+/* tslint:disable:no-var-requires */
+const IntroMarkdown = require('md/docs/ethereum_types/introduction');
+const InstallationMarkdown = require('md/docs/ethereum_types/installation');
+/* tslint:enable:no-var-requires */
+
+const docSections = {
+    introduction: 'introduction',
+    installation: 'installation',
+    types: docConstants.TYPES_SECTION_NAME,
+};
+
+const docsInfoConfig: DocsInfoConfig = {
+    id: DocPackages.EthereumTypes,
+    type: SupportedDocJson.TypeDoc,
+    displayName: 'Ethereum Types',
+    packageUrl: 'https://github.com/0xProject/0x-monorepo/packages/ethereum-types',
+    menu: {
+        introduction: [docSections.introduction],
+        install: [docSections.installation],
+        types: [docSections.types],
+    },
+    sectionNameToMarkdown: {
+        [docSections.introduction]: IntroMarkdown,
+        [docSections.installation]: InstallationMarkdown,
+    },
+    sectionNameToModulePath: {
+        [docSections.types]: ['"index"'],
+    },
+    visibleConstructors: [],
+    menuSubsectionToVersionWhenIntroduced: {},
+    sections: docSections,
+    typeConfigs: {
+        // Note: This needs to be kept in sync with the types exported in index.ts. Unfortunately there is
+        // currently no way to extract the re-exported types from index.ts via TypeDoc :(
+        publicTypes: [
+            'Provider',
+            'JSONRPCErrorCallback',
+            'Provider',
+            'ContractAbi',
+            'AbiDefinition',
+            'FunctionAbi',
+            'ConstructorStateMutability',
+            'StateMutability',
+            'MethodAbi',
+            'ConstructorAbi',
+            'FallbackAbi',
+            'EventParameter',
+            'EventAbi',
+            'DataItem',
+            'OpCode',
+            // 'StructLog',
+            'TransactionTrace',
+            'Unit',
+            'JSONRPCRequestPayload',
+            'JSONRPCResponsePayload',
+            'BlockWithoutTransactionData',
+            'BlockWithTransactionData',
+            'Transaction',
+            'TxData',
+            'CallData',
+            'FilterObject',
+            'LogTopic',
+            'DecodedLogEntry',
+            'DecodedLogEntryEvent',
+            'LogEntryEvent',
+            'LogEntry',
+            'TxDataPayable',
+            'TransactionReceipt',
+            'AbiType',
+            'ContractEventArg',
+            'DecodedLogArgs',
+            'LogWithDecodedArgs',
+            'RawLog',
+            'BlockParamLiteral',
+            'BlockParam',
+            'RawLogEntry',
+            'SolidityTypes',
+            'TransactionReceiptWithDecodedLogs',
+        ],
+        typeNameToExternalLink: {
+            BigNumber: constants.URL_BIGNUMBERJS_GITHUB,
+        },
+    },
+};
+const docsInfo = new DocsInfo(docsInfoConfig);
+
+interface ConnectedState {
+    docsVersion: string;
+    availableDocVersions: string[];
+    docsInfo: DocsInfo;
+    translate: Translate;
+}
+
+interface ConnectedDispatch {
+    dispatcher: Dispatcher;
+}
+
+const mapStateToProps = (state: State, ownProps: DocPageProps): ConnectedState => ({
+    docsVersion: state.docsVersion,
+    availableDocVersions: state.availableDocVersions,
+    translate: state.translate,
+    docsInfo,
+});
+
+const mapDispatchToProps = (dispatch: Dispatch<State>): ConnectedDispatch => ({
+    dispatcher: new Dispatcher(dispatch),
+});
+
+export const Documentation: React.ComponentClass<DocPageProps> = connect(mapStateToProps, mapDispatchToProps)(
+    DocPageComponent,
+);

--- a/packages/website/ts/index.tsx
+++ b/packages/website/ts/index.tsx
@@ -69,6 +69,9 @@ const LazySubprovidersDocumentation = createLazyComponent('Documentation', async
 const LazyOrderUtilsDocumentation = createLazyComponent('Documentation', async () =>
     System.import<any>(/* webpackChunkName: "orderUtilsDocs" */ 'ts/containers/order_utils_documentation'),
 );
+const LazyEthereumTypesDocumentation = createLazyComponent('Documentation', async () =>
+    System.import<any>(/* webpackChunkName: "ethereumTypesDocs" */ 'ts/containers/ethereum_types_documentation'),
+);
 
 analytics.init();
 // tslint:disable-next-line:no-floating-promises
@@ -115,6 +118,10 @@ render(
                             <Route
                                 path={`${WebsitePaths.SmartContracts}/:version?`}
                                 component={LazySmartContractsDocumentation}
+                            />
+                            <Route
+                                path={`${WebsitePaths.EthereumTypes}/:version?`}
+                                component={LazyEthereumTypesDocumentation}
                             />
 
                             {/* Legacy endpoints */}

--- a/packages/website/ts/pages/documentation/doc_page.tsx
+++ b/packages/website/ts/pages/documentation/doc_page.tsx
@@ -35,6 +35,7 @@ const docIdToSubpackageName: { [id: string]: string } = {
     [DocPackages.SolCov]: 'sol-cov',
     [DocPackages.Subproviders]: 'subproviders',
     [DocPackages.OrderUtils]: 'order-utils',
+    [DocPackages.EthereumTypes]: 'ethereum-types',
 };
 
 export interface DocPageProps {

--- a/packages/website/ts/types.ts
+++ b/packages/website/ts/types.ts
@@ -370,6 +370,7 @@ export enum WebsitePaths {
     SolCov = '/docs/sol-cov',
     Subproviders = '/docs/subproviders',
     OrderUtils = '/docs/order-utils',
+    EthereumTypes = '/docs/ethereum-types',
     Jobs = '/jobs',
 }
 
@@ -383,6 +384,7 @@ export enum DocPackages {
     SolCov = 'SOL_COV',
     Subproviders = 'SUBPROVIDERS',
     OrderUtils = 'ORDER_UTILS',
+    EthereumTypes = 'ETHEREUM_TYPES',
 }
 
 export enum Key {
@@ -434,6 +436,7 @@ export enum Key {
     SolCompiler = 'SOL_COMPILER',
     JsonSchemas = 'JSON_SCHEMAS',
     SolCov = 'SOL_COV',
+    EthereumTypes = 'ETHEREUM_TYPES',
     Subproviders = 'SUBPROVIDERS',
     Blog = 'BLOG',
     Forum = 'FORUM',

--- a/packages/website/ts/utils/doc_utils.ts
+++ b/packages/website/ts/utils/doc_utils.ts
@@ -8,7 +8,7 @@ import convert = require('xml-js');
 
 export const docUtils = {
     async getVersionToFilePathAsync(s3DocJsonRoot: string, folderName: string): Promise<VersionToFilePath> {
-        const versionFilePaths = await this.getVersionFileNamesAsync(s3DocJsonRoot, folderName);
+        const versionFilePaths = await docUtils.getVersionFileNamesAsync(s3DocJsonRoot, folderName);
         const versionToFilePath: VersionToFilePath = {};
         _.each(versionFilePaths, filePath => {
             const [version] = findVersions(filePath);


### PR DESCRIPTION
## Description

Adds a docs page for ethereum-types package

## Motivation and Context

Other people that will build ethereum-related type definitions are gonna use those and they'd better be documented.

## How Has This Been Tested?

Manually
<img width="1680" alt="screen shot 2018-06-04 at 11 02 09" src="https://user-images.githubusercontent.com/6204356/40933632-e9e9c538-67e6-11e8-9f36-af0bcbbda161.png">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [x] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [x] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [x] Labeled this PR with the labels corresponding to the changed package.
