### PR TITLE
use bullets, not a task list, for Types of Changes

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -8,11 +8,13 @@
 
 ## Types of changes
 
-<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->
 
-*   [ ] Bug fix (non-breaking change which fixes an issue)
-*   [ ] New feature (non-breaking change which adds functionality)
-*   [ ] Breaking change (fix or feature that would cause existing functionality to change)
+<!-- * Bug fix (non-breaking change which fixes an issue) -->
+
+<!-- * New feature (non-breaking change which adds functionality) -->
+
+<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->
 
 ## Checklist:
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Instead of using a task list to indicate Types of Changes in a PR, have contributors uncomment bullets instead.

I get mildly annoyed when I see a PR summary, such as in [the list of PR's](https://github.com/0xProject/0x-monorepo/pulls), and it says "X of 8", meaning that X of 8 task list items have been completed.  Having some tasks that will *never* be completed (eg the `Bug fix` item on a `New feature` PR) defeats the purpose of the task list, and makes the "X of 8" summary unreliable enough that it just gets ignored.

In the future I think we can put more thought into the actual "Checklist" items in the template, to phrase them such that people should check them off if they're undone and not-applicable.  (For example, perhaps the first one could be "Documentation has been updated or doesn't need changing.")  But for now I thought the change in this PR would be a good first step and provide food for thought.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->
Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [X] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
