### PR TITLE
[Order-utils] Order is valid when maker amount is very small

### DIFF
--- a/packages/contracts/test/exchange/fill_order.ts
+++ b/packages/contracts/test/exchange/fill_order.ts
@@ -104,6 +104,17 @@ describe('FillOrder Tests', () => {
             };
             await fillOrderCombinatorialUtils.testFillOrderScenarioAsync(provider, fillScenario);
         });
+        it('should transfer the correct amounts when makerAssetAmount < takerAssetAmount with zero decimals', async () => {
+            const fillScenario = {
+                ...defaultFillScenario,
+                orderScenario: {
+                    ...defaultFillScenario.orderScenario,
+                    makerAssetAmountScenario: OrderAssetAmountScenario.Small,
+                    makerAssetDataScenario: AssetDataScenario.ERC20ZeroDecimals,
+                },
+            };
+            await fillOrderCombinatorialUtils.testFillOrderScenarioAsync(provider, fillScenario);
+        });
         it('should transfer the correct amounts when taker is specified and order is claimed by taker', async () => {
             const fillScenario = {
                 ...defaultFillScenario,

--- a/packages/contracts/test/utils/fill_order_combinatorial_utils.ts
+++ b/packages/contracts/test/utils/fill_order_combinatorial_utils.ts
@@ -81,6 +81,12 @@ export async function fillOrderCombinatorialUtilsFactoryAsync(
         erc20FiveDecimalTokenCount,
         fiveDecimals,
     );
+    const zeroDecimals = new BigNumber(0);
+    const erc20ZeroDecimalTokenCount = 2;
+    const [erc20ZeroDecimalTokenA, erc20ZeroDecimalTokenB] = await erc20Wrapper.deployDummyTokensAsync(
+        erc20ZeroDecimalTokenCount,
+        zeroDecimals,
+    );
     const erc20Proxy = await erc20Wrapper.deployProxyAsync();
     await erc20Wrapper.setBalancesAndAllowancesAsync();
 
@@ -119,6 +125,7 @@ export async function fillOrderCombinatorialUtilsFactoryAsync(
         zrxToken.address,
         [erc20EighteenDecimalTokenA.address, erc20EighteenDecimalTokenB.address],
         [erc20FiveDecimalTokenA.address, erc20FiveDecimalTokenB.address],
+        [erc20ZeroDecimalTokenA.address, erc20ZeroDecimalTokenB.address],
         erc721Token,
         erc721Balances,
         exchangeContract.address,

--- a/packages/contracts/test/utils/order_factory_from_scenario.ts
+++ b/packages/contracts/test/utils/order_factory_from_scenario.ts
@@ -21,6 +21,8 @@ const POINT_ONE_UNITS_EIGHTEEN_DECIMALS = new BigNumber(100_000_000_000_000_000)
 const POINT_ZERO_FIVE_UNITS_EIGHTEEN_DECIMALS = new BigNumber(50_000_000_000_000_000);
 const TEN_UNITS_FIVE_DECIMALS = new BigNumber(1_000_000);
 const FIVE_UNITS_FIVE_DECIMALS = new BigNumber(500_000);
+const TEN_UNITS_ZERO_DECIMALS = new BigNumber(10);
+const ONE_THOUSAND_UNITS_ZERO_DECIMALS = new BigNumber(1000);
 const ONE_NFT_UNIT = new BigNumber(1);
 
 export class OrderFactoryFromScenario {
@@ -28,6 +30,7 @@ export class OrderFactoryFromScenario {
     private readonly _zrxAddress: string;
     private readonly _nonZrxERC20EighteenDecimalTokenAddresses: string[];
     private readonly _erc20FiveDecimalTokenAddresses: string[];
+    private readonly _erc20ZeroDecimalTokenAddresses: string[];
     private readonly _erc721Token: DummyERC721TokenContract;
     private readonly _erc721Balances: ERC721TokenIdsByOwner;
     private readonly _exchangeAddress: string;
@@ -36,6 +39,7 @@ export class OrderFactoryFromScenario {
         zrxAddress: string,
         nonZrxERC20EighteenDecimalTokenAddresses: string[],
         erc20FiveDecimalTokenAddresses: string[],
+        erc20ZeroDecimalTokenAddresses: string[],
         erc721Token: DummyERC721TokenContract,
         erc721Balances: ERC721TokenIdsByOwner,
         exchangeAddress: string,
@@ -44,6 +48,7 @@ export class OrderFactoryFromScenario {
         this._zrxAddress = zrxAddress;
         this._nonZrxERC20EighteenDecimalTokenAddresses = nonZrxERC20EighteenDecimalTokenAddresses;
         this._erc20FiveDecimalTokenAddresses = erc20FiveDecimalTokenAddresses;
+        this._erc20ZeroDecimalTokenAddresses = erc20ZeroDecimalTokenAddresses;
         this._erc721Token = erc721Token;
         this._erc721Balances = erc721Balances;
         this._exchangeAddress = exchangeAddress;
@@ -89,6 +94,9 @@ export class OrderFactoryFromScenario {
                     erc721MakerAssetIds[0],
                 );
                 break;
+            case AssetDataScenario.ERC20ZeroDecimals:
+                makerAssetData = assetDataUtils.encodeERC20AssetData(this._erc20ZeroDecimalTokenAddresses[0]);
+                break;
             default:
                 throw errorUtils.spawnSwitchErr('AssetDataScenario', orderScenario.makerAssetDataScenario);
         }
@@ -109,6 +117,9 @@ export class OrderFactoryFromScenario {
                     erc721TakerAssetIds[0],
                 );
                 break;
+            case AssetDataScenario.ERC20ZeroDecimals:
+                takerAssetData = assetDataUtils.encodeERC20AssetData(this._erc20ZeroDecimalTokenAddresses[1]);
+                break;
             default:
                 throw errorUtils.spawnSwitchErr('AssetDataScenario', orderScenario.takerAssetDataScenario);
         }
@@ -126,6 +137,9 @@ export class OrderFactoryFromScenario {
                     case AssetDataScenario.ERC721:
                         makerAssetAmount = ONE_NFT_UNIT;
                         break;
+                    case AssetDataScenario.ERC20ZeroDecimals:
+                        makerAssetAmount = ONE_THOUSAND_UNITS_ZERO_DECIMALS;
+                        break;
                     default:
                         throw errorUtils.spawnSwitchErr('AssetDataScenario', orderScenario.makerAssetDataScenario);
                 }
@@ -141,6 +155,9 @@ export class OrderFactoryFromScenario {
                         break;
                     case AssetDataScenario.ERC721:
                         makerAssetAmount = ONE_NFT_UNIT;
+                        break;
+                    case AssetDataScenario.ERC20ZeroDecimals:
+                        makerAssetAmount = TEN_UNITS_ZERO_DECIMALS;
                         break;
                     default:
                         throw errorUtils.spawnSwitchErr('AssetDataScenario', orderScenario.makerAssetDataScenario);
@@ -166,6 +183,9 @@ export class OrderFactoryFromScenario {
                     case AssetDataScenario.ERC721:
                         takerAssetAmount = ONE_NFT_UNIT;
                         break;
+                    case AssetDataScenario.ERC20ZeroDecimals:
+                        takerAssetAmount = ONE_THOUSAND_UNITS_ZERO_DECIMALS;
+                        break;
                     default:
                         throw errorUtils.spawnSwitchErr('AssetDataScenario', orderScenario.takerAssetDataScenario);
                 }
@@ -181,6 +201,9 @@ export class OrderFactoryFromScenario {
                         break;
                     case AssetDataScenario.ERC721:
                         takerAssetAmount = ONE_NFT_UNIT;
+                        break;
+                    case AssetDataScenario.ERC20ZeroDecimals:
+                        takerAssetAmount = TEN_UNITS_ZERO_DECIMALS;
                         break;
                     default:
                         throw errorUtils.spawnSwitchErr('AssetDataScenario', orderScenario.takerAssetDataScenario);

--- a/packages/contracts/test/utils/types.ts
+++ b/packages/contracts/test/utils/types.ts
@@ -177,10 +177,11 @@ export enum ExpirationTimeSecondsScenario {
 }
 
 export enum AssetDataScenario {
-    ERC721 = 'ERC721',
+    ERC20ZeroDecimals = 'ERC20_ZERO_DECIMALS',
     ZRXFeeToken = 'ZRX_FEE_TOKEN',
     ERC20FiveDecimals = 'ERC20_FIVE_DECIMALS',
     ERC20NonZRXEighteenDecimals = 'ERC20_NON_ZRX_EIGHTEEN_DECIMALS',
+    ERC721 = 'ERC721',
 }
 
 export enum TakerAssetFillAmountScenario {

--- a/packages/order-utils/CHANGELOG.json
+++ b/packages/order-utils/CHANGELOG.json
@@ -3,6 +3,10 @@
         "version": "1.0.1-rc.4",
         "changes": [
             {
+                "note": "Remove rounding error being thrown when maker amount is very small",
+                "pr": 959
+            },
+            {
                 "note": "Added rateUtils and sortingUtils",
                 "pr": 953
             },

--- a/packages/order-utils/test/order_state_utils_test.ts
+++ b/packages/order-utils/test/order_state_utils_test.ts
@@ -2,7 +2,9 @@ import { BigNumber } from '@0xproject/utils';
 import * as chai from 'chai';
 import 'mocha';
 
-import { AbstractBalanceAndProxyAllowanceFetcher, AbstractOrderFilledCancelledFetcher, OrderStateUtils } from '../src';
+import { AbstractBalanceAndProxyAllowanceFetcher } from '../src/abstract/abstract_balance_and_proxy_allowance_fetcher';
+import { AbstractOrderFilledCancelledFetcher } from '../src/abstract/abstract_order_filled_cancelled_fetcher';
+import { OrderStateUtils } from '../src/order_state_utils';
 
 import { chaiSetup } from './utils/chai_setup';
 import { testOrderFactory } from './utils/test_order_factory';

--- a/packages/order-utils/test/order_state_utils_test.ts
+++ b/packages/order-utils/test/order_state_utils_test.ts
@@ -1,0 +1,122 @@
+import { BigNumber } from '@0xproject/utils';
+import * as chai from 'chai';
+import 'mocha';
+
+import { AbstractBalanceAndProxyAllowanceFetcher, AbstractOrderFilledCancelledFetcher, OrderStateUtils } from '../src';
+
+import { chaiSetup } from './utils/chai_setup';
+import { testOrderFactory } from './utils/test_order_factory';
+
+chaiSetup.configure();
+const expect = chai.expect;
+
+describe('OrderStateUtils', () => {
+    describe('#getOpenOrderStateAsync', () => {
+        const buildMockBalanceFetcher = (takerBalance: BigNumber): AbstractBalanceAndProxyAllowanceFetcher => {
+            const balanceFetcher = {
+                async getBalanceAsync(_assetData: string, _userAddress: string): Promise<BigNumber> {
+                    return takerBalance;
+                },
+                async getProxyAllowanceAsync(_assetData: string, _userAddress: string): Promise<BigNumber> {
+                    return takerBalance;
+                },
+            };
+            return balanceFetcher;
+        };
+        const buildMockOrderFilledFetcher = (
+            filledAmount: BigNumber = new BigNumber(0),
+            cancelled: boolean = false,
+        ): AbstractOrderFilledCancelledFetcher => {
+            const orderFetcher = {
+                async getFilledTakerAmountAsync(_orderHash: string): Promise<BigNumber> {
+                    return filledAmount;
+                },
+                async isOrderCancelledAsync(_orderHash: string): Promise<boolean> {
+                    return cancelled;
+                },
+                getZRXAssetData(): string {
+                    return '';
+                },
+            };
+            return orderFetcher;
+        };
+        it('should have valid order state if order can be fully filled with small maker amount', async () => {
+            const makerAssetAmount = new BigNumber(10);
+            const takerAssetAmount = new BigNumber(10000000000000000);
+            const takerBalance = takerAssetAmount;
+            const orderFilledAmount = new BigNumber(0);
+            const mockBalanceFetcher = buildMockBalanceFetcher(takerBalance);
+            const mockOrderFilledFetcher = buildMockOrderFilledFetcher(orderFilledAmount);
+            const [signedOrder] = testOrderFactory.generateTestSignedOrders(
+                {
+                    makerAssetAmount,
+                    takerAssetAmount,
+                },
+                1,
+            );
+
+            const orderStateUtils = new OrderStateUtils(mockBalanceFetcher, mockOrderFilledFetcher);
+            const orderState = await orderStateUtils.getOpenOrderStateAsync(signedOrder);
+            expect(orderState.isValid).to.eq(true);
+        });
+        it('should be invalid when an order is partially filled where only a rounding error remains', async () => {
+            const makerAssetAmount = new BigNumber(1001);
+            const takerAssetAmount = new BigNumber(3);
+            const takerBalance = takerAssetAmount;
+            const orderFilledAmount = new BigNumber(2);
+            const mockBalanceFetcher = buildMockBalanceFetcher(takerBalance);
+            const mockOrderFilledFetcher = buildMockOrderFilledFetcher(orderFilledAmount);
+            const [signedOrder] = testOrderFactory.generateTestSignedOrders(
+                {
+                    makerAssetAmount,
+                    takerAssetAmount,
+                },
+                1,
+            );
+
+            const orderStateUtils = new OrderStateUtils(mockBalanceFetcher, mockOrderFilledFetcher);
+            const orderState = await orderStateUtils.getOpenOrderStateAsync(signedOrder);
+            expect(orderState.isValid).to.eq(false);
+        });
+        it('should be invalid when an order is cancelled', async () => {
+            const makerAssetAmount = new BigNumber(1000);
+            const takerAssetAmount = new BigNumber(2);
+            const takerBalance = takerAssetAmount;
+            const orderFilledAmount = new BigNumber(0);
+            const isCancelled = true;
+            const mockBalanceFetcher = buildMockBalanceFetcher(takerBalance);
+            const mockOrderFilledFetcher = buildMockOrderFilledFetcher(orderFilledAmount, isCancelled);
+            const [signedOrder] = testOrderFactory.generateTestSignedOrders(
+                {
+                    makerAssetAmount,
+                    takerAssetAmount,
+                },
+                1,
+            );
+
+            const orderStateUtils = new OrderStateUtils(mockBalanceFetcher, mockOrderFilledFetcher);
+            const orderState = await orderStateUtils.getOpenOrderStateAsync(signedOrder);
+            expect(orderState.isValid).to.eq(false);
+        });
+        it('should be invalid when an order is fully filled', async () => {
+            const makerAssetAmount = new BigNumber(1000);
+            const takerAssetAmount = new BigNumber(2);
+            const takerBalance = takerAssetAmount;
+            const orderFilledAmount = takerAssetAmount;
+            const isCancelled = false;
+            const mockBalanceFetcher = buildMockBalanceFetcher(takerBalance);
+            const mockOrderFilledFetcher = buildMockOrderFilledFetcher(orderFilledAmount, isCancelled);
+            const [signedOrder] = testOrderFactory.generateTestSignedOrders(
+                {
+                    makerAssetAmount,
+                    takerAssetAmount,
+                },
+                1,
+            );
+
+            const orderStateUtils = new OrderStateUtils(mockBalanceFetcher, mockOrderFilledFetcher);
+            const orderState = await orderStateUtils.getOpenOrderStateAsync(signedOrder);
+            expect(orderState.isValid).to.eq(false);
+        });
+    });
+});

--- a/packages/order-watcher/test/order_watcher_test.ts
+++ b/packages/order-watcher/test/order_watcher_test.ts
@@ -501,7 +501,7 @@ describe('OrderWatcher', () => {
                     expect(orderState.isValid).to.be.false();
                     const invalidOrderState = orderState as OrderStateInvalid;
                     expect(invalidOrderState.orderHash).to.be.equal(orderHash);
-                    expect(invalidOrderState.error).to.be.equal(ExchangeContractErrs.OrderAlreadyCancelledOrFilled);
+                    expect(invalidOrderState.error).to.be.equal(ExchangeContractErrs.OrderCancelled);
                 });
                 orderWatcher.subscribe(callback);
                 await contractWrappers.exchange.cancelOrderAsync(signedOrder);

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -62,8 +62,7 @@ export interface ValidatorSignature {
 export enum ExchangeContractErrs {
     OrderFillExpired = 'ORDER_FILL_EXPIRED',
     OrderCancelExpired = 'ORDER_CANCEL_EXPIRED',
-    OrderCancelAmountZero = 'ORDER_CANCEL_AMOUNT_ZERO',
-    OrderAlreadyCancelledOrFilled = 'ORDER_ALREADY_CANCELLED_OR_FILLED',
+    OrderCancelled = 'ORDER_CANCELLED',
     OrderFillAmountZero = 'ORDER_FILL_AMOUNT_ZERO',
     OrderRemainingFillAmountZero = 'ORDER_REMAINING_FILL_AMOUNT_ZERO',
     OrderFillRoundingError = 'ORDER_FILL_ROUNDING_ERROR',

--- a/packages/website/ts/utils/utils.ts
+++ b/packages/website/ts/utils/utils.ts
@@ -247,12 +247,9 @@ export const utils = {
         } = {
             [ExchangeContractErrs.OrderFillExpired]: 'This order has expired',
             [ExchangeContractErrs.OrderCancelExpired]: 'This order has expired',
-            [ExchangeContractErrs.OrderCancelAmountZero]: "Order cancel amount can't be 0",
-            [ExchangeContractErrs.OrderAlreadyCancelledOrFilled]:
-                'This order has already been completely filled or cancelled',
+            [ExchangeContractErrs.OrderCancelled]: 'This order has been cancelled',
             [ExchangeContractErrs.OrderFillAmountZero]: "Order fill amount can't be 0",
-            [ExchangeContractErrs.OrderRemainingFillAmountZero]:
-                'This order has already been completely filled or cancelled',
+            [ExchangeContractErrs.OrderRemainingFillAmountZero]: 'This order has already been completely filled',
             [ExchangeContractErrs.OrderFillRoundingError]:
                 'Rounding error will occur when filling this order. Please try filling a different amount.',
             [ExchangeContractErrs.InsufficientTakerBalance]:


### PR DESCRIPTION

#922 

Previously our min fillable calculation would throw a rounding error
when encountering a valid order (with a small maker amount). This was
inconsistent with the on-chain logic which allowed this order to be
filled.

e.g:
```
        makerAssetAmount: new BigNumber('10'),
        takerAssetAmount: new BigNumber('10000000000000000'),
```

Old logic would perform:
```
            minFillableTakerAssetAmountWithinNoRoundingErrorRange = signedOrder.takerAssetAmount
                .dividedBy(ACCEPTABLE_RELATIVE_ROUNDING_ERROR)
                .dividedBy(signedOrder.makerAssetAmount);
```
```
minFillableTakerAssetAmountWithinNoRoundingErrorRange 
=> 10000000000000000/0.0001/10
# a very big number
sidedOrderRelevantState.remainingFillableAssetAmount.lessThan(
                minFillableTakerAssetAmountWithinNoRoundingErrorRange)
=> false -> RoundingError
```

## Description

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefixed the title of this PR with `[WIP]` if it is a work in progress.
*   [x] Prefixed the title of this PR with bracketed package name(s) corresponding to the changed package(s). For example: `[sol-cov] Fixed bug`.
*   [x] Added tests to cover my changes, or decided that tests would be too impractical.
*   [ ] Updated documentation, or decided that no doc change is needed.
*   [x] Added new entries to the relevant CHANGELOG.jsons.
