### PR TITLE
Make sure lookupPath is a file in NPMResolver

### DIFF
--- a/packages/sol-resolver/src/resolvers/npm_resolver.ts
+++ b/packages/sol-resolver/src/resolvers/npm_resolver.ts
@@ -20,10 +20,11 @@ export class NPMResolver extends Resolver {
             while (currentPath !== ROOT_PATH) {
                 const lookupPath = path.join(currentPath, 'node_modules', packageName, pathWithinPackage);
                 // NodeJS documentation recommends using try/catch arround read
-                // instead of using fs.statSuync. We don't do this because:
+                // instead of using fs.statSync. We don't do this because:
                 // 1) We want it to fail when the file exists but does not
                 //    have read permissions.
-                // 2) The thrown error message is platform dependent.
+                // 2) The thrown error message is platform dependent and thus
+                //    hard to parse.
                 if (fs.existsSync(lookupPath) &&
                     fs.statSync(lookupPath).isFile()) {
                     const fileContent = fs.readFileSync(lookupPath).toString();

--- a/packages/sol-resolver/src/resolvers/npm_resolver.ts
+++ b/packages/sol-resolver/src/resolvers/npm_resolver.ts
@@ -19,7 +19,13 @@ export class NPMResolver extends Resolver {
             const ROOT_PATH = '/';
             while (currentPath !== ROOT_PATH) {
                 const lookupPath = path.join(currentPath, 'node_modules', packageName, pathWithinPackage);
-                if (fs.existsSync(lookupPath)) {
+                // NodeJS documentation recommends using try/catch arround read
+                // instead of using fs.statSuync. We don't do this because:
+                // 1) We want it to fail when the file exists but does not
+                //    have read permissions.
+                // 2) The thrown error message is platform dependent.
+                if (fs.existsSync(lookupPath) &&
+                    fs.statSync(lookupPath).isFile()) {
                     const fileContent = fs.readFileSync(lookupPath).toString();
                     return {
                         source: fileContent,


### PR DESCRIPTION
## Description

When you get the following error on `yarn build`:

```
| /Users/remco/WF/0x/0x-monorepo/node_modules/Validator
| { Error: EISDIR: illegal operation on a directory, read
|     at Object.fs.readSync (fs.js:690:18)
|     at tryReadSync (fs.js:554:20)
|     at Object.fs.readFileSync (fs.js:597:19)
|     at NPMResolver.resolveIfExists packages/contracts/(/Users/remco/WF/0x/0x-monorepo/packages/sol-resolver/lib/resolvers/npm_resolver.js:53:42)
|     at FallthroughResolver.resolveIfExists packages/contracts/(/Users/remco/WF/0x/0x-monorepo/packages/sol-resolver/lib/resolvers/fallthrough_resolver.js:40:55)
|     at FallthroughResolver.Resolver.resolve packages/contracts/(/Users/remco/WF/0x/0x-monorepo/packages/sol-resolver/lib/resolvers/resolver.js:8:43)
|     at Compiler.<anonymous> packages/contracts/(/Users/remco/WF/0x/0x-monorepo/packages/sol-compiler/lib/src/compiler.js:211:57)
|     at step packages/contracts/(/Users/remco/WF/0x/0x-monorepo/packages/sol-compiler/lib/src/compiler.js:40:23)
|     at Object.next packages/contracts/(/Users/remco/WF/0x/0x-monorepo/packages/sol-compiler/lib/src/compiler.js:21:53)
|     at /packages/contracts/Users/remco/WF/0x/0x-monorepo/packages/sol-compiler/lib/src/compiler.js:15:71 errno: -21, code: 'EISDIR', syscall: 'read' }
```

Then you need this patch!

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

* Check for the path being a file before calling `fs.readFileSync` in `NPMResolver`.

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [x] Prefixed the title of this PR with `[WIP]` if it is a work in progress.
*   [x] Prefixed the title of this PR with bracketed package name(s) corresponding to the changed package(s). For example: `[sol-cov] Fixed bug`.
*   [x] Added tests to cover my changes, or decided that tests would be too impractical.
*   [x] Updated documentation, or decided that no doc change is needed.
*   [ ] Added new entries to the relevant CHANGELOG.jsons.
