### PR TITLE
[Discussion] userData in Order structure

### DIFF
--- a/packages/contracts/src/contracts/current/protocol/Exchange/libs/LibOrder.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/libs/LibOrder.sol
@@ -38,6 +38,7 @@ contract LibOrder {
         "uint256 salt,",
         "bytes makerAssetData,",
         "bytes takerAssetData,",
+        "bytes userData,",
         ")"
     ));
 
@@ -66,6 +67,7 @@ contract LibOrder {
         uint256 salt;
         bytes makerAssetData;
         bytes takerAssetData;
+        bytes userData;
     }
 
     struct OrderInfo {
@@ -85,13 +87,8 @@ contract LibOrder {
         view
         returns (bytes32 orderHash)
     {
-        // TODO: EIP712 is not finalized yet
-        // Source: https://github.com/ethereum/EIPs/pull/712
-        orderHash = keccak256(abi.encodePacked(
-            DOMAIN_SEPARATOR_SCHEMA_HASH,
-            keccak256(abi.encodePacked(address(this))),
-            ORDER_SCHEMA_HASH,
-            keccak256(abi.encodePacked(
+        bytes32 orderDataHash = keccak256(
+            abi.encodePacked(
                 order.makerAddress,
                 order.takerAddress,
                 order.feeRecipientAddress,
@@ -103,9 +100,20 @@ contract LibOrder {
                 order.expirationTimeSeconds,
                 order.salt,
                 keccak256(abi.encodePacked(order.makerAssetData)),
-                keccak256(abi.encodePacked(order.takerAssetData))
-            ))
-        ));
+                keccak256(abi.encodePacked(order.takerAssetData)),
+                keccak256(abi.encodePacked(order.userData))
+            )
+        );
+        // TODO: EIP712 is not finalized yet
+        // Source: https://github.com/ethereum/EIPs/pull/712
+        orderHash = keccak256(
+            abi.encodePacked(
+                DOMAIN_SEPARATOR_SCHEMA_HASH,
+                keccak256(abi.encodePacked(address(this))),
+                ORDER_SCHEMA_HASH,
+                orderDataHash
+            )
+        );
         return orderHash;
     }
 }

--- a/packages/contracts/src/utils/order_factory.ts
+++ b/packages/contracts/src/utils/order_factory.ts
@@ -23,6 +23,7 @@ export class OrderFactory {
             expirationTimeSeconds: randomExpiration,
             salt: generatePseudoRandomSalt(),
             takerAddress: constants.NULL_ADDRESS,
+            userData: constants.NULL_BYTES,
             ...this._defaultOrderParams,
             ...customOrderParams,
         } as any) as Order;

--- a/packages/contracts/src/utils/order_utils.ts
+++ b/packages/contracts/src/utils/order_utils.ts
@@ -34,6 +34,7 @@ export const orderUtils = {
             salt: signedOrder.salt,
             makerAssetData: signedOrder.makerAssetData,
             takerAssetData: signedOrder.takerAssetData,
+            userData: signedOrder.userData,
         };
         return orderStruct;
     },

--- a/packages/order-utils/src/order_factory.ts
+++ b/packages/order-utils/src/order_factory.ts
@@ -24,11 +24,13 @@ export const orderFactory = {
         exchangeAddress: string,
         feeRecipientAddress: string,
         expirationTimeSecondsIfExists?: BigNumber,
+        userDataIfExists?: string,
     ): Promise<SignedOrder> {
         const defaultExpirationUnixTimestampSec = new BigNumber(2524604400); // Close to infinite
         const expirationTimeSeconds = _.isUndefined(expirationTimeSecondsIfExists)
             ? defaultExpirationUnixTimestampSec
             : expirationTimeSecondsIfExists;
+        const userData = _.isUndefined(userDataIfExists) ? '0x0' : userDataIfExists;
         const order = {
             makerAddress,
             takerAddress,
@@ -43,6 +45,7 @@ export const orderFactory = {
             exchangeAddress,
             feeRecipientAddress,
             expirationTimeSeconds,
+            userData,
         };
         const orderHash = orderHashUtils.getOrderHashHex(order);
         const messagePrefixOpts = {

--- a/packages/order-utils/src/order_hash.ts
+++ b/packages/order-utils/src/order_hash.ts
@@ -54,6 +54,7 @@ export const orderHashUtils = {
     getOrderHashBuff(order: SignedOrder | Order): Buffer {
         const makerAssetDataHash = crypto.solSHA3([ethUtil.toBuffer(order.makerAssetData)]);
         const takerAssetDataHash = crypto.solSHA3([ethUtil.toBuffer(order.takerAssetData)]);
+        const userDataHash = crypto.solSHA3([ethUtil.toBuffer(order.userData)]);
 
         const orderParamsHashBuff = crypto.solSHA3([
             order.makerAddress,
@@ -68,6 +69,7 @@ export const orderHashUtils = {
             order.salt,
             makerAssetDataHash,
             takerAssetDataHash,
+            userDataHash,
         ]);
         const orderParamsHashHex = `0x${orderParamsHashBuff.toString('hex')}`;
         const orderSchemaHashHex = this._getOrderSchemaHex();
@@ -96,6 +98,7 @@ export const orderHashUtils = {
             'uint256 salt,',
             'bytes makerAssetData,',
             'bytes takerAssetData,',
+            'bytes userData,',
             ')',
         ]);
         const schemaHashHex = `0x${orderSchemaHashBuff.toString('hex')}`;

--- a/packages/order-utils/test/order_hash_test.ts
+++ b/packages/order-utils/test/order_hash_test.ts
@@ -29,6 +29,7 @@ describe('Order hashing', () => {
             makerAssetAmount: new BigNumber(0),
             takerAssetAmount: new BigNumber(0),
             expirationTimeSeconds: new BigNumber(0),
+            userData: '0x0',
         };
         it('calculates the order hash', async () => {
             const orderHash = orderHashUtils.getOrderHashHex(order);

--- a/packages/order-utils/test/remaining_fillable_calculator_test.ts
+++ b/packages/order-utils/test/remaining_fillable_calculator_test.ts
@@ -56,6 +56,7 @@ describe('RemainingFillableCalculator', () => {
             takerAssetData,
             salt: zero,
             expirationTimeSeconds: zero,
+            userData: zeroAddress,
         };
     }
     describe('Maker token is NOT ZRX', () => {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -18,6 +18,7 @@ export interface Order {
     exchangeAddress: string;
     feeRecipientAddress: string;
     expirationTimeSeconds: BigNumber;
+    userData: string;
 }
 
 export interface OrderWithoutExchangeAddress {
@@ -33,6 +34,7 @@ export interface OrderWithoutExchangeAddress {
     salt: BigNumber;
     feeRecipientAddress: string;
     expirationTimeSeconds: BigNumber;
+    userData: string;
 }
 
 export interface SignedOrder extends Order {


### PR DESCRIPTION
<!--- Thank you for taking the time to submit a Pull Request -->

<!--- Provide a general summary of the issue in the Title above -->


## Description
Add an opaque field named `bytes userData` to the Order Format.

## Motivation and Context

<!--- Describe your changes in detail -->
0x architecture follows a pattern of off-chain orders on-chain settlement. Makers sign an order off-chain and after setting appropriate allowances is able to continuously trade without any additional blockchain interaction. 

The emergence of filter contracts and forwarding contracts enable 0x to be a building block in a particular dApp. Currently there is no way for more additional "data" to be signed by the maker as proof of intent. This leads to misuse of `salt` or `assetData` fields. These fields are 0x specific and have 0x specific meaning and can change in 0x exchange upgrades. 

This PR introduces a `bytes userData` field that is completely opaque to the 0x contracts. Though it is used and verified in order hash and signature calculation. This allows additional data encoding for use in filtering and forwarding contracts. For example, in a Dutch Auction contract parameters like the `auctionStartTime`. As the data remains opaque to 0x Exchange contracts unlike the salt or asset data this will continue to work in future protocol upgrades.

### Concerns
This adds an additional field to the Order format, which even when null adds a slight over head to all fill operations.

A basic gas cost estimate
```
fillOrder (without userData)
199682
fillOrder (userData: 0x0)
200832
fillOrder (userData: 0x1B61a3ed31b43c8780e905a260a35faefcc527be7516aa11c0256729b5b351bc3340349190569279751135161d22529dc25add4f6069af05be04cacbda2ace225403)
205748
```

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
