### PR TITLE
Emit an event when validator authorizations change

### DIFF
--- a/packages/contracts/src/contracts/current/protocol/Exchange/MixinSignatureValidator.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/MixinSignatureValidator.sol
@@ -70,6 +70,7 @@ contract MixinSignatureValidator is
     {
         address signer = getCurrentContextAddress();
         allowedValidators[signer][validator] = approval;
+        emit SetValidatorStatus(signer, validator, approval);
     }
 
     /// @dev Verifies that a hash has been signed by the given signer.

--- a/packages/contracts/src/contracts/current/protocol/Exchange/mixins/MSignatureValidator.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/mixins/MSignatureValidator.sol
@@ -23,6 +23,13 @@ import "../interfaces/ISignatureValidator.sol";
 contract MSignatureValidator is
     ISignatureValidator
 {
+    // Emitted when a signer adds or removes a validator
+    event SetValidatorStatus(
+        address indexed signerAddress,
+        address indexed validatorAddress,
+        bool approvalStatus
+    );
+
     // Allowed signature types.
     enum SignatureType {
         Illegal,        // 0x00, default value


### PR DESCRIPTION
Without an event to tell us when users add and remove validators, orders that use validators must be verified on a recurring basis. By adding an event when a user changes a validator authorization, we can remove orders proactively if a user de-authorizes a validator.

I feel like there should be a test to go with this, but the tests are written in solidity, and I'm not sure how (or if it's even possible) to detect events emitted in solidity.