### PR TITLE
Fix issue where hovered tiles appear over top bar

### DIFF
--- a/packages/website/ts/components/portal/portal.tsx
+++ b/packages/website/ts/components/portal/portal.tsx
@@ -243,8 +243,7 @@ export class Portal extends React.Component<PortalProps, PortalState> {
                     style={{
                         backgroundColor: colors.lightestGrey,
                         position: 'fixed',
-                        // Hack: used to make onboarding z-index logic work for both mobile and desktop
-                        zIndex: utils.isMobile(this.props.screenWidth) ? zIndex.topBar : undefined,
+                        zIndex: zIndex.topBar,
                     }}
                     maxWidth={LARGE_LAYOUT_MAX_WIDTH}
                 />
@@ -696,9 +695,14 @@ interface LargeLayoutProps {
 }
 const LargeLayout = (props: LargeLayoutProps) => {
     return (
-        <div className="mx-auto flex flex-center" style={{ maxWidth: LARGE_LAYOUT_MAX_WIDTH }}>
+        <Container className="mx-auto flex flex-center" maxWidth={LARGE_LAYOUT_MAX_WIDTH}>
             <div className="flex-last">
-                <Container width={LEFT_COLUMN_WIDTH} position="fixed" marginLeft={LARGE_LAYOUT_MARGIN}>
+                <Container
+                    width={LEFT_COLUMN_WIDTH}
+                    position="fixed"
+                    zIndex={zIndex.aboveTopBar}
+                    marginLeft={LARGE_LAYOUT_MARGIN}
+                >
                     {props.left}
                 </Container>
             </div>
@@ -707,7 +711,7 @@ const LargeLayout = (props: LargeLayoutProps) => {
                     {props.right}
                 </Container>
             </Container>
-        </div>
+        </Container>
     );
 };
 

--- a/packages/website/ts/style/z_index.ts
+++ b/packages/website/ts/style/z_index.ts
@@ -1,5 +1,6 @@
 export const zIndex = {
     topBar: 1100,
+    aboveTopBar: 1101,
     overlay: 1105,
     aboveOverlay: 1106,
 };


### PR DESCRIPTION
## Description

More z-index fun!! This actually cleaned things up a bit.
<img width="1012" alt="screen shot 2018-06-22 at 1 35 12 pm" src="https://user-images.githubusercontent.com/3066135/41800218-7dfe9640-7629-11e8-8ec8-29daa379013a.png">

## Testing instructions

Hover over a tile and scroll down and notice that it doesn't show up over the topbar anymore!

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [x] Labeled this PR with the labels corresponding to the changed package.
