### PR TITLE
Converted `hashZeroExTransaction` to assembly. Saves 1k gas

### DIFF
--- a/packages/contracts/src/contracts/current/protocol/Exchange/MixinTransactions.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/MixinTransactions.sol
@@ -66,7 +66,7 @@ contract MixinTransactions is
             let memPtr := mload(64)
             mstore(memPtr, schemaHash)
             mstore(add(memPtr, 32), salt)
-            mstore(add(memPtr, 64), signerAddress)
+            mstore(add(memPtr, 64), and(signerAddress, 0xffffffffffffffffffffffffffffffffffffffff))
             mstore(add(memPtr, 96), dataHash)
             result := keccak256(memPtr, 128)
         }

--- a/packages/contracts/src/contracts/current/protocol/Exchange/MixinTransactions.sol
+++ b/packages/contracts/src/contracts/current/protocol/Exchange/MixinTransactions.sol
@@ -51,17 +51,27 @@ contract MixinTransactions is
     /// @param signerAddress Address of transaction signer.
     /// @param data AbiV2 encoded calldata.
     /// @return EIP712 hash of the Transaction.
-    function hashZeroExTransaction(uint256 salt, address signerAddress, bytes data)
+    function hashZeroExTransaction(
+        uint256 salt,
+        address signerAddress,
+        bytes memory data
+    )
         internal
         pure
-        returns (bytes32)
+        returns (bytes32 result)
     {
-        return keccak256(abi.encode(
-            EIP712_ZEROEX_TRANSACTION_SCHEMA_HASH,
-            salt,
-            signerAddress,
-            keccak256(data)
-        ));
+        bytes32 schemaHash = EIP712_ZEROEX_TRANSACTION_SCHEMA_HASH;
+        bytes32 dataHash = keccak256(data);
+        assembly {
+            let memPtr := mload(64)
+            mstore(memPtr, schemaHash)
+            mstore(add(memPtr, 32), salt)
+            mstore(add(memPtr, 64), signerAddress)
+            mstore(add(memPtr, 96), dataHash)
+            result := keccak256(memPtr, 128)
+        }
+
+        return result;
     }
 
     /// @dev Executes an exchange method call in the context of signer.


### PR DESCRIPTION
## Description

Rewrote `hashZeroExTransaction` in assembly. Similar to what @Recmo did in [this RP](https://github.com/0xProject/0x-monorepo/pull/730/files).

Saved ~1k gas. Benchmarked using test on line 134 of `transactions.ts` (`should transfer the correct amounts when signed by taker and called by sender`).

## Testing instructions

No new tests were created. All existing tests pass.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [x] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
