### PR TITLE
FillOrder Combinatorial Testing Fixes

### DIFF
--- a/packages/contracts/src/utils/asset_wrapper.ts
+++ b/packages/contracts/src/utils/asset_wrapper.ts
@@ -85,8 +85,7 @@ export class AssetWrapper {
                         userAddress,
                     );
                 } else if (tokenOwner === userAddress && desiredBalance.eq(0)) {
-                    // Burn token
-                    // await erc721Wrapper.burnAsync(assetProxyData.tokenAddress, assetProxyData.tokenId, userAddress);
+                    // Transfer token to someone else
                     const userAddresses = await (erc721Wrapper as any)._web3Wrapper.getAvailableAddressesAsync();
                     const nonOwner = _.find(userAddresses, a => a !== userAddress);
                     await erc721Wrapper.transferFromAsync(

--- a/packages/contracts/src/utils/asset_wrapper.ts
+++ b/packages/contracts/src/utils/asset_wrapper.ts
@@ -86,7 +86,15 @@ export class AssetWrapper {
                     );
                 } else if (tokenOwner === userAddress && desiredBalance.eq(0)) {
                     // Burn token
-                    await erc721Wrapper.burnAsync(assetProxyData.tokenAddress, assetProxyData.tokenId, userAddress);
+                    // await erc721Wrapper.burnAsync(assetProxyData.tokenAddress, assetProxyData.tokenId, userAddress);
+                    const userAddresses = await (erc721Wrapper as any)._web3Wrapper.getAvailableAddressesAsync();
+                    const nonOwner = _.find(userAddresses, a => a !== userAddress);
+                    await erc721Wrapper.transferFromAsync(
+                        assetProxyData.tokenAddress,
+                        assetProxyData.tokenId,
+                        tokenOwner,
+                        nonOwner,
+                    );
                     return;
                 } else if (
                     (userAddress !== tokenOwner && desiredBalance.eq(0)) ||

--- a/packages/contracts/src/utils/core_combinatorial_utils.ts
+++ b/packages/contracts/src/utils/core_combinatorial_utils.ts
@@ -783,25 +783,17 @@ export class CoreCombinatorialUtils {
 
             case AllowanceAmountScenario.TooLow:
                 const tooLowAllowance = takerFee.minus(1);
-                await this.assetWrapper.setProxyAllowanceAsync(
-                    signedOrder.takerAddress,
-                    this.zrxAssetData,
-                    tooLowAllowance,
-                );
+                await this.assetWrapper.setProxyAllowanceAsync(this.takerAddress, this.zrxAssetData, tooLowAllowance);
                 break;
 
             case AllowanceAmountScenario.Exact:
                 const exactAllowance = takerFee;
-                await this.assetWrapper.setProxyAllowanceAsync(
-                    signedOrder.takerAddress,
-                    this.zrxAssetData,
-                    exactAllowance,
-                );
+                await this.assetWrapper.setProxyAllowanceAsync(this.takerAddress, this.zrxAssetData, exactAllowance);
                 break;
 
             case AllowanceAmountScenario.Unlimited:
                 await this.assetWrapper.setProxyAllowanceAsync(
-                    signedOrder.takerAddress,
+                    this.takerAddress,
                     this.zrxAssetData,
                     constants.UNLIMITED_ALLOWANCE_IN_BASE_UNITS,
                 );

--- a/packages/contracts/src/utils/core_combinatorial_utils.ts
+++ b/packages/contracts/src/utils/core_combinatorial_utils.ts
@@ -145,13 +145,39 @@ export class CoreCombinatorialUtils {
     public exchangeWrapper: ExchangeWrapper;
     public assetWrapper: AssetWrapper;
     public static generateFillOrderCombinations(): FillScenario[] {
-        const takerScenarios = [TakerScenario.Unspecified];
-        const feeRecipientScenarios = [FeeRecipientAddressScenario.EthUserAddress];
-        const makerAssetAmountScenario = [OrderAssetAmountScenario.Large];
-        const takerAssetAmountScenario = [OrderAssetAmountScenario.Large];
-        const makerFeeScenario = [OrderAssetAmountScenario.Large];
-        const takerFeeScenario = [OrderAssetAmountScenario.Large];
-        const expirationTimeSecondsScenario = [ExpirationTimeSecondsScenario.InFuture];
+        const takerScenarios = [
+            TakerScenario.Unspecified,
+            // TakerScenario.CorrectlySpecified,
+            // TakerScenario.IncorrectlySpecified,
+        ];
+        const feeRecipientScenarios = [
+            FeeRecipientAddressScenario.EthUserAddress,
+            // FeeRecipientAddressScenario.BurnAddress,
+        ];
+        const makerAssetAmountScenario = [
+            OrderAssetAmountScenario.Large,
+            // OrderAssetAmountScenario.Zero,
+            // OrderAssetAmountScenario.Small,
+        ];
+        const takerAssetAmountScenario = [
+            OrderAssetAmountScenario.Large,
+            // OrderAssetAmountScenario.Zero,
+            // OrderAssetAmountScenario.Small,
+        ];
+        const makerFeeScenario = [
+            OrderAssetAmountScenario.Large,
+            // OrderAssetAmountScenario.Small,
+            // OrderAssetAmountScenario.Zero,
+        ];
+        const takerFeeScenario = [
+            OrderAssetAmountScenario.Large,
+            // OrderAssetAmountScenario.Small,
+            // OrderAssetAmountScenario.Zero,
+        ];
+        const expirationTimeSecondsScenario = [
+            ExpirationTimeSecondsScenario.InFuture,
+            ExpirationTimeSecondsScenario.InPast,
+        ];
         const makerAssetDataScenario = [
             AssetDataScenario.ERC20FiveDecimals,
             AssetDataScenario.ERC20NonZRXEighteenDecimals,
@@ -164,15 +190,55 @@ export class CoreCombinatorialUtils {
             AssetDataScenario.ERC721,
             AssetDataScenario.ZRXFeeToken,
         ];
-        const takerAssetFillAmountScenario = [TakerAssetFillAmountScenario.ExactlyRemainingFillableTakerAssetAmount];
-        const makerAssetBalanceScenario = [BalanceAmountScenario.Higher];
-        const makerAssetAllowanceScenario = [AllowanceAmountScenario.Higher];
-        const makerZRXBalanceScenario = [BalanceAmountScenario.Higher];
-        const makerZRXAllowanceScenario = [AllowanceAmountScenario.Higher];
-        const takerAssetBalanceScenario = [BalanceAmountScenario.Higher];
-        const takerAssetAllowanceScenario = [AllowanceAmountScenario.Higher];
-        const takerZRXBalanceScenario = [BalanceAmountScenario.Higher];
-        const takerZRXAllowanceScenario = [AllowanceAmountScenario.Higher];
+        const takerAssetFillAmountScenario = [
+            TakerAssetFillAmountScenario.ExactlyRemainingFillableTakerAssetAmount,
+            // TakerAssetFillAmountScenario.GreaterThanRemainingFillableTakerAssetAmount,
+            // TakerAssetFillAmountScenario.LessThanRemainingFillableTakerAssetAmount,
+        ];
+        const makerAssetBalanceScenario = [
+            BalanceAmountScenario.Higher,
+            // BalanceAmountScenario.Exact,
+            // BalanceAmountScenario.TooLow,
+        ];
+        const makerAssetAllowanceScenario = [
+            AllowanceAmountScenario.Higher,
+            // AllowanceAmountScenario.Exact,
+            // AllowanceAmountScenario.TooLow,
+            // AllowanceAmountScenario.Unlimited,
+        ];
+        const makerZRXBalanceScenario = [
+            BalanceAmountScenario.Higher,
+            // BalanceAmountScenario.Exact,
+            // BalanceAmountScenario.TooLow,
+        ];
+        const makerZRXAllowanceScenario = [
+            AllowanceAmountScenario.Higher,
+            // AllowanceAmountScenario.Exact,
+            // AllowanceAmountScenario.TooLow,
+            // AllowanceAmountScenario.Unlimited,
+        ];
+        const takerAssetBalanceScenario = [
+            BalanceAmountScenario.Higher,
+            // BalanceAmountScenario.Exact,
+            // BalanceAmountScenario.TooLow,
+        ];
+        const takerAssetAllowanceScenario = [
+            AllowanceAmountScenario.Higher,
+            // AllowanceAmountScenario.Exact,
+            // AllowanceAmountScenario.TooLow,
+            // AllowanceAmountScenario.Unlimited,
+        ];
+        const takerZRXBalanceScenario = [
+            BalanceAmountScenario.Higher,
+            // BalanceAmountScenario.Exact,
+            // BalanceAmountScenario.TooLow,
+        ];
+        const takerZRXAllowanceScenario = [
+            AllowanceAmountScenario.Higher,
+            // AllowanceAmountScenario.Exact,
+            // AllowanceAmountScenario.TooLow,
+            // AllowanceAmountScenario.Unlimited,
+        ];
         const fillScenarioArrays = CoreCombinatorialUtils._getAllCombinations([
             takerScenarios,
             feeRecipientScenarios,

--- a/packages/contracts/src/utils/core_combinatorial_utils.ts
+++ b/packages/contracts/src/utils/core_combinatorial_utils.ts
@@ -165,6 +165,14 @@ export class CoreCombinatorialUtils {
             AssetDataScenario.ZRXFeeToken,
         ];
         const takerAssetFillAmountScenario = [TakerAssetFillAmountScenario.ExactlyRemainingFillableTakerAssetAmount];
+        const makerAssetBalanceScenario = [BalanceAmountScenario.Higher];
+        const makerAssetAllowanceScenario = [AllowanceAmountScenario.Higher];
+        const makerZRXBalanceScenario = [BalanceAmountScenario.Higher];
+        const makerZRXAllowanceScenario = [AllowanceAmountScenario.Higher];
+        const takerAssetBalanceScenario = [BalanceAmountScenario.Higher];
+        const takerAssetAllowanceScenario = [AllowanceAmountScenario.Higher];
+        const takerZRXBalanceScenario = [BalanceAmountScenario.Higher];
+        const takerZRXAllowanceScenario = [AllowanceAmountScenario.Higher];
         const fillScenarioArrays = CoreCombinatorialUtils._getAllCombinations([
             takerScenarios,
             feeRecipientScenarios,
@@ -176,6 +184,14 @@ export class CoreCombinatorialUtils {
             makerAssetDataScenario,
             takerAssetDataScenario,
             takerAssetFillAmountScenario,
+            makerAssetBalanceScenario,
+            makerAssetAllowanceScenario,
+            makerZRXBalanceScenario,
+            makerZRXAllowanceScenario,
+            takerAssetBalanceScenario,
+            takerAssetAllowanceScenario,
+            takerZRXBalanceScenario,
+            takerZRXAllowanceScenario,
         ]);
 
         const fillScenarios = _.map(fillScenarioArrays, fillScenarioArray => {
@@ -193,16 +209,16 @@ export class CoreCombinatorialUtils {
                 },
                 takerAssetFillAmountScenario: fillScenarioArray[9] as TakerAssetFillAmountScenario,
                 makerStateScenario: {
-                    traderAssetBalance: BalanceAmountScenario.Higher,
-                    traderAssetAllowance: AllowanceAmountScenario.Higher,
-                    zrxFeeBalance: BalanceAmountScenario.Higher,
-                    zrxFeeAllowance: AllowanceAmountScenario.Higher,
+                    traderAssetBalance: fillScenarioArray[10] as BalanceAmountScenario,
+                    traderAssetAllowance: fillScenarioArray[11] as AllowanceAmountScenario,
+                    zrxFeeBalance: fillScenarioArray[12] as BalanceAmountScenario,
+                    zrxFeeAllowance: fillScenarioArray[13] as AllowanceAmountScenario,
                 },
                 takerStateScenario: {
-                    traderAssetBalance: BalanceAmountScenario.Higher,
-                    traderAssetAllowance: AllowanceAmountScenario.Higher,
-                    zrxFeeBalance: BalanceAmountScenario.Higher,
-                    zrxFeeAllowance: AllowanceAmountScenario.Higher,
+                    traderAssetBalance: fillScenarioArray[14] as BalanceAmountScenario,
+                    traderAssetAllowance: fillScenarioArray[15] as AllowanceAmountScenario,
+                    zrxFeeBalance: fillScenarioArray[16] as BalanceAmountScenario,
+                    zrxFeeAllowance: fillScenarioArray[17] as AllowanceAmountScenario,
                 },
             };
             return fillScenario;

--- a/packages/contracts/test/exchange/fill_order.ts
+++ b/packages/contracts/test/exchange/fill_order.ts
@@ -67,13 +67,7 @@ describe('FillOrder Tests', () => {
         const test = (fillScenarios: FillScenario[]) => {
             _.forEach(fillScenarios, fillScenario => {
                 const orderScenario = fillScenario.orderScenario;
-                const description = `Combinatorial OrderFill: ${orderScenario.feeRecipientScenario} ${
-                    orderScenario.makerAssetAmountScenario
-                } ${orderScenario.takerAssetAmountScenario} ${orderScenario.makerFeeScenario} ${
-                    orderScenario.takerFeeScenario
-                } ${orderScenario.expirationTimeSecondsScenario} ${orderScenario.makerAssetDataScenario} ${
-                    orderScenario.takerAssetDataScenario
-                }`;
+                const description = `Combinatorial OrderFill: ${JSON.stringify(fillScenario)}`;
                 it(description, async () => {
                     await coreCombinatorialUtils.testFillOrderScenarioAsync(provider, fillScenario);
                 });

--- a/packages/order-utils/src/order_validation_utils.ts
+++ b/packages/order-utils/src/order_validation_utils.ts
@@ -140,11 +140,11 @@ export class OrderValidationUtils {
         takerAddress: string,
         zrxAssetData: string,
     ): Promise<BigNumber> {
-        if (fillTakerAssetAmount.eq(0)) {
-            throw new Error(RevertReason.InvalidTakerAmount);
-        }
         if (signedOrder.makerAssetAmount.eq(0) || signedOrder.takerAssetAmount.eq(0)) {
             throw new Error(RevertReason.OrderUnfillable);
+        }
+        if (fillTakerAssetAmount.eq(0)) {
+            throw new Error(RevertReason.InvalidTakerAmount);
         }
         const orderHash = orderHashUtils.getOrderHashHex(signedOrder);
         const isValid = await isValidSignatureAsync(


### PR DESCRIPTION
## Description

This PR fixes some issues found while running 20,000 orderFill scenarios.

- Added ability to permute maker/taker allowance/balance scenarios
- Fixed order of validation checks in TS implementation
- Transfer away ERC721 instead of burning
- Fix bug where we were using takerAddress from order (which could be nullAddress) instead of actual takerAddress.

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
