### PR TITLE
[WIP] Update TypeScript to version ^2.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
         "npm-run-all": "^4.1.2",
         "prettier": "^1.11.1",
         "source-map-support": "^0.5.6",
-        "wsrun": "^2.2.0"
+        "wsrun": "^2.2.0",
+        "typescript": "^2.8.0"
     },
     "resolutions": {
         "ethers": "0xproject/ethers.js#eip-838-reasons"

--- a/packages/0x.js/package.json
+++ b/packages/0x.js/package.json
@@ -94,7 +94,7 @@
         "source-map-support": "^0.5.0",
         "tslint": "5.11.0",
         "typedoc": "0xProject/typedoc",
-        "typescript": "2.7.1",
+        
         "webpack": "^3.1.0"
     },
     "dependencies": {

--- a/packages/abi-gen/package.json
+++ b/packages/abi-gen/package.json
@@ -62,8 +62,7 @@
         "mocha": "^5.2.0",
         "npm-run-all": "^4.1.2",
         "shx": "^0.2.2",
-        "tslint": "5.11.0",
-        "typescript": "2.7.1"
+        "tslint": "5.11.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -43,8 +43,7 @@
         "npm-run-all": "^4.1.2",
         "nyc": "^11.0.1",
         "shx": "^0.2.2",
-        "tslint": "5.11.0",
-        "typescript": "2.7.1"
+        "tslint": "5.11.0"
     },
     "dependencies": {
         "@0xproject/json-schemas": "^1.0.1-rc.3",

--- a/packages/base-contract/package.json
+++ b/packages/base-contract/package.json
@@ -39,8 +39,7 @@
         "mocha": "^4.0.1",
         "npm-run-all": "^4.1.2",
         "shx": "^0.2.2",
-        "tslint": "5.11.0",
-        "typescript": "2.7.1"
+        "tslint": "5.11.0"
     },
     "dependencies": {
         "@0xproject/typescript-typings": "^1.0.3",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -82,8 +82,7 @@
         "nyc": "^11.0.1",
         "shx": "^0.2.2",
         "tslint": "5.11.0",
-        "typedoc": "~0.8.0",
-        "typescript": "2.7.1"
+        "typedoc": "~0.8.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/contract-wrappers/package.json
+++ b/packages/contract-wrappers/package.json
@@ -68,7 +68,6 @@
         "sinon": "^4.0.0",
         "source-map-support": "^0.5.0",
         "tslint": "5.11.0",
-        "typescript": "2.7.1",
         "web3-provider-engine": "14.0.6"
     },
     "dependencies": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -68,7 +68,6 @@
         "solc": "^0.4.24",
         "solhint": "^1.2.1",
         "tslint": "5.11.0",
-        "typescript": "2.7.1",
         "yargs": "^10.0.3"
     },
     "dependencies": {

--- a/packages/contracts/test/exchange/match_orders.ts
+++ b/packages/contracts/test/exchange/match_orders.ts
@@ -69,13 +69,22 @@ describe('matchOrders', () => {
     before(async () => {
         // Create accounts
         const accounts = await web3Wrapper.getAvailableAddressesAsync();
+        // Hack(albrow): Both Prettier and TSLint insert a trailing comma below
+        // but that is invalid syntax as of TypeScript version >= 2.8. We don't
+        // have the right fine-grained configuration options in TSLint,
+        // Prettier, or TypeScript, to reconcile this, so we will just have to
+        // wait for them to sort it out. We disable TSLint and Prettier for
+        // this part of the code for now. This occurs several times in this
+        // file. See https://github.com/prettier/prettier/issues/4624.
+        // prettier-ignore
         const usedAddresses = ([
             owner,
             makerAddressLeft,
             makerAddressRight,
             takerAddress,
             feeRecipientAddressLeft,
-            feeRecipientAddressRight,
+            // tslint:disable-next-line:trailing-comma
+            feeRecipientAddressRight
         ] = _.slice(accounts, 0, 6));
         // Create wrappers
         erc20Wrapper = new ERC20Wrapper(provider, usedAddresses, owner);
@@ -201,9 +210,11 @@ describe('matchOrders', () => {
             // Match signedOrderLeft with signedOrderRight
             let newERC20BalancesByOwner: ERC20BalancesByOwner;
             let newERC721TokenIdsByOwner: ERC721TokenIdsByOwner;
+            // prettier-ignore
             [
                 newERC20BalancesByOwner,
-                newERC721TokenIdsByOwner,
+                // tslint:disable-next-line:trailing-comma
+                newERC721TokenIdsByOwner
             ] = await matchOrderTester.matchOrdersAndVerifyBalancesAsync(
                 signedOrderLeft,
                 signedOrderRight,
@@ -306,9 +317,11 @@ describe('matchOrders', () => {
             // Match orders
             let newERC20BalancesByOwner: ERC20BalancesByOwner;
             let newERC721TokenIdsByOwner: ERC721TokenIdsByOwner;
+            // prettier-ignore
             [
                 newERC20BalancesByOwner,
-                newERC721TokenIdsByOwner,
+                // tslint:disable-next-line:trailing-comma
+                newERC721TokenIdsByOwner
             ] = await matchOrderTester.matchOrdersAndVerifyBalancesAsync(
                 signedOrderLeft,
                 signedOrderRight,
@@ -374,9 +387,11 @@ describe('matchOrders', () => {
             // Match orders
             let newERC20BalancesByOwner: ERC20BalancesByOwner;
             let newERC721TokenIdsByOwner: ERC721TokenIdsByOwner;
+            // prettier-ignore
             [
                 newERC20BalancesByOwner,
-                newERC721TokenIdsByOwner,
+                // tslint:disable-next-line:trailing-comma
+                newERC721TokenIdsByOwner
             ] = await matchOrderTester.matchOrdersAndVerifyBalancesAsync(
                 signedOrderLeft,
                 signedOrderRight,

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -41,8 +41,7 @@
         "npm-run-all": "^4.1.2",
         "nyc": "^11.0.1",
         "shx": "^0.2.2",
-        "tslint": "5.11.0",
-        "typescript": "2.7.1"
+        "tslint": "5.11.0"
     },
     "dependencies": {
         "@0xproject/subproviders": "^1.0.4",

--- a/packages/ethereum-types/package.json
+++ b/packages/ethereum-types/package.json
@@ -40,8 +40,7 @@
         "copyfiles": "^1.2.0",
         "make-promises-safe": "^1.1.0",
         "shx": "^0.2.2",
-        "tslint": "5.11.0",
-        "typescript": "2.7.1"
+        "tslint": "5.11.0"
     },
     "dependencies": {
         "@types/node": "^8.0.53",

--- a/packages/fill-scenarios/package.json
+++ b/packages/fill-scenarios/package.json
@@ -37,8 +37,7 @@
         "make-promises-safe": "^1.1.0",
         "npm-run-all": "^4.1.2",
         "shx": "^0.2.2",
-        "tslint": "5.11.0",
-        "typescript": "2.7.1"
+        "tslint": "5.11.0"
     },
     "dependencies": {
         "@0xproject/base-contract": "^1.0.4",

--- a/packages/json-schemas/package.json
+++ b/packages/json-schemas/package.json
@@ -69,8 +69,7 @@
         "nyc": "^11.0.1",
         "shx": "^0.2.2",
         "tslint": "5.11.0",
-        "typedoc": "0xProject/typedoc",
-        "typescript": "2.7.1"
+        "typedoc": "0xProject/typedoc"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/metacoin/package.json
+++ b/packages/metacoin/package.json
@@ -55,7 +55,6 @@
         "make-promises-safe": "^1.1.0",
         "npm-run-all": "^4.1.2",
         "shx": "^0.2.2",
-        "tslint": "5.11.0",
-        "typescript": "2.7.1"
+        "tslint": "5.11.0"
     }
 }

--- a/packages/migrations/package.json
+++ b/packages/migrations/package.json
@@ -49,7 +49,6 @@
         "npm-run-all": "^4.1.2",
         "shx": "^0.2.2",
         "tslint": "5.11.0",
-        "typescript": "2.7.1",
         "yargs": "^10.0.3"
     },
     "dependencies": {

--- a/packages/monorepo-scripts/package.json
+++ b/packages/monorepo-scripts/package.json
@@ -38,8 +38,7 @@
         "make-promises-safe": "^1.1.0",
         "npm-run-all": "^4.1.2",
         "shx": "^0.2.2",
-        "tslint": "5.11.0",
-        "typescript": "2.7.1"
+        "tslint": "5.11.0"
     },
     "dependencies": {
         "@lerna/batch-packages": "^3.0.0-beta.18",

--- a/packages/order-utils/package.json
+++ b/packages/order-utils/package.json
@@ -69,8 +69,7 @@
         "shx": "^0.2.2",
         "sinon": "^4.0.0",
         "tslint": "5.11.0",
-        "typedoc": "0xProject/typedoc",
-        "typescript": "2.7.1"
+        "typedoc": "0xProject/typedoc"
     },
     "dependencies": {
         "@0xproject/assert": "^1.0.4",

--- a/packages/order-watcher/package.json
+++ b/packages/order-watcher/package.json
@@ -66,8 +66,7 @@
         "shx": "^0.2.2",
         "sinon": "^4.0.0",
         "source-map-support": "^0.5.0",
-        "tslint": "5.11.0",
-        "typescript": "2.7.1"
+        "tslint": "5.11.0"
     },
     "dependencies": {
         "@0xproject/assert": "^1.0.4",

--- a/packages/react-docs-example/package.json
+++ b/packages/react-docs-example/package.json
@@ -45,7 +45,6 @@
         "source-map-loader": "^0.2.3",
         "style-loader": "^0.20.2",
         "tslint": "^5.9.1",
-        "typescript": "2.7.1",
         "webpack": "^3.11.0",
         "webpack-dev-server": "^2.11.1"
     },

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -32,8 +32,7 @@
         "copyfiles": "^1.2.0",
         "make-promises-safe": "^1.1.0",
         "shx": "^0.2.2",
-        "tslint": "^5.9.1",
-        "typescript": "2.7.1"
+        "tslint": "^5.9.1"
     },
     "dependencies": {
         "@0xproject/react-shared": "^1.0.5",

--- a/packages/react-shared/package.json
+++ b/packages/react-shared/package.json
@@ -31,8 +31,7 @@
         "copyfiles": "^1.2.0",
         "make-promises-safe": "^1.1.0",
         "shx": "^0.2.2",
-        "tslint": "^5.9.1",
-        "typescript": "2.7.1"
+        "tslint": "^5.9.1"
     },
     "dependencies": {
         "@types/is-mobile": "0.3.0",

--- a/packages/sol-compiler/package.json
+++ b/packages/sol-compiler/package.json
@@ -71,7 +71,6 @@
         "tslint": "5.11.0",
         "typedoc": "0xProject/typedoc",
         "types-bn": "^0.0.1",
-        "typescript": "2.7.1",
         "web3-typescript-typings": "^0.10.2",
         "zeppelin-solidity": "1.8.0"
     },

--- a/packages/sol-cov/package.json
+++ b/packages/sol-cov/package.json
@@ -88,8 +88,7 @@
         "shx": "^0.2.2",
         "sinon": "^4.0.0",
         "tslint": "5.11.0",
-        "typedoc": "0xProject/typedoc",
-        "typescript": "2.7.1"
+        "typedoc": "0xProject/typedoc"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/sol-resolver/package.json
+++ b/packages/sol-resolver/package.json
@@ -29,8 +29,7 @@
         "copyfiles": "^1.2.0",
         "make-promises-safe": "^1.1.0",
         "shx": "^0.2.2",
-        "tslint": "5.11.0",
-        "typescript": "2.7.1"
+        "tslint": "5.11.0"
     },
     "dependencies": {
         "@0xproject/types": "^1.0.1-rc.3",

--- a/packages/sra-report/package.json
+++ b/packages/sra-report/package.json
@@ -65,8 +65,7 @@
         "npm-run-all": "^4.1.2",
         "nyc": "^11.0.1",
         "shx": "^0.2.2",
-        "tslint": "5.11.0",
-        "typescript": "2.7.1"
+        "tslint": "5.11.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/subproviders/package.json
+++ b/packages/subproviders/package.json
@@ -84,7 +84,6 @@
         "sinon": "^4.0.0",
         "tslint": "5.11.0",
         "typedoc": "0xProject/typedoc",
-        "typescript": "2.7.1",
         "webpack": "^3.1.0"
     },
     "optionalDependencies": {

--- a/packages/testnet-faucets/package.json
+++ b/packages/testnet-faucets/package.json
@@ -43,7 +43,6 @@
         "shx": "^0.2.2",
         "source-map-loader": "^0.1.6",
         "tslint": "5.11.0",
-        "typescript": "2.7.1",
         "webpack": "^3.1.0",
         "webpack-node-externals": "^1.6.0"
     }

--- a/packages/tslint-config/package.json
+++ b/packages/tslint-config/package.json
@@ -38,8 +38,7 @@
         "@types/lodash": "4.14.104",
         "copyfiles": "^1.2.0",
         "make-promises-safe": "^1.1.0",
-        "shx": "^0.2.2",
-        "typescript": "2.7.1"
+        "shx": "^0.2.2"
     },
     "dependencies": {
         "lodash": "^4.17.4",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -29,8 +29,7 @@
         "copyfiles": "^1.2.0",
         "make-promises-safe": "^1.1.0",
         "shx": "^0.2.2",
-        "tslint": "5.11.0",
-        "typescript": "2.7.1"
+        "tslint": "5.11.0"
     },
     "dependencies": {
         "@types/node": "^8.0.53",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -31,8 +31,7 @@
         "make-promises-safe": "^1.1.0",
         "npm-run-all": "^4.1.2",
         "shx": "^0.2.2",
-        "tslint": "5.11.0",
-        "typescript": "2.7.1"
+        "tslint": "5.11.0"
     },
     "dependencies": {
         "@0xproject/types": "^1.0.1-rc.3",

--- a/packages/web3-wrapper/package.json
+++ b/packages/web3-wrapper/package.json
@@ -60,8 +60,7 @@
         "nyc": "^11.0.1",
         "shx": "^0.2.2",
         "tslint": "5.11.0",
-        "typedoc": "0xProject/typedoc",
-        "typescript": "2.7.1"
+        "typedoc": "0xProject/typedoc"
     },
     "dependencies": {
         "@0xproject/assert": "^1.0.4",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -98,7 +98,6 @@
         "style-loader": "0.13.x",
         "tslint": "5.11.0",
         "tslint-config-0xproject": "^0.0.2",
-        "typescript": "2.7.1",
         "uglifyjs-webpack-plugin": "^1.2.5",
         "webpack": "^3.1.0",
         "webpack-dev-middleware": "^1.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -565,37 +565,6 @@
     lodash "4.17.10"
     uuid "3.2.1"
 
-"@0xproject/contract-wrappers@^1.0.1-rc.2":
-  version "1.0.1-rc.1"
-  dependencies:
-    "@0xproject/assert" "^1.0.3"
-    "@0xproject/base-contract" "^1.0.3"
-    "@0xproject/fill-scenarios" "^1.0.1-rc.1"
-    "@0xproject/json-schemas" "^1.0.1-rc.2"
-    "@0xproject/order-utils" "^1.0.1-rc.1"
-    "@0xproject/types" "^1.0.1-rc.2"
-    "@0xproject/typescript-typings" "^1.0.3"
-    "@0xproject/utils" "^1.0.3"
-    "@0xproject/web3-wrapper" "^1.1.1"
-    ethereum-types "^1.0.3"
-    ethereumjs-blockstream "5.0.0"
-    ethereumjs-util "^5.1.1"
-    ethers "3.0.22"
-    js-sha3 "^0.7.0"
-    lodash "^4.17.4"
-    uuid "^3.1.0"
-
-"@0xproject/dev-utils@^1.0.3":
-  version "1.0.2"
-  dependencies:
-    "@0xproject/subproviders" "^1.0.3"
-    "@0xproject/types" "^1.0.1-rc.2"
-    "@0xproject/typescript-typings" "^1.0.3"
-    "@0xproject/utils" "^1.0.3"
-    "@0xproject/web3-wrapper" "^1.1.1"
-    ethereum-types "^1.0.3"
-    lodash "^4.17.4"
-
 "@0xproject/fill-scenarios@^0.0.4":
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@0xproject/fill-scenarios/-/fill-scenarios-0.0.4.tgz#4d23c75abda7e9f117b698c0b8b142af07e0c69e"
@@ -653,23 +622,6 @@
     jsonschema "1.2.2"
     lodash.values "4.3.0"
 
-"@0xproject/migrations@^1.0.3":
-  version "1.0.2"
-  dependencies:
-    "@0xproject/base-contract" "^1.0.3"
-    "@0xproject/order-utils" "^1.0.1-rc.1"
-    "@0xproject/sol-compiler" "^1.0.3"
-    "@0xproject/subproviders" "^1.0.3"
-    "@0xproject/typescript-typings" "^1.0.3"
-    "@0xproject/utils" "^1.0.3"
-    "@0xproject/web3-wrapper" "^1.1.1"
-    "@ledgerhq/hw-app-eth" "^4.3.0"
-    ethereum-types "^1.0.3"
-    ethers "3.0.22"
-    lodash "^4.17.4"
-  optionalDependencies:
-    "@ledgerhq/hw-transport-node-hid" "^4.3.0"
-
 "@0xproject/order-utils@^0.0.7":
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/@0xproject/order-utils/-/order-utils-0.0.7.tgz#eaa465782ea5745bdad54e1a851533172d993b7c"
@@ -717,25 +669,6 @@
     ethereumjs-abi "0.6.5"
     ethereumjs-util "5.1.5"
     lodash "4.17.10"
-
-"@0xproject/order-utils@^1.0.1-rc.2":
-  version "1.0.1-rc.1"
-  dependencies:
-    "@0xproject/assert" "^1.0.3"
-    "@0xproject/base-contract" "^1.0.3"
-    "@0xproject/json-schemas" "^1.0.1-rc.2"
-    "@0xproject/sol-compiler" "^1.0.3"
-    "@0xproject/types" "^1.0.1-rc.2"
-    "@0xproject/typescript-typings" "^1.0.3"
-    "@0xproject/utils" "^1.0.3"
-    "@0xproject/web3-wrapper" "^1.1.1"
-    "@types/node" "^8.0.53"
-    bn.js "^4.11.8"
-    ethereum-types "^1.0.3"
-    ethereumjs-abi "0.6.5"
-    ethereumjs-util "^5.1.1"
-    ethers "3.0.22"
-    lodash "^4.17.4"
 
 "@0xproject/order-watcher@^0.0.7":
   version "0.0.7"
@@ -13145,6 +13078,10 @@ typescript@2.4.1:
 typescript@2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.1.tgz#bb3682c2c791ac90e7c6210b26478a8da085c359"
+
+typescript@^2.8.0:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
 
 typewise-core@^1.2, typewise-core@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR changes the TypeScript version we use in the monorepo from 2.7 to 2.8. This upgrade was somewhat forced upon us because of a change made in a dependency. (The type definitions for react and prop-types in some part of the dependency tree are not compatible with version 2.7).

I discovered this by running __packages/monorepo-scripts/src/test_installation.ts__. It will fail on TypeScript version 2.7 but succeed if we use version 2.8.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

Start verdaccio. Run `yarn run:publish:local` and then `yarn test:installation:local`.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefixed the title of this PR with `[WIP]` if it is a work in progress.
*   [ ] Prefixed the title of this PR with bracketed package name(s) corresponding to the changed package(s). For example: `[sol-cov] Fixed bug`.
*   [ ] Added tests to cover my changes, or decided that tests would be too impractical.
*   [ ] Updated documentation, or decided that no doc change is needed.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
