### PR TITLE
Fix NotFound component and render 0x.js docs for /docs

### DIFF
--- a/packages/website/ts/index.tsx
+++ b/packages/website/ts/index.tsx
@@ -97,6 +97,7 @@ render(
                             <Route path={WebsitePaths.FAQ} component={FAQ as any} />
                             <Route path={WebsitePaths.About} component={About as any} />
                             <Route path={WebsitePaths.Wiki} component={Wiki as any} />
+                            <Route path={`${WebsitePaths.Docs}`} component={LazyZeroExJSDocumentation} />
                             <Route path={`${WebsitePaths.ZeroExJs}/:version?`} component={LazyZeroExJSDocumentation} />
                             <Route path={`${WebsitePaths.Connect}/:version?`} component={LazyConnectDocumentation} />
                             <Route

--- a/packages/website/ts/pages/not_found.tsx
+++ b/packages/website/ts/pages/not_found.tsx
@@ -11,15 +11,15 @@ export interface NotFoundProps {
     dispatcher: Dispatcher;
 }
 
-export const NotFound = (_props: NotFoundProps) => {
+export const NotFound = (props: NotFoundProps) => {
     return (
         <div>
-            <TopBar blockchainIsLoaded={false} location={this.props.location} translate={this.props.translate} />
+            <TopBar blockchainIsLoaded={false} location={props.location} translate={props.translate} />
             <FullscreenMessage
                 headerText={'404 Not Found'}
                 bodyText={"Hm... looks like we couldn't find what you are looking for."}
             />
-            <Footer translate={this.props.translate} dispatcher={this.props.dispatcher} />
+            <Footer translate={props.translate} dispatcher={props.dispatcher} />
         </div>
     );
 };

--- a/packages/website/ts/types.ts
+++ b/packages/website/ts/types.ts
@@ -356,6 +356,7 @@ export enum WebsiteLegacyPaths {
 export enum WebsitePaths {
     Portal = '/portal',
     Wiki = '/wiki',
+    Docs = '/docs',
     ZeroExJs = '/docs/0x.js',
     Home = '/',
     FAQ = '/faq',


### PR DESCRIPTION
<!--- Describe your changes in detail -->

## Description:

* Fix buggy `NotFound` component
* Create a new route `/docs` that goes to the 0x.js docs
* How come the type checking didn't catch this? Does it not work for jsx?

<!--- Please describe how reviewers can test your changes -->

## Testing Instructions:

* Try going to `/docs` verify that 0x.js docs pops up
* Try going to `/hello` or some other unregistered route, verify a 404 page shows up

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
