### PR TITLE
Updated compiler runs to be 1,000,000

### DIFF
--- a/packages/contracts/compiler.json
+++ b/packages/contracts/compiler.json
@@ -4,7 +4,7 @@
     "compilerSettings": {
         "optimizer": {
             "enabled": true,
-            "runs": 200
+            "runs": 1000000
         },
         "outputSelection": {
             "*": {


### PR DESCRIPTION
## Description

Efficiency gains by setting `compilerRuns = 1000000`. After 1MM there were no longer any efficiency gains. There is no build time difference between `compilerRuns=200` and `compilerRuns=1000000`.

```
Benchmarks are taken from a single, unexceptional test case for each function:
`fillOrder`: `should transfer the correct amounts when makerAssetAmount === takerAssetAmount`
`cancelOrder`: `should be able to cancel a full order`
`cancelOrdersUpTo`: `should cancel only orders with a orderEpoch less than existing orderEpoch`

compilerRuns=200:
  `fillOrder` = 193,803
  `cancelOrder` = 66,652
  `cancelOrdersUpTo` = 45,154

compilerRuns=1,000,000:
  `fillOrder` = 187,779
  `cancelOrder` = 65,968
  `cancelOrdersUpTo` = 44,878

Savings:
  `fillOrder` = 3%
  `cancelOrder` = 1%
  `cancelOrdersUpTo` = 0.06%
```

## Testing instructions


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [x] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
