### PR TITLE
Document use of contract_templates (take 2; based on v2-prototype, not master)

### DIFF
--- a/packages/contract_templates/README.md
+++ b/packages/contract_templates/README.md
@@ -1,0 +1,15 @@
+These templates are used with [abi-gen](https://github.com/0xProject/0x-monorepo/tree/development/packages/abi-gen).
+
+To successfully compile the generated TypeScript contract wrappers, you must:
+* Install the packages on which the main contract template directly depends: `yarn add @0xproject/base-contract @0xproject/sol-compiler @0xproject/types @0xproject/utils @0xproject/web3-wrapper ethers lodash`
+* Install the packages on which the main contract template *in*directly depends: `yarn add @types/lodash`
+* Ensure that your TypeScript configuration includes the following:
+```
+"compilerOptions": {
+  "lib": ["ES2015"],
+  "typeRoots": [
+    "node_modules/@0xproject/typescript-typings/types",
+    "node_modules/@types"
+  ]
+}
+```

--- a/packages/contract_templates/contract.handlebars
+++ b/packages/contract_templates/contract.handlebars
@@ -1,7 +1,3 @@
-/**
- * This file is auto-generated using abi-gen. Don't edit directly.
- * Templates can be found at https://github.com/0xProject/0x-monorepo/tree/development/packages/contract_templates.
- */
 // tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma whitespace
 // tslint:disable:no-unused-variable
 import { BaseContract } from '@0xproject/base-contract';

--- a/packages/contract_templates/partials/params.handlebars
+++ b/packages/contract_templates/partials/params.handlebars
@@ -1,3 +1,3 @@
 {{#each inputs}}
-{{name}},
+{{name}}{{#if @last}}{{else}},{{/if}}
 {{/each}}


### PR DESCRIPTION
<!--- Thank you for taking the time to submit a Pull Request -->

<!--- Provide a general summary of the issue in the Title above -->

## Description

<!--- Describe your changes in detail -->
Explain what npm packages must be installed, and what TypeScript configuration changes must be made, in order to use the contract wrappers generated by using abi-gen with contract_templates.

Also, I made small a change to one of the templates, to work around [a TypeScript compiler bug](https://github.com/Microsoft/TypeScript/issues/24628), which I had encountered in my usage.  See details in my commit message.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->
I tried to start from a freshly generated `truffle init` project, and apply `abi-gen` to the stock contract, and then use `tsc` to compile the generated wrapper.  It was not a straightforward process, so I wanted to provide help to anyone else who might want to do that.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->
I manually verified all of the instructions I wrote, and also the template change, several times over, and even created a repo to show that verification (via the commit log), at https://github.com/feuGeneA/truffle-init-to-0xproject-abi-gen .
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [x] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
