### PR TITLE
Fix broken link to `contract_templates`

### DIFF
--- a/packages/abi-gen/README.md
+++ b/packages/abi-gen/README.md
@@ -5,7 +5,7 @@ It's heavily inspired by [Geth abigen](https://github.com/ethereum/go-ethereum/w
 You can write your custom handlebars templates which will allow you to seamlessly integrate the generated code into your existing codebase with existing conventions.
 
 For an example of the generated [wrapper files](https://github.com/0xProject/0x-monorepo/tree/development/packages/0x.js/src/contract_wrappers/generated) check out 0x.js.
-[Here](https://github.com/0xProject/0x-monorepo/tree/development/packages/0x.js/contract_templates) are the templates used to generate those files.
+[Here](https://github.com/0xProject/0x-monorepo/tree/development/packages/contract_templates) are the templates used to generate those files.
 
 ## Installation
 
@@ -45,7 +45,7 @@ You need to also specify the location of your main template used for every contr
 
 ## How to write custom templates?
 
-The best way to get started is to copy [0x.js templates](https://github.com/0xProject/0x-monorepo/tree/development/packages/0x.js/contract_templates) and start adjusting them for your needs.
+The best way to get started is to copy [0x.js templates](https://github.com/0xProject/0x-monorepo/tree/development/packages/contract_templates) and start adjusting them for your needs.
 We use [handlebars](http://handlebarsjs.com/) template engine under the hood.
 You need to have a master template called `contract.mustache`. it will be used to generate each contract wrapper. Although - you don't need and probably shouldn't write all your logic in a single template file. You can write [partial templates](http://handlebarsjs.com/partials.html) and as long as they are within a partials folder - they will be registered and available.
 


### PR DESCRIPTION
Note there is still a broken link here, a previously existing one which I would have fixed but for which I couldn't find the appropriate link.  It's the "wrapper files" one in the second paragraph.