### PR TITLE
Make batchFill methods return FIllResults struct

### DIFF
--- a/packages/contracts/src/contracts/current/protocol/Exchange/MixinWrapperFunctions.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/MixinWrapperFunctions.sol
@@ -263,40 +263,50 @@ contract MixinWrapperFunctions is
     /// @param orders Array of order specifications.
     /// @param takerAssetFillAmounts Array of desired amounts of takerAsset to sell in orders.
     /// @param signatures Proofs that orders have been created by makers.
+    /// @return Amounts filled and fees paid by makers and taker.
+    ///         NOTE: makerAssetFilledAmount and takerAssetFilledAmount may include amounts filled of different assets.
     function batchFillOrders(
         LibOrder.Order[] memory orders,
         uint256[] memory takerAssetFillAmounts,
         bytes[] memory signatures
     )
         public
+        returns (FillResults memory totalFillResults)
     {
         for (uint256 i = 0; i < orders.length; i++) {
-            fillOrder(
+            FillResults memory singleFillResults = fillOrder(
                 orders[i],
                 takerAssetFillAmounts[i],
                 signatures[i]
             );
+            addFillResults(totalFillResults, singleFillResults);
         }
+        return totalFillResults;
     }
 
     /// @dev Synchronously executes multiple calls of fillOrKill.
     /// @param orders Array of order specifications.
     /// @param takerAssetFillAmounts Array of desired amounts of takerAsset to sell in orders.
     /// @param signatures Proofs that orders have been created by makers.
+    /// @return Amounts filled and fees paid by makers and taker.
+    ///         NOTE: makerAssetFilledAmount and takerAssetFilledAmount may include amounts filled of different assets.
     function batchFillOrKillOrders(
         LibOrder.Order[] memory orders,
         uint256[] memory takerAssetFillAmounts,
         bytes[] memory signatures
     )
         public
+        returns (FillResults memory totalFillResults)
     {
         for (uint256 i = 0; i < orders.length; i++) {
-            fillOrKillOrder(
+            FillResults memory singleFillResults = fillOrKillOrder(
                 orders[i],
                 takerAssetFillAmounts[i],
                 signatures[i]
             );
+            addFillResults(totalFillResults, singleFillResults);
         }
+        return totalFillResults;
     }
 
     /// @dev Fills an order with specified parameters and ECDSA signature.
@@ -304,20 +314,25 @@ contract MixinWrapperFunctions is
     /// @param orders Array of order specifications.
     /// @param takerAssetFillAmounts Array of desired amounts of takerAsset to sell in orders.
     /// @param signatures Proofs that orders have been created by makers.
+    /// @return Amounts filled and fees paid by makers and taker.
+    ///         NOTE: makerAssetFilledAmount and takerAssetFilledAmount may include amounts filled of different assets.
     function batchFillOrdersNoThrow(
         LibOrder.Order[] memory orders,
         uint256[] memory takerAssetFillAmounts,
         bytes[] memory signatures
     )
         public
+        returns (FillResults memory totalFillResults)
     {
         for (uint256 i = 0; i < orders.length; i++) {
-            fillOrderNoThrow(
+            FillResults memory singleFillResults = fillOrderNoThrow(
                 orders[i],
                 takerAssetFillAmounts[i],
                 signatures[i]
             );
+            addFillResults(totalFillResults, singleFillResults);
         }
+        return totalFillResults;
     }
 
     /// @dev Synchronously executes multiple calls of fillOrder until total amount of takerAsset is sold by taker.

--- a/packages/contracts/src/contracts/current/protocol/Exchange/interfaces/IWrapperFunctions.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/interfaces/IWrapperFunctions.sol
@@ -22,10 +22,7 @@ pragma experimental ABIEncoderV2;
 import "../libs/LibOrder.sol";
 import "../libs/LibFillResults.sol";
 
-contract IWrapperFunctions is
-    LibOrder,
-    LibFillResults
-{
+contract IWrapperFunctions {
     /// @dev Fills the input order. Reverts if exact takerAssetFillAmount not filled.
     /// @param order LibOrder.Order struct containing order specifications.
     /// @param takerAssetFillAmount Desired amount of takerAsset to sell.
@@ -56,35 +53,41 @@ contract IWrapperFunctions is
     /// @param orders Array of order specifications.
     /// @param takerAssetFillAmounts Array of desired amounts of takerAsset to sell in orders.
     /// @param signatures Proofs that orders have been created by makers.
+    /// @return Amounts filled and fees paid by makers and taker.
     function batchFillOrders(
         LibOrder.Order[] memory orders,
         uint256[] memory takerAssetFillAmounts,
         bytes[] memory signatures
     )
-        public;
+        public
+        returns (LibFillResults.FillResults memory totalFillResults);
 
     /// @dev Synchronously executes multiple calls of fillOrKill.
     /// @param orders Array of order specifications.
     /// @param takerAssetFillAmounts Array of desired amounts of takerAsset to sell in orders.
     /// @param signatures Proofs that orders have been created by makers.
+    /// @return Amounts filled and fees paid by makers and taker.
     function batchFillOrKillOrders(
         LibOrder.Order[] memory orders,
         uint256[] memory takerAssetFillAmounts,
         bytes[] memory signatures
     )
-        public;
+        public
+        returns (LibFillResults.FillResults memory totalFillResults);
 
     /// @dev Fills an order with specified parameters and ECDSA signature.
     ///      Returns false if the transaction would otherwise revert.
     /// @param orders Array of order specifications.
     /// @param takerAssetFillAmounts Array of desired amounts of takerAsset to sell in orders.
     /// @param signatures Proofs that orders have been created by makers.
+    /// @return Amounts filled and fees paid by makers and taker.
     function batchFillOrdersNoThrow(
         LibOrder.Order[] memory orders,
         uint256[] memory takerAssetFillAmounts,
         bytes[] memory signatures
     )
-        public;
+        public
+        returns (LibFillResults.FillResults memory totalFillResults);
 
     /// @dev Synchronously executes multiple calls of fillOrder until total amount of takerAsset is sold by taker.
     /// @param orders Array of order specifications.


### PR DESCRIPTION
<!--- Thank you for taking the time to submit a Pull Request -->

<!--- Provide a general summary of the issue in the Title above -->

## Description

<!--- Describe your changes in detail -->
Returns a `FillResults` instance for  all derivatives of `batchFillOrders`. This is useful for certain external contracts (like the forwarding contract), and also creates a consistent interface (now all fill methods return a `FillResults`).

Note that `makerAssetFilledAmount` and `takerAssetFilledAmount` do not actually give much information unless we know that the function was called with the same `makerAsset` and `takerAsset` for each order.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
