### PR TITLE
Update expectRevertReasonOrAlwaysFailingTransactionAsync to check status codes

### DIFF
--- a/packages/contracts/src/utils/assertions.ts
+++ b/packages/contracts/src/utils/assertions.ts
@@ -1,8 +1,10 @@
 import { RevertReason } from '@0xproject/types';
 import * as chai from 'chai';
+import { TransactionReceipt, TransactionReceiptWithDecodedLogs } from 'ethereum-types';
 import * as _ from 'lodash';
 
 import { constants } from './constants';
+import { web3Wrapper } from './web3_wrapper';
 
 const expect = chai.expect;
 
@@ -53,18 +55,45 @@ export function expectRevertOrAlwaysFailingTransactionAsync<T>(p: Promise<T>): P
 }
 
 /**
- * Rejects if the given Promise does not reject with the given revert reason or "always
- * failing transaction" error.
+ * Rejects if at least one the following conditions is not met:
+ * 1) The given Promise rejects with the given revert reason.
+ * 2) The given Promise rejects with an error containing "always failing transaction"
+ * 3) The given Promise fulfills with a txReceipt that has a status of 0 or '0', indicating the transaction failed.
+ * 4) The given Promise fulfills with a txHash and corresponding txReceipt has a status of 0 or '0'.
  * @param p the Promise which is expected to reject
  * @param reason a specific revert reason
  * @returns a new Promise which will reject if the conditions are not met and
  * otherwise resolve with no value.
  */
-export function expectRevertReasonOrAlwaysFailingTransactionAsync<T>(
-    p: Promise<T>,
+export async function expectRevertReasonOrAlwaysFailingTransactionAsync(
+    p: Promise<string | TransactionReceiptWithDecodedLogs | TransactionReceipt>,
     reason: RevertReason,
-): PromiseLike<void> {
-    return _expectEitherErrorAsync(p, 'always failing transaction', reason);
+): Promise<void> {
+    return p
+        .then(async result => {
+            let txReceiptStatus: string | 0 | 1 | null;
+            if (typeof result === 'string') {
+                // Result is a txHash. We need to make a web3 call to get the receipt.
+                const txReceipt = await web3Wrapper.getTransactionReceiptAsync(result);
+                txReceiptStatus = txReceipt.status;
+            } else if ('status' in result) {
+                // Result is a TransactionReceiptWithDecodedLogs or TransactionReceipt
+                // and status is a field of result.
+                txReceiptStatus = result.status;
+            } else {
+                throw new Error('Unexpected result type');
+            }
+            expect(_.toString(txReceiptStatus)).to.equal(
+                '0',
+                'transactionReceipt had a non-zero status, indicating success',
+            );
+        })
+        .catch(err => {
+            expect(err.message).to.satisfy(
+                (msg: string) => _.includes(msg, reason) || _.includes(msg, 'always failing transaction'),
+                `Expected ${reason} or 'always failing transaction' but error message was ${err.message}`,
+            );
+        });
 }
 
 /**

--- a/packages/contracts/test/exchange/match_orders.ts
+++ b/packages/contracts/test/exchange/match_orders.ts
@@ -651,13 +651,7 @@ describe('matchOrders', () => {
             });
             // Match orders
             return expectRevertReasonOrAlwaysFailingTransactionAsync(
-                matchOrderTester.matchOrdersAndVerifyBalancesAsync(
-                    signedOrderLeft,
-                    signedOrderRight,
-                    takerAddress,
-                    erc20BalancesByOwner,
-                    erc721TokenIdsByOwner,
-                ),
+                exchangeWrapper.matchOrdersAsync(signedOrderLeft, signedOrderRight, takerAddress),
                 RevertReason.NegativeSpreadRequired,
             );
         });
@@ -680,13 +674,7 @@ describe('matchOrders', () => {
             });
             // Match orders
             return expectRevertReasonOrAlwaysFailingTransactionAsync(
-                matchOrderTester.matchOrdersAndVerifyBalancesAsync(
-                    signedOrderLeft,
-                    signedOrderRight,
-                    takerAddress,
-                    erc20BalancesByOwner,
-                    erc721TokenIdsByOwner,
-                ),
+                exchangeWrapper.matchOrdersAsync(signedOrderLeft, signedOrderRight, takerAddress),
                 // We are assuming assetData fields of the right order are the
                 // reverse of the left order, rather than checking equality. This
                 // saves a bunch of gas, but as a result if the assetData fields are
@@ -715,13 +703,7 @@ describe('matchOrders', () => {
             });
             // Match orders
             return expectRevertReasonOrAlwaysFailingTransactionAsync(
-                matchOrderTester.matchOrdersAndVerifyBalancesAsync(
-                    signedOrderLeft,
-                    signedOrderRight,
-                    takerAddress,
-                    erc20BalancesByOwner,
-                    erc721TokenIdsByOwner,
-                ),
+                exchangeWrapper.matchOrdersAsync(signedOrderLeft, signedOrderRight, takerAddress),
                 RevertReason.InvalidOrderSignature,
             );
         });


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR fixes the assertions to work for an edge case on Geth: `sendTrasnaction` succeeds but the txReceipt has a status code of 0, indicating a failure.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
