### PR TITLE
Mine a dummy block in blockchain_lifecycle to re-apply any time offset

### DIFF
--- a/packages/dev-utils/src/blockchain_lifecycle.ts
+++ b/packages/dev-utils/src/blockchain_lifecycle.ts
@@ -34,6 +34,12 @@ export class BlockchainLifecycle {
                     blockNumber = await this._web3Wrapper.getBlockNumberAsync();
                 }
                 this._snapshotIdsStack.push(blockNumber);
+                // HACK(albrow) It's possible that we applied a time offset but
+                // the transaction we mined to put that time offset into the
+                // blockchain was reverted. As a workaround, we mine a new dummy
+                // block so that the latest block timestamp accounts for any
+                // possible time offsets.
+                await this._mineDummyBlockAsync();
                 break;
             default:
                 throw new Error(`Unknown node type: ${nodeType}`);
@@ -59,22 +65,9 @@ export class BlockchainLifecycle {
     }
     private async _mineMinimumBlocksAsync(): Promise<void> {
         logUtils.warn('WARNING: minimum block number for tests not met. Mining additional blocks...');
-        if (this._addresses.length === 0) {
-            this._addresses = await this._web3Wrapper.getAvailableAddressesAsync();
-            if (this._addresses.length === 0) {
-                throw new Error('No accounts found');
-            }
-        }
         while ((await this._web3Wrapper.getBlockNumberAsync()) < MINIMUM_BLOCKS) {
             logUtils.warn('Mining block...');
-            await this._web3Wrapper.awaitTransactionMinedAsync(
-                await this._web3Wrapper.sendTransactionAsync({
-                    from: this._addresses[0],
-                    to: this._addresses[0],
-                    value: '0',
-                }),
-                0,
-            );
+            await this._mineDummyBlockAsync();
         }
         logUtils.warn('Done mining the minimum number of blocks.');
     }
@@ -83,5 +76,23 @@ export class BlockchainLifecycle {
             this._nodeType = await this._web3Wrapper.getNodeTypeAsync();
         }
         return this._nodeType;
+    }
+    // Sends a transaction that has no real effect on the state and waits for it
+    // to be mined.
+    private async _mineDummyBlockAsync(): Promise<void> {
+        if (this._addresses.length === 0) {
+            this._addresses = await this._web3Wrapper.getAvailableAddressesAsync();
+            if (this._addresses.length === 0) {
+                throw new Error('No accounts found');
+            }
+        }
+        await this._web3Wrapper.awaitTransactionMinedAsync(
+            await this._web3Wrapper.sendTransactionAsync({
+                from: this._addresses[0],
+                to: this._addresses[0],
+                value: '0',
+            }),
+            0,
+        );
     }
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR fixes a subtle bug that can occur when using `increaseTimeAndMineBlockAsync` in conjunction with `revertAsync` on Geth.

`increaseTimeAndMineBlockAsync` mines a dummy block in order to set the timestamp of the latest block in the chain to the desired time + offset. (This is necessary because our smart contracts only know the time by looking at the latest block timestamp).

However, `revertAsync` can revert the dummy transaction we mined, making it so that the time offset is no longer visible on the chain. Even though there is not a block timestamp reflecting the time offset, it ***does*** still exist. From Geth's perspective that time still passed and it is working in the future. The mismatch between Geth's view of time and the latest block timestamp can cause problems.

There is a simple workaround to fix this issue. In __blockchain_lifecycle.ts__ we now always mine a dummy block in `startAsync` so that the time offset is guaranteed to be reflected in the timestamp of the latest mined block.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
