### PR TITLE
[website] Revert changes to website causing it to fail building

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# See https://help.github.com/articles/about-codeowners/
+# for more info about CODEOWNERS file
+
+# It uses the same pattern rule for gitignore file
+# https://git-scm.com/docs/gitignore#_pattern_format
+
+# Website
+packages/website/  @BMillman19 @fragosti

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -7,7 +7,7 @@
     "private": true,
     "description": "Website and 0x portal dapp",
     "scripts": {
-        "build": "NODE_ENV=production node --max_old_space_size=8192 ../../node_modules/.bin/webpack; exit 0;",
+        "build": "NODE_ENV=production node --max_old_space_size=8192 ../../node_modules/.bin/webpack",
         "clean": "shx rm -f public/bundle*",
         "lint": "tslint --project . 'ts/**/*.ts' 'ts/**/*.tsx'",
         "watch_without_deps": "webpack-dev-server --content-base public --https",

--- a/packages/website/ts/utils/utils.ts
+++ b/packages/website/ts/utils/utils.ts
@@ -247,9 +247,12 @@ export const utils = {
         } = {
             [ExchangeContractErrs.OrderFillExpired]: 'This order has expired',
             [ExchangeContractErrs.OrderCancelExpired]: 'This order has expired',
-            [ExchangeContractErrs.OrderCancelled]: 'This order has been cancelled',
+            [ExchangeContractErrs.OrderCancelAmountZero]: "Order cancel amount can't be 0",
+            [ExchangeContractErrs.OrderAlreadyCancelledOrFilled]:
+                'This order has already been completely filled or cancelled',
             [ExchangeContractErrs.OrderFillAmountZero]: "Order fill amount can't be 0",
-            [ExchangeContractErrs.OrderRemainingFillAmountZero]: 'This order has already been completely filled',
+            [ExchangeContractErrs.OrderRemainingFillAmountZero]:
+                'This order has already been completely filled or cancelled',
             [ExchangeContractErrs.OrderFillRoundingError]:
                 'Rounding error will occur when filling this order. Please try filling a different amount.',
             [ExchangeContractErrs.InsufficientTakerBalance]:


### PR DESCRIPTION
## Description

* Some changes were made to website assuming that it is on the latest RC versions of the packages, this PR reverts those changes
* The changes made it past CI because of the extra `exit 0` that was appended to the website package's build command
* The exit 0 was added a long time ago to silence uglify errors which seem to be fixed now
* This PR

## Testing instructions

```bash
yarn install && PKG=@0xproject/website yarn build
```

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefix PR title with `[WIP]` if necessary.
*   [ ] Prefix PR title with bracketed package name(s) corresponding to the changed package(s). For example: `[sol-cov] Fixed bug`.
*   [ ] Add tests to cover changes as needed.
*   [ ] Update documentation as needed.
*   [ ] Add new entries to the relevant CHANGELOG.jsons.
