### PR TITLE
make PR template checklist more useful

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -18,12 +18,10 @@
 
 ## Checklist:
 
-<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 
-<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-
-*   [ ] Change requires a change to the documentation.
-*   [ ] Added tests to cover my changes.
+*   [ ] Prefixed the title of this PR with `[WIP]` if it is a work in progress.
+*   [ ] Prefixed the title of this PR with bracketed package name(s) corresponding to the changed package(s). For example: `[sol-cov] Fixed bug`.
+*   [ ] Added tests to cover my changes, or decided that tests would be too impractical.
+*   [ ] Updated documentation, or decided that no doc change is needed.
 *   [ ] Added new entries to the relevant CHANGELOG.jsons.
-*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
-*   [ ] Labeled this PR with the labels corresponding to the changed package.


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Goal is to make it so that every PR should check off every checklist item before it is considered complete.

Removed mention of labels.  Since contributors outside the org don't have permission to add labels, it's not possible for any such contributor to ever check those items off.  Opted instead to prescribe bracketed PR title prefixes, which are accessible to all.

Re-ordered checklist items to better represent chronological progress.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->
*  Meta

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
