### PR TITLE
[sol-cov] show when modifier _; is covered

### DIFF
--- a/packages/sol-cov/src/ast_visitor.ts
+++ b/packages/sol-cov/src/ast_visitor.ts
@@ -79,7 +79,8 @@ export class ASTVisitor {
         this._visitStatement(ast);
     }
     public ExpressionStatement(ast: Parser.ExpressionStatement): void {
-        if (ast.expression.type === 'Identifier' && ast.expression.name === '_') {
+        // TODO update types
+        if (ast.expression.type === 'Identifier' && (ast as any).expression.name === '_') {
             // this is "_;" in a modifier
             // add to the modifiersStatementdIds so we can collect coverage info
             this._modifiersStatementIds.push(this._entryId);

--- a/packages/sol-cov/src/ast_visitor.ts
+++ b/packages/sol-cov/src/ast_visitor.ts
@@ -79,6 +79,11 @@ export class ASTVisitor {
         this._visitStatement(ast);
     }
     public ExpressionStatement(ast: Parser.ExpressionStatement): void {
+        if (ast.expression.type === 'Identifier' && ast.expression.name === '_') {
+            // this is "_;" in a modifier
+            // add to the modifiersStatementdIds so we can collect coverage info
+            this._modifiersStatementIds.push(this._entryId);
+        }
         this._visitStatement(ast.expression);
     }
     public InlineAssemblyStatement(ast: Parser.InlineAssemblyStatement): void {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Adds support for marking `_;` statements within a modifier as covered.

I'm not too familiar w/ ts, so I'm not sure if it's possible to check the type of `ast.expression` such as:
```
if (ast.expression instanceof Parser.Identity) {...}
```

lmk if there is a better way to make that check in the if statement.

Also, the types for `solidity-parser-antlr` need to be updated to include `name` in the `Identifier` node


## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [x] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
