### PR TITLE
in subproviders/package.json, cite typescript-typings only once

### DIFF
--- a/packages/subproviders/package.json
+++ b/packages/subproviders/package.json
@@ -42,7 +42,7 @@
     "dependencies": {
         "@0xproject/assert": "^0.2.12",
         "@0xproject/types": "^0.8.1",
-        "@0xproject/typescript-typings": "^0.4.1",
+        "@0xproject/typescript-typings": "^0.4.2",
         "@0xproject/utils": "^0.7.1",
         "@ledgerhq/hw-app-eth": "^4.3.0",
         "@ledgerhq/hw-transport-u2f": "^4.3.0",
@@ -61,7 +61,6 @@
     "devDependencies": {
         "@0xproject/monorepo-scripts": "^0.2.1",
         "@0xproject/tslint-config": "^0.4.20",
-        "@0xproject/typescript-typings": "^0.4.2",
         "@0xproject/utils": "^0.7.1",
         "@types/bip39": "^2.4.0",
         "@types/bn.js": "^4.11.0",


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
`yarn build` was giving the following warning:

```
gene@precision5510:~/0x-monorepo/packages/subproviders$ yarn build
yarn run v1.7.0
warning package.json: "dependencies" has dependency "@0xproject/typescript-typings" with range "^0.4.1" that collides with a dependency in "devDependencies" of the same name with version "^0.4.2"
$ tsc && copyfiles -u 3 './lib/src/monorepo_scripts/**/*' ./scripts
Done in 2.82s.
```

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [X] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
