### PR TITLE
Add and apply solidity linter (V2, updated)

### DIFF
--- a/packages/contracts/.solhint.json
+++ b/packages/contracts/.solhint.json
@@ -1,0 +1,17 @@
+{
+    "extends": "default",
+    "rules": {
+        "bracket-align": "warn",
+        "code-complexity": "warn",
+        "const-name-snakecase": "warn",
+        "expression-indent": "warn",
+        "function-max-lines": "warn",
+        "statement-indent": "warn",
+        "indent": ["warn", 4],
+        "quotes": ["error", "double"],
+        "max-line-length": ["warn", 120],
+        "separate-by-one-line-in-contract": "warn",
+        "space-after-comma": "error",
+        "func-order": "warn"
+    }
+}

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -31,7 +31,8 @@
         "coverage:report:html": "istanbul report html && open coverage/index.html",
         "profiler:report:html": "istanbul report html && open coverage/index.html",
         "coverage:report:lcov": "istanbul report lcov",
-        "test:circleci": "yarn test"
+        "test:circleci": "yarn test",
+        "lint-contracts": "solhint src/2.0.0/**/*.sol"
     },
     "config": {
         "abis":
@@ -68,6 +69,7 @@
         "npm-run-all": "^4.1.2",
         "shx": "^0.2.2",
         "solc": "^0.4.24",
+        "solhint": "^1.2.1",
         "tslint": "5.8.0",
         "typescript": "2.7.1",
         "yargs": "^10.0.3"

--- a/packages/contracts/src/2.0.0/multisig/MultiSigWallet.sol
+++ b/packages/contracts/src/2.0.0/multisig/MultiSigWallet.sol
@@ -1,5 +1,7 @@
 pragma solidity ^0.4.10;
 
+// solhint-disable
+
 /// @title Multisignature wallet - Allows multiple parties to agree on transactions before execution.
 /// @author Stefan George - <stefan.george@consensys.net>
 contract MultiSigWallet {

--- a/packages/contracts/src/2.0.0/multisig/MultiSigWalletWithTimeLock.sol
+++ b/packages/contracts/src/2.0.0/multisig/MultiSigWalletWithTimeLock.sol
@@ -20,6 +20,8 @@ pragma solidity ^0.4.10;
 
 import "./MultiSigWallet.sol";
 
+// solhint-disable
+
 /// @title Multisignature wallet with time lock- Allows multiple parties to execute a transaction after a time lock has passed.
 /// @author Amir Bandeali - <amir@0xProject.com>
 contract MultiSigWalletWithTimeLock is MultiSigWallet {

--- a/packages/contracts/src/2.0.0/protocol/AssetProxy/MixinAuthorizable.sol
+++ b/packages/contracts/src/2.0.0/protocol/AssetProxy/MixinAuthorizable.sol
@@ -22,6 +22,7 @@ pragma experimental ABIEncoderV2;
 import "../../utils/Ownable/Ownable.sol";
 import "./mixins/MAuthorizable.sol";
 
+
 contract MixinAuthorizable is
     Ownable,
     MAuthorizable

--- a/packages/contracts/src/2.0.0/protocol/AssetProxy/interfaces/IAssetData.sol
+++ b/packages/contracts/src/2.0.0/protocol/AssetProxy/interfaces/IAssetData.sol
@@ -18,15 +18,18 @@
 
 pragma solidity ^0.4.23;
 
+
 // @dev Interface of the asset proxy's assetData.
 // The asset proxies take an ABI encoded `bytes assetData` as argument.
 // This argument is ABI encoded as one of the methods of this interface.
 interface IAssetData {
-    
+
+    // solhint-disable-next-line func-name-mixedcase
     function ERC20Token(address tokenContract)
         external
         pure;
     
+    // solhint-disable-next-line func-name-mixedcase
     function ERC721Token(
         address tokenContract,
         uint256 tokenId,

--- a/packages/contracts/src/2.0.0/protocol/AssetProxy/interfaces/IAssetProxy.sol
+++ b/packages/contracts/src/2.0.0/protocol/AssetProxy/interfaces/IAssetProxy.sol
@@ -21,6 +21,7 @@ pragma experimental ABIEncoderV2;
 
 import "./IAuthorizable.sol";
 
+
 contract IAssetProxy is
     IAuthorizable
 {

--- a/packages/contracts/src/2.0.0/protocol/AssetProxy/interfaces/IAuthorizable.sol
+++ b/packages/contracts/src/2.0.0/protocol/AssetProxy/interfaces/IAuthorizable.sol
@@ -21,6 +21,7 @@ pragma experimental ABIEncoderV2;
 
 import "../../../utils/Ownable/IOwnable.sol";
 
+
 contract IAuthorizable is
     IOwnable
 {

--- a/packages/contracts/src/2.0.0/protocol/AssetProxy/libs/LibAssetProxyErrors.sol
+++ b/packages/contracts/src/2.0.0/protocol/AssetProxy/libs/LibAssetProxyErrors.sol
@@ -18,6 +18,7 @@
 
 pragma solidity ^0.4.24;
 
+
 /// @dev This contract documents the revert reasons used in the AssetProxy contracts.
 /// This contract is intended to serve as a reference, but is not actually used for efficiency reasons.
 contract LibAssetProxyErrors {

--- a/packages/contracts/src/2.0.0/protocol/AssetProxy/mixins/MAuthorizable.sol
+++ b/packages/contracts/src/2.0.0/protocol/AssetProxy/mixins/MAuthorizable.sol
@@ -21,6 +21,7 @@ pragma experimental ABIEncoderV2;
 
 import "../interfaces/IAuthorizable.sol";
 
+
 contract MAuthorizable is
     IAuthorizable
 {

--- a/packages/contracts/src/2.0.0/protocol/AssetProxyOwner/AssetProxyOwner.sol
+++ b/packages/contracts/src/2.0.0/protocol/AssetProxyOwner/AssetProxyOwner.sol
@@ -21,6 +21,7 @@ pragma solidity ^0.4.10;
 import "../../multisig/MultiSigWalletWithTimeLock.sol";
 import "../../utils/LibBytes/LibBytes.sol";
 
+
 contract AssetProxyOwner is
     MultiSigWalletWithTimeLock
 {

--- a/packages/contracts/src/2.0.0/protocol/Exchange/Exchange.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/Exchange.sol
@@ -27,6 +27,7 @@ import "./MixinAssetProxyDispatcher.sol";
 import "./MixinTransactions.sol";
 import "./MixinMatchOrders.sol";
 
+
 contract Exchange is
     MixinExchangeCore,
     MixinMatchOrders,

--- a/packages/contracts/src/2.0.0/protocol/Exchange/MixinAssetProxyDispatcher.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/MixinAssetProxyDispatcher.sol
@@ -23,6 +23,7 @@ import "../../utils/LibBytes/LibBytes.sol";
 import "./mixins/MAssetProxyDispatcher.sol";
 import "../AssetProxy/interfaces/IAssetProxy.sol";
 
+
 contract MixinAssetProxyDispatcher is
     Ownable,
     MAssetProxyDispatcher

--- a/packages/contracts/src/2.0.0/protocol/Exchange/MixinExchangeCore.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/MixinExchangeCore.sol
@@ -28,6 +28,7 @@ import "./mixins/MSignatureValidator.sol";
 import "./mixins/MTransactions.sol";
 import "./mixins/MAssetProxyDispatcher.sol";
 
+
 contract MixinExchangeCore is
     LibConstants,
     LibMath,

--- a/packages/contracts/src/2.0.0/protocol/Exchange/MixinMatchOrders.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/MixinMatchOrders.sol
@@ -23,6 +23,7 @@ import "./mixins/MMatchOrders.sol";
 import "./mixins/MTransactions.sol";
 import "./mixins/MAssetProxyDispatcher.sol";
 
+
 contract MixinMatchOrders is
     LibConstants,
     LibMath,

--- a/packages/contracts/src/2.0.0/protocol/Exchange/MixinSignatureValidator.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/MixinSignatureValidator.sol
@@ -24,6 +24,7 @@ import "./mixins/MTransactions.sol";
 import "./interfaces/IWallet.sol";
 import "./interfaces/IValidator.sol";
 
+
 contract MixinSignatureValidator is
     MSignatureValidator,
     MTransactions

--- a/packages/contracts/src/2.0.0/protocol/Exchange/MixinTransactions.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/MixinTransactions.sol
@@ -22,6 +22,7 @@ import "./mixins/MSignatureValidator.sol";
 import "./mixins/MTransactions.sol";
 import "./libs/LibEIP712.sol";
 
+
 contract MixinTransactions is
     LibEIP712,
     MSignatureValidator,

--- a/packages/contracts/src/2.0.0/protocol/Exchange/MixinWrapperFunctions.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/MixinWrapperFunctions.sol
@@ -24,6 +24,7 @@ import "./libs/LibOrder.sol";
 import "./libs/LibFillResults.sol";
 import "./mixins/MExchangeCore.sol";
 
+
 contract MixinWrapperFunctions is
     LibMath,
     LibFillResults,

--- a/packages/contracts/src/2.0.0/protocol/Exchange/interfaces/IAssetProxyDispatcher.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/interfaces/IAssetProxyDispatcher.sol
@@ -18,6 +18,7 @@
 
 pragma solidity ^0.4.24;
 
+
 contract IAssetProxyDispatcher {
 
     /// @dev Registers an asset proxy to its asset proxy id.

--- a/packages/contracts/src/2.0.0/protocol/Exchange/interfaces/IExchange.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/interfaces/IExchange.sol
@@ -26,6 +26,7 @@ import "./ITransactions.sol";
 import "./IAssetProxyDispatcher.sol";
 import "./IWrapperFunctions.sol";
 
+
 contract IExchange is
     IExchangeCore,
     IMatchOrders,

--- a/packages/contracts/src/2.0.0/protocol/Exchange/interfaces/IExchangeCore.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/interfaces/IExchangeCore.sol
@@ -22,6 +22,7 @@ pragma experimental ABIEncoderV2;
 import "../libs/LibOrder.sol";
 import "../libs/LibFillResults.sol";
 
+
 contract IExchangeCore {
 
     /// @dev Cancels all orders created by makerAddress with a salt less than or equal to the targetOrderEpoch

--- a/packages/contracts/src/2.0.0/protocol/Exchange/interfaces/IMatchOrders.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/interfaces/IMatchOrders.sol
@@ -21,6 +21,7 @@ pragma experimental ABIEncoderV2;
 import "../libs/LibOrder.sol";
 import "../libs/LibFillResults.sol";
 
+
 contract IMatchOrders {
 
     /// @dev Match two complementary orders that have a profitable spread.

--- a/packages/contracts/src/2.0.0/protocol/Exchange/interfaces/ISignatureValidator.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/interfaces/ISignatureValidator.sol
@@ -18,6 +18,7 @@
 
 pragma solidity ^0.4.24;
 
+
 contract ISignatureValidator {
 
     /// @dev Approves a hash on-chain using any valid signature type.

--- a/packages/contracts/src/2.0.0/protocol/Exchange/interfaces/ITransactions.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/interfaces/ITransactions.sol
@@ -17,6 +17,7 @@
 */
 pragma solidity ^0.4.24;
 
+
 contract ITransactions {
 
     /// @dev Executes an exchange method call in the context of signer.

--- a/packages/contracts/src/2.0.0/protocol/Exchange/interfaces/IValidator.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/interfaces/IValidator.sol
@@ -18,6 +18,7 @@
 
 pragma solidity ^0.4.23;
 
+
 contract IValidator {
 
     /// @dev Verifies that a signature is valid.

--- a/packages/contracts/src/2.0.0/protocol/Exchange/interfaces/IWallet.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/interfaces/IWallet.sol
@@ -18,6 +18,7 @@
 
 pragma solidity ^0.4.24;
 
+
 contract IWallet {
 
     /// @dev Verifies that a signature is valid.

--- a/packages/contracts/src/2.0.0/protocol/Exchange/interfaces/IWrapperFunctions.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/interfaces/IWrapperFunctions.sol
@@ -22,6 +22,7 @@ pragma experimental ABIEncoderV2;
 import "../libs/LibOrder.sol";
 import "../libs/LibFillResults.sol";
 
+
 contract IWrapperFunctions {
     /// @dev Fills the input order. Reverts if exact takerAssetFillAmount not filled.
     /// @param order LibOrder.Order struct containing order specifications.

--- a/packages/contracts/src/2.0.0/protocol/Exchange/libs/LibConstants.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/libs/LibConstants.sol
@@ -18,11 +18,13 @@
 
 pragma solidity ^0.4.24;
 
+
 contract LibConstants {
    
     // Asset data for ZRX token. Used for fee transfers.
     // @TODO: Hardcode constant when we deploy. Currently 
     //        not constant to make testing easier.
+    // solhint-disable-next-line var-name-mixedcase
     bytes public ZRX_ASSET_DATA;
 
     // @TODO: Remove when we deploy.

--- a/packages/contracts/src/2.0.0/protocol/Exchange/libs/LibEIP712.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/libs/LibEIP712.sol
@@ -18,6 +18,7 @@
 
 pragma solidity ^0.4.24;
 
+
 contract LibEIP712 {
     // EIP191 header for EIP712 prefix
     string constant EIP191_HEADER = "\x19\x01";
@@ -38,6 +39,7 @@ contract LibEIP712 {
     ));
 
     // Hash of the EIP712 Domain Separator data
+    // solhint-disable-next-line var-name-mixedcase
     bytes32 public EIP712_DOMAIN_HASH;
 
     constructor ()

--- a/packages/contracts/src/2.0.0/protocol/Exchange/libs/LibExchangeErrors.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/libs/LibExchangeErrors.sol
@@ -18,6 +18,7 @@
 
 pragma solidity ^0.4.24;
 
+
 /// @dev This contract documents the revert reasons used in the Exchange contract.
 /// This contract is intended to serve as a reference, but is not actually used for efficiency reasons.
 contract LibExchangeErrors {

--- a/packages/contracts/src/2.0.0/protocol/Exchange/libs/LibFillResults.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/libs/LibFillResults.sol
@@ -20,6 +20,7 @@ pragma solidity ^0.4.24;
 
 import "../../../utils/SafeMath/SafeMath.sol";
 
+
 contract LibFillResults is
     SafeMath
 {

--- a/packages/contracts/src/2.0.0/protocol/Exchange/libs/LibMath.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/libs/LibMath.sol
@@ -20,6 +20,7 @@ pragma solidity ^0.4.24;
 
 import "../../../utils/SafeMath/SafeMath.sol";
 
+
 contract LibMath is
     SafeMath
 {

--- a/packages/contracts/src/2.0.0/protocol/Exchange/libs/LibOrder.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/libs/LibOrder.sol
@@ -20,6 +20,7 @@ pragma solidity ^0.4.24;
 
 import "./LibEIP712.sol";
 
+
 contract LibOrder is
     LibEIP712
 {
@@ -115,17 +116,20 @@ contract LibOrder is
         //   ));
         assembly {
             // Backup
+            // solhint-disable-next-line space-after-comma
             let temp1 := mload(sub(order,  32))
             let temp2 := mload(add(order, 320))
             let temp3 := mload(add(order, 352))
             
             // Hash in place
+            // solhint-disable-next-line space-after-comma
             mstore(sub(order,  32), schemaHash)
             mstore(add(order, 320), makerAssetDataHash)
             mstore(add(order, 352), takerAssetDataHash)
             result := keccak256(sub(order, 32), 416)
             
             // Restore
+            // solhint-disable-next-line space-after-comma
             mstore(sub(order,  32), temp1)
             mstore(add(order, 320), temp2)
             mstore(add(order, 352), temp3)

--- a/packages/contracts/src/2.0.0/protocol/Exchange/mixins/MAssetProxyDispatcher.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/mixins/MAssetProxyDispatcher.sol
@@ -21,6 +21,7 @@ pragma experimental ABIEncoderV2;
 
 import "../interfaces/IAssetProxyDispatcher.sol";
 
+
 contract MAssetProxyDispatcher is
     IAssetProxyDispatcher
 {

--- a/packages/contracts/src/2.0.0/protocol/Exchange/mixins/MExchangeCore.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/mixins/MExchangeCore.sol
@@ -23,6 +23,7 @@ import "../libs/LibOrder.sol";
 import "../libs/LibFillResults.sol";
 import "../interfaces/IExchangeCore.sol";
 
+
 contract MExchangeCore is
     IExchangeCore
 {

--- a/packages/contracts/src/2.0.0/protocol/Exchange/mixins/MMatchOrders.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/mixins/MMatchOrders.sol
@@ -22,6 +22,7 @@ import "../libs/LibOrder.sol";
 import "../libs/LibFillResults.sol";
 import "../interfaces/IMatchOrders.sol";
 
+
 contract MMatchOrders is
     IMatchOrders
 {

--- a/packages/contracts/src/2.0.0/protocol/Exchange/mixins/MSignatureValidator.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/mixins/MSignatureValidator.sol
@@ -20,6 +20,7 @@ pragma solidity ^0.4.24;
 
 import "../interfaces/ISignatureValidator.sol";
 
+
 contract MSignatureValidator is
     ISignatureValidator
 {

--- a/packages/contracts/src/2.0.0/protocol/Exchange/mixins/MTransactions.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/mixins/MTransactions.sol
@@ -19,6 +19,7 @@ pragma solidity ^0.4.24;
 
 import "../interfaces/ITransactions.sol";
 
+
 contract MTransactions is
     ITransactions
 {

--- a/packages/contracts/src/2.0.0/test/DummyERC20Token/DummyERC20Token.sol
+++ b/packages/contracts/src/2.0.0/test/DummyERC20Token/DummyERC20Token.sol
@@ -22,6 +22,7 @@ pragma experimental ABIEncoderV2;
 import "../Mintable/Mintable.sol";
 import "../../utils/Ownable/Ownable.sol";
 
+
 contract DummyERC20Token is Mintable, Ownable {
     string public name;
     string public symbol;

--- a/packages/contracts/src/2.0.0/test/DummyERC721Receiver/DummyERC721Receiver.sol
+++ b/packages/contracts/src/2.0.0/test/DummyERC721Receiver/DummyERC721Receiver.sol
@@ -27,6 +27,7 @@ pragma solidity ^0.4.24;
 
 import "../../tokens/ERC721Token/IERC721Receiver.sol";
 
+
 contract DummyERC721Receiver is
     IERC721Receiver
 {

--- a/packages/contracts/src/2.0.0/test/DummyERC721Token/DummyERC721Token.sol
+++ b/packages/contracts/src/2.0.0/test/DummyERC721Token/DummyERC721Token.sol
@@ -22,6 +22,7 @@ pragma experimental ABIEncoderV2;
 import "../../tokens/ERC721Token/ERC721Token.sol";
 import "../../utils/Ownable/Ownable.sol";
 
+
 contract DummyERC721Token is
     Ownable,
     ERC721Token

--- a/packages/contracts/src/2.0.0/test/ExchangeWrapper/ExchangeWrapper.sol
+++ b/packages/contracts/src/2.0.0/test/ExchangeWrapper/ExchangeWrapper.sol
@@ -22,9 +22,11 @@ pragma experimental ABIEncoderV2;
 import "../../protocol/Exchange/interfaces/IExchange.sol";
 import "../../protocol/Exchange/libs/LibOrder.sol";
 
+
 contract ExchangeWrapper {
 
     // Exchange contract.
+    // solhint-disable-next-line var-name-mixedcase
     IExchange EXCHANGE;
 
     constructor (address _exchange)

--- a/packages/contracts/src/2.0.0/test/Mintable/Mintable.sol
+++ b/packages/contracts/src/2.0.0/test/Mintable/Mintable.sol
@@ -22,6 +22,7 @@ pragma experimental ABIEncoderV2;
 import "../../tokens/UnlimitedAllowanceToken/UnlimitedAllowanceToken.sol";
 import "../../utils/SafeMath/SafeMath.sol";
 
+
 /*
  * Mintable
  * Base contract that creates a mintable UnlimitedAllowanceToken

--- a/packages/contracts/src/2.0.0/test/TestAssetProxyDispatcher/TestAssetProxyDispatcher.sol
+++ b/packages/contracts/src/2.0.0/test/TestAssetProxyDispatcher/TestAssetProxyDispatcher.sol
@@ -21,6 +21,7 @@ pragma experimental ABIEncoderV2;
 
 import "../../protocol/Exchange/MixinAssetProxyDispatcher.sol";
 
+
 contract TestAssetProxyDispatcher is MixinAssetProxyDispatcher {
     function publicDispatchTransferFrom(
         bytes memory assetData,

--- a/packages/contracts/src/2.0.0/test/TestAssetProxyOwner/TestAssetProxyOwner.sol
+++ b/packages/contracts/src/2.0.0/test/TestAssetProxyOwner/TestAssetProxyOwner.sol
@@ -20,6 +20,7 @@ pragma solidity ^0.4.24;
 
 import "../../protocol/AssetProxyOwner/AssetProxyOwner.sol";
 
+
 contract TestAssetProxyOwner is
     AssetProxyOwner
 {

--- a/packages/contracts/src/2.0.0/test/TestLibBytes/TestLibBytes.sol
+++ b/packages/contracts/src/2.0.0/test/TestLibBytes/TestLibBytes.sol
@@ -21,6 +21,7 @@ pragma experimental ABIEncoderV2;
 
 import "../../utils/LibBytes/LibBytes.sol";
 
+
 contract TestLibBytes {
     
     using LibBytes for bytes;

--- a/packages/contracts/src/2.0.0/test/TestLibs/TestLibs.sol
+++ b/packages/contracts/src/2.0.0/test/TestLibs/TestLibs.sol
@@ -23,6 +23,7 @@ import "../../protocol/Exchange/libs/LibMath.sol";
 import "../../protocol/Exchange/libs/LibOrder.sol";
 import "../../protocol/Exchange/libs/LibFillResults.sol";
 
+
 contract TestLibs is 
     LibMath,
     LibOrder,

--- a/packages/contracts/src/2.0.0/test/TestSignatureValidator/TestSignatureValidator.sol
+++ b/packages/contracts/src/2.0.0/test/TestSignatureValidator/TestSignatureValidator.sol
@@ -22,6 +22,7 @@ pragma experimental ABIEncoderV2;
 import "../../protocol/Exchange/MixinSignatureValidator.sol";
 import "../../protocol/Exchange/MixinTransactions.sol";
 
+
 contract TestSignatureValidator is
     MixinSignatureValidator,
     MixinTransactions

--- a/packages/contracts/src/2.0.0/test/TestValidator/TestValidator.sol
+++ b/packages/contracts/src/2.0.0/test/TestValidator/TestValidator.sol
@@ -20,11 +20,13 @@ pragma solidity ^0.4.24;
 
 import "../../protocol/Exchange/interfaces/IValidator.sol";
 
+
 contract TestValidator is 
     IValidator
 {
 
     // The single valid signer for this wallet.
+    // solhint-disable-next-line var-name-mixedcase
     address VALID_SIGNER;
 
     /// @dev constructs a new `TestValidator` with a single valid signer.

--- a/packages/contracts/src/2.0.0/test/TestWallet/TestWallet.sol
+++ b/packages/contracts/src/2.0.0/test/TestWallet/TestWallet.sol
@@ -21,6 +21,7 @@ pragma solidity ^0.4.24;
 import "../../protocol/Exchange/interfaces/IWallet.sol";
 import "../../utils/LibBytes/LibBytes.sol";
 
+
 contract TestWallet is 
     IWallet
 {
@@ -29,6 +30,7 @@ contract TestWallet is
     string constant LENGTH_65_REQUIRED = "LENGTH_65_REQUIRED";
 
     // The owner of this wallet.
+    // solhint-disable-next-line var-name-mixedcase
     address WALLET_OWNER;
 
     /// @dev constructs a new `TestWallet` with a single owner.

--- a/packages/contracts/src/2.0.0/test/Whitelist/Whitelist.sol
+++ b/packages/contracts/src/2.0.0/test/Whitelist/Whitelist.sol
@@ -23,6 +23,7 @@ import "../../protocol/Exchange/interfaces/IExchange.sol";
 import "../../protocol/Exchange/libs/LibOrder.sol";
 import "../../utils/Ownable/Ownable.sol";
 
+
 contract Whitelist is
     Ownable
 {
@@ -35,15 +36,19 @@ contract Whitelist is
     mapping (address => bool) public isWhitelisted;
 
     // Exchange contract.
+    // solhint-disable-next-line var-name-mixedcase
     IExchange EXCHANGE;
 
     byte constant VALIDATOR_SIGNATURE_BYTE = "\x06";
+    // solhint-disable-next-line var-name-mixedcase
     bytes TX_ORIGIN_SIGNATURE;
 
     constructor (address _exchange)
         public
     {
+        // solhint-disable-next-line var-name-mixedcase
         EXCHANGE = IExchange(_exchange);
+        // solhint-disable-next-line var-name-mixedcase
         TX_ORIGIN_SIGNATURE = abi.encodePacked(address(this), VALIDATOR_SIGNATURE_BYTE);
     }
 

--- a/packages/contracts/src/2.0.0/tokens/ERC20Token/ERC20Token.sol
+++ b/packages/contracts/src/2.0.0/tokens/ERC20Token/ERC20Token.sol
@@ -21,6 +21,7 @@ pragma experimental ABIEncoderV2;
 
 import "./IERC20Token.sol";
 
+
 contract ERC20Token is IERC20Token {
 
     string constant INSUFFICIENT_BALANCE = "ERC20_INSUFFICIENT_BALANCE";

--- a/packages/contracts/src/2.0.0/tokens/ERC20Token/IERC20Token.sol
+++ b/packages/contracts/src/2.0.0/tokens/ERC20Token/IERC20Token.sol
@@ -19,6 +19,7 @@
 pragma solidity ^0.4.24;
 pragma experimental ABIEncoderV2;
 
+
 contract IERC20Token {
 
     /// @notice send `value` token to `to` from `msg.sender`

--- a/packages/contracts/src/2.0.0/tokens/ERC721Token/ERC721Token.sol
+++ b/packages/contracts/src/2.0.0/tokens/ERC721Token/ERC721Token.sol
@@ -29,6 +29,7 @@ import "./IERC721Token.sol";
 import "./IERC721Receiver.sol";
 import "../../utils/SafeMath/SafeMath.sol";
 
+
 /**
  * @title ERC721 Non-Fungible Token Standard basic implementation
  * @dev see https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md

--- a/packages/contracts/src/2.0.0/tokens/ERC721Token/IERC721Receiver.sol
+++ b/packages/contracts/src/2.0.0/tokens/ERC721Token/IERC721Receiver.sol
@@ -25,6 +25,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 pragma solidity ^0.4.24;
 
+
 /**
  * @title ERC721 token receiver interface
  * @dev Interface for any contract that wants to support safeTransfers

--- a/packages/contracts/src/2.0.0/tokens/ERC721Token/IERC721Token.sol
+++ b/packages/contracts/src/2.0.0/tokens/ERC721Token/IERC721Token.sol
@@ -25,6 +25,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 pragma solidity ^0.4.24;
 
+
 /**
  * @title ERC721 Non-Fungible Token Standard basic interface
  * @dev see https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md

--- a/packages/contracts/src/2.0.0/tokens/UnlimitedAllowanceToken/UnlimitedAllowanceToken.sol
+++ b/packages/contracts/src/2.0.0/tokens/UnlimitedAllowanceToken/UnlimitedAllowanceToken.sol
@@ -21,6 +21,7 @@ pragma experimental ABIEncoderV2;
 
 import "../ERC20Token/ERC20Token.sol";
 
+
 contract UnlimitedAllowanceToken is ERC20Token {
 
     uint256 constant MAX_UINT = 2**256 - 1;

--- a/packages/contracts/src/2.0.0/tokens/WETH9/WETH9.sol
+++ b/packages/contracts/src/2.0.0/tokens/WETH9/WETH9.sol
@@ -15,6 +15,7 @@
 
 pragma solidity ^0.4.18;
 
+
 contract WETH9 {
     string public name     = "Wrapped Ether";
     string public symbol   = "WETH";

--- a/packages/contracts/src/2.0.0/tokens/ZRXToken/ZRXToken.sol
+++ b/packages/contracts/src/2.0.0/tokens/ZRXToken/ZRXToken.sol
@@ -20,6 +20,8 @@ pragma solidity ^0.4.11;
 
 import { UnlimitedAllowanceToken_v1 as UnlimitedAllowanceToken } from "../../../1.0.0/UnlimitedAllowanceToken/UnlimitedAllowanceToken_v1.sol";
 
+
+
 contract ZRXToken is UnlimitedAllowanceToken {
 
     uint8 constant public decimals = 18;

--- a/packages/contracts/src/2.0.0/utils/LibBytes/LibBytes.sol
+++ b/packages/contracts/src/2.0.0/utils/LibBytes/LibBytes.sol
@@ -18,6 +18,7 @@
 
 pragma solidity ^0.4.24;
 
+
 library LibBytes {
 
     using LibBytes for bytes;

--- a/packages/contracts/src/2.0.0/utils/Ownable/Ownable.sol
+++ b/packages/contracts/src/2.0.0/utils/Ownable/Ownable.sol
@@ -10,6 +10,7 @@ pragma experimental ABIEncoderV2;
 
 import "./IOwnable.sol";
 
+
 contract Ownable is IOwnable {
     address public owner;
 

--- a/packages/contracts/src/2.0.0/utils/SafeMath/SafeMath.sol
+++ b/packages/contracts/src/2.0.0/utils/SafeMath/SafeMath.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.4.24;
 pragma experimental ABIEncoderV2;
 
+
 contract SafeMath {
     function safeMul(uint a, uint b)
         internal

--- a/yarn.lock
+++ b/yarn.lock
@@ -557,6 +557,16 @@ acorn-dynamic-import@^2.0.0:
   dependencies:
     acorn "^4.0.3"
 
+acorn-jsx@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
+  dependencies:
+    acorn "^3.0.4"
+
+acorn@^3.0.4:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
+
 acorn@^4.0.3:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
@@ -564,6 +574,10 @@ acorn@^4.0.3:
 acorn@^5.0.0:
   version "5.5.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
+
+acorn@^5.5.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
 
 add-stream@^1.0.0:
   version "1.0.0"
@@ -577,6 +591,10 @@ aes-js@^0.2.3:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-0.2.4.tgz#94b881ab717286d015fa219e08fb66709dda5a3d"
 
+ajv-keywords@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
+
 ajv-keywords@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.1.0.tgz#ac2b27939c543e95d2c06e7f7f5c27be4aa543be"
@@ -588,7 +606,7 @@ ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.1.0:
+ajv@^5.1.0, ajv@^5.2.3, ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
   dependencies:
@@ -675,6 +693,10 @@ ansi-styles@~1.0.0:
 ansi-wrap@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/ansi-wrap/-/ansi-wrap-0.1.0.tgz#a82250ddb0015e9a27ca82e82ea603bbfa45efaf"
+
+antlr4@4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/antlr4/-/antlr4-4.7.0.tgz#297f956ddc06f83397fc0990ecf2e0cf20bfbbee"
 
 any-observable@^0.2.0:
   version "0.2.0"
@@ -2181,6 +2203,16 @@ call-me-maybe@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.1.tgz#26d208ea89e37b5cbde60250a15f031c16a4d66b"
 
+caller-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
+  dependencies:
+    callsites "^0.2.0"
+
+callsites@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
+
 camelcase-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
@@ -2373,6 +2405,10 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
 circular-json@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.1.tgz#be8b36aefccde8b3ca7aa2d6afc07a37242c0d2d"
+
+circular-json@^0.3.1:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
 
 clap@^1.0.9:
   version "1.2.3"
@@ -2686,7 +2722,7 @@ concat-stream@^1.4.10, concat-stream@^1.5.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-concat-stream@^1.5.1:
+concat-stream@^1.5.1, concat-stream@^1.6.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   dependencies:
@@ -3480,6 +3516,18 @@ defined@^1.0.0, defined@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
 
+del@^2.0.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/del/-/del-2.2.2.tgz#c12c981d067846c84bcaf862cff930d907ffd1a8"
+  dependencies:
+    globby "^5.0.0"
+    is-path-cwd "^1.0.0"
+    is-path-in-cwd "^1.0.0"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+    rimraf "^2.2.8"
+
 del@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/del/-/del-3.0.0.tgz#53ecf699ffcbcb39637691ab13baf160819766e5"
@@ -3622,6 +3670,12 @@ doctrine@^0.7.2:
   dependencies:
     esutils "^1.1.6"
     isarray "0.0.1"
+
+doctrine@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  dependencies:
+    esutils "^2.0.2"
 
 dom-helpers@^3.2.0:
   version "3.3.1"
@@ -3971,6 +4025,67 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-scope@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint-visitor-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
+
+eslint@^4.19.1:
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.19.1.tgz#32d1d653e1d90408854bfb296f076ec7e186a300"
+  dependencies:
+    ajv "^5.3.0"
+    babel-code-frame "^6.22.0"
+    chalk "^2.1.0"
+    concat-stream "^1.6.0"
+    cross-spawn "^5.1.0"
+    debug "^3.1.0"
+    doctrine "^2.1.0"
+    eslint-scope "^3.7.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^3.5.4"
+    esquery "^1.0.0"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^11.0.1"
+    ignore "^3.3.3"
+    imurmurhash "^0.1.4"
+    inquirer "^3.0.6"
+    is-resolvable "^1.0.0"
+    js-yaml "^3.9.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.4"
+    minimatch "^3.0.2"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.2"
+    pluralize "^7.0.0"
+    progress "^2.0.0"
+    regexpp "^1.0.1"
+    require-uncached "^1.0.3"
+    semver "^5.3.0"
+    strip-ansi "^4.0.0"
+    strip-json-comments "~2.0.1"
+    table "4.0.2"
+    text-table "~0.2.0"
+
+espree@^3.5.4:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
+  dependencies:
+    acorn "^5.5.0"
+    acorn-jsx "^3.0.0"
+
 esprima@2.7.x, esprima@^2.6.0, esprima@^2.7.1:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
@@ -3978,6 +4093,12 @@ esprima@2.7.x, esprima@^2.6.0, esprima@^2.7.1:
 esprima@^4.0.0, esprima@~4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
+
+esquery@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
+  dependencies:
+    estraverse "^4.0.0"
 
 esrecurse@^4.1.0:
   version "4.2.1"
@@ -3989,7 +4110,7 @@ estraverse@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.9.3.tgz#af67f2dc922582415950926091a4005d29c9bb44"
 
-estraverse@^4.1.0, estraverse@^4.1.1:
+estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
@@ -4630,6 +4751,13 @@ figures@^2.0.0:
   dependencies:
     escape-string-regexp "^1.0.5"
 
+file-entry-cache@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-2.0.0.tgz#c392990c3e684783d838b8c84a45d8a048458361"
+  dependencies:
+    flat-cache "^1.2.1"
+    object-assign "^4.0.1"
+
 file-type@3.9.0, file-type@^3.6.0, file-type@^3.8.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/file-type/-/file-type-3.9.0.tgz#257a078384d1db8087bc449d107d52a52672b9e9"
@@ -4759,6 +4887,15 @@ first-chunk-stream@^2.0.0:
 flagged-respawn@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/flagged-respawn/-/flagged-respawn-1.0.0.tgz#4e79ae9b2eb38bf86b3bb56bf3e0a56aa5fcabd7"
+
+flat-cache@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.0.tgz#d3030b32b38154f4e3b7e9c709f490f7ef97c481"
+  dependencies:
+    circular-json "^0.3.1"
+    del "^2.0.2"
+    graceful-fs "^4.1.2"
+    write "^0.2.1"
 
 flatten@^1.0.2:
   version "1.0.2"
@@ -5266,9 +5403,24 @@ global@~4.3.0:
     min-document "^2.19.0"
     process "~0.5.1"
 
+globals@^11.0.1:
+  version "11.7.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.7.0.tgz#a583faa43055b1aca771914bf68258e2fc125673"
+
 globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
+
+globby@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-5.0.0.tgz#ebd84667ca0dbb330b99bcfc68eac2bc54370e0d"
+  dependencies:
+    array-union "^1.0.1"
+    arrify "^1.0.0"
+    glob "^7.0.3"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
 
 globby@^6.1.0:
   version "6.1.0"
@@ -5851,6 +6003,10 @@ ignore-by-default@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
 
+ignore@^3.3.3, ignore@^3.3.7:
+  version "3.3.10"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
+
 ignore@^3.3.5:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
@@ -5950,7 +6106,7 @@ inquirer@^0.8.2:
     rx "^2.4.3"
     through "^2.3.6"
 
-inquirer@^3.2.2:
+inquirer@^3.0.6, inquirer@^3.2.2:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
   dependencies:
@@ -6328,6 +6484,10 @@ is-relative@^1.0.0:
   dependencies:
     is-unc-path "^1.0.0"
 
+is-resolvable@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
+
 is-retry-allowed@^1.0.0, is-retry-allowed@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
@@ -6555,6 +6715,13 @@ js-yaml@3.x, js-yaml@^3.4.2, js-yaml@^3.6.1, js-yaml@^3.7.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^3.9.1:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 js-yaml@~3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
@@ -6653,6 +6820,10 @@ json-schema-traverse@^0.3.0:
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
+
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
 
 json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   version "1.0.1"
@@ -6950,7 +7121,7 @@ levelup@~0.19.0:
     semver "~5.1.0"
     xtend "~3.0.0"
 
-levn@~0.3.0:
+levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
   dependencies:
@@ -7890,6 +8061,10 @@ natives@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.3.tgz#44a579be64507ea2d6ed1ca04a9415915cf75558"
 
+natural-compare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
 ncp@1.0.x:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ncp/-/ncp-1.0.1.tgz#d15367e5cb87432ba117d2bf80fdf45aecfb4246"
@@ -8374,7 +8549,7 @@ optimist@^0.6.1:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
-optionator@^0.8.1:
+optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
   dependencies:
@@ -8640,7 +8815,7 @@ path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
-path-is-inside@^1.0.1:
+path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
@@ -8767,6 +8942,10 @@ plur@^2.1.2:
   resolved "https://registry.yarnpkg.com/plur/-/plur-2.1.2.tgz#7482452c1a0f508e3e344eaec312c91c29dc655a"
   dependencies:
     irregular-plurals "^1.0.0"
+
+pluralize@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
 
 polished@^1.9.2:
   version "1.9.2"
@@ -9954,6 +10133,10 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
+regexpp@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-1.1.0.tgz#0e3516dd0b7904f413d2d4193dce4618c3a689ab"
+
 regexpu-core@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-1.0.0.tgz#86a763f58ee4d7c2f6b102e4764050de7ed90c6b"
@@ -10132,6 +10315,13 @@ require-package-name@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/require-package-name/-/require-package-name-2.0.1.tgz#c11e97276b65b8e2923f75dabf5fb2ef0c3841b9"
 
+require-uncached@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
+  dependencies:
+    caller-path "^0.1.0"
+    resolve-from "^1.0.0"
+
 requires-port@1.0.x, requires-port@1.x.x, requires-port@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -10152,6 +10342,10 @@ resolve-dir@^1.0.0, resolve-dir@^1.0.1:
 resolve-from@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
+
+resolve-from@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
 resolve-from@^2.0.0:
   version "2.0.0"
@@ -10683,6 +10877,12 @@ slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
 
+slice-ansi@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
+
 slide@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
@@ -10773,6 +10973,17 @@ solc@^0.4.23:
     require-from-string "^1.1.0"
     semver "^5.3.0"
     yargs "^4.7.1"
+
+solhint@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/solhint/-/solhint-1.2.1.tgz#59a1416cef94da38d587f768a73536d6e3403dd3"
+  dependencies:
+    antlr4 "4.7.0"
+    commander "2.11.0"
+    eslint "^4.19.1"
+    glob "7.1.2"
+    ignore "^3.3.7"
+    lodash "^4.17.10"
 
 solidity-parser-antlr@^0.2.12:
   version "0.2.12"
@@ -11339,6 +11550,17 @@ symbol@~0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/symbol/-/symbol-0.3.1.tgz#b6f9a900d496a57f02408f22198c109dda063041"
 
+table@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/table/-/table-4.0.2.tgz#a33447375391e766ad34d3486e6e2aedc84d2e36"
+  dependencies:
+    ajv "^5.2.3"
+    ajv-keywords "^2.1.0"
+    chalk "^2.1.0"
+    lodash "^4.17.4"
+    slice-ansi "1.0.0"
+    string-width "^2.1.1"
+
 tapable@^0.2.5, tapable@^0.2.7:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.2.8.tgz#99372a5c999bf2df160afc0d74bed4f47948cd22"
@@ -11478,7 +11700,7 @@ text-extensions@^1.0.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.7.0.tgz#faaaba2625ed746d568a23e4d0aacd9bf08a8b39"
 
-text-table@^0.2.0:
+text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
@@ -13003,6 +13225,12 @@ write-pkg@^3.1.0:
   dependencies:
     sort-keys "^2.0.0"
     write-json-file "^2.2.0"
+
+write@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
+  dependencies:
+    mkdirp "^0.5.1"
 
 ws@^3.0.0:
   version "3.3.3"


### PR DESCRIPTION
## Adds Security and [Style Guide](http://solidity.readthedocs.io/en/develop/style-guide.html) checking and validation on solidity contracts.

This PR adds [Solhint](https://github.com/protofire/solhint) to achieve this goal.
I have only updated the code on those contracts where it had no impact on the functionality, mostly indentation issues. This should make code review fairly straightforward.


I have only configured the linter to output a warning instead of throwing errors as a starting point. Solhint can add more value. If you like this approach, more time can be invested analyzing and fixing those issues. Or you can simply update the linter configuration to ignore them without a warning.

Run:
`npm run lint-contracts`