### PR TITLE
Fix some bugs in sol-cov

### DIFF
--- a/packages/sol-cov/src/utils.ts
+++ b/packages/sol-cov/src/utils.ts
@@ -5,6 +5,10 @@ import * as _ from 'lodash';
 
 import { ContractData, LineColumn, SingleFileSourceRange } from './types';
 
+// This is the minimum length of valid contract bytecode. The Solidity compiler
+// metadata is 86 bytes. If you add the '0x' prefix, we get 88.
+const MIN_CONTRACT_BYTECODE_LENGTH = 88;
+
 export const utils = {
     compareLineColumn(lhs: LineColumn, rhs: LineColumn): number {
         return lhs.line !== rhs.line ? lhs.line - rhs.line : lhs.column - rhs.column;
@@ -38,7 +42,15 @@ export const utils = {
         }
         const contractData = _.find(contractsData, contractDataCandidate => {
             const bytecodeRegex = utils.bytecodeToBytecodeRegex(contractDataCandidate.bytecode);
+            // If the bytecode is less than the minimum length, we are probably
+            // dealing with an interface. This isn't what we're looking for.
+            if (bytecodeRegex.length < MIN_CONTRACT_BYTECODE_LENGTH) {
+                return false;
+            }
             const runtimeBytecodeRegex = utils.bytecodeToBytecodeRegex(contractDataCandidate.runtimeBytecode);
+            if (runtimeBytecodeRegex.length < MIN_CONTRACT_BYTECODE_LENGTH) {
+                return false;
+            }
             // We use that function to find by bytecode or runtimeBytecode. Those are quasi-random strings so
             // collisions are practically impossible and it allows us to reuse that code
             return !_.isNull(bytecode.match(bytecodeRegex)) || !_.isNull(bytecode.match(runtimeBytecodeRegex));


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR fixes two bugs in sol-cov:

1. There was sometimes an infinite loop being triggered due to a bug in a `while` loop in __revert_trace_subprovider.ts__.
2. The wrong contract data was sometimes being returned by `getContractDataIfExists`, especially when dealing with interfaces.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

Run `SOLIDITY_REVERT_TRACE=true yarn wsrun test contracts` and verify output.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
