### PR TITLE
Add marketUtils object for assisting with market buy calculations

### DIFF
--- a/packages/contract-wrappers/src/contract_wrappers/forwarder_wrapper.ts
+++ b/packages/contract-wrappers/src/contract_wrappers/forwarder_wrapper.ts
@@ -27,7 +27,7 @@ export class ForwarderWrapper extends ContractWrapper {
     /**
      * Takes an array of orders and returns a subset of those orders that has enough makerAssetAmount (taking into account on-chain balances,
      * allowances, and partial fills) in order to fill the input makerAssetFillAmount plus slippageBufferAmount. Iterates from first order to last.
-     * Sort the input by rate in order to get the subset of orders that will cost the least ETH.
+     * Sort the input by ascending rate in order to get the subset of orders that will cost the least ETH.
      * @param   signedOrders         An array of objects that conform to the SignedOrder interface. All orders should specify the same makerAsset.
      *                               All orders should specify WETH as the takerAsset.
      * @param   orderStates          An array of objects corresponding to the signedOrders parameter that each contain on-chain state
@@ -46,26 +46,81 @@ export class ForwarderWrapper extends ContractWrapper {
         assert.doesConformToSchema('signedOrders', signedOrders, schemas.signedOrdersSchema);
         assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
         assert.isBigNumber('slippageBufferAmount', slippageBufferAmount);
-        // calculate total amount of makerAsset needed to fill
+        // calculate total amount of makerAsset needed to be filled
         const totalFillAmount = makerAssetFillAmount.plus(slippageBufferAmount);
         // iterate through the signedOrders input from left to right until we have enough makerAsset to fill totalFillAmount
         const result = _.reduce(
             signedOrders,
             ({ resultOrders, remainingFillAmount }, order, index) => {
                 if (remainingFillAmount.lessThanOrEqualTo(constants.ZERO_AMOUNT)) {
-                    return { resultOrders, remainingFillAmount };
+                    return { resultOrders, remainingFillAmount: constants.ZERO_AMOUNT };
                 } else {
                     const orderState = orderStates[index];
-                    const orderRemainingFillableMakerAssetAmount = orderState.remainingFillableMakerAssetAmount;
+                    const makerAssetAmountAvailable = ForwarderWrapper._getMakerAssetAmountAvailable(orderState);
                     return {
                         resultOrders: _.concat(resultOrders, order),
-                        remainingFillAmount: remainingFillAmount.minus(orderState.remainingFillableMakerAssetAmount),
+                        remainingFillAmount: remainingFillAmount.minus(makerAssetAmountAvailable),
                     };
                 }
             },
             { resultOrders: [] as SignedOrder[], remainingFillAmount: totalFillAmount },
         );
         return result;
+    }
+    /**
+     * Takes an array of orders and an array of feeOrders. Returns a subset of the feeOrders that has enough ZRX (taking into account
+     * on-chain balances, allowances, and partial fills) in order to fill the takerFees required by signedOrders plus a
+     * slippageBufferAmount. Iterates from first feeOrder to last. Sort the feeOrders by ascending rate in order to get the subset of
+     * feeOrders that will cost the least ETH.
+     * @param   signedOrders         An array of objects that conform to the SignedOrder interface. All orders should specify ZRX as
+     *                               the makerAsset and WETH as the takerAsset.
+     * @param   orderStates          An array of objects corresponding to the signedOrders parameter that each contain on-chain state
+     *                               relevant to that order.
+     * @param   signedFeeOrders      An array of objects that conform to the SignedOrder interface. All orders should specify ZRX as
+     *                               the makerAsset and WETH as the takerAsset.
+     * @param   feeOrderStates       An array of objects corresponding to the signedOrders parameter that each contain on-chain state
+     *                               relevant to that order.
+     * @param   makerAssetFillAmount The amount of makerAsset desired to be filled.
+     * @param   slippageBufferAmount An additional amount makerAsset to be covered by the result in case of trade collisions or partial fills.
+     * @return  Resulting orders and remaining fill amount that could not be covered by the input.
+     */
+    public static findFeeOrdersThatCoverFeesForTargetOrders(
+        signedOrders: SignedOrder[],
+        orderStates: OrderRelevantState[],
+        signedFeeOrders: SignedOrder[],
+        feeOrderStates: OrderRelevantState[],
+        slippageBufferAmount: BigNumber = constants.ZERO_AMOUNT,
+    ): { resultOrders: SignedOrder[]; remainingFillAmount: BigNumber } {
+        // type assertions
+        assert.doesConformToSchema('signedOrders', signedOrders, schemas.signedOrdersSchema);
+        assert.doesConformToSchema('signedFeeOrders', signedFeeOrders, schemas.signedOrdersSchema);
+        assert.isBigNumber('slippageBufferAmount', slippageBufferAmount);
+        // calculate total amount of ZRX needed to fill signedOrders
+        const totalFeeAmount = _.reduce(
+            signedOrders,
+            (accFees, order, index) => {
+                const orderState = orderStates[index];
+                const makerAssetAmountAvailable = ForwarderWrapper._getMakerAssetAmountAvailable(orderState);
+                const feeToFillMakerAssetAmountAvailable = makerAssetAmountAvailable
+                    .div(order.makerAssetAmount)
+                    .mul(order.takerFee);
+                return feeToFillMakerAssetAmountAvailable;
+            },
+            constants.ZERO_AMOUNT,
+        );
+        return ForwarderWrapper.findOrdersThatCoverMakerAssetFillAmount(
+            signedFeeOrders,
+            feeOrderStates,
+            totalFeeAmount,
+            slippageBufferAmount,
+        );
+    }
+    private static _getMakerAssetAmountAvailable(orderState: OrderRelevantState): BigNumber {
+        return BigNumber.min(
+            orderState.makerBalance,
+            orderState.remainingFillableMakerAssetAmount,
+            orderState.makerProxyAllowance,
+        );
     }
     constructor(
         web3Wrapper: Web3Wrapper,

--- a/packages/contract-wrappers/src/contract_wrappers/forwarder_wrapper.ts
+++ b/packages/contract-wrappers/src/contract_wrappers/forwarder_wrapper.ts
@@ -1,5 +1,5 @@
 import { schemas } from '@0xproject/json-schemas';
-import { AssetProxyId, OrderRelevantState, SignedOrder } from '@0xproject/types';
+import { AssetProxyId, SignedOrder } from '@0xproject/types';
 import { BigNumber } from '@0xproject/utils';
 import { Web3Wrapper } from '@0xproject/web3-wrapper';
 import { ContractAbi } from 'ethereum-types';
@@ -24,104 +24,6 @@ export class ForwarderWrapper extends ContractWrapper {
     private _forwarderContractIfExists?: ForwarderContract;
     private _contractAddressIfExists?: string;
     private _zrxContractAddressIfExists?: string;
-    /**
-     * Takes an array of orders and returns a subset of those orders that has enough makerAssetAmount (taking into account on-chain balances,
-     * allowances, and partial fills) in order to fill the input makerAssetFillAmount plus slippageBufferAmount. Iterates from first order to last.
-     * Sort the input by ascending rate in order to get the subset of orders that will cost the least ETH.
-     * @param   signedOrders         An array of objects that conform to the SignedOrder interface. All orders should specify the same makerAsset.
-     *                               All orders should specify WETH as the takerAsset.
-     * @param   orderStates          An array of objects corresponding to the signedOrders parameter that each contain on-chain state
-     *                               relevant to that order.
-     * @param   makerAssetFillAmount The amount of makerAsset desired to be filled.
-     * @param   slippageBufferAmount An additional amount makerAsset to be covered by the result in case of trade collisions or partial fills.
-     * @return  Resulting orders and remaining fill amount that could not be covered by the input.
-     */
-    public static findOrdersThatCoverMakerAssetFillAmount(
-        signedOrders: SignedOrder[],
-        orderStates: OrderRelevantState[],
-        makerAssetFillAmount: BigNumber,
-        slippageBufferAmount: BigNumber = constants.ZERO_AMOUNT,
-    ): { resultOrders: SignedOrder[]; remainingFillAmount: BigNumber } {
-        // type assertions
-        assert.doesConformToSchema('signedOrders', signedOrders, schemas.signedOrdersSchema);
-        assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-        assert.isBigNumber('slippageBufferAmount', slippageBufferAmount);
-        // calculate total amount of makerAsset needed to be filled
-        const totalFillAmount = makerAssetFillAmount.plus(slippageBufferAmount);
-        // iterate through the signedOrders input from left to right until we have enough makerAsset to fill totalFillAmount
-        const result = _.reduce(
-            signedOrders,
-            ({ resultOrders, remainingFillAmount }, order, index) => {
-                if (remainingFillAmount.lessThanOrEqualTo(constants.ZERO_AMOUNT)) {
-                    return { resultOrders, remainingFillAmount: constants.ZERO_AMOUNT };
-                } else {
-                    const orderState = orderStates[index];
-                    const makerAssetAmountAvailable = ForwarderWrapper._getMakerAssetAmountAvailable(orderState);
-                    return {
-                        resultOrders: _.concat(resultOrders, order),
-                        remainingFillAmount: remainingFillAmount.minus(makerAssetAmountAvailable),
-                    };
-                }
-            },
-            { resultOrders: [] as SignedOrder[], remainingFillAmount: totalFillAmount },
-        );
-        return result;
-    }
-    /**
-     * Takes an array of orders and an array of feeOrders. Returns a subset of the feeOrders that has enough ZRX (taking into account
-     * on-chain balances, allowances, and partial fills) in order to fill the takerFees required by signedOrders plus a
-     * slippageBufferAmount. Iterates from first feeOrder to last. Sort the feeOrders by ascending rate in order to get the subset of
-     * feeOrders that will cost the least ETH.
-     * @param   signedOrders         An array of objects that conform to the SignedOrder interface. All orders should specify ZRX as
-     *                               the makerAsset and WETH as the takerAsset.
-     * @param   orderStates          An array of objects corresponding to the signedOrders parameter that each contain on-chain state
-     *                               relevant to that order.
-     * @param   signedFeeOrders      An array of objects that conform to the SignedOrder interface. All orders should specify ZRX as
-     *                               the makerAsset and WETH as the takerAsset.
-     * @param   feeOrderStates       An array of objects corresponding to the signedOrders parameter that each contain on-chain state
-     *                               relevant to that order.
-     * @param   makerAssetFillAmount The amount of makerAsset desired to be filled.
-     * @param   slippageBufferAmount An additional amount makerAsset to be covered by the result in case of trade collisions or partial fills.
-     * @return  Resulting orders and remaining fill amount that could not be covered by the input.
-     */
-    public static findFeeOrdersThatCoverFeesForTargetOrders(
-        signedOrders: SignedOrder[],
-        orderStates: OrderRelevantState[],
-        signedFeeOrders: SignedOrder[],
-        feeOrderStates: OrderRelevantState[],
-        slippageBufferAmount: BigNumber = constants.ZERO_AMOUNT,
-    ): { resultOrders: SignedOrder[]; remainingFillAmount: BigNumber } {
-        // type assertions
-        assert.doesConformToSchema('signedOrders', signedOrders, schemas.signedOrdersSchema);
-        assert.doesConformToSchema('signedFeeOrders', signedFeeOrders, schemas.signedOrdersSchema);
-        assert.isBigNumber('slippageBufferAmount', slippageBufferAmount);
-        // calculate total amount of ZRX needed to fill signedOrders
-        const totalFeeAmount = _.reduce(
-            signedOrders,
-            (accFees, order, index) => {
-                const orderState = orderStates[index];
-                const makerAssetAmountAvailable = ForwarderWrapper._getMakerAssetAmountAvailable(orderState);
-                const feeToFillMakerAssetAmountAvailable = makerAssetAmountAvailable
-                    .div(order.makerAssetAmount)
-                    .mul(order.takerFee);
-                return feeToFillMakerAssetAmountAvailable;
-            },
-            constants.ZERO_AMOUNT,
-        );
-        return ForwarderWrapper.findOrdersThatCoverMakerAssetFillAmount(
-            signedFeeOrders,
-            feeOrderStates,
-            totalFeeAmount,
-            slippageBufferAmount,
-        );
-    }
-    private static _getMakerAssetAmountAvailable(orderState: OrderRelevantState): BigNumber {
-        return BigNumber.min(
-            orderState.makerBalance,
-            orderState.remainingFillableMakerAssetAmount,
-            orderState.makerProxyAllowance,
-        );
-    }
     constructor(
         web3Wrapper: Web3Wrapper,
         networkId: number,

--- a/packages/json-schemas/CHANGELOG.json
+++ b/packages/json-schemas/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "1.0.1-rc.4",
+        "changes": [
+            {
+                "note": "Change hexSchema to match `0x`",
+                "pr": 937
+            }
+        ]
+    },
+    {
         "version": "1.0.1-rc.3",
         "changes": [
             {

--- a/packages/json-schemas/schemas/basic_type_schemas.ts
+++ b/packages/json-schemas/schemas/basic_type_schemas.ts
@@ -7,7 +7,7 @@ export const addressSchema = {
 export const hexSchema = {
     id: '/Hex',
     type: 'string',
-    pattern: '^0x([0-9a-f][0-9a-f])+$',
+    pattern: '^0x(([0-9a-f][0-9a-f])+)?$',
 };
 
 export const numberSchema = {

--- a/packages/json-schemas/test/schema_test.ts
+++ b/packages/json-schemas/test/schema_test.ts
@@ -89,7 +89,7 @@ describe('Schema', () => {
             validateAgainstSchema(testCases, hexSchema);
         });
         it('should fail for invalid hex string', () => {
-            const testCases = ['0x', '0', '0xzzzzzzB11a196601eD2ce54B665CaFEca0347D42'];
+            const testCases = ['0', '0xzzzzzzB11a196601eD2ce54B665CaFEca0347D42'];
             const shouldFail = true;
             validateAgainstSchema(testCases, hexSchema, shouldFail);
         });

--- a/packages/order-utils/CHANGELOG.json
+++ b/packages/order-utils/CHANGELOG.json
@@ -6,6 +6,10 @@
                 "note":
                     "Added a synchronous `createOrder` method in `orderFactory`, updated public interfaces to support some optional parameters",
                 "pr": 936
+            },
+            {
+                "note": "Added marketUtils",
+                "pr": 937
             }
         ]
     },

--- a/packages/order-utils/src/constants.ts
+++ b/packages/order-utils/src/constants.ts
@@ -2,6 +2,7 @@ import { BigNumber } from '@0xproject/utils';
 
 export const constants = {
     NULL_ADDRESS: '0x0000000000000000000000000000000000000000',
+    NULL_BYTES: '0x',
     // tslint:disable-next-line:custom-no-magic-numbers
     UNLIMITED_ALLOWANCE_IN_BASE_UNITS: new BigNumber(2).pow(256).minus(1),
     TESTRPC_NETWORK_ID: 50,

--- a/packages/order-utils/src/constants.ts
+++ b/packages/order-utils/src/constants.ts
@@ -10,6 +10,6 @@ export const constants = {
     ERC721_ASSET_DATA_MINIMUM_BYTE_LENGTH: 53,
     SELECTOR_LENGTH: 4,
     BASE_16: 16,
-    INFINITE_TIMESTAMP_SEC: new BigNumber(2524604400), // Close to infinite
+    INFINITE_TIMESTAMP_SEC: new BigNumber(2524604400), // Close to infinite,
     ZERO_AMOUNT: new BigNumber(0),
 };

--- a/packages/order-utils/src/constants.ts
+++ b/packages/order-utils/src/constants.ts
@@ -11,6 +11,6 @@ export const constants = {
     ERC721_ASSET_DATA_MINIMUM_BYTE_LENGTH: 53,
     SELECTOR_LENGTH: 4,
     BASE_16: 16,
-    INFINITE_TIMESTAMP_SEC: new BigNumber(2524604400), // Close to infinite,
+    INFINITE_TIMESTAMP_SEC: new BigNumber(2524604400), // Close to infinite
     ZERO_AMOUNT: new BigNumber(0),
 };

--- a/packages/order-utils/src/index.ts
+++ b/packages/order-utils/src/index.ts
@@ -32,3 +32,4 @@ export { assetDataUtils } from './asset_data_utils';
 export { EIP712Utils } from './eip712_utils';
 export { OrderValidationUtils } from './order_validation_utils';
 export { ExchangeTransferSimulator } from './exchange_transfer_simulator';
+export { marketUtils } from './market_utils';

--- a/packages/order-utils/src/market_utils.ts
+++ b/packages/order-utils/src/market_utils.ts
@@ -1,0 +1,109 @@
+import { schemas } from '@0xproject/json-schemas';
+import { OrderRelevantState, SignedOrder } from '@0xproject/types';
+import { BigNumber } from '@0xproject/utils';
+import * as _ from 'lodash';
+
+import { assert } from './assert';
+import { constants } from './constants';
+
+export const marketUtils = {
+    /**
+     * Takes an array of orders and returns a subset of those orders that has enough makerAssetAmount (taking into account on-chain balances,
+     * allowances, and partial fills) in order to fill the input makerAssetFillAmount plus slippageBufferAmount. Iterates from first order to last.
+     * Sort the input by ascending rate in order to get the subset of orders that will cost the least ETH.
+     * @param   signedOrders         An array of objects that conform to the SignedOrder interface. All orders should specify the same makerAsset.
+     *                               All orders should specify WETH as the takerAsset.
+     * @param   orderStates          An array of objects corresponding to the signedOrders parameter that each contain on-chain state
+     *                               relevant to that order.
+     * @param   makerAssetFillAmount The amount of makerAsset desired to be filled.
+     * @param   slippageBufferAmount An additional amount makerAsset to be covered by the result in case of trade collisions or partial fills.
+     * @return  Resulting orders and remaining fill amount that could not be covered by the input.
+     */
+    findOrdersThatCoverMakerAssetFillAmount(
+        signedOrders: SignedOrder[],
+        orderStates: OrderRelevantState[],
+        makerAssetFillAmount: BigNumber,
+        slippageBufferAmount: BigNumber = constants.ZERO_AMOUNT,
+    ): { resultOrders: SignedOrder[]; remainingFillAmount: BigNumber } {
+        // type assertions
+        assert.doesConformToSchema('signedOrders', signedOrders, schemas.signedOrdersSchema);
+        assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+        assert.isBigNumber('slippageBufferAmount', slippageBufferAmount);
+        // calculate total amount of makerAsset needed to be filled
+        const totalFillAmount = makerAssetFillAmount.plus(slippageBufferAmount);
+        // iterate through the signedOrders input from left to right until we have enough makerAsset to fill totalFillAmount
+        const result = _.reduce(
+            signedOrders,
+            ({ resultOrders, remainingFillAmount }, order, index) => {
+                if (remainingFillAmount.lessThanOrEqualTo(constants.ZERO_AMOUNT)) {
+                    return { resultOrders, remainingFillAmount: constants.ZERO_AMOUNT };
+                } else {
+                    const orderState = orderStates[index];
+                    const makerAssetAmountAvailable = getMakerAssetAmountAvailable(orderState);
+                    return {
+                        resultOrders: _.concat(resultOrders, order),
+                        remainingFillAmount: remainingFillAmount.minus(makerAssetAmountAvailable),
+                    };
+                }
+            },
+            { resultOrders: [] as SignedOrder[], remainingFillAmount: totalFillAmount },
+        );
+        return result;
+    },
+    /**
+     * Takes an array of orders and an array of feeOrders. Returns a subset of the feeOrders that has enough ZRX (taking into account
+     * on-chain balances, allowances, and partial fills) in order to fill the takerFees required by signedOrders plus a
+     * slippageBufferAmount. Iterates from first feeOrder to last. Sort the feeOrders by ascending rate in order to get the subset of
+     * feeOrders that will cost the least ETH.
+     * @param   signedOrders         An array of objects that conform to the SignedOrder interface. All orders should specify ZRX as
+     *                               the makerAsset and WETH as the takerAsset.
+     * @param   orderStates          An array of objects corresponding to the signedOrders parameter that each contain on-chain state
+     *                               relevant to that order.
+     * @param   signedFeeOrders      An array of objects that conform to the SignedOrder interface. All orders should specify ZRX as
+     *                               the makerAsset and WETH as the takerAsset.
+     * @param   feeOrderStates       An array of objects corresponding to the signedOrders parameter that each contain on-chain state
+     *                               relevant to that order.
+     * @param   makerAssetFillAmount The amount of makerAsset desired to be filled.
+     * @param   slippageBufferAmount An additional amount makerAsset to be covered by the result in case of trade collisions or partial fills.
+     * @return  Resulting orders and remaining fill amount that could not be covered by the input.
+     */
+    findFeeOrdersThatCoverFeesForTargetOrders(
+        signedOrders: SignedOrder[],
+        orderStates: OrderRelevantState[],
+        signedFeeOrders: SignedOrder[],
+        feeOrderStates: OrderRelevantState[],
+        slippageBufferAmount: BigNumber = constants.ZERO_AMOUNT,
+    ): { resultOrders: SignedOrder[]; remainingFillAmount: BigNumber } {
+        // type assertions
+        assert.doesConformToSchema('signedOrders', signedOrders, schemas.signedOrdersSchema);
+        assert.doesConformToSchema('signedFeeOrders', signedFeeOrders, schemas.signedOrdersSchema);
+        assert.isBigNumber('slippageBufferAmount', slippageBufferAmount);
+        // calculate total amount of ZRX needed to fill signedOrders
+        const totalFeeAmount = _.reduce(
+            signedOrders,
+            (accFees, order, index) => {
+                const orderState = orderStates[index];
+                const makerAssetAmountAvailable = getMakerAssetAmountAvailable(orderState);
+                const feeToFillMakerAssetAmountAvailable = makerAssetAmountAvailable
+                    .div(order.makerAssetAmount)
+                    .mul(order.takerFee);
+                return accFees.plus(feeToFillMakerAssetAmountAvailable);
+            },
+            constants.ZERO_AMOUNT,
+        );
+        return marketUtils.findOrdersThatCoverMakerAssetFillAmount(
+            signedFeeOrders,
+            feeOrderStates,
+            totalFeeAmount,
+            slippageBufferAmount,
+        );
+    },
+};
+
+const getMakerAssetAmountAvailable = (orderState: OrderRelevantState) => {
+    return BigNumber.min(
+        orderState.makerBalance,
+        orderState.remainingFillableMakerAssetAmount,
+        orderState.makerProxyAllowance,
+    );
+};

--- a/packages/order-utils/src/market_utils.ts
+++ b/packages/order-utils/src/market_utils.ts
@@ -1,5 +1,5 @@
 import { schemas } from '@0xproject/json-schemas';
-import { OrderRelevantState, SignedOrder } from '@0xproject/types';
+import { SignedOrder } from '@0xproject/types';
 import { BigNumber } from '@0xproject/utils';
 import * as _ from 'lodash';
 
@@ -11,24 +11,33 @@ export const marketUtils = {
      * Takes an array of orders and returns a subset of those orders that has enough makerAssetAmount (taking into account on-chain balances,
      * allowances, and partial fills) in order to fill the input makerAssetFillAmount plus slippageBufferAmount. Iterates from first order to last.
      * Sort the input by ascending rate in order to get the subset of orders that will cost the least ETH.
-     * @param   signedOrders         An array of objects that conform to the SignedOrder interface. All orders should specify the same makerAsset.
-     *                               All orders should specify WETH as the takerAsset.
-     * @param   orderStates          An array of objects corresponding to the signedOrders parameter that each contain on-chain state
-     *                               relevant to that order.
-     * @param   makerAssetFillAmount The amount of makerAsset desired to be filled.
-     * @param   slippageBufferAmount An additional amount makerAsset to be covered by the result in case of trade collisions or partial fills.
+     * @param   signedOrders                        An array of objects that conform to the SignedOrder interface. All orders should specify the same makerAsset.
+     *                                              All orders should specify WETH as the takerAsset.
+     * @param   remainingFillableMakerAssetAmounts  An array of BigNumbers corresponding to the signedOrders parameter.
+     *                                              You can use OrderStateUtils @0xproject/order-utils to perform blockchain lookups
+     *                                              for these values.
+     * @param   makerAssetFillAmount                The amount of makerAsset desired to be filled.
+     * @param   slippageBufferAmount                An additional amount makerAsset to be covered by the result in case of trade collisions or partial fills.
      * @return  Resulting orders and remaining fill amount that could not be covered by the input.
      */
     findOrdersThatCoverMakerAssetFillAmount(
         signedOrders: SignedOrder[],
-        orderStates: OrderRelevantState[],
+        remainingFillableMakerAssetAmounts: BigNumber[],
         makerAssetFillAmount: BigNumber,
         slippageBufferAmount: BigNumber = constants.ZERO_AMOUNT,
     ): { resultOrders: SignedOrder[]; remainingFillAmount: BigNumber } {
         // type assertions
         assert.doesConformToSchema('signedOrders', signedOrders, schemas.signedOrdersSchema);
-        assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-        assert.isBigNumber('slippageBufferAmount', slippageBufferAmount);
+        _.forEach(remainingFillableMakerAssetAmounts, (amount, index) =>
+            assert.isValidBaseUnitAmount(`remainingFillableMakerAssetAmount[${index}]`, amount),
+        );
+        assert.isValidBaseUnitAmount('makerAssetFillAmount', makerAssetFillAmount);
+        assert.isValidBaseUnitAmount('slippageBufferAmount', slippageBufferAmount);
+        // other assertions
+        assert.assert(
+            signedOrders.length === remainingFillableMakerAssetAmounts.length,
+            'Expected signedOrders.length to equal remainingFillableMakerAssetAmounts.length',
+        );
         // calculate total amount of makerAsset needed to be filled
         const totalFillAmount = makerAssetFillAmount.plus(slippageBufferAmount);
         // iterate through the signedOrders input from left to right until we have enough makerAsset to fill totalFillAmount
@@ -38,8 +47,7 @@ export const marketUtils = {
                 if (remainingFillAmount.lessThanOrEqualTo(constants.ZERO_AMOUNT)) {
                     return { resultOrders, remainingFillAmount: constants.ZERO_AMOUNT };
                 } else {
-                    const orderState = orderStates[index];
-                    const makerAssetAmountAvailable = orderState.remainingFillableMakerAssetAmount;
+                    const makerAssetAmountAvailable = remainingFillableMakerAssetAmounts[index];
                     // if there is no makerAssetAmountAvailable do not append order to resultOrders
                     // if we have exceeded the total amount we want to fill set remainingFillAmount to 0
                     return {
@@ -62,47 +70,64 @@ export const marketUtils = {
      * on-chain balances, allowances, and partial fills) in order to fill the takerFees required by signedOrders plus a
      * slippageBufferAmount. Iterates from first feeOrder to last. Sort the feeOrders by ascending rate in order to get the subset of
      * feeOrders that will cost the least ETH.
-     * @param   signedOrders         An array of objects that conform to the SignedOrder interface. All orders should specify ZRX as
-     *                               the makerAsset and WETH as the takerAsset.
-     * @param   orderStates          An array of objects corresponding to the signedOrders parameter that each contain on-chain state
-     *                               relevant to that order.
-     * @param   signedFeeOrders      An array of objects that conform to the SignedOrder interface. All orders should specify ZRX as
-     *                               the makerAsset and WETH as the takerAsset.
-     * @param   feeOrderStates       An array of objects corresponding to the signedOrders parameter that each contain on-chain state
-     *                               relevant to that order.
-     * @param   makerAssetFillAmount The amount of makerAsset desired to be filled.
-     * @param   slippageBufferAmount An additional amount makerAsset to be covered by the result in case of trade collisions or partial fills.
+     * @param   signedOrders                        An array of objects that conform to the SignedOrder interface. All orders should specify ZRX as
+     *                                              the makerAsset and WETH as the takerAsset.
+     * @param   remainingFillableMakerAssetAmounts  An array of BigNumbers corresponding to the signedOrders parameter.
+     *                                              You can use OrderStateUtils @0xproject/order-utils to perform blockchain lookups
+     *                                              for these values.
+     * @param   signedFeeOrders                     An array of objects that conform to the SignedOrder interface. All orders should specify ZRX as
+     *                                              the makerAsset and WETH as the takerAsset.
+     * @param   remainingFillableFeeAmounts         An array of BigNumbers corresponding to the signedFeeOrders parameter.
+     *                                              You can use OrderStateUtils @0xproject/order-utils to perform blockchain lookups
+     *                                              for these values.
+     * @param   slippageBufferAmount                An additional amount makerAsset to be covered by the result in case of trade collisions or partial fills.
      * @return  Resulting orders and remaining fill amount that could not be covered by the input.
      */
     findFeeOrdersThatCoverFeesForTargetOrders(
         signedOrders: SignedOrder[],
-        orderStates: OrderRelevantState[],
+        remainingFillableMakerAssetAmounts: BigNumber[],
         signedFeeOrders: SignedOrder[],
-        feeOrderStates: OrderRelevantState[],
+        remainingFillableFeeAmounts: BigNumber[],
         slippageBufferAmount: BigNumber = constants.ZERO_AMOUNT,
     ): { resultOrders: SignedOrder[]; remainingFillAmount: BigNumber } {
         // type assertions
         assert.doesConformToSchema('signedOrders', signedOrders, schemas.signedOrdersSchema);
+        _.forEach(remainingFillableMakerAssetAmounts, (amount, index) =>
+            assert.isValidBaseUnitAmount(`remainingFillableMakerAssetAmount[${index}]`, amount),
+        );
         assert.doesConformToSchema('signedFeeOrders', signedFeeOrders, schemas.signedOrdersSchema);
-        assert.isBigNumber('slippageBufferAmount', slippageBufferAmount);
+        _.forEach(remainingFillableFeeAmounts, (amount, index) =>
+            assert.isValidBaseUnitAmount(`remainingFillableFeeAmounts[${index}]`, amount),
+        );
+        assert.isValidBaseUnitAmount('slippageBufferAmount', slippageBufferAmount);
+        // other assertions
+        assert.assert(
+            signedOrders.length === remainingFillableMakerAssetAmounts.length,
+            'Expected signedOrders.length to equal remainingFillableMakerAssetAmounts.length',
+        );
+        assert.assert(
+            signedOrders.length === remainingFillableMakerAssetAmounts.length,
+            'Expected signedFeeOrders.length to equal remainingFillableFeeAmounts.length',
+        );
         // calculate total amount of ZRX needed to fill signedOrders
         const totalFeeAmount = _.reduce(
             signedOrders,
             (accFees, order, index) => {
-                const orderState = orderStates[index];
-                const makerAssetAmountAvailable = orderState.remainingFillableMakerAssetAmount;
+                const makerAssetAmountAvailable = remainingFillableMakerAssetAmounts[index];
                 const feeToFillMakerAssetAmountAvailable = makerAssetAmountAvailable
-                    .div(order.makerAssetAmount)
-                    .mul(order.takerFee);
+                    .mul(order.takerFee)
+                    .div(order.makerAssetAmount);
                 return accFees.plus(feeToFillMakerAssetAmountAvailable);
             },
             constants.ZERO_AMOUNT,
         );
         return marketUtils.findOrdersThatCoverMakerAssetFillAmount(
             signedFeeOrders,
-            feeOrderStates,
+            remainingFillableFeeAmounts,
             totalFeeAmount,
             slippageBufferAmount,
         );
+        // TODO: add more orders here to cover rounding
+        // https://github.com/0xProject/0x-protocol-specification/blob/master/v2/forwarding-contract-specification.md#over-buying-zrx
     },
 };

--- a/packages/order-utils/src/market_utils.ts
+++ b/packages/order-utils/src/market_utils.ts
@@ -26,14 +26,12 @@ export const marketUtils = {
         makerAssetFillAmount: BigNumber,
         slippageBufferAmount: BigNumber = constants.ZERO_AMOUNT,
     ): { resultOrders: SignedOrder[]; remainingFillAmount: BigNumber } {
-        // type assertions
         assert.doesConformToSchema('signedOrders', signedOrders, schemas.signedOrdersSchema);
         _.forEach(remainingFillableMakerAssetAmounts, (amount, index) =>
             assert.isValidBaseUnitAmount(`remainingFillableMakerAssetAmount[${index}]`, amount),
         );
         assert.isValidBaseUnitAmount('makerAssetFillAmount', makerAssetFillAmount);
         assert.isValidBaseUnitAmount('slippageBufferAmount', slippageBufferAmount);
-        // other assertions
         assert.assert(
             signedOrders.length === remainingFillableMakerAssetAmounts.length,
             'Expected signedOrders.length to equal remainingFillableMakerAssetAmounts.length',
@@ -90,7 +88,6 @@ export const marketUtils = {
         remainingFillableFeeAmounts: BigNumber[],
         slippageBufferAmount: BigNumber = constants.ZERO_AMOUNT,
     ): { resultOrders: SignedOrder[]; remainingFeeAmount: BigNumber } {
-        // type assertions
         assert.doesConformToSchema('signedOrders', signedOrders, schemas.signedOrdersSchema);
         _.forEach(remainingFillableMakerAssetAmounts, (amount, index) =>
             assert.isValidBaseUnitAmount(`remainingFillableMakerAssetAmount[${index}]`, amount),
@@ -100,7 +97,6 @@ export const marketUtils = {
             assert.isValidBaseUnitAmount(`remainingFillableFeeAmounts[${index}]`, amount),
         );
         assert.isValidBaseUnitAmount('slippageBufferAmount', slippageBufferAmount);
-        // other assertions
         assert.assert(
             signedOrders.length === remainingFillableMakerAssetAmounts.length,
             'Expected signedOrders.length to equal remainingFillableMakerAssetAmounts.length',

--- a/packages/order-utils/src/market_utils.ts
+++ b/packages/order-utils/src/market_utils.ts
@@ -17,7 +17,7 @@ export const marketUtils = {
      *                                              You can use OrderStateUtils @0xproject/order-utils to perform blockchain lookups
      *                                              for these values.
      * @param   makerAssetFillAmount                The amount of makerAsset desired to be filled.
-     * @param   slippageBufferAmount                An additional amount makerAsset to be covered by the result in case of trade collisions or partial fills.
+     * @param   slippageBufferAmount                An additional amount of makerAsset to be covered by the result in case of trade collisions or partial fills.
      * @return  Resulting orders and remaining fill amount that could not be covered by the input.
      */
     findOrdersThatCoverMakerAssetFillAmount(
@@ -80,8 +80,8 @@ export const marketUtils = {
      * @param   remainingFillableFeeAmounts         An array of BigNumbers corresponding to the signedFeeOrders parameter.
      *                                              You can use OrderStateUtils @0xproject/order-utils to perform blockchain lookups
      *                                              for these values.
-     * @param   slippageBufferAmount                An additional amount makerAsset to be covered by the result in case of trade collisions or partial fills.
-     * @return  Resulting orders and remaining fill amount that could not be covered by the input.
+     * @param   slippageBufferAmount                An additional amount of fee to be covered by the result in case of trade collisions or partial fills.
+     * @return  Resulting orders and remaining fee amount that could not be covered by the input.
      */
     findFeeOrdersThatCoverFeesForTargetOrders(
         signedOrders: SignedOrder[],
@@ -89,7 +89,7 @@ export const marketUtils = {
         signedFeeOrders: SignedOrder[],
         remainingFillableFeeAmounts: BigNumber[],
         slippageBufferAmount: BigNumber = constants.ZERO_AMOUNT,
-    ): { resultOrders: SignedOrder[]; remainingFillAmount: BigNumber } {
+    ): { resultOrders: SignedOrder[]; remainingFeeAmount: BigNumber } {
         // type assertions
         assert.doesConformToSchema('signedOrders', signedOrders, schemas.signedOrdersSchema);
         _.forEach(remainingFillableMakerAssetAmounts, (amount, index) =>
@@ -121,12 +121,16 @@ export const marketUtils = {
             },
             constants.ZERO_AMOUNT,
         );
-        return marketUtils.findOrdersThatCoverMakerAssetFillAmount(
+        const { resultOrders, remainingFillAmount } = marketUtils.findOrdersThatCoverMakerAssetFillAmount(
             signedFeeOrders,
             remainingFillableFeeAmounts,
             totalFeeAmount,
             slippageBufferAmount,
         );
+        return {
+            resultOrders,
+            remainingFeeAmount: remainingFillAmount,
+        };
         // TODO: add more orders here to cover rounding
         // https://github.com/0xProject/0x-protocol-specification/blob/master/v2/forwarding-contract-specification.md#over-buying-zrx
     },

--- a/packages/order-utils/test/market_utils_test.ts
+++ b/packages/order-utils/test/market_utils_test.ts
@@ -1,0 +1,146 @@
+import { OrderRelevantState, SignedOrder } from '@0xproject/types';
+import { BigNumber } from '@0xproject/utils';
+import * as chai from 'chai';
+import * as _ from 'lodash';
+import 'mocha';
+
+import { constants, marketUtils, orderFactory } from '../src';
+
+import { chaiSetup } from './utils/chai_setup';
+import { testOrderFactory } from './utils/test_order_factory';
+
+chaiSetup.configure();
+const expect = chai.expect;
+
+// tslint:disable: no-unused-expression
+describe('marketUtils', () => {
+    describe.only('#findOrdersThatCoverMakerAssetFillAmount', () => {
+        describe('no orders', () => {
+            it('returns empty and unchanged remainingFillAmount', async () => {
+                const fillAmount = new BigNumber(10);
+                const { resultOrders, remainingFillAmount } = marketUtils.findOrdersThatCoverMakerAssetFillAmount(
+                    [],
+                    [],
+                    fillAmount,
+                );
+                expect(resultOrders).to.be.empty;
+                expect(remainingFillAmount).to.be.bignumber.equal(fillAmount);
+            });
+        });
+        describe('orders are all completely fillable', () => {
+            // generate three signed orders each with 10 units of makerAsset, 30 total
+            const testOrderCount = 3;
+            const makerAssetAmount = new BigNumber(10);
+            const inputOrders = testOrderFactory.generateTestSignedOrders(
+                {
+                    makerAssetAmount,
+                },
+                testOrderCount,
+            );
+            // generate order states that cover the required fill amount
+            const inputOrderStates = testOrderFactory.generateTestOrderRelevantStates(
+                {
+                    remainingFillableMakerAssetAmount: makerAssetAmount,
+                },
+                testOrderCount,
+            );
+            it('returns input orders and zero remainingFillAmount when input exactly matches requested fill amount', async () => {
+                // try to fill 30 units of makerAsset
+                const fillAmount = new BigNumber(30);
+                const { resultOrders, remainingFillAmount } = marketUtils.findOrdersThatCoverMakerAssetFillAmount(
+                    inputOrders,
+                    inputOrderStates,
+                    fillAmount,
+                );
+                expect(resultOrders).to.be.deep.equal(inputOrders);
+                expect(remainingFillAmount).to.be.bignumber.equal(constants.ZERO_AMOUNT);
+            });
+            it('returns input orders and zero remainingFillAmount when input has more than requested fill amount', async () => {
+                // try to fill 25 units of makerAsset
+                const fillAmount = new BigNumber(25);
+                const { resultOrders, remainingFillAmount } = marketUtils.findOrdersThatCoverMakerAssetFillAmount(
+                    inputOrders,
+                    inputOrderStates,
+                    fillAmount,
+                );
+                expect(resultOrders).to.be.deep.equal(inputOrders);
+                expect(remainingFillAmount).to.be.bignumber.equal(constants.ZERO_AMOUNT);
+            });
+            it('returns input orders and non-zero remainingFillAmount when input has less than requested fill amount', async () => {
+                // try to fill 35 units of makerAsset
+                const fillAmount = new BigNumber(35);
+                const { resultOrders, remainingFillAmount } = marketUtils.findOrdersThatCoverMakerAssetFillAmount(
+                    inputOrders,
+                    inputOrderStates,
+                    fillAmount,
+                );
+                expect(resultOrders).to.be.deep.equal(inputOrders);
+                expect(remainingFillAmount).to.be.bignumber.equal(new BigNumber(5));
+            });
+            it('returns first order and zero remainingFillAmount when requested fill amount is exactly covered by the first order', async () => {
+                // try to fill 10 units of makerAsset
+                const fillAmount = new BigNumber(10);
+                const { resultOrders, remainingFillAmount } = marketUtils.findOrdersThatCoverMakerAssetFillAmount(
+                    inputOrders,
+                    inputOrderStates,
+                    fillAmount,
+                );
+                expect(resultOrders).to.be.deep.equal([inputOrders[0]]);
+                expect(remainingFillAmount).to.be.bignumber.equal(constants.ZERO_AMOUNT);
+            });
+            it('returns first two orders and zero remainingFillAmount when requested fill amount is over covered by the first two order', async () => {
+                // try to fill 15 units of makerAsset
+                const fillAmount = new BigNumber(15);
+                const { resultOrders, remainingFillAmount } = marketUtils.findOrdersThatCoverMakerAssetFillAmount(
+                    inputOrders,
+                    inputOrderStates,
+                    fillAmount,
+                );
+                expect(resultOrders).to.be.deep.equal([inputOrders[0], inputOrders[1]]);
+                expect(remainingFillAmount).to.be.bignumber.equal(constants.ZERO_AMOUNT);
+            });
+        });
+        describe('orders are partially fillable', () => {
+            // generate three signed orders each with 10 units of makerAsset, 30 total
+            const testOrderCount = 3;
+            const makerAssetAmount = new BigNumber(10);
+            const inputOrders = testOrderFactory.generateTestSignedOrders(
+                {
+                    makerAssetAmount,
+                },
+                testOrderCount,
+            );
+            // generate order states that cover different scenarios
+            // 1. order is completely filled already
+            // 2. order is partially fillable
+            // 3. order is completely fillable
+            const partialOrderStates: Array<Partial<OrderRelevantState>> = [
+                {
+                    remainingFillableMakerAssetAmount: constants.ZERO_AMOUNT,
+                },
+                {
+                    remainingFillableMakerAssetAmount: new BigNumber(5),
+                },
+                {
+                    remainingFillableMakerAssetAmount: makerAssetAmount,
+                },
+            ];
+            const inputOrderStates: OrderRelevantState[] = _.map(
+                partialOrderStates,
+                testOrderFactory.generateTestOrderRelevantState,
+            );
+            it('returns last 2 orders and non-zero remainingFillAmount when trying to fill original makerAssetAmounts', async () => {
+                // try to fill 30 units of makerAsset
+                const fillAmount = new BigNumber(30);
+                const { resultOrders, remainingFillAmount } = marketUtils.findOrdersThatCoverMakerAssetFillAmount(
+                    inputOrders,
+                    inputOrderStates,
+                    fillAmount,
+                );
+                expect(resultOrders).to.be.deep.equal([inputOrders[1], inputOrders[2]]);
+                expect(remainingFillAmount).to.be.bignumber.equal(new BigNumber(15));
+            });
+        });
+    });
+    describe('#findFeeOrdersThatCoverFeesForTargetOrders', () => {});
+});

--- a/packages/order-utils/test/market_utils_test.ts
+++ b/packages/order-utils/test/market_utils_test.ts
@@ -1,10 +1,8 @@
-import { OrderRelevantState, SignedOrder } from '@0xproject/types';
 import { BigNumber } from '@0xproject/utils';
 import * as chai from 'chai';
-import * as _ from 'lodash';
 import 'mocha';
 
-import { constants, marketUtils, orderFactory } from '../src';
+import { constants, marketUtils } from '../src';
 
 import { chaiSetup } from './utils/chai_setup';
 import { testOrderFactory } from './utils/test_order_factory';
@@ -37,19 +35,14 @@ describe('marketUtils', () => {
                 },
                 testOrderCount,
             );
-            // generate order states that cover the required fill amount
-            const inputOrderStates = testOrderFactory.generateTestOrderRelevantStates(
-                {
-                    remainingFillableMakerAssetAmount: makerAssetAmount,
-                },
-                testOrderCount,
-            );
+            // generate remainingFillableMakerAssetAmounts that equal the makerAssetAmount
+            const remainingFillableMakerAssetAmounts = [makerAssetAmount, makerAssetAmount, makerAssetAmount];
             it('returns input orders and zero remainingFillAmount when input exactly matches requested fill amount', async () => {
                 // try to fill 30 units of makerAsset
                 const fillAmount = new BigNumber(30);
                 const { resultOrders, remainingFillAmount } = marketUtils.findOrdersThatCoverMakerAssetFillAmount(
                     inputOrders,
-                    inputOrderStates,
+                    remainingFillableMakerAssetAmounts,
                     fillAmount,
                 );
                 expect(resultOrders).to.be.deep.equal(inputOrders);
@@ -60,7 +53,7 @@ describe('marketUtils', () => {
                 const fillAmount = new BigNumber(25);
                 const { resultOrders, remainingFillAmount } = marketUtils.findOrdersThatCoverMakerAssetFillAmount(
                     inputOrders,
-                    inputOrderStates,
+                    remainingFillableMakerAssetAmounts,
                     fillAmount,
                 );
                 expect(resultOrders).to.be.deep.equal(inputOrders);
@@ -71,7 +64,7 @@ describe('marketUtils', () => {
                 const fillAmount = new BigNumber(35);
                 const { resultOrders, remainingFillAmount } = marketUtils.findOrdersThatCoverMakerAssetFillAmount(
                     inputOrders,
-                    inputOrderStates,
+                    remainingFillableMakerAssetAmounts,
                     fillAmount,
                 );
                 expect(resultOrders).to.be.deep.equal(inputOrders);
@@ -82,7 +75,7 @@ describe('marketUtils', () => {
                 const fillAmount = new BigNumber(10);
                 const { resultOrders, remainingFillAmount } = marketUtils.findOrdersThatCoverMakerAssetFillAmount(
                     inputOrders,
-                    inputOrderStates,
+                    remainingFillableMakerAssetAmounts,
                     fillAmount,
                 );
                 expect(resultOrders).to.be.deep.equal([inputOrders[0]]);
@@ -93,7 +86,7 @@ describe('marketUtils', () => {
                 const fillAmount = new BigNumber(15);
                 const { resultOrders, remainingFillAmount } = marketUtils.findOrdersThatCoverMakerAssetFillAmount(
                     inputOrders,
-                    inputOrderStates,
+                    remainingFillableMakerAssetAmounts,
                     fillAmount,
                 );
                 expect(resultOrders).to.be.deep.equal([inputOrders[0], inputOrders[1]]);
@@ -110,31 +103,17 @@ describe('marketUtils', () => {
                 },
                 testOrderCount,
             );
-            // generate order states that cover different scenarios
+            // generate remainingFillableMakerAssetAmounts that cover different partial fill scenarios
             // 1. order is completely filled already
             // 2. order is partially fillable
             // 3. order is completely fillable
-            const partialOrderStates: Array<Partial<OrderRelevantState>> = [
-                {
-                    remainingFillableMakerAssetAmount: constants.ZERO_AMOUNT,
-                },
-                {
-                    remainingFillableMakerAssetAmount: new BigNumber(5),
-                },
-                {
-                    remainingFillableMakerAssetAmount: makerAssetAmount,
-                },
-            ];
-            const inputOrderStates: OrderRelevantState[] = _.map(
-                partialOrderStates,
-                testOrderFactory.generateTestOrderRelevantState,
-            );
+            const remainingFillableMakerAssetAmounts = [constants.ZERO_AMOUNT, new BigNumber(5), makerAssetAmount];
             it('returns last 2 orders and non-zero remainingFillAmount when trying to fill original makerAssetAmounts', async () => {
                 // try to fill 30 units of makerAsset
                 const fillAmount = new BigNumber(30);
                 const { resultOrders, remainingFillAmount } = marketUtils.findOrdersThatCoverMakerAssetFillAmount(
                     inputOrders,
-                    inputOrderStates,
+                    remainingFillableMakerAssetAmounts,
                     fillAmount,
                 );
                 expect(resultOrders).to.be.deep.equal([inputOrders[1], inputOrders[2]]);

--- a/packages/order-utils/test/market_utils_test.ts
+++ b/packages/order-utils/test/market_utils_test.ts
@@ -37,34 +37,43 @@ describe('marketUtils', () => {
             // generate remainingFillableMakerAssetAmounts that equal the makerAssetAmount
             const remainingFillableMakerAssetAmounts = [makerAssetAmount, makerAssetAmount, makerAssetAmount];
             it('returns input orders and zero remainingFillAmount when input exactly matches requested fill amount', async () => {
-                // try to fill 30 units of makerAsset
-                const fillAmount = new BigNumber(30);
+                // try to fill 20 units of makerAsset
+                // include 10 units of slippageBufferAmount
+                const fillAmount = new BigNumber(20);
+                const slippageBufferAmount = new BigNumber(10);
                 const { resultOrders, remainingFillAmount } = marketUtils.findOrdersThatCoverMakerAssetFillAmount(
                     inputOrders,
                     remainingFillableMakerAssetAmounts,
                     fillAmount,
+                    slippageBufferAmount,
                 );
                 expect(resultOrders).to.be.deep.equal(inputOrders);
                 expect(remainingFillAmount).to.be.bignumber.equal(constants.ZERO_AMOUNT);
             });
             it('returns input orders and zero remainingFillAmount when input has more than requested fill amount', async () => {
-                // try to fill 25 units of makerAsset
-                const fillAmount = new BigNumber(25);
+                // try to fill 15 units of makerAsset
+                // include 10 units of slippageBufferAmount
+                const fillAmount = new BigNumber(15);
+                const slippageBufferAmount = new BigNumber(10);
                 const { resultOrders, remainingFillAmount } = marketUtils.findOrdersThatCoverMakerAssetFillAmount(
                     inputOrders,
                     remainingFillableMakerAssetAmounts,
                     fillAmount,
+                    slippageBufferAmount,
                 );
                 expect(resultOrders).to.be.deep.equal(inputOrders);
                 expect(remainingFillAmount).to.be.bignumber.equal(constants.ZERO_AMOUNT);
             });
             it('returns input orders and non-zero remainingFillAmount when input has less than requested fill amount', async () => {
-                // try to fill 35 units of makerAsset
-                const fillAmount = new BigNumber(35);
+                // try to fill 30 units of makerAsset
+                // include 5 units of slippageBufferAmount
+                const fillAmount = new BigNumber(30);
+                const slippageBufferAmount = new BigNumber(5);
                 const { resultOrders, remainingFillAmount } = marketUtils.findOrdersThatCoverMakerAssetFillAmount(
                     inputOrders,
                     remainingFillableMakerAssetAmounts,
                     fillAmount,
+                    slippageBufferAmount,
                 );
                 expect(resultOrders).to.be.deep.equal(inputOrders);
                 expect(remainingFillAmount).to.be.bignumber.equal(new BigNumber(5));

--- a/packages/order-utils/test/utils/test_order_factory.ts
+++ b/packages/order-utils/test/utils/test_order_factory.ts
@@ -1,5 +1,4 @@
-import { Order, OrderRelevantState, SignedOrder } from '@0xproject/types';
-import { BigNumber } from '@0xproject/utils';
+import { Order, SignedOrder } from '@0xproject/types';
 import * as _ from 'lodash';
 
 import { constants, orderFactory } from '../../src';
@@ -21,43 +20,18 @@ const BASE_TEST_SIGNED_ORDER: SignedOrder = {
     ...BASE_TEST_ORDER,
     signature: constants.NULL_BYTES,
 };
-const BASE_TEST_ORDER_RELEVANT_STATE: OrderRelevantState = {
-    makerBalance: constants.ZERO_AMOUNT,
-    makerProxyAllowance: constants.ZERO_AMOUNT,
-    makerFeeBalance: constants.ZERO_AMOUNT,
-    makerFeeProxyAllowance: constants.ZERO_AMOUNT,
-    filledTakerAssetAmount: constants.ZERO_AMOUNT,
-    remainingFillableMakerAssetAmount: constants.ZERO_AMOUNT,
-    remainingFillableTakerAssetAmount: constants.ZERO_AMOUNT,
-};
 
 export const testOrderFactory = {
     generateTestSignedOrder(partialOrder: Partial<SignedOrder>): SignedOrder {
         return transformObject(BASE_TEST_SIGNED_ORDER, partialOrder);
     },
     generateTestSignedOrders(partialOrder: Partial<SignedOrder>, numOrders: number): SignedOrder[] {
-        const baseTestOrders = generateArrayOfInput(BASE_TEST_SIGNED_ORDER, numOrders);
-        return transformObjects(baseTestOrders, partialOrder);
-    },
-    generateTestOrderRelevantState(partialOrderRelevantState: Partial<OrderRelevantState>): OrderRelevantState {
-        return transformObject(BASE_TEST_ORDER_RELEVANT_STATE, partialOrderRelevantState);
-    },
-    generateTestOrderRelevantStates(
-        partialOrderRelevantState: Partial<OrderRelevantState>,
-        numOrderStates: number,
-    ): OrderRelevantState[] {
-        const baseTestOrderStates = generateArrayOfInput(BASE_TEST_ORDER_RELEVANT_STATE, numOrderStates);
-        return transformObjects(baseTestOrderStates, partialOrderRelevantState);
+        const baseTestOrders = _.map(_.range(numOrders), () => BASE_TEST_SIGNED_ORDER);
+        return _.map(baseTestOrders, order => transformObject(order, partialOrder));
     },
 };
 
-function generateArrayOfInput<T>(input: T, rangeLength: number): T[] {
-    return _.map(_.range(rangeLength), () => input);
-}
 function transformObject<T>(input: T, transformation: Partial<T>): T {
     const copy = _.cloneDeep(input);
     return _.assign(copy, transformation);
-}
-function transformObjects<T>(inputs: T[], transformation: Partial<T>): T[] {
-    return _.map(inputs, input => transformObject(input, transformation));
 }

--- a/packages/order-utils/test/utils/test_order_factory.ts
+++ b/packages/order-utils/test/utils/test_order_factory.ts
@@ -1,0 +1,63 @@
+import { Order, OrderRelevantState, SignedOrder } from '@0xproject/types';
+import { BigNumber } from '@0xproject/utils';
+import * as _ from 'lodash';
+
+import { constants, orderFactory } from '../../src';
+
+const BASE_TEST_ORDER: Order = orderFactory.createOrder(
+    constants.NULL_ADDRESS,
+    constants.NULL_ADDRESS,
+    constants.NULL_ADDRESS,
+    constants.ZERO_AMOUNT,
+    constants.ZERO_AMOUNT,
+    constants.ZERO_AMOUNT,
+    constants.NULL_BYTES,
+    constants.ZERO_AMOUNT,
+    constants.NULL_BYTES,
+    constants.NULL_ADDRESS,
+    constants.NULL_ADDRESS,
+);
+const BASE_TEST_SIGNED_ORDER: SignedOrder = {
+    ...BASE_TEST_ORDER,
+    signature: constants.NULL_BYTES,
+};
+const BASE_TEST_ORDER_RELEVANT_STATE: OrderRelevantState = {
+    makerBalance: constants.ZERO_AMOUNT,
+    makerProxyAllowance: constants.ZERO_AMOUNT,
+    makerFeeBalance: constants.ZERO_AMOUNT,
+    makerFeeProxyAllowance: constants.ZERO_AMOUNT,
+    filledTakerAssetAmount: constants.ZERO_AMOUNT,
+    remainingFillableMakerAssetAmount: constants.ZERO_AMOUNT,
+    remainingFillableTakerAssetAmount: constants.ZERO_AMOUNT,
+};
+
+export const testOrderFactory = {
+    generateTestSignedOrder(partialOrder: Partial<SignedOrder>): SignedOrder {
+        return transformObject(BASE_TEST_SIGNED_ORDER, partialOrder);
+    },
+    generateTestSignedOrders(partialOrder: Partial<SignedOrder>, numOrders: number): SignedOrder[] {
+        const baseTestOrders = generateArrayOfInput(BASE_TEST_SIGNED_ORDER, numOrders);
+        return transformObjects(baseTestOrders, partialOrder);
+    },
+    generateTestOrderRelevantState(partialOrderRelevantState: Partial<OrderRelevantState>): OrderRelevantState {
+        return transformObject(BASE_TEST_ORDER_RELEVANT_STATE, partialOrderRelevantState);
+    },
+    generateTestOrderRelevantStates(
+        partialOrderRelevantState: Partial<OrderRelevantState>,
+        numOrderStates: number,
+    ): OrderRelevantState[] {
+        const baseTestOrderStates = generateArrayOfInput(BASE_TEST_ORDER_RELEVANT_STATE, numOrderStates);
+        return transformObjects(baseTestOrderStates, partialOrderRelevantState);
+    },
+};
+
+function generateArrayOfInput<T>(input: T, rangeLength: number): T[] {
+    return _.map(_.range(rangeLength), () => input);
+}
+function transformObject<T>(input: T, transformation: Partial<T>): T {
+    const copy = _.cloneDeep(input);
+    return _.assign(copy, transformation);
+}
+function transformObjects<T>(inputs: T[], transformation: Partial<T>): T[] {
+    return _.map(inputs, input => transformObject(input, transformation));
+}

--- a/packages/order-utils/test/utils/test_order_factory.ts
+++ b/packages/order-utils/test/utils/test_order_factory.ts
@@ -5,14 +5,9 @@ import { constants, orderFactory } from '../../src';
 
 const BASE_TEST_ORDER: Order = orderFactory.createOrder(
     constants.NULL_ADDRESS,
+    constants.ZERO_AMOUNT,
     constants.NULL_ADDRESS,
-    constants.NULL_ADDRESS,
     constants.ZERO_AMOUNT,
-    constants.ZERO_AMOUNT,
-    constants.ZERO_AMOUNT,
-    constants.NULL_BYTES,
-    constants.ZERO_AMOUNT,
-    constants.NULL_BYTES,
     constants.NULL_ADDRESS,
     constants.NULL_ADDRESS,
 );


### PR DESCRIPTION
## Description

* We need a way to take a set of orders and an amount of maker asset to fill as input and output a subset of orders that cover the fill amount
* We need a way to take a set of orders and find the total amount of fees required to fill them

## Testing instructions

```bash
yarn install && PKG=@0xproject/order-utils yarn build
cd packages/order-utils && yarn test
```

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefixed the title of this PR with `[WIP]` if it is a work in progress.
*   [ ] Prefixed the title of this PR with bracketed package name(s) corresponding to the changed package(s). For example: `[sol-cov] Fixed bug`.
*   [ ] Added tests to cover my changes, or decided that tests would be too impractical.
*   [ ] Updated documentation, or decided that no doc change is needed.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
