### PR TITLE
[order-utils] Add rate and sorting utilities

### DIFF
--- a/packages/order-utils/CHANGELOG.json
+++ b/packages/order-utils/CHANGELOG.json
@@ -13,6 +13,10 @@
             },
             {
                 "note": "Dependencies updated"
+            },
+            {
+                "note": "Added rateUtils and sortingUtils",
+                "pr": 953
             }
         ]
     },

--- a/packages/order-utils/src/index.ts
+++ b/packages/order-utils/src/index.ts
@@ -33,3 +33,4 @@ export { EIP712Utils } from './eip712_utils';
 export { OrderValidationUtils } from './order_validation_utils';
 export { ExchangeTransferSimulator } from './exchange_transfer_simulator';
 export { marketUtils } from './market_utils';
+export { rateUtils } from './rate_utils';

--- a/packages/order-utils/src/index.ts
+++ b/packages/order-utils/src/index.ts
@@ -34,3 +34,4 @@ export { OrderValidationUtils } from './order_validation_utils';
 export { ExchangeTransferSimulator } from './exchange_transfer_simulator';
 export { marketUtils } from './market_utils';
 export { rateUtils } from './rate_utils';
+export { sortingUtils } from './sorting_utils';

--- a/packages/order-utils/src/rate_utils.ts
+++ b/packages/order-utils/src/rate_utils.ts
@@ -1,6 +1,7 @@
 import { schemas } from '@0xproject/json-schemas';
 import { SignedOrder } from '@0xproject/types';
 import { BigNumber } from '@0xproject/utils';
+import * as _ from 'lodash';
 
 import { assert } from './assert';
 import { constants } from './constants';
@@ -12,12 +13,16 @@ export const rateUtils = {
      * @param   signedOrder     An object that conforms to the signedOrder interface
      * @param   feeRate         The market rate of ZRX denominated in takerAssetAmount
      *                          (ex. feeRate is 0.1 takerAsset/ZRX if it takes 1 unit of takerAsset to buy 10 ZRX)
+     *                          Defaults to 0
      * @return  The rate (takerAsset/makerAsset) of the order adjusted for fees
      */
-    getFeeAdjustedRateOfOrder(signedOrder: SignedOrder, feeRate: BigNumber): BigNumber {
+    getFeeAdjustedRateOfOrder(signedOrder: SignedOrder, feeRate: BigNumber = constants.ZERO_AMOUNT): BigNumber {
         assert.doesConformToSchema('signedOrder', signedOrder, schemas.signedOrderSchema);
         assert.isBigNumber('feeRate', feeRate);
-        assert.assert(feeRate.greaterThan(constants.ZERO_AMOUNT), `Expected feeRate: ${feeRate} to be greater than 0`);
+        assert.assert(
+            feeRate.gte(constants.ZERO_AMOUNT),
+            `Expected feeRate: ${feeRate} to be greater than or equal to 0`,
+        );
         const takerAssetAmountNeededToPayForFees = signedOrder.takerFee.mul(feeRate);
         const totalTakerAssetAmount = takerAssetAmountNeededToPayForFees.plus(signedOrder.takerAssetAmount);
         const rate = totalTakerAssetAmount.div(signedOrder.makerAssetAmount);

--- a/packages/order-utils/src/rate_utils.ts
+++ b/packages/order-utils/src/rate_utils.ts
@@ -1,0 +1,44 @@
+import { schemas } from '@0xproject/json-schemas';
+import { SignedOrder } from '@0xproject/types';
+import { BigNumber } from '@0xproject/utils';
+
+import { assert } from './assert';
+import { constants } from './constants';
+
+export const rateUtils = {
+    /**
+     * Takes a signed order and calculates the fee adjusted rate (takerAsset/makerAsset) by calculating how much takerAsset
+     * is required to cover the fees (feeRate * takerFee), adding the takerAssetAmount and dividing by makerAssetAmount
+     * @param   signedOrder     An object that conforms to the signedOrder interface
+     * @param   feeRate         The market rate of ZRX denominated in takerAssetAmount
+     *                          (ex. feeRate is 0.1 takerAsset/ZRX if it takes 1 unit of takerAsset to buy 10 ZRX)
+     * @return  The rate (takerAsset/makerAsset) of the order adjusted for fees
+     */
+    getFeeAdjustedRateOfOrder(signedOrder: SignedOrder, feeRate: BigNumber): BigNumber {
+        assert.doesConformToSchema('signedOrder', signedOrder, schemas.signedOrderSchema);
+        assert.isBigNumber('feeRate', feeRate);
+        assert.assert(feeRate.greaterThan(constants.ZERO_AMOUNT), `Expected feeRate: ${feeRate} to be greater than 0`);
+        const takerAssetAmountNeededToPayForFees = signedOrder.takerFee.mul(feeRate);
+        const totalTakerAssetAmount = takerAssetAmountNeededToPayForFees.plus(signedOrder.takerAssetAmount);
+        const rate = totalTakerAssetAmount.div(signedOrder.makerAssetAmount);
+        return rate;
+    },
+    /**
+     * Takes a signed fee order (makerAssetData corresponds to ZRX and takerAssetData corresponds to WETH) and calculates
+     * the fee adjusted rate (WETH/ZRX) by dividing the takerAssetAmount by the makerAmount minus the takerFee
+     * @param   signedFeeOrder    An object that conforms to the signedOrder interface
+     * @return  The rate (WETH/ZRX) of the fee order adjusted for fees
+     */
+    getFeeAdjustedRateOfFeeOrder(signedFeeOrder: SignedOrder): BigNumber {
+        assert.doesConformToSchema('signedFeeOrder', signedFeeOrder, schemas.signedOrderSchema);
+        const zrxAmountAfterFees = signedFeeOrder.makerAssetAmount.sub(signedFeeOrder.takerFee);
+        assert.assert(
+            zrxAmountAfterFees.greaterThan(constants.ZERO_AMOUNT),
+            `Expected takerFee: ${JSON.stringify(
+                signedFeeOrder.takerFee,
+            )} to be less than makerAssetAmount: ${JSON.stringify(signedFeeOrder.makerAssetAmount)}`,
+        );
+        const rate = signedFeeOrder.takerAssetAmount.div(zrxAmountAfterFees);
+        return rate;
+    },
+};

--- a/packages/order-utils/src/rate_utils.ts
+++ b/packages/order-utils/src/rate_utils.ts
@@ -1,5 +1,5 @@
 import { schemas } from '@0xproject/json-schemas';
-import { SignedOrder } from '@0xproject/types';
+import { Order } from '@0xproject/types';
 import { BigNumber } from '@0xproject/utils';
 
 import { assert } from './assert';
@@ -7,42 +7,42 @@ import { constants } from './constants';
 
 export const rateUtils = {
     /**
-     * Takes a signed order and calculates the fee adjusted rate (takerAsset/makerAsset) by calculating how much takerAsset
+     * Takes an order and calculates the fee adjusted rate (takerAsset/makerAsset) by calculating how much takerAsset
      * is required to cover the fees (feeRate * takerFee), adding the takerAssetAmount and dividing by makerAssetAmount
-     * @param   signedOrder     An object that conforms to the signedOrder interface
-     * @param   feeRate         The market rate of ZRX denominated in takerAssetAmount
-     *                          (ex. feeRate is 0.1 takerAsset/ZRX if it takes 1 unit of takerAsset to buy 10 ZRX)
-     *                          Defaults to 0
+     * @param   order       An object that conforms to the order interface
+     * @param   feeRate     The market rate of ZRX denominated in takerAssetAmount
+     *                      (ex. feeRate is 0.1 takerAsset/ZRX if it takes 1 unit of takerAsset to buy 10 ZRX)
+     *                      Defaults to 0
      * @return  The rate (takerAsset/makerAsset) of the order adjusted for fees
      */
-    getFeeAdjustedRateOfOrder(signedOrder: SignedOrder, feeRate: BigNumber = constants.ZERO_AMOUNT): BigNumber {
-        assert.doesConformToSchema('signedOrder', signedOrder, schemas.signedOrderSchema);
+    getFeeAdjustedRateOfOrder(order: Order, feeRate: BigNumber = constants.ZERO_AMOUNT): BigNumber {
+        assert.doesConformToSchema('order', order, schemas.orderSchema);
         assert.isBigNumber('feeRate', feeRate);
         assert.assert(
             feeRate.gte(constants.ZERO_AMOUNT),
             `Expected feeRate: ${feeRate} to be greater than or equal to 0`,
         );
-        const takerAssetAmountNeededToPayForFees = signedOrder.takerFee.mul(feeRate);
-        const totalTakerAssetAmount = takerAssetAmountNeededToPayForFees.plus(signedOrder.takerAssetAmount);
-        const rate = totalTakerAssetAmount.div(signedOrder.makerAssetAmount);
+        const takerAssetAmountNeededToPayForFees = order.takerFee.mul(feeRate);
+        const totalTakerAssetAmount = takerAssetAmountNeededToPayForFees.plus(order.takerAssetAmount);
+        const rate = totalTakerAssetAmount.div(order.makerAssetAmount);
         return rate;
     },
     /**
-     * Takes a signed fee order (makerAssetData corresponds to ZRX and takerAssetData corresponds to WETH) and calculates
+     * Takes a fee order (makerAssetData corresponds to ZRX and takerAssetData corresponds to WETH) and calculates
      * the fee adjusted rate (WETH/ZRX) by dividing the takerAssetAmount by the makerAmount minus the takerFee
-     * @param   signedFeeOrder    An object that conforms to the signedOrder interface
+     * @param   feeOrder    An object that conforms to the order interface
      * @return  The rate (WETH/ZRX) of the fee order adjusted for fees
      */
-    getFeeAdjustedRateOfFeeOrder(signedFeeOrder: SignedOrder): BigNumber {
-        assert.doesConformToSchema('signedFeeOrder', signedFeeOrder, schemas.signedOrderSchema);
-        const zrxAmountAfterFees = signedFeeOrder.makerAssetAmount.sub(signedFeeOrder.takerFee);
+    getFeeAdjustedRateOfFeeOrder(feeOrder: Order): BigNumber {
+        assert.doesConformToSchema('feeOrder', feeOrder, schemas.orderSchema);
+        const zrxAmountAfterFees = feeOrder.makerAssetAmount.sub(feeOrder.takerFee);
         assert.assert(
             zrxAmountAfterFees.greaterThan(constants.ZERO_AMOUNT),
-            `Expected takerFee: ${JSON.stringify(
-                signedFeeOrder.takerFee,
-            )} to be less than makerAssetAmount: ${JSON.stringify(signedFeeOrder.makerAssetAmount)}`,
+            `Expected takerFee: ${JSON.stringify(feeOrder.takerFee)} to be less than makerAssetAmount: ${JSON.stringify(
+                feeOrder.makerAssetAmount,
+            )}`,
         );
-        const rate = signedFeeOrder.takerAssetAmount.div(zrxAmountAfterFees);
+        const rate = feeOrder.takerAssetAmount.div(zrxAmountAfterFees);
         return rate;
     },
 };

--- a/packages/order-utils/src/rate_utils.ts
+++ b/packages/order-utils/src/rate_utils.ts
@@ -1,7 +1,6 @@
 import { schemas } from '@0xproject/json-schemas';
 import { SignedOrder } from '@0xproject/types';
 import { BigNumber } from '@0xproject/utils';
-import * as _ from 'lodash';
 
 import { assert } from './assert';
 import { constants } from './constants';

--- a/packages/order-utils/src/sorting_utils.ts
+++ b/packages/order-utils/src/sorting_utils.ts
@@ -1,5 +1,5 @@
 import { schemas } from '@0xproject/json-schemas';
-import { SignedOrder } from '@0xproject/types';
+import { Order } from '@0xproject/types';
 import { BigNumber } from '@0xproject/utils';
 import * as _ from 'lodash';
 
@@ -9,64 +9,46 @@ import { rateUtils } from './rate_utils';
 
 export const sortingUtils = {
     /**
-     * Takes an array of signed orders and sorts them by takerAsset/makerAsset rate in ascending order (best rate first).
+     * Takes an array of orders and sorts them by takerAsset/makerAsset rate in ascending order (best rate first).
      * Adjusts the rate of each order according to the feeRate and takerFee for that order.
-     * @param   signedFeeOrders     An array of objects that conform to the SignedOrder interface. All orders should specify ZRX as
-     *                              the makerAsset and WETH as the takerAsset.
-     * @param   feeRate             The market rate of ZRX denominated in takerAssetAmount
-     *                              (ex. feeRate is 0.1 takerAsset/ZRX if it takes 1 unit of takerAsset to buy 10 ZRX)
-     *                              Defaults to 0
+     * @param   orders      An array of objects that extend the Order interface. All orders should specify ZRX as
+     *                      the makerAsset and WETH as the takerAsset.
+     * @param   feeRate     The market rate of ZRX denominated in takerAssetAmount
+     *                      (ex. feeRate is 0.1 takerAsset/ZRX if it takes 1 unit of takerAsset to buy 10 ZRX)
+     *                      Defaults to 0
      * @return  The input orders sorted by rate in ascending order
      */
-    sortOrdersByFeeAdjustedRate(
-        signedOrders: SignedOrder[],
-        feeRate: BigNumber = constants.ZERO_AMOUNT,
-    ): SignedOrder[] {
-        assert.doesConformToSchema('signedOrders', signedOrders, schemas.signedOrdersSchema);
+    sortOrdersByFeeAdjustedRate<T extends Order>(orders: T[], feeRate: BigNumber = constants.ZERO_AMOUNT): T[] {
+        assert.doesConformToSchema('orders', orders, schemas.ordersSchema);
         assert.isBigNumber('feeRate', feeRate);
-        const rateCalculator = (signedOrder: SignedOrder) => rateUtils.getFeeAdjustedRateOfOrder(signedOrder, feeRate);
-        const sortedOrders = sortOrders(signedOrders, rateCalculator);
+        const rateCalculator = (order: Order) => rateUtils.getFeeAdjustedRateOfOrder(order, feeRate);
+        const sortedOrders = sortOrders(orders, rateCalculator);
         return sortedOrders;
     },
     /**
-     * Takes an array of signed fee orders (makerAssetData corresponds to ZRX and takerAssetData corresponds to WETH)
+     * Takes an array of fee orders (makerAssetData corresponds to ZRX and takerAssetData corresponds to WETH)
      * and sorts them by rate in ascending order (best rate first). Adjusts the rate according to the takerFee.
-     * @param   signedFeeOrders     An array of objects that conform to the SignedOrder interface. All orders should specify ZRX as
-     *                              the makerAsset and WETH as the takerAsset.
+     * @param   feeOrders       An array of objects that extend the Order interface. All orders should specify ZRX as
+     *                          the makerAsset and WETH as the takerAsset.
      * @return  The input orders sorted by rate in ascending order
      */
-    sortFeeOrdersByFeeAdjustedRate(signedFeeOrders: SignedOrder[]): SignedOrder[] {
-        assert.doesConformToSchema('signedFeeOrders', signedFeeOrders, schemas.signedOrdersSchema);
+    sortFeeOrdersByFeeAdjustedRate(feeOrders: Order[]): Order[] {
+        assert.doesConformToSchema('feeOrders', feeOrders, schemas.ordersSchema);
         const rateCalculator = rateUtils.getFeeAdjustedRateOfFeeOrder.bind(rateUtils);
-        const sortedOrders = sortOrders(signedFeeOrders, rateCalculator);
+        const sortedOrders = sortOrders(feeOrders, rateCalculator);
         return sortedOrders;
     },
 };
 
-type RateCalculator = (signedOrder: SignedOrder) => BigNumber;
+type RateCalculator = (order: Order) => BigNumber;
 
 // takes an array of orders, copies them, and sorts the copy based on the rate definition provided by rateCalculator
-const sortOrders = (signedOrders: SignedOrder[], rateCalculator: RateCalculator): SignedOrder[] => {
-    const copiedOrders = _.cloneDeep(signedOrders);
-    const feeOrderComparator = getOrderComparator(rateCalculator);
-    copiedOrders.sort(feeOrderComparator);
+function sortOrders<T extends Order>(orders: T[], rateCalculator: RateCalculator): T[] {
+    const copiedOrders = _.cloneDeep(orders);
+    copiedOrders.sort((firstOrder, secondOrder) => {
+        const firstOrderRate = rateCalculator(firstOrder);
+        const secondOrderRate = rateCalculator(secondOrder);
+        return firstOrderRate.comparedTo(secondOrderRate);
+    });
     return copiedOrders;
-};
-
-type Comparator<T> = (first: T, second: T) => number;
-
-// takes a function that calculates rate for a signed order and returns a comparator that sorts based on rate
-const getOrderComparator = (rateCalculator: RateCalculator): Comparator<SignedOrder> => (
-    firstSignedOrder,
-    secondSignedOrder,
-) => {
-    const firstOrderRate = rateCalculator(firstSignedOrder);
-    const secondOrderRate = rateCalculator(secondSignedOrder);
-    if (firstOrderRate.lt(secondOrderRate)) {
-        return -1;
-    } else if (firstOrderRate.gt(secondOrderRate)) {
-        return 1;
-    } else {
-        return 0;
-    }
-};
+}

--- a/packages/order-utils/src/sorting_utils.ts
+++ b/packages/order-utils/src/sorting_utils.ts
@@ -37,7 +37,7 @@ export const sortingUtils = {
      */
     sortFeeOrdersByFeeAdjustedRate(signedFeeOrders: SignedOrder[]): SignedOrder[] {
         assert.doesConformToSchema('signedFeeOrders', signedFeeOrders, schemas.signedOrdersSchema);
-        const rateCalculator = rateUtils.getFeeAdjustedRateOfFeeOrder;
+        const rateCalculator = rateUtils.getFeeAdjustedRateOfFeeOrder.bind(rateUtils);
         const sortedOrders = sortOrders(signedFeeOrders, rateCalculator);
         return sortedOrders;
     },

--- a/packages/order-utils/src/sorting_utils.ts
+++ b/packages/order-utils/src/sorting_utils.ts
@@ -15,9 +15,13 @@ export const sortingUtils = {
      *                              the makerAsset and WETH as the takerAsset.
      * @param   feeRate             The market rate of ZRX denominated in takerAssetAmount
      *                              (ex. feeRate is 0.1 takerAsset/ZRX if it takes 1 unit of takerAsset to buy 10 ZRX)
+     *                              Defaults to 0
      * @return  The input orders sorted by rate in ascending order
      */
-    sortOrdersByFeeAdjustedRate(signedOrders: SignedOrder[], feeRate: BigNumber): SignedOrder[] {
+    sortOrdersByFeeAdjustedRate(
+        signedOrders: SignedOrder[],
+        feeRate: BigNumber = constants.ZERO_AMOUNT,
+    ): SignedOrder[] {
         assert.doesConformToSchema('signedOrders', signedOrders, schemas.signedOrdersSchema);
         assert.isBigNumber('feeRate', feeRate);
         const rateCalculator = (signedOrder: SignedOrder) => rateUtils.getFeeAdjustedRateOfOrder(signedOrder, feeRate);

--- a/packages/order-utils/src/sorting_utils.ts
+++ b/packages/order-utils/src/sorting_utils.ts
@@ -20,7 +20,6 @@ export const sortingUtils = {
     sortOrdersByFeeAdjustedRate(signedOrders: SignedOrder[], feeRate: BigNumber): SignedOrder[] {
         assert.doesConformToSchema('signedOrders', signedOrders, schemas.signedOrdersSchema);
         assert.isBigNumber('feeRate', feeRate);
-        assert.assert(feeRate.greaterThan(constants.ZERO_AMOUNT), `Expected feeRate: ${feeRate} to be greater than 0`);
         const rateCalculator = (signedOrder: SignedOrder) => rateUtils.getFeeAdjustedRateOfOrder(signedOrder, feeRate);
         const sortedOrders = sortOrders(signedOrders, rateCalculator);
         return sortedOrders;

--- a/packages/order-utils/src/sorting_utils.ts
+++ b/packages/order-utils/src/sorting_utils.ts
@@ -1,0 +1,69 @@
+import { schemas } from '@0xproject/json-schemas';
+import { SignedOrder } from '@0xproject/types';
+import { BigNumber } from '@0xproject/utils';
+import * as _ from 'lodash';
+
+import { assert } from './assert';
+import { constants } from './constants';
+import { rateUtils } from './rate_utils';
+
+export const sortingUtils = {
+    /**
+     * Takes an array of signed orders and sorts them by takerAsset/makerAsset rate in ascending order (best rate first).
+     * Adjusts the rate of each order according to the feeRate and takerFee for that order.
+     * @param   signedFeeOrders     An array of objects that conform to the SignedOrder interface. All orders should specify ZRX as
+     *                              the makerAsset and WETH as the takerAsset.
+     * @param   feeRate             The market rate of ZRX denominated in takerAssetAmount
+     *                              (ex. feeRate is 0.1 takerAsset/ZRX if it takes 1 unit of takerAsset to buy 10 ZRX)
+     * @return  The input orders sorted by rate in ascending order
+     */
+    sortOrdersByFeeAdjustedRate(signedOrders: SignedOrder[], feeRate: BigNumber): SignedOrder[] {
+        assert.doesConformToSchema('signedOrders', signedOrders, schemas.signedOrdersSchema);
+        assert.isBigNumber('feeRate', feeRate);
+        assert.assert(feeRate.greaterThan(constants.ZERO_AMOUNT), `Expected feeRate: ${feeRate} to be greater than 0`);
+        const rateCalculator = (signedOrder: SignedOrder) => rateUtils.getFeeAdjustedRateOfOrder(signedOrder, feeRate);
+        const sortedOrders = sortOrders(signedOrders, rateCalculator);
+        return sortedOrders;
+    },
+    /**
+     * Takes an array of signed fee orders (makerAssetData corresponds to ZRX and takerAssetData corresponds to WETH)
+     * and sorts them by rate in ascending order (best rate first). Adjusts the rate according to the takerFee.
+     * @param   signedFeeOrders     An array of objects that conform to the SignedOrder interface. All orders should specify ZRX as
+     *                              the makerAsset and WETH as the takerAsset.
+     * @return  The input orders sorted by rate in ascending order
+     */
+    sortFeeOrdersByFeeAdjustedRate(signedFeeOrders: SignedOrder[]): SignedOrder[] {
+        assert.doesConformToSchema('signedFeeOrders', signedFeeOrders, schemas.signedOrdersSchema);
+        const rateCalculator = rateUtils.getFeeAdjustedRateOfFeeOrder;
+        const sortedOrders = sortOrders(signedFeeOrders, rateCalculator);
+        return sortedOrders;
+    },
+};
+
+type RateCalculator = (signedOrder: SignedOrder) => BigNumber;
+
+// takes an array of orders, copies them, and sorts the copy based on the rate definition provided by rateCalculator
+const sortOrders = (signedOrders: SignedOrder[], rateCalculator: RateCalculator): SignedOrder[] => {
+    const copiedOrders = _.cloneDeep(signedOrders);
+    const feeOrderComparator = getOrderComparator(rateCalculator);
+    copiedOrders.sort(feeOrderComparator);
+    return copiedOrders;
+};
+
+type Comparator<T> = (first: T, second: T) => number;
+
+// takes a function that calculates rate for a signed order and returns a comparator that sorts based on rate
+const getOrderComparator = (rateCalculator: RateCalculator): Comparator<SignedOrder> => (
+    firstSignedOrder,
+    secondSignedOrder,
+) => {
+    const firstOrderRate = rateCalculator(firstSignedOrder);
+    const secondOrderRate = rateCalculator(secondSignedOrder);
+    if (firstOrderRate.lt(secondOrderRate)) {
+        return -1;
+    } else if (firstOrderRate.gt(secondOrderRate)) {
+        return 1;
+    } else {
+        return 0;
+    }
+};

--- a/packages/order-utils/test/rate_utils_test.ts
+++ b/packages/order-utils/test/rate_utils_test.ts
@@ -23,11 +23,17 @@ describe('rateUtils', () => {
                 'Expected feeRate: -1 to be greater than or equal to 0',
             );
         });
-        it('correctly calculates fee adjusted rate', async () => {
+        it('correctly calculates fee adjusted rate when feeRate is provided', async () => {
             const feeRate = new BigNumber(2); // ZRX costs 2 units of takerAsset per 1 unit of ZRX
             const feeAdjustedRate = rateUtils.getFeeAdjustedRateOfOrder(testOrder, feeRate);
             // the order actually takes 100 + (2 * 20) takerAsset units to fill 100 units of makerAsset
             expect(feeAdjustedRate).to.bignumber.equal(new BigNumber(1.4));
+        });
+        it('correctly calculates fee adjusted rate when no feeRate is provided', async () => {
+            const feeAdjustedRate = rateUtils.getFeeAdjustedRateOfOrder(testOrder);
+            // because no feeRate was provided we just assume 0 fees
+            // the order actually takes 100 takerAsset units to fill 100 units of makerAsset
+            expect(feeAdjustedRate).to.bignumber.equal(new BigNumber(1));
         });
     });
     describe('#getFeeAdjustedRateOfFeeOrder', () => {

--- a/packages/order-utils/test/rate_utils_test.ts
+++ b/packages/order-utils/test/rate_utils_test.ts
@@ -1,0 +1,55 @@
+import { BigNumber } from '@0xproject/utils';
+import * as chai from 'chai';
+import 'mocha';
+
+import { constants, rateUtils } from '../src';
+
+import { chaiSetup } from './utils/chai_setup';
+import { testOrderFactory } from './utils/test_order_factory';
+
+chaiSetup.configure();
+const expect = chai.expect;
+
+describe('rateUtils', () => {
+    const testOrder = testOrderFactory.generateTestSignedOrder({
+        makerAssetAmount: new BigNumber(100),
+        takerAssetAmount: new BigNumber(100),
+        takerFee: new BigNumber(20),
+    });
+    describe('#getFeeAdjustedRateOfOrder', () => {
+        it('throws when feeRate is zero', async () => {
+            const feeRate = constants.ZERO_AMOUNT;
+            expect(() => rateUtils.getFeeAdjustedRateOfOrder(testOrder, feeRate)).to.throw(
+                'Expected feeRate: 0 to be greater than 0',
+            );
+        });
+        it('throws when feeRate is less than zero', async () => {
+            const feeRate = new BigNumber(-1);
+            expect(() => rateUtils.getFeeAdjustedRateOfOrder(testOrder, feeRate)).to.throw(
+                'Expected feeRate: -1 to be greater than 0',
+            );
+        });
+        it('correctly calculates fee adjusted rate', async () => {
+            const feeRate = new BigNumber(2); // ZRX costs 2 units of takerAsset per 1 unit of ZRX
+            const feeAdjustedRate = rateUtils.getFeeAdjustedRateOfOrder(testOrder, feeRate);
+            // the order actually takes 100 + (2 * 20) takerAsset units to fill 100 units of makerAsset
+            expect(feeAdjustedRate).to.bignumber.equal(new BigNumber(1.4));
+        });
+    });
+    describe('#getFeeAdjustedRateOfFeeOrder', () => {
+        it('throws when takerFee exceeds makerAssetAmount', async () => {
+            const badOrder = testOrderFactory.generateTestSignedOrder({
+                makerAssetAmount: new BigNumber(100),
+                takerFee: new BigNumber(101),
+            });
+            expect(() => rateUtils.getFeeAdjustedRateOfFeeOrder(badOrder)).to.throw(
+                'Expected takerFee: "101" to be less than makerAssetAmount: "100"',
+            );
+        });
+        it('correctly calculates fee adjusted rate', async () => {
+            const feeAdjustedRate = rateUtils.getFeeAdjustedRateOfFeeOrder(testOrder);
+            // the order actually takes 100 takerAsset units to fill (100 - 20) units of makerAsset
+            expect(feeAdjustedRate).to.bignumber.equal(new BigNumber(1.25));
+        });
+    });
+});

--- a/packages/order-utils/test/rate_utils_test.ts
+++ b/packages/order-utils/test/rate_utils_test.ts
@@ -2,7 +2,7 @@ import { BigNumber } from '@0xproject/utils';
 import * as chai from 'chai';
 import 'mocha';
 
-import { constants, rateUtils } from '../src';
+import { rateUtils } from '../src';
 
 import { chaiSetup } from './utils/chai_setup';
 import { testOrderFactory } from './utils/test_order_factory';

--- a/packages/order-utils/test/rate_utils_test.ts
+++ b/packages/order-utils/test/rate_utils_test.ts
@@ -17,16 +17,10 @@ describe('rateUtils', () => {
         takerFee: new BigNumber(20),
     });
     describe('#getFeeAdjustedRateOfOrder', () => {
-        it('throws when feeRate is zero', async () => {
-            const feeRate = constants.ZERO_AMOUNT;
-            expect(() => rateUtils.getFeeAdjustedRateOfOrder(testOrder, feeRate)).to.throw(
-                'Expected feeRate: 0 to be greater than 0',
-            );
-        });
         it('throws when feeRate is less than zero', async () => {
             const feeRate = new BigNumber(-1);
             expect(() => rateUtils.getFeeAdjustedRateOfOrder(testOrder, feeRate)).to.throw(
-                'Expected feeRate: -1 to be greater than 0',
+                'Expected feeRate: -1 to be greater than or equal to 0',
             );
         });
         it('correctly calculates fee adjusted rate', async () => {

--- a/packages/order-utils/test/sorting_utils_test.ts
+++ b/packages/order-utils/test/sorting_utils_test.ts
@@ -1,9 +1,8 @@
 import { BigNumber } from '@0xproject/utils';
 import * as chai from 'chai';
-import * as _ from 'lodash';
 import 'mocha';
 
-import { constants, rateUtils, sortingUtils } from '../src';
+import { sortingUtils } from '../src';
 
 import { chaiSetup } from './utils/chai_setup';
 import { testOrderFactory } from './utils/test_order_factory';
@@ -32,15 +31,12 @@ describe('sortingUtils', () => {
         });
         it('correctly sorts by fee adjusted rate when feeRate is Provided', async () => {
             const orders = [testOrder1, testOrder2, testOrder3];
-            const sortedOrders = sortingUtils.sortOrdersByFeeAdjustedRate(
-                [testOrder1, testOrder2, testOrder3],
-                feeRate,
-            );
+            const sortedOrders = sortingUtils.sortOrdersByFeeAdjustedRate(orders, feeRate);
             expect(sortedOrders).to.deep.equal([testOrder2, testOrder1, testOrder3]);
         });
         it('correctly sorts by fee adjusted rate when no feeRate is Provided', async () => {
             const orders = [testOrder1, testOrder2, testOrder3];
-            const sortedOrders = sortingUtils.sortOrdersByFeeAdjustedRate([testOrder1, testOrder2, testOrder3]);
+            const sortedOrders = sortingUtils.sortOrdersByFeeAdjustedRate(orders);
             expect(sortedOrders).to.deep.equal([testOrder2, testOrder1, testOrder3]);
         });
     });
@@ -64,7 +60,7 @@ describe('sortingUtils', () => {
         });
         it('correctly sorts by fee adjusted rate', async () => {
             const orders = [testOrder1, testOrder2, testOrder3];
-            const sortedOrders = sortingUtils.sortFeeOrdersByFeeAdjustedRate([testOrder1, testOrder2, testOrder3]);
+            const sortedOrders = sortingUtils.sortFeeOrdersByFeeAdjustedRate(orders);
             expect(sortedOrders).to.deep.equal([testOrder2, testOrder3, testOrder1]);
         });
     });

--- a/packages/order-utils/test/sorting_utils_test.ts
+++ b/packages/order-utils/test/sorting_utils_test.ts
@@ -1,0 +1,66 @@
+import { BigNumber } from '@0xproject/utils';
+import * as chai from 'chai';
+import * as _ from 'lodash';
+import 'mocha';
+
+import { constants, rateUtils, sortingUtils } from '../src';
+
+import { chaiSetup } from './utils/chai_setup';
+import { testOrderFactory } from './utils/test_order_factory';
+
+chaiSetup.configure();
+const expect = chai.expect;
+
+describe('sortingUtils', () => {
+    describe('#sortOrdersByFeeAdjustedRate', () => {
+        // rate: 2 takerAsset / makerAsset
+        const testOrder1 = testOrderFactory.generateTestSignedOrder({
+            makerAssetAmount: new BigNumber(100),
+            takerAssetAmount: new BigNumber(200),
+        });
+        // rate: 1 takerAsset / makerAsset
+        const testOrder2 = testOrderFactory.generateTestSignedOrder({
+            makerAssetAmount: new BigNumber(100),
+            takerAssetAmount: new BigNumber(100),
+        });
+        // rate: 2.5 takerAsset / makerAsset
+        const testOrder3 = testOrderFactory.generateTestSignedOrder({
+            makerAssetAmount: new BigNumber(100),
+            takerAssetAmount: new BigNumber(200),
+            takerFee: new BigNumber(50),
+        });
+        it('correctly sorts by fee adjusted rate', async () => {
+            const feeRate = new BigNumber(1); // ZRX costs 1 unit of takerAsset per 1 unit of ZRX
+            const orders = [testOrder1, testOrder2, testOrder3];
+            const sortedOrders = sortingUtils.sortOrdersByFeeAdjustedRate(
+                [testOrder1, testOrder2, testOrder3],
+                feeRate,
+            );
+            expect(sortedOrders).to.deep.equal([testOrder2, testOrder1, testOrder3]);
+        });
+    });
+    describe('#sortFeeOrdersByFeeAdjustedRate', () => {
+        // rate: 200 takerAsset / makerAsset
+        const testOrder1 = testOrderFactory.generateTestSignedOrder({
+            makerAssetAmount: new BigNumber(100),
+            takerAssetAmount: new BigNumber(200),
+            takerFee: new BigNumber(99),
+        });
+        // rate: 1 takerAsset / makerAsset
+        const testOrder2 = testOrderFactory.generateTestSignedOrder({
+            makerAssetAmount: new BigNumber(100),
+            takerAssetAmount: new BigNumber(100),
+        });
+        // rate: 4 takerAsset / makerAsset
+        const testOrder3 = testOrderFactory.generateTestSignedOrder({
+            makerAssetAmount: new BigNumber(100),
+            takerAssetAmount: new BigNumber(200),
+            takerFee: new BigNumber(50),
+        });
+        it('correctly sorts by fee adjusted rate', async () => {
+            const orders = [testOrder1, testOrder2, testOrder3];
+            const sortedOrders = sortingUtils.sortFeeOrdersByFeeAdjustedRate([testOrder1, testOrder2, testOrder3]);
+            expect(sortedOrders).to.deep.equal([testOrder2, testOrder3, testOrder1]);
+        });
+    });
+});

--- a/packages/order-utils/test/sorting_utils_test.ts
+++ b/packages/order-utils/test/sorting_utils_test.ts
@@ -13,6 +13,7 @@ const expect = chai.expect;
 
 describe('sortingUtils', () => {
     describe('#sortOrdersByFeeAdjustedRate', () => {
+        const feeRate = new BigNumber(1); // ZRX costs 1 unit of takerAsset per 1 unit of ZRX
         // rate: 2 takerAsset / makerAsset
         const testOrder1 = testOrderFactory.generateTestSignedOrder({
             makerAssetAmount: new BigNumber(100),
@@ -29,13 +30,17 @@ describe('sortingUtils', () => {
             takerAssetAmount: new BigNumber(200),
             takerFee: new BigNumber(50),
         });
-        it('correctly sorts by fee adjusted rate', async () => {
-            const feeRate = new BigNumber(1); // ZRX costs 1 unit of takerAsset per 1 unit of ZRX
+        it('correctly sorts by fee adjusted rate when feeRate is Provided', async () => {
             const orders = [testOrder1, testOrder2, testOrder3];
             const sortedOrders = sortingUtils.sortOrdersByFeeAdjustedRate(
                 [testOrder1, testOrder2, testOrder3],
                 feeRate,
             );
+            expect(sortedOrders).to.deep.equal([testOrder2, testOrder1, testOrder3]);
+        });
+        it('correctly sorts by fee adjusted rate when no feeRate is Provided', async () => {
+            const orders = [testOrder1, testOrder2, testOrder3];
+            const sortedOrders = sortingUtils.sortOrdersByFeeAdjustedRate([testOrder1, testOrder2, testOrder3]);
             expect(sortedOrders).to.deep.equal([testOrder2, testOrder1, testOrder3]);
         });
     });


### PR DESCRIPTION
## Description

* Add utilities for calculating fee-adjusted rates
* Add utilities for sorting order by best fee-adjusted rate

When calculating rates for orders we need to take into account how much fees the taker needs to pay to fill the order. In the case of fee orders (ZRX/WETH) the fee is taken out of the makerAmount. In the case of non ZRX orders (ex. REP/WETH) a feeRate can be provided to estimate how much takerAsset is actually required to fill that order when performing fee abstraction

## Testing instructions

```bash
yarn install && PKG=@0xproject/order-utils yarn build
cd packages/order-utils && yarn test
```

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature (non-breaking change which adds functionality)

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [x] Prefixed the title of this PR with `[WIP]` if it is a work in progress.
*   [x] Prefixed the title of this PR with bracketed package name(s) corresponding to the changed package(s). For example: `[sol-cov] Fixed bug`.
*   [x] Added tests to cover my changes, or decided that tests would be too impractical.
*   [x] Updated documentation, or decided that no doc change is needed.
*   [x] Added new entries to the relevant CHANGELOG.jsons.
