### PR TITLE
Split transfer implementation and AssetProxyMixin

### DIFF
--- a/packages/contracts/src/contracts/current/protocol/AssetProxy/ERC721Proxy.sol
+++ b/packages/contracts/src/contracts/current/protocol/AssetProxy/ERC721Proxy.sol
@@ -22,51 +22,15 @@ pragma experimental ABIEncoderV2;
 import "../../utils/LibBytes/LibBytes.sol";
 import "./MixinAssetProxy.sol";
 import "./MixinAuthorizable.sol";
-import "../../tokens/ERC721Token/ERC721Token.sol";
+import "./MixinERC721Transfer.sol";
 
 contract ERC721Proxy is
-    LibBytes,
     MixinAssetProxy,
-    MixinAuthorizable
+    MixinAuthorizable,
+    MixinERC721Transfer
 {
-
     // Id of this proxy.
     uint8 constant PROXY_ID = 2;
-
-    /// @dev Internal version of `transferFrom`.
-    /// @param assetData Encoded byte array.
-    /// @param from Address to transfer asset from.
-    /// @param to Address to transfer asset to.
-    /// @param amount Amount of asset to transfer.
-    function transferFromInternal(
-        bytes memory assetData,
-        address from,
-        address to,
-        uint256 amount
-    )
-        internal
-    {
-        // There exists only 1 of each token.
-        require(
-            amount == 1,
-            INVALID_AMOUNT
-        );
-    
-        // Decode asset data.
-        (
-            address token,
-            uint256 tokenId,
-            bytes memory receiverData
-        ) = decodeERC721AssetData(assetData);
-
-        // Transfer token. Saves gas by calling safeTransferFrom only
-        // when there is receiverData present. Either succeeds or throws.
-        if (receiverData.length > 0) {
-            ERC721Token(token).safeTransferFrom(from, to, tokenId, receiverData);
-        } else {
-            ERC721Token(token).transferFrom(from, to, tokenId);
-        }
-    }
 
     /// @dev Gets the proxy id associated with the proxy address.
     /// @return Proxy id.

--- a/packages/contracts/src/contracts/current/protocol/AssetProxy/MixinERC20Transfer.sol
+++ b/packages/contracts/src/contracts/current/protocol/AssetProxy/MixinERC20Transfer.sol
@@ -1,0 +1,71 @@
+/*
+
+  Copyright 2018 ZeroEx Intl.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+*/
+
+pragma solidity ^0.4.24;
+pragma experimental ABIEncoderV2;
+
+import "../../utils/LibBytes/LibBytes.sol";
+import "../../tokens/ERC20Token/IERC20Token.sol";
+
+contract MixinERC20Transfer is
+    LibBytes
+{
+    // Id of this proxy.
+    uint8 constant PROXY_ID = 1;
+    // Revert reasons
+    string constant INVALID_METADATA_LENGTH = "Metadata must have a length of 21.";
+    string constant TRANSFER_FAILED = "Transfer failed.";
+    string constant PROXY_ID_MISMATCH = "Proxy id in metadata does not match this proxy id.";
+
+    /// @dev Internal version of `transferFrom`.
+    /// @param assetMetadata Encoded byte array.
+    /// @param from Address to transfer asset from.
+    /// @param to Address to transfer asset to.
+    /// @param amount Amount of asset to transfer.
+    function transferFromInternal(
+        bytes memory assetMetadata,
+        address from,
+        address to,
+        uint256 amount
+    )
+        internal
+    {
+        // Data must be intended for this proxy.
+        uint256 length = assetMetadata.length;
+
+        require(
+            length == 21,
+            INVALID_METADATA_LENGTH
+        );
+
+        require(
+            uint8(assetMetadata[length - 1]) == PROXY_ID,
+            PROXY_ID_MISMATCH
+        );
+
+        // Decode metadata.
+        address token = readAddress(assetMetadata, 0);
+
+        // Transfer tokens.
+        bool success = IERC20Token(token).transferFrom(from, to, amount);
+        require(
+            success == true,
+            TRANSFER_FAILED
+        );
+    }
+}

--- a/packages/contracts/src/contracts/current/protocol/AssetProxy/MixinERC20Transfer.sol
+++ b/packages/contracts/src/contracts/current/protocol/AssetProxy/MixinERC20Transfer.sol
@@ -21,50 +21,60 @@ pragma experimental ABIEncoderV2;
 
 import "../../utils/LibBytes/LibBytes.sol";
 import "../../tokens/ERC20Token/IERC20Token.sol";
+import "./libs/LibTransferErrors.sol";
 
 contract MixinERC20Transfer is
-    LibBytes
+    LibBytes,
+    LibTransferErrors
 {
-    // Id of this proxy.
-    uint8 constant PROXY_ID = 1;
-    // Revert reasons
-    string constant INVALID_METADATA_LENGTH = "Metadata must have a length of 21.";
-    string constant TRANSFER_FAILED = "Transfer failed.";
-    string constant PROXY_ID_MISMATCH = "Proxy id in metadata does not match this proxy id.";
-
     /// @dev Internal version of `transferFrom`.
-    /// @param assetMetadata Encoded byte array.
+    /// @param assetData Encoded byte array.
     /// @param from Address to transfer asset from.
     /// @param to Address to transfer asset to.
     /// @param amount Amount of asset to transfer.
     function transferFromInternal(
-        bytes memory assetMetadata,
+        bytes memory assetData,
         address from,
         address to,
         uint256 amount
     )
         internal
     {
-        // Data must be intended for this proxy.
-        uint256 length = assetMetadata.length;
-
-        require(
-            length == 21,
-            INVALID_METADATA_LENGTH
-        );
-
-        require(
-            uint8(assetMetadata[length - 1]) == PROXY_ID,
-            PROXY_ID_MISMATCH
-        );
-
-        // Decode metadata.
-        address token = readAddress(assetMetadata, 0);
+        // Decode asset data.
+        address token = readAddress(assetData, 0);
 
         // Transfer tokens.
-        bool success = IERC20Token(token).transferFrom(from, to, amount);
+        // We do a raw call so we can check the success separate
+        // from the return data.
+        bool success = token.call(abi.encodeWithSelector(
+            IERC20Token(token).transferFrom.selector,
+            from,
+            to,
+            amount
+        ));
         require(
-            success == true,
+            success,
+            TRANSFER_FAILED
+        );
+        
+        // Check return data.
+        // If there is no return data, we assume the token incorrectly
+        // does not return a bool. In this case we expect it to revert
+        // on failure, which was handled above.
+        // If the token does return data, we require that it is a single
+        // value that evaluates to true.
+        assembly {
+            if returndatasize {
+                success := 0
+                if eq(returndatasize, 32) {
+                    // First 64 bytes of memory are reserved scratch space
+                    returndatacopy(0, 0, 32)
+                    success := mload(0)
+                }
+            }
+        }
+        require(
+            success,
             TRANSFER_FAILED
         );
     }

--- a/packages/contracts/src/contracts/current/protocol/AssetProxy/MixinERC721Transfer.sol
+++ b/packages/contracts/src/contracts/current/protocol/AssetProxy/MixinERC721Transfer.sol
@@ -1,0 +1,79 @@
+/*
+
+  Copyright 2018 ZeroEx Intl.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+*/
+
+pragma solidity ^0.4.24;
+pragma experimental ABIEncoderV2;
+
+import "../../utils/LibBytes/LibBytes.sol";
+import "../../tokens/ERC721Token/ERC721Token.sol";
+
+contract MixinERC721Transfer is
+    LibBytes
+{
+
+    // Id of this proxy.
+    uint8 constant PROXY_ID = 2;
+
+    // Revert reasons
+    string constant INVALID_TRANSFER_AMOUNT = "Transfer amount must equal 1.";
+    string constant INVALID_METADATA_LENGTH = "Metadata must have a length of 53.";
+    string constant PROXY_ID_MISMATCH = "Proxy id in metadata does not match this proxy id.";
+
+    /// @dev Internal version of `transferFrom`.
+    /// @param assetMetadata Encoded byte array.
+    /// @param from Address to transfer asset from.
+    /// @param to Address to transfer asset to.
+    /// @param amount Amount of asset to transfer.
+    function transferFromInternal(
+        bytes memory assetMetadata,
+        address from,
+        address to,
+        uint256 amount
+    )
+        internal
+    {
+        // Data must be intended for this proxy.
+        uint256 length = assetMetadata.length;
+
+        require(
+            length == 53,
+            INVALID_METADATA_LENGTH
+        );
+
+        require(
+            uint8(assetMetadata[length - 1]) == PROXY_ID,
+            PROXY_ID_MISMATCH
+        );
+
+        // There exists only 1 of each token.
+        require(
+            amount == 1,
+            INVALID_TRANSFER_AMOUNT
+        );
+
+        // Decode metadata
+        address token = readAddress(assetMetadata, 0);
+        uint256 tokenId = readUint256(assetMetadata, 20);
+
+        // Transfer token.
+        // Either succeeds or throws.
+        // @TODO: Call safeTransferFrom if there is additional
+        //        data stored in `assetMetadata`.
+        ERC721Token(token).transferFrom(from, to, tokenId);
+    }
+}

--- a/packages/contracts/src/contracts/current/protocol/AssetProxy/MixinERC721Transfer.sol
+++ b/packages/contracts/src/contracts/current/protocol/AssetProxy/MixinERC721Transfer.sol
@@ -21,59 +21,74 @@ pragma experimental ABIEncoderV2;
 
 import "../../utils/LibBytes/LibBytes.sol";
 import "../../tokens/ERC721Token/ERC721Token.sol";
+import "./libs/LibTransferErrors.sol";
 
 contract MixinERC721Transfer is
-    LibBytes
+    LibBytes,
+    LibTransferErrors
 {
-
-    // Id of this proxy.
-    uint8 constant PROXY_ID = 2;
-
-    // Revert reasons
-    string constant INVALID_TRANSFER_AMOUNT = "Transfer amount must equal 1.";
-    string constant INVALID_METADATA_LENGTH = "Metadata must have a length of 53.";
-    string constant PROXY_ID_MISMATCH = "Proxy id in metadata does not match this proxy id.";
-
     /// @dev Internal version of `transferFrom`.
-    /// @param assetMetadata Encoded byte array.
+    /// @param assetData Encoded byte array.
     /// @param from Address to transfer asset from.
     /// @param to Address to transfer asset to.
     /// @param amount Amount of asset to transfer.
     function transferFromInternal(
-        bytes memory assetMetadata,
+        bytes memory assetData,
         address from,
         address to,
         uint256 amount
     )
         internal
     {
-        // Data must be intended for this proxy.
-        uint256 length = assetMetadata.length;
-
-        require(
-            length == 53,
-            INVALID_METADATA_LENGTH
-        );
-
-        require(
-            uint8(assetMetadata[length - 1]) == PROXY_ID,
-            PROXY_ID_MISMATCH
-        );
-
         // There exists only 1 of each token.
         require(
             amount == 1,
-            INVALID_TRANSFER_AMOUNT
+            INVALID_AMOUNT
         );
+    
+        // Decode asset data.
+        (
+            address token,
+            uint256 tokenId,
+            bytes memory receiverData
+        ) = decodeERC721AssetData(assetData);
 
-        // Decode metadata
-        address token = readAddress(assetMetadata, 0);
-        uint256 tokenId = readUint256(assetMetadata, 20);
+        // Transfer token. Saves gas by calling safeTransferFrom only
+        // when there is receiverData present. Either succeeds or throws.
+        if (receiverData.length > 0) {
+            ERC721Token(token).safeTransferFrom(from, to, tokenId, receiverData);
+        } else {
+            ERC721Token(token).transferFrom(from, to, tokenId);
+        }
+    }
 
-        // Transfer token.
-        // Either succeeds or throws.
-        // @TODO: Call safeTransferFrom if there is additional
-        //        data stored in `assetMetadata`.
-        ERC721Token(token).transferFrom(from, to, tokenId);
+    /// @dev Decodes ERC721 Asset data.
+    /// @param assetData Encoded byte array.
+    /// @return proxyId Intended ERC721 proxy id.
+    /// @return token ERC721 token address.
+    /// @return tokenId ERC721 token id.
+    /// @return receiverData Additional data with no specific format, which
+    ///                      is passed to the receiving contract's onERC721Received.
+    function decodeERC721AssetData(bytes memory assetData)
+        internal
+        pure
+        returns (
+            address token,
+            uint256 tokenId,
+            bytes memory receiverData
+        )
+    {
+        // Decode asset data.
+        token = readAddress(assetData, 0);
+        tokenId = readUint256(assetData, 20);
+        if (assetData.length > 52) {
+            receiverData = readBytes(assetData, 52);
+        }
+
+        return (
+            token,
+            tokenId,
+            receiverData
+        );
     }
 }

--- a/packages/contracts/src/contracts/current/protocol/AssetProxy/libs/LibAssetProxyErrors.sol
+++ b/packages/contracts/src/contracts/current/protocol/AssetProxy/libs/LibAssetProxyErrors.sol
@@ -25,8 +25,4 @@ contract LibAssetProxyErrors {
     string constant TARGET_ALREADY_AUTHORIZED = "TARGET_ALREADY_AUTHORIZED";      // Target address must not already be authorized.
     string constant INDEX_OUT_OF_BOUNDS = "INDEX_OUT_OF_BOUNDS";                  // Specified array index is out of bounds.
     string constant AUTHORIZED_ADDRESS_MISMATCH = "AUTHORIZED_ADDRESS_MISMATCH";  // Address at index does not match given target address.
-
-    /// AssetProxy errors ///
-    string constant INVALID_AMOUNT = "INVALID_AMOUNT";                            // Transfer amount must equal 1.
-    string constant TRANSFER_FAILED = "TRANSFER_FAILED";                          // Transfer failed.
 }

--- a/packages/contracts/src/contracts/current/protocol/AssetProxy/libs/LibTransferErrors.sol
+++ b/packages/contracts/src/contracts/current/protocol/AssetProxy/libs/LibTransferErrors.sol
@@ -17,28 +17,9 @@
 */
 
 pragma solidity ^0.4.24;
-pragma experimental ABIEncoderV2;
 
-import "../../utils/LibBytes/LibBytes.sol";
-import "./MixinAssetProxy.sol";
-import "./MixinAuthorizable.sol";
-import "./MixinERC721Transfer.sol";
-
-contract ERC721Proxy is
-    MixinAssetProxy,
-    MixinAuthorizable,
-    MixinERC721Transfer
-{
-    // Id of this proxy.
-    uint8 constant PROXY_ID = 2;
-
-    /// @dev Gets the proxy id associated with the proxy address.
-    /// @return Proxy id.
-    function getProxyId()
-        external
-        view
-        returns (uint8)
-    {
-        return PROXY_ID;
-    }
+contract LibTransferErrors {
+    /// Transfer errors ///
+    string constant INVALID_AMOUNT = "INVALID_AMOUNT";                            // Transfer amount must equal 1.
+    string constant TRANSFER_FAILED = "TRANSFER_FAILED";                          // Transfer failed.
 }


### PR DESCRIPTION
<!--- Thank you for taking the time to submit a Pull Request -->

<!--- Provide a general summary of the issue in the Title above -->

## Description

Split the Transfer implementation and the AssetProxy-ness so the Transfer impl can be mixed in without the AssetProxy.


## Motivation and Context

This is useful for the Forwarding contract as we can get the validation and the and safeTransfer without the AssetProxy public methods.


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
