### PR TITLE
Improve reliability of the minimum block number hack for devnet/geth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,9 +53,9 @@ jobs:
       - restore_cache:
           keys:
             - repo-{{ .Environment.CIRCLE_SHA1 }}
-      # HACK(albrow): we need to sleep 15 seconds to ensure the devnet is
+      # HACK(albrow): we need to sleep 10 seconds to ensure the devnet is
       # initialized
-      - run: sleep 15 && TEST_PROVIDER=geth yarn wsrun test contracts
+      - run: sleep 10 && TEST_PROVIDER=geth yarn wsrun test contracts
   test-rest:
     docker:
       - image: circleci/node:9

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -47,6 +47,7 @@
     "dependencies": {
         "@0xproject/subproviders": "^0.10.4",
         "@0xproject/types": "^0.8.1",
+        "@0xproject/utils": "^0.7.1",
         "ethereum-types": "^0.0.1",
         "@0xproject/typescript-typings": "^0.4.1",
         "@0xproject/web3-wrapper": "^0.7.1",

--- a/packages/dev-utils/src/blockchain_lifecycle.ts
+++ b/packages/dev-utils/src/blockchain_lifecycle.ts
@@ -1,3 +1,4 @@
+import { logUtils } from '@0xproject/utils';
 import { uniqueVersionIds, Web3Wrapper } from '@0xproject/web3-wrapper';
 import { includes } from 'lodash';
 
@@ -6,9 +7,17 @@ enum NodeType {
     Ganache = 'GANACHE',
 }
 
+// HACK(albrow): 🐉 We have to do this so that debug.setHead works correctly.
+// (Geth does not seem to like debug.setHead(0), so by sending some transactions
+// we increase the current block number beyond 0). Additionally, some tests seem
+// to break when there are fewer than 3 blocks in the chain. (We have no idea
+// why, but it was consistently reproducible).
+const MINIMUM_BLOCKS = 3;
+
 export class BlockchainLifecycle {
     private _web3Wrapper: Web3Wrapper;
     private _snapshotIdsStack: number[];
+    private _addresses: string[] = [];
     constructor(web3Wrapper: Web3Wrapper) {
         this._web3Wrapper = web3Wrapper;
         this._snapshotIdsStack = [];
@@ -21,7 +30,13 @@ export class BlockchainLifecycle {
                 this._snapshotIdsStack.push(snapshotId);
                 break;
             case NodeType.Geth:
-                const blockNumber = await this._web3Wrapper.getBlockNumberAsync();
+                let blockNumber = await this._web3Wrapper.getBlockNumberAsync();
+                if (blockNumber < MINIMUM_BLOCKS) {
+                    // If the minimum block number is not met, force Geth to
+                    // mine some blocks by sending some dummy transactions.
+                    await this._mineMinimumBlocksAsync();
+                    blockNumber = await this._web3Wrapper.getBlockNumberAsync();
+                }
                 this._snapshotIdsStack.push(blockNumber);
                 break;
             default:
@@ -55,5 +70,26 @@ export class BlockchainLifecycle {
         } else {
             throw new Error(`Unknown client version: ${version}`);
         }
+    }
+    private async _mineMinimumBlocksAsync(): Promise<void> {
+        logUtils.warn('WARNING: minimum block number for tests not met. Mining additional blocks...');
+        if (this._addresses.length === 0) {
+            this._addresses = await this._web3Wrapper.getAvailableAddressesAsync();
+            if (this._addresses.length === 0) {
+                throw new Error('No accounts found');
+            }
+        }
+        while ((await this._web3Wrapper.getBlockNumberAsync()) < MINIMUM_BLOCKS) {
+            logUtils.warn('Mining block...');
+            await this._web3Wrapper.awaitTransactionMinedAsync(
+                await this._web3Wrapper.sendTransactionAsync({
+                    from: this._addresses[0],
+                    to: this._addresses[0],
+                    value: '0',
+                }),
+                0,
+            );
+        }
+        logUtils.warn('Done mining the minimum number of blocks.');
     }
 }

--- a/packages/devnet/run.sh
+++ b/packages/devnet/run.sh
@@ -3,7 +3,7 @@ set -e
 # Create log directory for Geth
 mkdir -p /var/log
 
-# Start Geth in background and redirect output to log file
+# Start Geth and direct output to stdout
 /geth \
     --verbosity 5 \
     --datadir node0/ \
@@ -22,23 +22,4 @@ mkdir -p /var/log
     --mine \
     --etherbase '0xe8816898d851d5b61b7f950627d04d794c07ca37' \
     --unlock '0xe8816898d851d5b61b7f950627d04d794c07ca37,0x5409ed021d9299bf6814279a6a1411a7e866a631,0x6ecbe1db9ef729cbe972c83fb886247691fb6beb,0xe36ea790bc9d7ab70c55260c66d52b1eca985f84,0xe834ec434daba538cd1b9fe1582052b880bd7e63,0x78dc5d2d739606d31509c31d654056a45185ecb6,0xa8dda8d7f5310e4a9e24f8eba77e091ac264f872,0x06cef8e666768cc40cc78cf93d9611019ddcb628,0x4404ac8bd8f9618d27ad2f1485aa1b2cfd82482d,0x7457d5e02197480db681d3fdf256c7aca21bdc12,0x91c987bf62d25945db517bdaa840a6c661374402' \
-    --password=node0/password.txt \
-    > /var/log/geth &
-
-# Wait for Geth to unlock the first account
-sleep 10
-
-# Send some transactions.
-# HACK(albrow): 🐉 We have to do this so that debug.setHead works correctly.
-# (Geth does not seem to like debug.setHead(0), so by sending some transactions
-# we increase the current block number beyond 0). Additionally, some tests seem
-# to break when there are fewer than 3 blocks in the chain. (We have no idea
-# why, but it was consistently reproducible).
-/geth --datadir node0/ attach --exec 'eth.sendTransaction({"from": "0x5409ED021D9299bf6814279A6A1411A7e866A631", "to": "0x84bd1cfa409cb0bb9b23b8b1a33515b4ac00a0af", "value": "0x1"})'
-sleep 3
-/geth --datadir node0/ attach --exec 'eth.sendTransaction({"from": "0x5409ED021D9299bf6814279A6A1411A7e866A631", "to": "0x84bd1cfa409cb0bb9b23b8b1a33515b4ac00a0af", "value": "0x1"})'
-sleep 3
-/geth --datadir node0/ attach --exec 'eth.sendTransaction({"from": "0x5409ED021D9299bf6814279A6A1411A7e866A631", "to": "0x84bd1cfa409cb0bb9b23b8b1a33515b4ac00a0af", "value": "0x1"})'
-
-# Use tail to re-attach to the log file and actually see the output.
-tail -f /var/log/geth
+    --password=node0/password.txt


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

There's a weird bug we've known about for a long time having to do with the devnet/Geth. If you try to deploy a contract, it will fail if there are less than 3 blocks on the chain. To address this, we introduced a hack in the __run.sh__ file, which is run when the devnet is initialized. The hack was to simply send 3 transactions with a value of 0, effectively increasing the length of the chain by 3 without really changing anything else.

However, @fabioberger reported a bug where Geth was sometimes resetting the block number all the way back to 0 (and resetting any corresponding state). This meant that the next time you tried to deploy a contract after this happened, it would fail.

This PR improves the reliability of the minimum block hack by moving it out of the __run.sh__ file and into __blockchain_lifecycle.ts__. The advantage is twofold:

1. It's faster because we have the ability to use `awaitTransactionMinedAsync` and wait exactly the right amount of time before sending the next transaction. In __run.sh__ we had to resort for sleeping for 3 seconds between each transaction.
2. It's more reliable because we can check the block number every time we call `startAsync()`. This means that even if Geth resets back to the genesis block, we can re-mine the minimum number of blocks and our tests will still work.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

The bug reported by @fabioberger seems to be fairly non-deterministic and (may be due to a race condition in Geth). You can *usually* reproduce it by deploying extra dummy ERC20 tokens. For example, you can make this change in __contracts/test/asset_proxy/proxies.ts__:

```diff
[zrxToken] = await erc20Wrapper.deployDummyTokensAsync(
-    constants.NUM_DUMMY_ERC20_TOKEN_TO_DEPLOY,
+    constants.NUM_DUMMY_ERC20_TOKEN_TO_DEPLOY + 10,
    constants.DUMMY_TOKEN_DECIMALS,
);
```

Without the changes in this PR, the tests will fail at some point when trying to deploy a contract. With the changes in this PR applied, the tests should work (but you might see a warning about the minimum number of blocks not being met).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
