### PR TITLE
Remove unreachable PreSigned check

### DIFF
--- a/packages/contracts/src/contracts/current/protocol/Exchange/MixinSignatureValidator.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/MixinSignatureValidator.sol
@@ -232,10 +232,6 @@ contract MixinSignatureValidator is
             isValid = signer == recovered;
             return isValid;
 
-        // Signer signed hash previously using the preSign function
-        } else if (signatureType == SignatureType.PreSigned) {
-            isValid = preSigned[hash][signer];
-            return isValid;
         }
 
         // Anything else is illegal (We do not return false because


### PR DESCRIPTION
This code was unreachable, as it had the exact same condition as line 206.

## Description

Line 206 checks for signatureType == SignatureType.PreSigned. This was repeated on line 236, but that condition could never be met after the condition on line 206.

