### PR TITLE
Fix bug where we do not fetch balances on wallet login

### DIFF
--- a/packages/website/ts/components/portal/portal.tsx
+++ b/packages/website/ts/components/portal/portal.tsx
@@ -167,8 +167,8 @@ export class Portal extends React.Component<PortalProps, PortalState> {
     }
     public componentDidUpdate(prevProps: PortalProps): void {
         if (!prevProps.blockchainIsLoaded && this.props.blockchainIsLoaded) {
-            // tslint:disable-next-line:no-floating-promises
             const trackedTokenAddresses = _.keys(this.state.trackedTokenStateByAddress);
+            // tslint:disable-next-line:no-floating-promises
             this._fetchBalancesAndAllowancesAsync(trackedTokenAddresses);
         }
     }

--- a/packages/website/ts/components/portal/portal.tsx
+++ b/packages/website/ts/components/portal/portal.tsx
@@ -155,9 +155,6 @@ export class Portal extends React.Component<PortalProps, PortalState> {
     }
     public componentWillMount(): void {
         this._blockchain = new Blockchain(this.props.dispatcher);
-        const trackedTokenAddresses = _.keys(this.state.trackedTokenStateByAddress);
-        // tslint:disable-next-line:no-floating-promises
-        this._fetchBalancesAndAllowancesAsync(trackedTokenAddresses);
     }
     public componentWillUnmount(): void {
         this._blockchain.destroy();
@@ -167,6 +164,13 @@ export class Portal extends React.Component<PortalProps, PortalState> {
         // initialization inconsistencies (i.e While the portal was unrendered, the user might have
         // become disconnected from their backing Ethereum node, changed user accounts, etc...)
         this.props.dispatcher.resetState();
+    }
+    public componentDidUpdate(prevProps: PortalProps): void {
+        if (!prevProps.blockchainIsLoaded && this.props.blockchainIsLoaded) {
+            // tslint:disable-next-line:no-floating-promises
+            const trackedTokenAddresses = _.keys(this.state.trackedTokenStateByAddress);
+            this._fetchBalancesAndAllowancesAsync(trackedTokenAddresses);
+        }
     }
     public componentWillReceiveProps(nextProps: PortalProps): void {
         if (nextProps.networkId !== this.state.prevNetworkId) {


### PR DESCRIPTION

## Description
The bug was that we were only refreshing token balances in `componentWillMount`, now we selectively fetch them in `componentDidUpdate`.

## How Has This Been Tested?
Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [x] Labeled this PR with the labels corresponding to the changed package.
