### PR TITLE
Rename json schema call data id to CallData. 

### DIFF
--- a/packages/json-schemas/CHANGELOG.json
+++ b/packages/json-schemas/CHANGELOG.json
@@ -9,6 +9,10 @@
             {
                 "note": "Added CallData schema",
                 "pr": 821
+            },
+            {
+                "note": "Update CallData schema id to CallData",
+                "pr": 894
             }
         ]
     },

--- a/packages/json-schemas/schemas/call_data_schema.ts
+++ b/packages/json-schemas/schemas/call_data_schema.ts
@@ -1,5 +1,5 @@
 export const callDataSchema = {
-    id: '/TxData',
+    id: '/CallData',
     properties: {
         from: { $ref: '/Address' },
         to: { $ref: '/Address' },

--- a/packages/order-utils/CHANGELOG.json
+++ b/packages/order-utils/CHANGELOG.json
@@ -9,6 +9,10 @@
             {
                 "note": "Export parseECSignature method",
                 "pr": 684
+            },
+            {
+                "note": "Handle Typed Arrays when hashing data",
+                "pr": 894
             }
         ]
     },

--- a/packages/order-utils/src/crypto.ts
+++ b/packages/order-utils/src/crypto.ts
@@ -32,7 +32,7 @@ export const crypto = {
                 argTypes.push('address');
             } else if (_.isString(arg)) {
                 argTypes.push('string');
-            } else if (_.isBuffer(arg)) {
+            } else if (_.isBuffer(arg) || _.isTypedArray(arg)) {
                 argTypes.push('bytes');
             } else if (_.isBoolean(arg)) {
                 argTypes.push('bool');


### PR DESCRIPTION
Check for TypedArray when hashing data in order-utils crypto

## Description

Rename json schema call data id to CallData. 
Support TypedArray when hashing data in order-utils. Ethereumjs-utils uses safe-buffer which can support both buffers and typed arrays. In certain environments (browsers) a TypedArray is returned, though lodash does not treat both cases as Buffer (`_.isBuffer` check fails). 

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Change requires a change to the documentation.
*   [ ] Added tests to cover my changes.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
*   [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
*   [ ] Labeled this PR with the labels corresponding to the changed package.
