### PR TITLE
feat(monorepo-scripts): Auto add/remove npm beta tag when publishing

### DIFF
--- a/packages/monorepo-scripts/src/publish.ts
+++ b/packages/monorepo-scripts/src/publish.ts
@@ -190,7 +190,10 @@ async function updateChangeLogsAsync(updatedPublicPackages: Package[]): Promise<
     return packageToNextVersion;
 }
 
-async function updateAllNpmBetaTagsAsync(updatedPublicPackages: Package[], packageToNextVersion: PackageToNextVersion): Promise<void> {
+async function updateAllNpmBetaTagsAsync(
+    updatedPublicPackages: Package[],
+    packageToNextVersion: PackageToNextVersion,
+): Promise<void> {
     _.each(updatedPublicPackages, async pkg => {
         const packageName = pkg.packageJson.name;
         const nextVersion = packageToNextVersion[packageName];


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR automatically adds the "beta" tag to npm when publishing packages which have a release candidate version. Up until now we have been adding these tags manually.

![screen shot 2018-08-15 at 3 19 14 pm](https://user-images.githubusercontent.com/800857/44176431-9fbc6100-a09e-11e8-8c3b-7c6329532aa1.png)

It works by modifying __package.json__ and adding/removing the `publishConfig.tag` field as needed. Lerna looks at this field when publishing, and if present, adds it as a tag when calling `npm publish`.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

I tested this locally with `yarn run:publish:local`. I verified the tags appear in __packaage.json__ in the `publishConfig.tag` field. Unfortunately, Verdaccio does not display tags on the web page for each package, so we will need to confirm they show up on npmjs.org the next time we publish for real.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature (non-breaking change which adds functionality)

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefix PR title with `[WIP]` if necessary.
*   [ ] Prefix PR title with bracketed package name(s) corresponding to the changed package(s). For example: `[sol-cov] Fixed bug`.
*   [ ] Add tests to cover changes as needed.
*   [ ] Update documentation as needed.
*   [ ] Add new entries to the relevant CHANGELOG.jsons.
