### PR TITLE
[contracts] Test fillOrder return values and abiEncodeFillOrder

### DIFF
--- a/packages/contracts/src/2.0.0/protocol/Exchange/MixinAssetProxyDispatcher.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/MixinAssetProxyDispatcher.sol
@@ -159,22 +159,18 @@ contract MixinAssetProxyDispatcher is
                 }
 
                 /////// Call `assetProxy.transferFrom` using the constructed calldata ///////
-                let inputLen := sub(cdEnd, cdStart)
                 let success := call(
                     gas,                    // forward all gas
                     assetProxy,             // call address of asset proxy
                     0,                      // don't send any ETH
                     cdStart,                // pointer to start of input
-                    inputLen,               // length of input  
+                    sub(cdEnd, cdStart),    // length of input  
                     cdStart,                // write output over input
                     512                     // reserve 512 bytes for output
                 )
                 if iszero(success) {
                     revert(cdStart, returndatasize())
                 }
-
-                // Increment free memory pointer
-                mstore(64, add(cdStart, inputLen))
             }
         }
     }

--- a/packages/contracts/src/2.0.0/protocol/Exchange/MixinAssetProxyDispatcher.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/MixinAssetProxyDispatcher.sol
@@ -159,18 +159,22 @@ contract MixinAssetProxyDispatcher is
                 }
 
                 /////// Call `assetProxy.transferFrom` using the constructed calldata ///////
+                let inputLen := sub(cdEnd, cdStart)
                 let success := call(
                     gas,                    // forward all gas
                     assetProxy,             // call address of asset proxy
                     0,                      // don't send any ETH
                     cdStart,                // pointer to start of input
-                    sub(cdEnd, cdStart),    // length of input  
+                    inputLen,               // length of input  
                     cdStart,                // write output over input
                     512                     // reserve 512 bytes for output
                 )
                 if iszero(success) {
                     revert(cdStart, returndatasize())
                 }
+
+                // Increment free memory pointer
+                mstore(64, add(cdStart, inputLen))
             }
         }
     }

--- a/packages/contracts/src/2.0.0/protocol/Exchange/MixinTransactions.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/MixinTransactions.sol
@@ -142,7 +142,6 @@ contract MixinTransactions is
             // Compute hash
             result := keccak256(memPtr, 128)
         }
-
         return result;
     }
 

--- a/packages/contracts/src/2.0.0/protocol/Exchange/libs/LibAbiEncoder.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/libs/LibAbiEncoder.sol
@@ -24,20 +24,17 @@ import "./LibOrder.sol";
 
 contract LibAbiEncoder {
 
-    /// @dev ABI encodes calldata for `fillOrder` in memory and returns the address range.
-    ///      This range can be passed into `call` or `delegatecall` to invoke an external
-    ///      call to `fillOrder`.
+    /// @dev ABI encodes calldata for `fillOrder`.
     /// @param order Order struct containing order specifications.
     /// @param takerAssetFillAmount Desired amount of takerAsset to sell.
     /// @param signature Proof that order has been created by maker.
-    /// @return calldataBegin Memory address of ABI encoded calldata.
-    /// @return calldataLength Lenfgth of ABI encoded calldata.
+    /// @return ABI encoded calldata for `fillOrder`.
     function abiEncodeFillOrder(
         LibOrder.Order memory order,
         uint256 takerAssetFillAmount,
         bytes memory signature
     )
-        public
+        internal
         pure
         returns (bytes memory fillOrderCalldata)
     {
@@ -207,10 +204,11 @@ contract LibAbiEncoder {
             }
 
             // Set length of calldata
-            mstore(
-                fillOrderCalldata,
-                sub(dataAreaEnd, add(fillOrderCalldata, 0x20))
-            )
+            let calldataLen := sub(dataAreaEnd, add(fillOrderCalldata, 0x20))
+            mstore(fillOrderCalldata, calldataLen)
+
+            // Increment free memory pointer
+            mstore(0x40, add(fillOrderCalldata, add(calldataLen, 0x20)))
         }
 
         return fillOrderCalldata;

--- a/packages/contracts/src/2.0.0/protocol/Exchange/libs/LibAbiEncoder.sol
+++ b/packages/contracts/src/2.0.0/protocol/Exchange/libs/LibAbiEncoder.sol
@@ -204,11 +204,10 @@ contract LibAbiEncoder {
             }
 
             // Set length of calldata
-            let calldataLen := sub(dataAreaEnd, add(fillOrderCalldata, 0x20))
-            mstore(fillOrderCalldata, calldataLen)
+            mstore(fillOrderCalldata, sub(dataAreaEnd, add(fillOrderCalldata, 0x20)))
 
             // Increment free memory pointer
-            mstore(0x40, add(fillOrderCalldata, add(calldataLen, 0x20)))
+            mstore(0x40, dataAreaEnd)
         }
 
         return fillOrderCalldata;

--- a/packages/contracts/src/2.0.0/test/TestExchangeInternals/TestExchangeInternals.sol
+++ b/packages/contracts/src/2.0.0/test/TestExchangeInternals/TestExchangeInternals.sol
@@ -22,6 +22,7 @@ pragma experimental ABIEncoderV2;
 import "../../protocol/Exchange/Exchange.sol";
 
 
+// solhint-disable no-empty-blocks
 contract TestExchangeInternals is
     Exchange
 {

--- a/packages/contracts/src/2.0.0/test/TestLibs/TestLibs.sol
+++ b/packages/contracts/src/2.0.0/test/TestLibs/TestLibs.sol
@@ -22,13 +22,33 @@ pragma experimental ABIEncoderV2;
 import "../../protocol/Exchange/libs/LibMath.sol";
 import "../../protocol/Exchange/libs/LibOrder.sol";
 import "../../protocol/Exchange/libs/LibFillResults.sol";
+import "../../protocol/Exchange/libs/LibAbiEncoder.sol";
 
 
 contract TestLibs is 
     LibMath,
     LibOrder,
-    LibFillResults
+    LibFillResults,
+    LibAbiEncoder
 {
+
+    function publicAbiEncodeFillOrder(
+        Order memory order,
+        uint256 takerAssetFillAmount,
+        bytes memory signature
+    )
+        public
+        pure
+        returns (bytes memory fillOrderCalldata)
+    {
+        fillOrderCalldata = abiEncodeFillOrder(
+            order,
+            takerAssetFillAmount,
+            signature
+        );
+        return fillOrderCalldata;
+    }
+
     function publicGetPartialAmount(
         uint256 numerator,
         uint256 denominator,

--- a/packages/contracts/test/utils/exchange_wrapper.ts
+++ b/packages/contracts/test/utils/exchange_wrapper.ts
@@ -8,7 +8,7 @@ import { ExchangeContract } from '../../generated_contract_wrappers/exchange';
 import { formatters } from './formatters';
 import { LogDecoder } from './log_decoder';
 import { orderUtils } from './order_utils';
-import { OrderInfo, SignedTransaction } from './types';
+import { FillResults, OrderInfo, SignedTransaction } from './types';
 
 export class ExchangeWrapper {
     private readonly _exchange: ExchangeContract;
@@ -242,5 +242,32 @@ export class ExchangeWrapper {
         );
         const tx = await this._logDecoder.getTxWithDecodedLogsAsync(txHash);
         return tx;
+    }
+    public async getFillOrderResultsAsync(
+        signedOrder: SignedOrder,
+        from: string,
+        opts: { takerAssetFillAmount?: BigNumber } = {},
+    ): Promise<FillResults> {
+        const params = orderUtils.createFill(signedOrder, opts.takerAssetFillAmount);
+        const fillResults = await this._exchange.fillOrder.callAsync(
+            params.order,
+            params.takerAssetFillAmount,
+            params.signature,
+            { from },
+        );
+        return fillResults;
+    }
+    public abiEncodeFillOrder(
+        signedOrder: SignedOrder,
+        from: string,
+        opts: { takerAssetFillAmount?: BigNumber } = {},
+    ): string {
+        const params = orderUtils.createFill(signedOrder, opts.takerAssetFillAmount);
+        const data = this._exchange.fillOrder.getABIEncodedTransactionData(
+            params.order,
+            params.takerAssetFillAmount,
+            params.signature,
+        );
+        return data;
     }
 }

--- a/packages/contracts/test/utils/exchange_wrapper.ts
+++ b/packages/contracts/test/utils/exchange_wrapper.ts
@@ -257,11 +257,7 @@ export class ExchangeWrapper {
         );
         return fillResults;
     }
-    public abiEncodeFillOrder(
-        signedOrder: SignedOrder,
-        from: string,
-        opts: { takerAssetFillAmount?: BigNumber } = {},
-    ): string {
+    public abiEncodeFillOrder(signedOrder: SignedOrder, opts: { takerAssetFillAmount?: BigNumber } = {}): string {
         const params = orderUtils.createFill(signedOrder, opts.takerAssetFillAmount);
         const data = this._exchange.fillOrder.getABIEncodedTransactionData(
             params.order,

--- a/packages/contracts/test/utils/fill_order_combinatorial_utils.ts
+++ b/packages/contracts/test/utils/fill_order_combinatorial_utils.ts
@@ -456,6 +456,29 @@ export class FillOrderCombinatorialUtils {
             signedOrder.takerAssetAmount,
             signedOrder.makerAssetAmount,
         );
+        const expMakerFeePaid = orderUtils.getPartialAmount(
+            expFilledTakerAmount,
+            signedOrder.takerAssetAmount,
+            signedOrder.makerFee,
+        );
+        const expTakerFeePaid = orderUtils.getPartialAmount(
+            expFilledTakerAmount,
+            signedOrder.takerAssetAmount,
+            signedOrder.takerFee,
+        );
+        const fillResults = await this.exchangeWrapper.getFillOrderResultsAsync(signedOrder, this.takerAddress, {
+            takerAssetFillAmount,
+        });
+        expect(fillResults.takerAssetFilledAmount).to.be.bignumber.equal(
+            expFilledTakerAmount,
+            'takerAssetFilledAmount',
+        );
+        expect(fillResults.makerAssetFilledAmount).to.be.bignumber.equal(
+            expFilledMakerAmount,
+            'makerAssetFilledAmount',
+        );
+        expect(fillResults.takerFeePaid).to.be.bignumber.equal(expTakerFeePaid, 'takerFeePaid');
+        expect(fillResults.makerFeePaid).to.be.bignumber.equal(expMakerFeePaid, 'makerFeePaid');
 
         // - Let's fill the order!
         const txReceipt = await this.exchangeWrapper.fillOrderAsync(signedOrder, this.takerAddress, {
@@ -479,17 +502,7 @@ export class FillOrderCombinatorialUtils {
             expFilledTakerAmount,
             'log.args.takerAssetFilledAmount',
         );
-        const expMakerFeePaid = orderUtils.getPartialAmount(
-            expFilledTakerAmount,
-            signedOrder.takerAssetAmount,
-            signedOrder.makerFee,
-        );
         expect(log.args.makerFeePaid).to.be.bignumber.equal(expMakerFeePaid, 'log.args.makerFeePaid');
-        const expTakerFeePaid = orderUtils.getPartialAmount(
-            expFilledTakerAmount,
-            signedOrder.takerAssetAmount,
-            signedOrder.takerFee,
-        );
         expect(log.args.takerFeePaid).to.be.bignumber.equal(expTakerFeePaid, 'logs.args.takerFeePaid');
         expect(log.args.orderHash).to.be.equal(orderHash, 'log.args.orderHash');
         expect(log.args.makerAssetData).to.be.equal(makerAssetData, 'log.args.makerAssetData');

--- a/packages/migrations/package.json
+++ b/packages/migrations/package.json
@@ -13,8 +13,10 @@
         "manual:postpublish": "yarn build; node ./scripts/postpublish.js",
         "pre_build": "run-s copy_artifacts generate_contract_wrappers",
         "copy_artifacts": "copyfiles 'artifacts/**/*' ./lib",
-        "clean": "shx rm -rf lib src/contract_wrappers",
-        "lint": "tslint --project . --exclude **/src/v2/contract_wrappers/**/* --exclude **/src/v1/contract_wrappers/**/*",
+        "clean":
+            "shx rm -rf lib src/1.0.0/contract_wrappers src/2.0.0/contract_wrappers src/2.0.0-beta-testnet/contract_wrappers",
+        "lint":
+            "tslint --project . --exclude **/src/v2/contract_wrappers/**/* --exclude **/src/v1/contract_wrappers/**/*",
         "migrate:v1": "run-s build compile:v1 script:migrate:v1",
         "migrate:v2": "run-s build compile:v2 script:migrate:v2",
         "migrate:v2-beta-testnet": "run-s build compile:v2-beta-testnet script:migrate:v2-beta-testnet",
@@ -22,18 +24,27 @@
         "script:migrate:v2": "node ./lib/migrate.js --contracts-version 2.0.0",
         "script:migrate:v2-beta-testnet": "node ./lib/migrate.js --contracts-version 2.0.0-beta-testnet",
         "generate_contract_wrappers": "run-p generate_contract_wrappers:*",
-        "generate_contract_wrappers:v1": "abi-gen --abis  ${npm_package_config_abis_v1} --template ../contract_templates/contract.handlebars --partials '../contract_templates/partials/**/*.handlebars' --output src/1.0.0/contract_wrappers --backend ethers",
-        "generate_contract_wrappers:v2": "abi-gen --abis  ${npm_package_config_abis_v2} --template ../contract_templates/contract.handlebars --partials '../contract_templates/partials/**/*.handlebars' --output src/2.0.0/contract_wrappers --backend ethers",
-        "generate_contract_wrappers:v2-beta-testnet": "abi-gen --abis  ${npm_package_config_abis_v2BetaTestnet} --template ../contract_templates/contract.handlebars --partials '../contract_templates/partials/**/*.handlebars' --output src/2.0.0-beta-testnet/contract_wrappers --backend ethers",
-        "compile:v1": "sol-compiler --artifacts-dir artifacts/1.0.0 --contracts Exchange_v1,DummyERC20Token,ZRXToken,WETH9,TokenTransferProxy_v1,MultiSigWallet,MultiSigWalletWithTimeLock,MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress,TokenRegistry",
-        "compile:v2": "sol-compiler --artifacts-dir artifacts/2.0.0 --contracts ERC20Token,DummyERC20Token,ERC721Token,DummyERC721Token,ERC20Proxy,ERC721Proxy,Exchange,Forwarder,MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress,ZRXToken,WETH9,IWallet,IValidator",
-        "compile:v2-beta-testnet": "sol-compiler --artifacts-dir artifacts/2.0.0-beta-testnet --contracts AssetProxyOwner,ERC20Proxy,ERC721Proxy,Exchange,Forwarder,IWallet,IValidator,ERC20Token,ERC721Token"
+        "generate_contract_wrappers:v1":
+            "abi-gen --abis  ${npm_package_config_abis_v1} --template ../contract_templates/contract.handlebars --partials '../contract_templates/partials/**/*.handlebars' --output src/1.0.0/contract_wrappers --backend ethers",
+        "generate_contract_wrappers:v2":
+            "abi-gen --abis  ${npm_package_config_abis_v2} --template ../contract_templates/contract.handlebars --partials '../contract_templates/partials/**/*.handlebars' --output src/2.0.0/contract_wrappers --backend ethers",
+        "generate_contract_wrappers:v2-beta-testnet":
+            "abi-gen --abis  ${npm_package_config_abis_v2BetaTestnet} --template ../contract_templates/contract.handlebars --partials '../contract_templates/partials/**/*.handlebars' --output src/2.0.0-beta-testnet/contract_wrappers --backend ethers",
+        "compile:v1":
+            "sol-compiler --artifacts-dir artifacts/1.0.0 --contracts Exchange_v1,DummyERC20Token,ZRXToken,WETH9,TokenTransferProxy_v1,MultiSigWallet,MultiSigWalletWithTimeLock,MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress,TokenRegistry",
+        "compile:v2":
+            "sol-compiler --artifacts-dir artifacts/2.0.0 --contracts ERC20Token,DummyERC20Token,ERC721Token,DummyERC721Token,ERC20Proxy,ERC721Proxy,Exchange,Forwarder,MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress,ZRXToken,WETH9,IWallet,IValidator",
+        "compile:v2-beta-testnet":
+            "sol-compiler --artifacts-dir artifacts/2.0.0-beta-testnet --contracts AssetProxyOwner,ERC20Proxy,ERC721Proxy,Exchange,Forwarder,IWallet,IValidator,ERC20Token,ERC721Token"
     },
     "config": {
         "abis": {
-            "v1": "artifacts/1.0.0/@(DummyERC20Token|TokenTransferProxy_v1|Exchange_v1|TokenRegistry|MultiSigWallet|MultiSigWalletWithTimeLock|MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress|TokenRegistry|ZRXToken|WETH9).json",
-            "v2": "artifacts/2.0.0/@(ERC20Token|DummyERC20Token|ERC721Token|DummyERC721Token|ERC20Proxy|ERC721Proxy|Exchange|Forwarder|AssetProxyOwner|ZRXToken|WETH9|IWallet|IValidator).json",
-            "v2BetaTestnet": "artifacts/2.0.0-beta-testnet/@(ERC20Token|ERC721Token|ERC20Proxy|ERC721Proxy|Exchange|Forwarder|AssetProxyOwner|IWallet|IValidator).json"
+            "v1":
+                "artifacts/1.0.0/@(DummyERC20Token|TokenTransferProxy_v1|Exchange_v1|TokenRegistry|MultiSigWallet|MultiSigWalletWithTimeLock|MultiSigWalletWithTimeLockExceptRemoveAuthorizedAddress|TokenRegistry|ZRXToken|WETH9).json",
+            "v2":
+                "artifacts/2.0.0/@(ERC20Token|DummyERC20Token|ERC721Token|DummyERC721Token|ERC20Proxy|ERC721Proxy|Exchange|Forwarder|AssetProxyOwner|ZRXToken|WETH9|IWallet|IValidator).json",
+            "v2BetaTestnet":
+                "artifacts/2.0.0-beta-testnet/@(ERC20Token|ERC721Token|ERC20Proxy|ERC721Proxy|Exchange|Forwarder|AssetProxyOwner|IWallet|IValidator).json"
         }
     },
     "license": "Apache-2.0",


### PR DESCRIPTION
## Description

- Test `FillResults` and `abiEncodeFillOrder` within the combinatorial tests for `fillOrder`
- Increment the free memory pointer at the end of the assembly blocks in `dispatchTransferFrom` and `abiEncodeFillOrder`. It _shouldn't_ be an issue to overwrite this memory (which was happening previously), but feels like a good safety addition.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefixed the title of this PR with `[WIP]` if it is a work in progress.
*   [ ] Prefixed the title of this PR with bracketed package name(s) corresponding to the changed package(s). For example: `[sol-cov] Fixed bug`.
*   [ ] Added tests to cover my changes, or decided that tests would be too impractical.
*   [ ] Updated documentation, or decided that no doc change is needed.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
