### PR TITLE
Introduce subprovider for printing revert stack traces

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -19,6 +19,7 @@
         "rebuild_and_test": "run-s build test",
         "test:coverage": "SOLIDITY_COVERAGE=true run-s build run_mocha coverage:report:text coverage:report:lcov",
         "test:profiler": "SOLIDITY_PROFILER=true run-s build run_mocha profiler:report:html",
+        "test:trace": "SOLIDITY_REVERT_TRACE=true run-s run_mocha",
         "run_mocha": "mocha --require source-map-support/register 'lib/test/**/*.js' --timeout 100000 --bail --exit",
         "compile": "sol-compiler",
         "clean": "shx rm -rf lib src/generated_contract_wrappers",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -19,7 +19,7 @@
         "rebuild_and_test": "run-s build test",
         "test:coverage": "SOLIDITY_COVERAGE=true run-s build run_mocha coverage:report:text coverage:report:lcov",
         "test:profiler": "SOLIDITY_PROFILER=true run-s build run_mocha profiler:report:html",
-        "test:trace": "SOLIDITY_REVERT_TRACE=true run-s run_mocha",
+        "test:trace": "SOLIDITY_REVERT_TRACE=true run-s build run_mocha",
         "run_mocha": "mocha --require source-map-support/register 'lib/test/**/*.js' --timeout 100000 --bail --exit",
         "compile": "sol-compiler",
         "clean": "shx rm -rf lib src/generated_contract_wrappers",

--- a/packages/contracts/src/utils/revert_trace.ts
+++ b/packages/contracts/src/utils/revert_trace.ts
@@ -1,0 +1,21 @@
+import { devConstants } from '@0xproject/dev-utils';
+import { RevertTraceSubprovider, SolCompilerArtifactAdapter } from '@0xproject/sol-cov';
+import * as _ from 'lodash';
+
+let revertTraceSubprovider: RevertTraceSubprovider;
+
+export const revertTrace = {
+    getRevertTraceSubproviderSingleton(): RevertTraceSubprovider {
+        if (_.isUndefined(revertTraceSubprovider)) {
+            revertTraceSubprovider = revertTrace._getRevertTraceSubprovider();
+        }
+        return revertTraceSubprovider;
+    },
+    _getRevertTraceSubprovider(): RevertTraceSubprovider {
+        const defaultFromAddress = devConstants.TESTRPC_FIRST_ADDRESS;
+        const solCompilerArtifactAdapter = new SolCompilerArtifactAdapter();
+        const isVerbose = true;
+        const subprovider = new RevertTraceSubprovider(solCompilerArtifactAdapter, defaultFromAddress, isVerbose);
+        return subprovider;
+    },
+};

--- a/packages/contracts/src/utils/web3_wrapper.ts
+++ b/packages/contracts/src/utils/web3_wrapper.ts
@@ -7,6 +7,8 @@ import { coverage } from './coverage';
 import { profiler } from './profiler';
 import { revertTrace } from './revert_trace';
 
+import * as _ from 'lodash';
+
 enum ProviderType {
     Ganache = 'ganache',
     Geth = 'geth',
@@ -50,11 +52,10 @@ export const provider = web3Factory.getRpcProvider(providerConfigs);
 const isCoverageEnabled = env.parseBoolean(EnvVars.SolidityCoverage);
 const isProfilerEnabled = env.parseBoolean(EnvVars.SolidityProfiler);
 const isRevertTraceEnabled = env.parseBoolean(EnvVars.SolidityRevertTrace);
-// TODO(albrow): Include revertTrace checks in the warnings below.
-if (isCoverageEnabled && isProfilerEnabled) {
-    throw new Error(
-        `Unfortunately for now you can't enable both coverage and profiler at the same time. They both use coverage.json file and there is no way to configure that.`,
-    );
+const enabledSubproviderCount = _.filter([isCoverageEnabled, isProfilerEnabled, isRevertTraceEnabled], _.identity)
+    .length;
+if (enabledSubproviderCount > 1) {
+    throw new Error(`Only one of coverage, profiler, and revert trace subproviders can be enabled at a time`);
 }
 if (isCoverageEnabled) {
     const coverageSubprovider = coverage.getCoverageSubproviderSingleton();

--- a/packages/contracts/src/utils/web3_wrapper.ts
+++ b/packages/contracts/src/utils/web3_wrapper.ts
@@ -2,12 +2,11 @@ import { devConstants, env, EnvVars, web3Factory } from '@0xproject/dev-utils';
 import { prependSubprovider } from '@0xproject/subproviders';
 import { logUtils } from '@0xproject/utils';
 import { Web3Wrapper } from '@0xproject/web3-wrapper';
+import * as _ from 'lodash';
 
 import { coverage } from './coverage';
 import { profiler } from './profiler';
 import { revertTrace } from './revert_trace';
-
-import * as _ from 'lodash';
 
 enum ProviderType {
     Ganache = 'ganache',

--- a/packages/contracts/src/utils/web3_wrapper.ts
+++ b/packages/contracts/src/utils/web3_wrapper.ts
@@ -54,7 +54,7 @@ const isRevertTraceEnabled = env.parseBoolean(EnvVars.SolidityRevertTrace);
 const enabledSubproviderCount = _.filter([isCoverageEnabled, isProfilerEnabled, isRevertTraceEnabled], _.identity)
     .length;
 if (enabledSubproviderCount > 1) {
-    throw new Error(`Only one of coverage, profiler, and revert trace subproviders can be enabled at a time`);
+    throw new Error(`Only one of coverage, profiler, or revert trace subproviders can be enabled at a time`);
 }
 if (isCoverageEnabled) {
     const coverageSubprovider = coverage.getCoverageSubproviderSingleton();

--- a/packages/contracts/src/utils/web3_wrapper.ts
+++ b/packages/contracts/src/utils/web3_wrapper.ts
@@ -51,29 +51,29 @@ const isCoverageEnabled = env.parseBoolean(EnvVars.SolidityCoverage);
 const isProfilerEnabled = env.parseBoolean(EnvVars.SolidityProfiler);
 const isRevertTraceEnabled = env.parseBoolean(EnvVars.SolidityRevertTrace);
 // TODO(albrow): Include revertTrace checks in the warnings below.
-// if (isCoverageEnabled && isProfilerEnabled) {
-//     throw new Error(
-//         `Unfortunately for now you can't enable both coverage and profiler at the same time. They both use coverage.json file and there is no way to configure that.`,
-//     );
-// }
-// if (isCoverageEnabled) {
-//     const coverageSubprovider = coverage.getCoverageSubproviderSingleton();
-//     prependSubprovider(provider, coverageSubprovider);
-// }
-// if (isProfilerEnabled) {
-//     if (testProvider === ProviderType.Ganache) {
-//         logUtils.warn(
-//             "Gas costs in Ganache traces are incorrect and we don't recommend using it for profiling. Please switch to Geth",
-//         );
-//         process.exit(1);
-//     }
-//     const profilerSubprovider = profiler.getProfilerSubproviderSingleton();
-//     logUtils.log(
-//         "By default profilerSubprovider is stopped so that you don't get noise from setup code. Don't forget to start it before the code you want to profile and stop it afterwards",
-//     );
-//     profilerSubprovider.stop();
-//     prependSubprovider(provider, profilerSubprovider);
-// }
+if (isCoverageEnabled && isProfilerEnabled) {
+    throw new Error(
+        `Unfortunately for now you can't enable both coverage and profiler at the same time. They both use coverage.json file and there is no way to configure that.`,
+    );
+}
+if (isCoverageEnabled) {
+    const coverageSubprovider = coverage.getCoverageSubproviderSingleton();
+    prependSubprovider(provider, coverageSubprovider);
+}
+if (isProfilerEnabled) {
+    if (testProvider === ProviderType.Ganache) {
+        logUtils.warn(
+            "Gas costs in Ganache traces are incorrect and we don't recommend using it for profiling. Please switch to Geth",
+        );
+        process.exit(1);
+    }
+    const profilerSubprovider = profiler.getProfilerSubproviderSingleton();
+    logUtils.log(
+        "By default profilerSubprovider is stopped so that you don't get noise from setup code. Don't forget to start it before the code you want to profile and stop it afterwards",
+    );
+    profilerSubprovider.stop();
+    prependSubprovider(provider, profilerSubprovider);
+}
 if (isRevertTraceEnabled) {
     const revertTraceSubprovider = revertTrace.getRevertTraceSubproviderSingleton();
     prependSubprovider(provider, revertTraceSubprovider);

--- a/packages/contracts/src/utils/web3_wrapper.ts
+++ b/packages/contracts/src/utils/web3_wrapper.ts
@@ -5,6 +5,7 @@ import { Web3Wrapper } from '@0xproject/web3-wrapper';
 
 import { coverage } from './coverage';
 import { profiler } from './profiler';
+import { revertTrace } from './revert_trace';
 
 enum ProviderType {
     Ganache = 'ganache',
@@ -48,28 +49,34 @@ const providerConfigs = testProvider === ProviderType.Ganache ? ganacheConfigs :
 export const provider = web3Factory.getRpcProvider(providerConfigs);
 const isCoverageEnabled = env.parseBoolean(EnvVars.SolidityCoverage);
 const isProfilerEnabled = env.parseBoolean(EnvVars.SolidityProfiler);
-if (isCoverageEnabled && isProfilerEnabled) {
-    throw new Error(
-        `Unfortunately for now you can't enable both coverage and profiler at the same time. They both use coverage.json file and there is no way to configure that.`,
-    );
-}
-if (isCoverageEnabled) {
-    const coverageSubprovider = coverage.getCoverageSubproviderSingleton();
-    prependSubprovider(provider, coverageSubprovider);
-}
-if (isProfilerEnabled) {
-    if (testProvider === ProviderType.Ganache) {
-        logUtils.warn(
-            "Gas costs in Ganache traces are incorrect and we don't recommend using it for profiling. Please switch to Geth",
-        );
-        process.exit(1);
-    }
-    const profilerSubprovider = profiler.getProfilerSubproviderSingleton();
-    logUtils.log(
-        "By default profilerSubprovider is stopped so that you don't get noise from setup code. Don't forget to start it before the code you want to profile and stop it afterwards",
-    );
-    profilerSubprovider.stop();
-    prependSubprovider(provider, profilerSubprovider);
+const isRevertTraceEnabled = env.parseBoolean(EnvVars.SolidityRevertTrace);
+// TODO(albrow): Include revertTrace checks in the warnings below.
+// if (isCoverageEnabled && isProfilerEnabled) {
+//     throw new Error(
+//         `Unfortunately for now you can't enable both coverage and profiler at the same time. They both use coverage.json file and there is no way to configure that.`,
+//     );
+// }
+// if (isCoverageEnabled) {
+//     const coverageSubprovider = coverage.getCoverageSubproviderSingleton();
+//     prependSubprovider(provider, coverageSubprovider);
+// }
+// if (isProfilerEnabled) {
+//     if (testProvider === ProviderType.Ganache) {
+//         logUtils.warn(
+//             "Gas costs in Ganache traces are incorrect and we don't recommend using it for profiling. Please switch to Geth",
+//         );
+//         process.exit(1);
+//     }
+//     const profilerSubprovider = profiler.getProfilerSubproviderSingleton();
+//     logUtils.log(
+//         "By default profilerSubprovider is stopped so that you don't get noise from setup code. Don't forget to start it before the code you want to profile and stop it afterwards",
+//     );
+//     profilerSubprovider.stop();
+//     prependSubprovider(provider, profilerSubprovider);
+// }
+if (isRevertTraceEnabled) {
+    const revertTraceSubprovider = revertTrace.getRevertTraceSubproviderSingleton();
+    prependSubprovider(provider, revertTraceSubprovider);
 }
 
 export const web3Wrapper = new Web3Wrapper(provider);

--- a/packages/dev-utils/src/env.ts
+++ b/packages/dev-utils/src/env.ts
@@ -4,6 +4,7 @@ import * as process from 'process';
 export enum EnvVars {
     SolidityCoverage = 'SOLIDITY_COVERAGE',
     SolidityProfiler = 'SOLIDITY_PROFILER',
+    SolidityRevertTrace = 'SOLIDITY_REVERT_TRACE',
     VerboseGanache = 'VERBOSE_GANACHE',
 }
 

--- a/packages/sol-cov/src/coverage_subprovider.ts
+++ b/packages/sol-cov/src/coverage_subprovider.ts
@@ -2,8 +2,8 @@ import * as _ from 'lodash';
 
 import { AbstractArtifactAdapter } from './artifact_adapters/abstract_artifact_adapter';
 import { collectCoverageEntries } from './collect_coverage_entries';
-import { TraceCollectionSubprovider } from './trace_collection_subprovider';
 import { SingleFileSubtraceHandler, TraceCollector } from './trace_collector';
+import { TraceInfoSubprovider } from './trace_info_subprovider';
 import {
     BranchCoverage,
     ContractData,
@@ -22,7 +22,7 @@ import { utils } from './utils';
  * This class implements the [web3-provider-engine](https://github.com/MetaMask/provider-engine) subprovider interface.
  * It's used to compute your code coverage while running solidity tests.
  */
-export class CoverageSubprovider extends TraceCollectionSubprovider {
+export class CoverageSubprovider extends TraceInfoSubprovider {
     private _coverageCollector: TraceCollector;
     /**
      * Instantiates a CoverageSubprovider instance
@@ -39,7 +39,7 @@ export class CoverageSubprovider extends TraceCollectionSubprovider {
         super(defaultFromAddress, traceCollectionSubproviderConfig);
         this._coverageCollector = new TraceCollector(artifactAdapter, isVerbose, coverageHandler);
     }
-    public async handleTraceInfoAsync(traceInfo: TraceInfo): Promise<void> {
+    protected async _handleTraceInfoAsync(traceInfo: TraceInfo): Promise<void> {
         await this._coverageCollector.computeSingleTraceCoverageAsync(traceInfo);
     }
     /**

--- a/packages/sol-cov/src/index.ts
+++ b/packages/sol-cov/src/index.ts
@@ -1,6 +1,7 @@
 export { CoverageSubprovider } from './coverage_subprovider';
 // HACK: ProfilerSubprovider is a hacky way to do profiling using coverage tools. Not production ready
 export { ProfilerSubprovider } from './profiler_subprovider';
+export { RevertTraceSubprovider } from './revert_trace_subprovider';
 export { SolCompilerArtifactAdapter } from './artifact_adapters/sol_compiler_artifact_adapter';
 export { TruffleArtifactAdapter } from './artifact_adapters/truffle_artifact_adapter';
 export { AbstractArtifactAdapter } from './artifact_adapters/abstract_artifact_adapter';

--- a/packages/sol-cov/src/profiler_subprovider.ts
+++ b/packages/sol-cov/src/profiler_subprovider.ts
@@ -2,8 +2,8 @@ import * as _ from 'lodash';
 
 import { AbstractArtifactAdapter } from './artifact_adapters/abstract_artifact_adapter';
 import { collectCoverageEntries } from './collect_coverage_entries';
-import { TraceCollectionSubprovider } from './trace_collection_subprovider';
 import { SingleFileSubtraceHandler, TraceCollector } from './trace_collector';
+import { TraceInfoSubprovider } from './trace_info_subprovider';
 import { ContractData, Coverage, SourceRange, Subtrace, TraceInfo } from './types';
 import { utils } from './utils';
 
@@ -11,7 +11,7 @@ import { utils } from './utils';
  * This class implements the [web3-provider-engine](https://github.com/MetaMask/provider-engine) subprovider interface.
  * ProfilerSubprovider is used to profile Solidity code while running tests.
  */
-export class ProfilerSubprovider extends TraceCollectionSubprovider {
+export class ProfilerSubprovider extends TraceInfoSubprovider {
     private _profilerCollector: TraceCollector;
     /**
      * Instantiates a ProfilerSubprovider instance
@@ -28,7 +28,7 @@ export class ProfilerSubprovider extends TraceCollectionSubprovider {
         super(defaultFromAddress, traceCollectionSubproviderConfig);
         this._profilerCollector = new TraceCollector(artifactAdapter, isVerbose, profilerHandler);
     }
-    public async handleTraceInfoAsync(traceInfo: TraceInfo): Promise<void> {
+    protected async _handleTraceInfoAsync(traceInfo: TraceInfo): Promise<void> {
         await this._profilerCollector.computeSingleTraceCoverageAsync(traceInfo);
     }
     /**

--- a/packages/sol-cov/src/revert_trace.ts
+++ b/packages/sol-cov/src/revert_trace.ts
@@ -3,7 +3,7 @@ import { OpCode, StructLog } from 'ethereum-types';
 
 import * as _ from 'lodash';
 
-import { EvmCallStack, EvmCallStackEntry } from './types';
+import { EvmCallStack } from './types';
 import { utils } from './utils';
 
 export function getRevertTrace(structLogs: StructLog[], startAddress: string): EvmCallStack {

--- a/packages/sol-cov/src/revert_trace.ts
+++ b/packages/sol-cov/src/revert_trace.ts
@@ -30,9 +30,6 @@ export function getRevertTrace(structLogs: StructLog[], startAddress: string): E
                 structLog.stack[structLog.stack.length - jumpAddressOffset - 1],
             );
 
-            if (structLog === _.last(normalizedStructLogs)) {
-                throw new Error('Malformed trace. CALL-like opcode can not be the last one');
-            }
             // Sometimes calls don't change the execution context (current address). When we do a transfer to an
             // externally owned account - it does the call and immediately returns because there is no fallback
             // function. We manually check if the call depth had changed to handle that case.

--- a/packages/sol-cov/src/revert_trace_subprovider.ts
+++ b/packages/sol-cov/src/revert_trace_subprovider.ts
@@ -228,7 +228,7 @@ export class RevertTraceSubprovider extends Subprovider {
         }
         if (sourceRanges.length > 0) {
             this._logger.error('\n\nStack trace for REVERT:\n');
-            _.forEach(sourceRanges, sourceRange => {
+            _.forEach(_.reverse(sourceRanges), sourceRange => {
                 this._logger.error(
                     `${sourceRange.fileName}:${sourceRange.location.start.line}:${sourceRange.location.start.column}`,
                 );

--- a/packages/sol-cov/src/revert_trace_subprovider.ts
+++ b/packages/sol-cov/src/revert_trace_subprovider.ts
@@ -117,14 +117,14 @@ export class RevertTraceSubprovider extends Subprovider {
         if (_.isNull(err)) {
             const toAddress =
                 _.isUndefined(txData.to) || txData.to === NULL_ADDRESS ? constants.NEW_CONTRACT : txData.to;
-            await this._recordTxTraceAsync(toAddress, txData.data, txHash as string);
+            await this._recordTxTraceAsync(toAddress, txHash as string);
         } else {
             const latestBlock = await this._web3Wrapper.getBlockWithTransactionDataAsync(BlockParamLiteral.Latest);
             const transactions = latestBlock.transactions;
             for (const transaction of transactions) {
                 const toAddress =
                     _.isUndefined(txData.to) || txData.to === NULL_ADDRESS ? constants.NEW_CONTRACT : txData.to;
-                await this._recordTxTraceAsync(toAddress, transaction.input, transaction.hash);
+                await this._recordTxTraceAsync(toAddress, transaction.hash);
             }
         }
         if (!txData.isFakeTransaction) {
@@ -143,7 +143,7 @@ export class RevertTraceSubprovider extends Subprovider {
         await this._recordCallOrGasEstimateTraceAsync(callData);
         cb();
     }
-    private async _recordTxTraceAsync(address: string, data: string | undefined, txHash: string): Promise<void> {
+    private async _recordTxTraceAsync(address: string, txHash: string): Promise<void> {
         await this._web3Wrapper.awaitTransactionMinedAsync(txHash, 0);
         const trace = await this._web3Wrapper.getTransactionTraceAsync(txHash, {
             disableMemory: true,

--- a/packages/sol-cov/src/revert_trace_subprovider.ts
+++ b/packages/sol-cov/src/revert_trace_subprovider.ts
@@ -1,0 +1,237 @@
+import { BlockchainLifecycle } from '@0xproject/dev-utils';
+import { Callback, ErrorCallback, NextCallback, Subprovider } from '@0xproject/subproviders';
+import { Web3Wrapper } from '@0xproject/web3-wrapper';
+import { CallData, JSONRPCRequestPayload, Provider, TxData } from 'ethereum-types';
+import { stripHexPrefix } from 'ethereumjs-util';
+import * as _ from 'lodash';
+import { getLogger, levels, Logger } from 'loglevel';
+import { Lock } from 'semaphore-async-await';
+
+import { AbstractArtifactAdapter } from './artifact_adapters/abstract_artifact_adapter';
+import { constants } from './constants';
+import { getRevertTrace } from './revert_trace';
+import { parseSourceMap } from './source_maps';
+import { BlockParamLiteral, ContractData, EvmCallStack, SourceRange } from './types';
+import { utils } from './utils';
+
+interface MaybeFakeTxData extends TxData {
+    isFakeTransaction?: boolean;
+}
+
+const BLOCK_GAS_LIMIT = 6000000;
+
+/**
+ * This class implements the [web3-provider-engine](https://github.com/MetaMask/provider-engine) subprovider interface.
+ * It is used to report call stack traces whenever a revert occurs.
+ */
+export class RevertTraceSubprovider extends Subprovider {
+    // Lock is used to not accept normal transactions while doing call/snapshot magic because they'll be reverted later otherwise
+    private _lock = new Lock();
+    private _defaultFromAddress: string;
+    private _web3Wrapper!: Web3Wrapper;
+    private _isEnabled = true;
+    private _artifactAdapter: AbstractArtifactAdapter;
+    private _contractsData!: ContractData[];
+    private _logger: Logger;
+
+    /**
+     * Instantiates a TraceCollectionSubprovider instance
+     * @param defaultFromAddress default from address to use when sending transactions
+     */
+    constructor(artifactAdapter: AbstractArtifactAdapter, defaultFromAddress: string, isVerbose: boolean) {
+        super();
+        this._artifactAdapter = artifactAdapter;
+        this._defaultFromAddress = defaultFromAddress;
+        this._logger = getLogger('sol-cov');
+        this._logger.setLevel(isVerbose ? levels.TRACE : levels.ERROR);
+    }
+    /**
+     * Starts trace collection
+     */
+    public start(): void {
+        this._isEnabled = true;
+    }
+    /**
+     * Stops trace collection
+     */
+    public stop(): void {
+        this._isEnabled = false;
+    }
+    /**
+     * This method conforms to the web3-provider-engine interface.
+     * It is called internally by the ProviderEngine when it is this subproviders
+     * turn to handle a JSON RPC request.
+     * @param payload JSON RPC payload
+     * @param next Callback to call if this subprovider decides not to handle the request
+     * @param end Callback to call if subprovider handled the request and wants to pass back the request.
+     */
+    // tslint:disable-next-line:prefer-function-over-method async-suffix
+    public async handleRequest(payload: JSONRPCRequestPayload, next: NextCallback, _end: ErrorCallback): Promise<void> {
+        if (this._isEnabled) {
+            switch (payload.method) {
+                case 'eth_sendTransaction':
+                    const txData = payload.params[0];
+                    next(this._onTransactionSentAsync.bind(this, txData));
+                    return;
+
+                case 'eth_call':
+                    const callData = payload.params[0];
+                    next(this._onCallOrGasEstimateExecutedAsync.bind(this, callData));
+                    return;
+
+                case 'eth_estimateGas':
+                    const estimateGasData = payload.params[0];
+                    next(this._onCallOrGasEstimateExecutedAsync.bind(this, estimateGasData));
+                    return;
+
+                default:
+                    next();
+                    return;
+            }
+        } else {
+            next();
+            return;
+        }
+    }
+    /**
+     * Set's the subprovider's engine to the ProviderEngine it is added to.
+     * This is only called within the ProviderEngine source code, do not call
+     * directly.
+     */
+    public setEngine(engine: Provider): void {
+        super.setEngine(engine);
+        this._web3Wrapper = new Web3Wrapper(engine);
+    }
+    private async _onTransactionSentAsync(
+        txData: MaybeFakeTxData,
+        err: Error | null,
+        txHash: string | undefined,
+        cb: Callback,
+    ): Promise<void> {
+        if (!txData.isFakeTransaction) {
+            // This transaction is a usual transaction. Not a call executed as one.
+            // And we don't want it to be executed within a snapshotting period
+            await this._lock.acquire();
+        }
+        const NULL_ADDRESS = '0x0';
+        if (_.isNull(err)) {
+            const toAddress =
+                _.isUndefined(txData.to) || txData.to === NULL_ADDRESS ? constants.NEW_CONTRACT : txData.to;
+            await this._recordTxTraceAsync(toAddress, txData.data, txHash as string);
+        } else {
+            const latestBlock = await this._web3Wrapper.getBlockWithTransactionDataAsync(BlockParamLiteral.Latest);
+            const transactions = latestBlock.transactions;
+            for (const transaction of transactions) {
+                const toAddress =
+                    _.isUndefined(txData.to) || txData.to === NULL_ADDRESS ? constants.NEW_CONTRACT : txData.to;
+                await this._recordTxTraceAsync(toAddress, transaction.input, transaction.hash);
+            }
+        }
+        if (!txData.isFakeTransaction) {
+            // This transaction is a usual transaction. Not a call executed as one.
+            // And we don't want it to be executed within a snapshotting period
+            this._lock.release();
+        }
+        cb();
+    }
+    private async _onCallOrGasEstimateExecutedAsync(
+        callData: Partial<CallData>,
+        _err: Error | null,
+        _callResult: string,
+        cb: Callback,
+    ): Promise<void> {
+        await this._recordCallOrGasEstimateTraceAsync(callData);
+        cb();
+    }
+    private async _recordTxTraceAsync(address: string, data: string | undefined, txHash: string): Promise<void> {
+        await this._web3Wrapper.awaitTransactionMinedAsync(txHash, 0);
+        const trace = await this._web3Wrapper.getTransactionTraceAsync(txHash, {
+            disableMemory: true,
+            disableStack: false,
+            disableStorage: true,
+        });
+        const evmCallStack = getRevertTrace(trace.structLogs, address);
+        if (evmCallStack.length > 0) {
+            // if getRevertTrace returns a call stack it means there was a
+            // revert.
+            await this._printStackTraceAsync(evmCallStack);
+        }
+    }
+    private async _recordCallOrGasEstimateTraceAsync(callData: Partial<CallData>): Promise<void> {
+        // We don't want other transactions to be exeucted during snashotting period, that's why we lock the
+        // transaction execution for all transactions except our fake ones.
+        await this._lock.acquire();
+        const blockchainLifecycle = new BlockchainLifecycle(this._web3Wrapper);
+        await blockchainLifecycle.startAsync();
+        const fakeTxData: MaybeFakeTxData = {
+            gas: BLOCK_GAS_LIMIT,
+            isFakeTransaction: true, // This transaction (and only it) is allowed to come through when the lock is locked
+            ...callData,
+            from: callData.from || this._defaultFromAddress,
+        };
+        try {
+            const txHash = await this._web3Wrapper.sendTransactionAsync(fakeTxData);
+            await this._web3Wrapper.awaitTransactionMinedAsync(txHash, 0);
+        } catch (err) {
+            // Even if this transaction failed - we've already recorded it's trace.
+            _.noop();
+        }
+        await blockchainLifecycle.revertAsync();
+        this._lock.release();
+    }
+    private async _printStackTraceAsync(evmCallStack: EvmCallStack): Promise<void> {
+        const sourceRanges: SourceRange[] = [];
+        if (_.isUndefined(this._contractsData)) {
+            this._contractsData = await this._artifactAdapter.collectContractsDataAsync();
+        }
+        for (const evmCallStackEntry of evmCallStack) {
+            const isContractCreation = evmCallStackEntry.address === constants.NEW_CONTRACT;
+            const bytecode = await this._web3Wrapper.getContractCodeAsync(evmCallStackEntry.address);
+            const contractData = utils.getContractDataIfExists(this._contractsData, bytecode);
+            if (_.isUndefined(contractData)) {
+                const errMsg = isContractCreation
+                    ? `Unknown contract creation transaction`
+                    : `Transaction to an unknown address: ${evmCallStackEntry.address}`;
+                this._logger.warn(errMsg);
+                continue;
+            }
+            const bytecodeHex = stripHexPrefix(bytecode);
+            const sourceMap = isContractCreation ? contractData.sourceMap : contractData.sourceMapRuntime;
+            const pcToSourceRange = parseSourceMap(
+                contractData.sourceCodes,
+                sourceMap,
+                bytecodeHex,
+                contractData.sources,
+            );
+            // tslint:disable-next-line:no-unnecessary-initializer
+            let sourceRange: SourceRange | undefined = undefined;
+            let pc = evmCallStackEntry.structLog.pc;
+            // Sometimes there is not a mapping for this pc (e.g. if the revert
+            // actually happens in assembly). In that case, we want to keep
+            // searching backwards by decrementing the pc until we find a
+            // mapped source range.
+            while (_.isUndefined(sourceRange)) {
+                sourceRange = pcToSourceRange[pc];
+                pc -= 1;
+                if (pc <= 0) {
+                    this._logger.warn(
+                        `could not find matching sourceRange for structLog: ${evmCallStackEntry.structLog}`,
+                    );
+                    continue;
+                }
+            }
+            sourceRanges.push(sourceRange);
+        }
+        if (sourceRanges.length > 0) {
+            this._logger.error('\n\nStack trace:\n');
+            _.forEach(sourceRanges, sourceRange => {
+                this._logger.error(
+                    `${sourceRange.fileName}:${sourceRange.location.start.line}:${sourceRange.location.start.column}`,
+                );
+            });
+            this._logger.error('\n');
+        } else {
+            this._logger.error('Could not determine stack trace');
+        }
+    }
+}

--- a/packages/sol-cov/src/revert_trace_subprovider.ts
+++ b/packages/sol-cov/src/revert_trace_subprovider.ts
@@ -1,149 +1,43 @@
-import { BlockchainLifecycle } from '@0xproject/dev-utils';
-import { Callback, ErrorCallback, NextCallback, Subprovider } from '@0xproject/subproviders';
-import { Web3Wrapper } from '@0xproject/web3-wrapper';
-import { CallData, JSONRPCRequestPayload, Provider, TxData } from 'ethereum-types';
 import { stripHexPrefix } from 'ethereumjs-util';
 import * as _ from 'lodash';
 import { getLogger, levels, Logger } from 'loglevel';
-import { Lock } from 'semaphore-async-await';
 
 import { AbstractArtifactAdapter } from './artifact_adapters/abstract_artifact_adapter';
 import { constants } from './constants';
 import { getRevertTrace } from './revert_trace';
 import { parseSourceMap } from './source_maps';
-import { BlockParamLiteral, ContractData, EvmCallStack, SourceRange } from './types';
+import { TraceCollectionSubprovider } from './trace_collection_subprovider';
+import { ContractData, EvmCallStack, SourceRange } from './types';
 import { utils } from './utils';
-
-interface MaybeFakeTxData extends TxData {
-    isFakeTransaction?: boolean;
-}
-
-const BLOCK_GAS_LIMIT = 6000000;
 
 /**
  * This class implements the [web3-provider-engine](https://github.com/MetaMask/provider-engine) subprovider interface.
  * It is used to report call stack traces whenever a revert occurs.
  */
-export class RevertTraceSubprovider extends Subprovider {
+export class RevertTraceSubprovider extends TraceCollectionSubprovider {
     // Lock is used to not accept normal transactions while doing call/snapshot magic because they'll be reverted later otherwise
-    private _lock = new Lock();
-    private _defaultFromAddress: string;
-    private _web3Wrapper!: Web3Wrapper;
-    private _isEnabled = true;
-    private _artifactAdapter: AbstractArtifactAdapter;
     private _contractsData!: ContractData[];
+    private _artifactAdapter: AbstractArtifactAdapter;
     private _logger: Logger;
 
     /**
-     * Instantiates a TraceCollectionSubprovider instance
+     * Instantiates a RevertTraceSubprovider instance
+     * @param artifactAdapter Adapter for used artifacts format (0x, truffle, giveth, etc.)
      * @param defaultFromAddress default from address to use when sending transactions
+     * @param isVerbose If true, we will log any unknown transactions. Otherwise we will ignore them
      */
-    constructor(artifactAdapter: AbstractArtifactAdapter, defaultFromAddress: string, isVerbose: boolean) {
-        super();
+    constructor(artifactAdapter: AbstractArtifactAdapter, defaultFromAddress: string, isVerbose: boolean = true) {
+        const traceCollectionSubproviderConfig = {
+            shouldCollectTransactionTraces: true,
+            shouldCollectGasEstimateTraces: true,
+            shouldCollectCallTraces: true,
+        };
+        super(defaultFromAddress, traceCollectionSubproviderConfig);
         this._artifactAdapter = artifactAdapter;
-        this._defaultFromAddress = defaultFromAddress;
         this._logger = getLogger('sol-cov');
         this._logger.setLevel(isVerbose ? levels.TRACE : levels.ERROR);
     }
-    /**
-     * Starts trace collection
-     */
-    public start(): void {
-        this._isEnabled = true;
-    }
-    /**
-     * Stops trace collection
-     */
-    public stop(): void {
-        this._isEnabled = false;
-    }
-    /**
-     * This method conforms to the web3-provider-engine interface.
-     * It is called internally by the ProviderEngine when it is this subproviders
-     * turn to handle a JSON RPC request.
-     * @param payload JSON RPC payload
-     * @param next Callback to call if this subprovider decides not to handle the request
-     * @param end Callback to call if subprovider handled the request and wants to pass back the request.
-     */
-    // tslint:disable-next-line:prefer-function-over-method async-suffix
-    public async handleRequest(payload: JSONRPCRequestPayload, next: NextCallback, _end: ErrorCallback): Promise<void> {
-        if (this._isEnabled) {
-            switch (payload.method) {
-                case 'eth_sendTransaction':
-                    const txData = payload.params[0];
-                    next(this._onTransactionSentAsync.bind(this, txData));
-                    return;
-
-                case 'eth_call':
-                    const callData = payload.params[0];
-                    next(this._onCallOrGasEstimateExecutedAsync.bind(this, callData));
-                    return;
-
-                case 'eth_estimateGas':
-                    const estimateGasData = payload.params[0];
-                    next(this._onCallOrGasEstimateExecutedAsync.bind(this, estimateGasData));
-                    return;
-
-                default:
-                    next();
-                    return;
-            }
-        } else {
-            next();
-            return;
-        }
-    }
-    /**
-     * Set's the subprovider's engine to the ProviderEngine it is added to.
-     * This is only called within the ProviderEngine source code, do not call
-     * directly.
-     */
-    public setEngine(engine: Provider): void {
-        super.setEngine(engine);
-        this._web3Wrapper = new Web3Wrapper(engine);
-    }
-    private async _onTransactionSentAsync(
-        txData: MaybeFakeTxData,
-        err: Error | null,
-        txHash: string | undefined,
-        cb: Callback,
-    ): Promise<void> {
-        if (!txData.isFakeTransaction) {
-            // This transaction is a usual transaction. Not a call executed as one.
-            // And we don't want it to be executed within a snapshotting period
-            await this._lock.acquire();
-        }
-        const NULL_ADDRESS = '0x0';
-        if (_.isNull(err)) {
-            const toAddress =
-                _.isUndefined(txData.to) || txData.to === NULL_ADDRESS ? constants.NEW_CONTRACT : txData.to;
-            await this._recordTxTraceAsync(toAddress, txHash as string);
-        } else {
-            const latestBlock = await this._web3Wrapper.getBlockWithTransactionDataAsync(BlockParamLiteral.Latest);
-            const transactions = latestBlock.transactions;
-            for (const transaction of transactions) {
-                const toAddress =
-                    _.isUndefined(txData.to) || txData.to === NULL_ADDRESS ? constants.NEW_CONTRACT : txData.to;
-                await this._recordTxTraceAsync(toAddress, transaction.hash);
-            }
-        }
-        if (!txData.isFakeTransaction) {
-            // This transaction is a usual transaction. Not a call executed as one.
-            // And we don't want it to be executed within a snapshotting period
-            this._lock.release();
-        }
-        cb();
-    }
-    private async _onCallOrGasEstimateExecutedAsync(
-        callData: Partial<CallData>,
-        _err: Error | null,
-        _callResult: string,
-        cb: Callback,
-    ): Promise<void> {
-        await this._recordCallOrGasEstimateTraceAsync(callData);
-        cb();
-    }
-    private async _recordTxTraceAsync(address: string, txHash: string): Promise<void> {
+    protected async _recordTxTraceAsync(address: string, data: string | undefined, txHash: string): Promise<void> {
         await this._web3Wrapper.awaitTransactionMinedAsync(txHash, 0);
         const trace = await this._web3Wrapper.getTransactionTraceAsync(txHash, {
             disableMemory: true,
@@ -156,28 +50,6 @@ export class RevertTraceSubprovider extends Subprovider {
             // revert.
             await this._printStackTraceAsync(evmCallStack);
         }
-    }
-    private async _recordCallOrGasEstimateTraceAsync(callData: Partial<CallData>): Promise<void> {
-        // We don't want other transactions to be exeucted during snashotting period, that's why we lock the
-        // transaction execution for all transactions except our fake ones.
-        await this._lock.acquire();
-        const blockchainLifecycle = new BlockchainLifecycle(this._web3Wrapper);
-        await blockchainLifecycle.startAsync();
-        const fakeTxData: MaybeFakeTxData = {
-            gas: BLOCK_GAS_LIMIT,
-            isFakeTransaction: true, // This transaction (and only it) is allowed to come through when the lock is locked
-            ...callData,
-            from: callData.from || this._defaultFromAddress,
-        };
-        try {
-            const txHash = await this._web3Wrapper.sendTransactionAsync(fakeTxData);
-            await this._web3Wrapper.awaitTransactionMinedAsync(txHash, 0);
-        } catch (err) {
-            // Even if this transaction failed - we've already recorded it's trace.
-            _.noop();
-        }
-        await blockchainLifecycle.revertAsync();
-        this._lock.release();
     }
     private async _printStackTraceAsync(evmCallStack: EvmCallStack): Promise<void> {
         const sourceRanges: SourceRange[] = [];

--- a/packages/sol-cov/src/revert_trace_subprovider.ts
+++ b/packages/sol-cov/src/revert_trace_subprovider.ts
@@ -186,6 +186,10 @@ export class RevertTraceSubprovider extends Subprovider {
         }
         for (const evmCallStackEntry of evmCallStack) {
             const isContractCreation = evmCallStackEntry.address === constants.NEW_CONTRACT;
+            if (isContractCreation) {
+                this._logger.error('Contract creation not supported');
+                continue;
+            }
             const bytecode = await this._web3Wrapper.getContractCodeAsync(evmCallStackEntry.address);
             const contractData = utils.getContractDataIfExists(this._contractsData, bytecode);
             if (_.isUndefined(contractData)) {
@@ -223,7 +227,7 @@ export class RevertTraceSubprovider extends Subprovider {
             sourceRanges.push(sourceRange);
         }
         if (sourceRanges.length > 0) {
-            this._logger.error('\n\nStack trace:\n');
+            this._logger.error('\n\nStack trace for REVERT:\n');
             _.forEach(sourceRanges, sourceRange => {
                 this._logger.error(
                     `${sourceRange.fileName}:${sourceRange.location.start.line}:${sourceRange.location.start.column}`,

--- a/packages/sol-cov/src/revert_trace_subprovider.ts
+++ b/packages/sol-cov/src/revert_trace_subprovider.ts
@@ -37,6 +37,7 @@ export class RevertTraceSubprovider extends TraceCollectionSubprovider {
         this._logger = getLogger('sol-cov');
         this._logger.setLevel(isVerbose ? levels.TRACE : levels.ERROR);
     }
+    // tslint:disable-next-line:no-unused-variable
     protected async _recordTxTraceAsync(address: string, data: string | undefined, txHash: string): Promise<void> {
         await this._web3Wrapper.awaitTransactionMinedAsync(txHash, 0);
         const trace = await this._web3Wrapper.getTransactionTraceAsync(txHash, {

--- a/packages/sol-cov/src/trace.ts
+++ b/packages/sol-cov/src/trace.ts
@@ -33,9 +33,7 @@ export function getTracesByContractAddress(structLogs: StructLog[], startAddress
             const newAddress = utils.getAddressFromStackEntry(
                 structLog.stack[structLog.stack.length - jumpAddressOffset - 1],
             );
-            if (structLog === _.last(normalizedStructLogs)) {
-                throw new Error('Malformed trace. CALL-like opcode can not be the last one');
-            }
+
             // Sometimes calls don't change the execution context (current address). When we do a transfer to an
             // externally owned account - it does the call and immediately returns because there is no fallback
             // function. We manually check if the call depth had changed to handle that case.

--- a/packages/sol-cov/src/trace_info_subprovider.ts
+++ b/packages/sol-cov/src/trace_info_subprovider.ts
@@ -1,0 +1,59 @@
+import * as _ from 'lodash';
+
+import { constants } from './constants';
+import { getTracesByContractAddress } from './trace';
+import { TraceCollectionSubprovider } from './trace_collection_subprovider';
+import { TraceInfo, TraceInfoExistingContract, TraceInfoNewContract } from './types';
+
+// TraceInfoSubprovider is extended by subproviders which need to work with one
+// TraceInfo at a time. It has one abstract method: _handleTraceInfoAsync, which
+// is called for each TraceInfo.
+export abstract class TraceInfoSubprovider extends TraceCollectionSubprovider {
+    protected abstract _handleTraceInfoAsync(traceInfo: TraceInfo): Promise<void>;
+    protected async _recordTxTraceAsync(address: string, data: string | undefined, txHash: string): Promise<void> {
+        await this._web3Wrapper.awaitTransactionMinedAsync(txHash, 0);
+        const trace = await this._web3Wrapper.getTransactionTraceAsync(txHash, {
+            disableMemory: true,
+            disableStack: false,
+            disableStorage: true,
+        });
+        const tracesByContractAddress = getTracesByContractAddress(trace.structLogs, address);
+        const subcallAddresses = _.keys(tracesByContractAddress);
+        if (address === constants.NEW_CONTRACT) {
+            for (const subcallAddress of subcallAddresses) {
+                let traceInfo: TraceInfoNewContract | TraceInfoExistingContract;
+                if (subcallAddress === 'NEW_CONTRACT') {
+                    const traceForThatSubcall = tracesByContractAddress[subcallAddress];
+                    traceInfo = {
+                        subtrace: traceForThatSubcall,
+                        txHash,
+                        address: subcallAddress,
+                        bytecode: data as string,
+                    };
+                } else {
+                    const runtimeBytecode = await this._web3Wrapper.getContractCodeAsync(subcallAddress);
+                    const traceForThatSubcall = tracesByContractAddress[subcallAddress];
+                    traceInfo = {
+                        subtrace: traceForThatSubcall,
+                        txHash,
+                        address: subcallAddress,
+                        runtimeBytecode,
+                    };
+                }
+                await this._handleTraceInfoAsync(traceInfo);
+            }
+        } else {
+            for (const subcallAddress of subcallAddresses) {
+                const runtimeBytecode = await this._web3Wrapper.getContractCodeAsync(subcallAddress);
+                const traceForThatSubcall = tracesByContractAddress[subcallAddress];
+                const traceInfo: TraceInfoExistingContract = {
+                    subtrace: traceForThatSubcall,
+                    txHash,
+                    address: subcallAddress,
+                    runtimeBytecode,
+                };
+                await this._handleTraceInfoAsync(traceInfo);
+            }
+        }
+    }
+}

--- a/packages/sol-cov/src/types.ts
+++ b/packages/sol-cov/src/types.ts
@@ -107,3 +107,10 @@ export type TraceInfo = TraceInfoNewContract | TraceInfoExistingContract;
 export enum BlockParamLiteral {
     Latest = 'latest',
 }
+
+export interface EvmCallStackEntry {
+    structLog: StructLog;
+    address: string;
+}
+
+export type EvmCallStack = EvmCallStackEntry[];


### PR DESCRIPTION
<!--- Thank you for taking the time to submit a Pull Request -->

<!--- Provide a general summary of the issue in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR introduces a new subprovider, `RevertTraceSubprovider`, which can be enabled in the contracts tests by setting `SOLIDITY_REVERT_TRACE=true` (or running  `yarn wsrun test:trace contracts`).

Much like the coverage and profiler subproviders, the `RevertTraceSubprovider` will inject itself into calls to `eth_sendTransaction`, `eth_call`, and `eth_estimateGas`. It gets the trace data for each transaction, keeps track of the call stack, and looks for the `REVERT` opcode. If it sees the `REVERT` opcode, it will simply print out the stack trace which led to the revert.

In effect this means that if our tests cause a revert, we will be able to see the origin of that revert as a line number in a Solidity file 🎉 

<img width="837" alt="screen shot 2018-06-13 at 7 10 36 pm" src="https://user-images.githubusercontent.com/800857/41443624-ef5aeda8-6ff2-11e8-9d17-0c86fd40bb62.png">
<img width="794" alt="screen shot 2018-06-13 at 7 10 28 pm" src="https://user-images.githubusercontent.com/800857/41443629-f23902b2-6ff2-11e8-8337-33fb2f94e80b.png">


It's not perfect, but it's a good starting point. One thing we would like to add in the future is including function calls in the stack trace. Right now, entries only appear in the stack trace when we call to another contract (e.g., via the `CALL` opcode) and we don't track function calls within the same contract.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [x] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
