### PR TITLE
Check network state immediately instead of waiting for delay

### DIFF
--- a/packages/website/ts/blockchain.ts
+++ b/packages/website/ts/blockchain.ts
@@ -229,7 +229,7 @@ export class Blockchain {
             shouldPollUserAddress,
         );
         this._contractWrappers.setProvider(provider, this.networkId);
-        this._blockchainWatcher.startEmittingNetworkConnectionAndUserBalanceState();
+        await this._blockchainWatcher.startEmittingNetworkConnectionAndUserBalanceStateAsync();
         this._dispatcher.updateProviderType(ProviderType.Ledger);
     }
     public async updateProviderToInjectedAsync(): Promise<void> {
@@ -259,7 +259,7 @@ export class Blockchain {
         this._contractWrappers.setProvider(provider, this.networkId);
 
         await this.fetchTokenInformationAsync();
-        this._blockchainWatcher.startEmittingNetworkConnectionAndUserBalanceState();
+        await this._blockchainWatcher.startEmittingNetworkConnectionAndUserBalanceStateAsync();
         this._dispatcher.updateProviderType(ProviderType.Injected);
         delete this._ledgerSubprovider;
         delete this._cachedProvider;
@@ -816,7 +816,7 @@ export class Blockchain {
         this._userAddressIfExists = userAddresses[0];
         this._dispatcher.updateUserAddress(this._userAddressIfExists);
         await this.fetchTokenInformationAsync();
-        this._blockchainWatcher.startEmittingNetworkConnectionAndUserBalanceState();
+        await this._blockchainWatcher.startEmittingNetworkConnectionAndUserBalanceStateAsync();
         await this._rehydrateStoreWithContractEventsAsync();
     }
     private _updateProviderName(injectedWeb3: Web3): void {


### PR DESCRIPTION
## Description

In the `Wallet` component, ether balance loads significantly later than other token balances. This is because we poll for users ether balance and network state on a 5s timer in the `BlockchainWatcher` class. To fix this problem we just load the user's ether balance and network state before starting the timer.

## Motivation and Context

Ether balance doesn't load until 5s delay, looks like a bug.

## How Has This Been Tested?

Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [x] Labeled this PR with the labels corresponding to the changed package.
