### PR TITLE
Fix known order hash value test in order-utils

### DIFF
--- a/packages/order-utils/test/order_hash_test.ts
+++ b/packages/order-utils/test/order_hash_test.ts
@@ -12,8 +12,8 @@ const expect = chai.expect;
 
 describe('Order hashing', () => {
     describe('#getOrderHashHex', () => {
-        const expectedOrderHash = '0x367ad7730eb8b5feab8a9c9f47c6fcba77a2d4df125ee6a59cc26ac955710f7e';
-        const fakeExchangeContractAddress = '0xb69e673309512a9d726f87304c6984054f87a93b';
+        const expectedOrderHash = '0x434c6b41e2fb6dfcfe1b45c4492fb03700798e9c1afc6f801ba6203f948c1fa7';
+        const fakeExchangeContractAddress = '0x1dc4c1cefef38a777b15aa20260a54e584b16c48';
         const order: Order = {
             makerAddress: constants.NULL_ADDRESS,
             takerAddress: constants.NULL_ADDRESS,
@@ -29,15 +29,11 @@ describe('Order hashing', () => {
             takerAssetAmount: new BigNumber(0),
             expirationTimeSeconds: new BigNumber(0),
         };
-        // HACK: Temporarily disable these tests until @dekz has time to fix.
-        // This allows us to get all tests running on CI immediately
-        it.skip('calculates the order hash', async () => {
+        it('calculates the order hash', async () => {
             const orderHash = orderHashUtils.getOrderHashHex(order);
             expect(orderHash).to.be.equal(expectedOrderHash);
         });
-        // HACK: Temporarily disable these tests until @dekz has time to fix.
-        // This allows us to get all tests running on CI immediately
-        it.skip('throws a readable error message if taker format is invalid', async () => {
+        it('throws a readable error message if taker format is invalid', async () => {
             const orderWithInvalidtakerFormat = {
                 ...order,
                 takerAddress: (null as any) as string,


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->


## Testing instructions

This was testing end to end by deploying an Exchange contract on ganache and requesting it to hash the 0 order. With this hash (and contract address) as fixture data, it is then confirmed as a known data test in the order-utils package. 


<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
