### PR TITLE
[WIP][contracts] Fix testWithReferenceFunc (PR #1000 🎉)

### DIFF
--- a/packages/contracts/test/exchange/internal.ts
+++ b/packages/contracts/test/exchange/internal.ts
@@ -74,14 +74,18 @@ describe('Exchange core internal functions', () => {
         );
 
         // TODO: Move to assertions.ts
+        callErrors = {
+            invalidOpcode: new Error(await getInvalidOpcodeErrorMessageForCallAsync()),
+        };
+        sendErrors = {
+            invalidOpcode: new Error(await getInvalidOpcodeErrorMessageForSendTransactionAsync()),
+        };
         for (const key in RevertReason) {
             // TODO: avoid casting
             const reason: RevertReason = RevertReason[key] as RevertReason;
             callErrors[key] = new Error(await getRevertReasonOrErrorMessageForCallAsync(reason));
             sendErrors[key] = new Error(await getRevertReasonOrErrorMessageForSendTransactionAsync(reason));
         }
-        callErrors.invalidOpcode = new Error(await getInvalidOpcodeErrorMessageForCallAsync());
-        sendErrors.invalidOpcode = new Error(await getInvalidOpcodeErrorMessageForSendTransactionAsync());
     });
     // Note(albrow): Don't forget to add beforeEach and afterEach calls to reset
     // the blockchain state for any tests which modify it!
@@ -285,7 +289,7 @@ describe('Exchange core internal functions', () => {
         ): Promise<BigNumber> {
             const totalFilledAmount = takerAssetFilledAmount.add(orderTakerAssetFilledAmount);
             if (totalFilledAmount.greaterThan(MAX_UINT256)) {
-                throw sendErrors.Uint256Overlfow;
+                throw sendErrors.Uint256Overflow;
             }
             return totalFilledAmount;
         }

--- a/packages/contracts/test/exchange/internal.ts
+++ b/packages/contracts/test/exchange/internal.ts
@@ -81,10 +81,14 @@ describe('Exchange core internal functions', () => {
             invalidOpcode: new Error(await getInvalidOpcodeErrorMessageForSendTransactionAsync()),
         };
         for (const key in RevertReason) {
-            // TODO: avoid casting
-            const reason: RevertReason = RevertReason[key] as RevertReason;
-            callErrors[key] = new Error(await getRevertReasonOrErrorMessageForCallAsync(reason));
-            sendErrors[key] = new Error(await getRevertReasonOrErrorMessageForSendTransactionAsync(reason));
+            if (RevertReason.hasOwnProperty(key)) {
+                // TODO: remove casting that ts requires
+                //       and tslint wants removed
+                // tslint:disable-next-line: no-unnecessary-type-assertion
+                const reason = RevertReason[key] as RevertReason;
+                callErrors[key] = new Error(await getRevertReasonOrErrorMessageForCallAsync(reason));
+                sendErrors[key] = new Error(await getRevertReasonOrErrorMessageForSendTransactionAsync(reason));
+            }
         }
     });
     // Note(albrow): Don't forget to add beforeEach and afterEach calls to reset

--- a/packages/contracts/test/exchange/internal.ts
+++ b/packages/contracts/test/exchange/internal.ts
@@ -41,7 +41,7 @@ const emptySignedOrder: SignedOrder = {
     signature: '',
 };
 
-const overflowErrorForCall = new Error(RevertReason.Uint256Overflow);
+const overflowErrorForCall = new Error(`revert ${RevertReason.Uint256Overflow}`);
 
 async function referenceGetPartialAmountAsync(
     numerator: BigNumber,

--- a/packages/contracts/test/utils/assertions.ts
+++ b/packages/contracts/test/utils/assertions.ts
@@ -57,7 +57,7 @@ async function _getContractCallFailedErrorMessageAsync(): Promise<string> {
 export async function getInvalidOpcodeErrorMessageForCallAsync(): Promise<string> {
     return _getGanacheOrGethError(
         'VM Exception while processing transaction: invalid opcode',
-        'Contract call failed',
+        'Contract call failed (returned null)',
     );
 }
 
@@ -69,7 +69,7 @@ export async function getInvalidOpcodeErrorMessageForCallAsync(): Promise<string
 export async function getInvalidOpcodeErrorMessageForSendTransactionAsync(): Promise<string> {
     return _getGanacheOrGethError(
         'VM Exception while processing transaction: invalid opcode',
-        'Contract call failed',
+        'Contract call failed (returned null)',
     );
 }
 

--- a/packages/contracts/test/utils/assertions.ts
+++ b/packages/contracts/test/utils/assertions.ts
@@ -54,7 +54,10 @@ async function _getContractCallFailedErrorMessageAsync(): Promise<string> {
  * contract call. The exact error message depends on the backing Ethereum node.
  */
 export async function getInvalidOpcodeErrorMessageForCallAsync(): Promise<string> {
-    return _getGanacheOrGethError('invalid opcode', 'Contract call failed');
+    return _getGanacheOrGethError(
+        'VM Exception while processing transaction: invalid opcode',
+        'Contract call failed',
+    );
 }
 
 /**
@@ -63,7 +66,10 @@ export async function getInvalidOpcodeErrorMessageForCallAsync(): Promise<string
  * Ethereum node.
  */
 export async function getInvalidOpcodeErrorMessageForSendTransactionAsync(): Promise<string> {
-    return _getGanacheOrGethError('invalid opcode', 'Contract call failed');
+    return _getGanacheOrGethError(
+        'VM Exception while processing transaction: invalid opcode',
+        'Contract call failed',
+    );
 }
 
 /**
@@ -74,7 +80,10 @@ export async function getInvalidOpcodeErrorMessageForSendTransactionAsync(): Pro
  * @returns the expected error message.
  */
 export async function getRevertReasonOrErrorMessageForSendTransactionAsync(reason: RevertReason): Promise<string> {
-    return _getGanacheOrGethError(reason, 'always failing transaction');
+    return _getGanacheOrGethError(
+        `VM Exception while processing transaction: revert ${reason}`,
+        'always failing transaction',
+    );
 }
 
 /**
@@ -85,7 +94,10 @@ export async function getRevertReasonOrErrorMessageForSendTransactionAsync(reaso
  * @returns the expected error message.
  */
 export async function getRevertReasonOrErrorMessageForCallAsync(reason: RevertReason): Promise<string> {
-    return _getGanacheOrGethError(reason, 'always failing transaction');
+    return _getGanacheOrGethError(
+        `VM Exception while processing transaction: revert ${reason}`,
+        'always failing transaction',
+    );
 }
 
 /**

--- a/packages/contracts/test/utils/assertions.ts
+++ b/packages/contracts/test/utils/assertions.ts
@@ -58,6 +58,15 @@ export async function getInvalidOpcodeErrorMessageForCallAsync(): Promise<string
 }
 
 /**
+ * Returns the expected error message for an 'invalid opcode' resulting from a
+ * send transaction call. The exact error message depends on the backing
+ * Ethereum node.
+ */
+export async function getInvalidOpcodeErrorMessageForSendTransactionAsync(): Promise<string> {
+    return _getGanacheOrGethError('invalid opcode', 'Contract call failed');
+}
+
+/**
  * Returns the expected error message for the given revert reason resulting from
  * a sendTransaction call. The exact error message depends on the backing
  * Ethereum node and whether it supports revert reasons.
@@ -65,6 +74,17 @@ export async function getInvalidOpcodeErrorMessageForCallAsync(): Promise<string
  * @returns the expected error message.
  */
 export async function getRevertReasonOrErrorMessageForSendTransactionAsync(reason: RevertReason): Promise<string> {
+    return _getGanacheOrGethError(reason, 'always failing transaction');
+}
+
+/**
+ * Returns the expected error message for the given revert reason resulting from
+ * a eth_call call. The exact error message depends on the backing
+ * Ethereum node and whether it supports revert reasons.
+ * @param reason a specific revert reason.
+ * @returns the expected error message.
+ */
+export async function getRevertReasonOrErrorMessageForCallAsync(reason: RevertReason): Promise<string> {
     return _getGanacheOrGethError(reason, 'always failing transaction');
 }
 

--- a/packages/contracts/test/utils/assertions.ts
+++ b/packages/contracts/test/utils/assertions.ts
@@ -83,7 +83,7 @@ export async function getInvalidOpcodeErrorMessageForSendTransactionAsync(): Pro
 export async function getRevertReasonOrErrorMessageForSendTransactionAsync(reason: RevertReason): Promise<string> {
     return _getGanacheOrGethError(
         `VM Exception while processing transaction: revert ${reason}`,
-        `invalid data for function output (arg="data", errorArg=undefined, errorValue=undefined, value="${abi.simpleEncode('Error(string)', reason).toString('hex')}", reason="${reason}")]`,
+        `invalid data for function output (arg="data", errorArg=undefined, errorValue=undefined, value="0x${abi.simpleEncode('Error(string)', reason).toString('hex')}", reason="${reason}")`,
     );
 }
 
@@ -97,7 +97,7 @@ export async function getRevertReasonOrErrorMessageForSendTransactionAsync(reaso
 export async function getRevertReasonOrErrorMessageForCallAsync(reason: RevertReason): Promise<string> {
     return _getGanacheOrGethError(
         `VM Exception while processing transaction: revert ${reason}`,
-        `invalid data for function output (arg="data", errorArg=undefined, errorValue=undefined, value="${abi.simpleEncode('Error(string)', reason).toString('hex')}", reason="${reason}")]`,
+        `invalid data for function output (arg="data", errorArg=undefined, errorValue=undefined, value="0x${abi.simpleEncode('Error(string)', reason).toString('hex')}", reason="${reason}")`,
     );
 }
 

--- a/packages/contracts/test/utils/assertions.ts
+++ b/packages/contracts/test/utils/assertions.ts
@@ -3,6 +3,7 @@ import { logUtils } from '@0xproject/utils';
 import { NodeType } from '@0xproject/web3-wrapper';
 import * as chai from 'chai';
 import { TransactionReceipt, TransactionReceiptStatus, TransactionReceiptWithDecodedLogs } from 'ethereum-types';
+import * as abi from 'ethereumjs-abi';
 import * as _ from 'lodash';
 
 import { web3Wrapper } from './web3_wrapper';
@@ -82,7 +83,7 @@ export async function getInvalidOpcodeErrorMessageForSendTransactionAsync(): Pro
 export async function getRevertReasonOrErrorMessageForSendTransactionAsync(reason: RevertReason): Promise<string> {
     return _getGanacheOrGethError(
         `VM Exception while processing transaction: revert ${reason}`,
-        'always failing transaction',
+        `invalid data for function output (arg="data", errorArg=undefined, errorValue=undefined, value="${abi.simpleEncode('Error(string)', reason).toString('hex')}", reason="${reason}")]`,
     );
 }
 
@@ -96,7 +97,7 @@ export async function getRevertReasonOrErrorMessageForSendTransactionAsync(reaso
 export async function getRevertReasonOrErrorMessageForCallAsync(reason: RevertReason): Promise<string> {
     return _getGanacheOrGethError(
         `VM Exception while processing transaction: revert ${reason}`,
-        'always failing transaction',
+        `invalid data for function output (arg="data", errorArg=undefined, errorValue=undefined, value="${abi.simpleEncode('Error(string)', reason).toString('hex')}", reason="${reason}")]`,
     );
 }
 

--- a/packages/contracts/test/utils/test_with_reference.ts
+++ b/packages/contracts/test/utils/test_with_reference.ts
@@ -1,27 +1,22 @@
-import * as chai from 'chai';
 import * as _ from 'lodash';
-
-import { chaiSetup } from './chai_setup';
-
-chaiSetup.configure();
-const expect = chai.expect;
 
 class Value<T> {
     public value: T;
     constructor(value: T) {
         this.value = value;
     }
-    public toString() {
+    public toString(): string {
         return `[Value: ${this.value}]`;
     }
 }
 
+// tslint:disable-next-line: max-classes-per-file
 class ErrorMessage {
     public error: string;
     constructor(message: string) {
         this.error = message;
     }
-    public toString() {
+    public toString(): string {
         return `[Error: ${this.error}]`;
     }
 }
@@ -31,7 +26,7 @@ type PromiseResult<T> = Value<T> | ErrorMessage;
 // TODO: This seems like a generic utility function that could exist in lodash.
 //       We should replace it by a library implementation, or move it to our
 //       own.
-export async function evaluatePromise<T>(
+async function evaluatePromise<T>(
     promise: Promise<T>,
 ): Promise<PromiseResult<T>> {
     try {

--- a/packages/contracts/test/utils/test_with_reference.ts
+++ b/packages/contracts/test/utils/test_with_reference.ts
@@ -1,12 +1,14 @@
+import * as chai from 'chai';
 import * as _ from 'lodash';
+
+import { chaiSetup } from '../utils/chai_setup';
+
+chaiSetup.configure();
 
 class Value<T> {
     public value: T;
     constructor(value: T) {
         this.value = value;
-    }
-    public toString(): string {
-        return `[Value: ${this.value}]`;
     }
 }
 
@@ -15,9 +17,6 @@ class ErrorMessage {
     public error: string;
     constructor(message: string) {
         this.error = message;
-    }
-    public toString(): string {
-        return `[Error: ${this.error}]`;
     }
 }
 
@@ -101,11 +100,9 @@ export async function testWithReferenceFuncAsync(
     const actual = await evaluatePromise(testFuncAsync(...values));
 
     // Compare behaviour
-    // Note: We could also use `expect(actual).to.deep.equal(expected)` but
-    //       this results in a less readable error message.
-    if (!_.isEqual(actual, expected)) {
-        throw new Error(`Test case ${_getTestCaseString(referenceFuncAsync, values)} expected ${expected} to equal ${actual}`);
-    }
+    chai.expect(actual).to.deep.equal(expected,
+        `Test case ${_getTestCaseString(referenceFuncAsync, values)}`,
+    );
 }
 
 function _getTestCaseString(referenceFuncAsync: (...args: any[]) => Promise<any>, values: any[]): string {

--- a/packages/contracts/test/utils/test_with_reference.ts
+++ b/packages/contracts/test/utils/test_with_reference.ts
@@ -37,10 +37,7 @@ export async function evaluatePromise<T>(
     try {
         return new Value<T>(await promise);
     } catch (e) {
-        // Canonicalize the error message to ease comparisson.
-        return new ErrorMessage(e.message
-            .replace('VM Exception while processing transaction: ', ''),
-        );
+        return new ErrorMessage(e.message);
     }
 }
 


### PR DESCRIPTION
## Description

Currently when using `testWithReferenceFuncAsync` or testing infrastructure depending on it like combinatorial tests, the tests incorrectly pass if the testee should throw but doesn't.

This is because:

* [`testWithReferenceFuncAsync:78`](https://github.com/0xProject/0x-monorepo/blob/554d5f97df55779beed35ef73214e80b386d7927/packages/contracts/test/utils/test_with_reference.ts#L78) throws an error to fail the test.
* This is caught (incorrectly) in line 85.
* It branches to line 88 because an error was expected.
* The test passes because the thrown error contains the expected message.

It is fixed by encapsulating the behaviour in a single data structure and doing a deep comparison.

### TODO

*  [ ] Solve handling of Geth Errors. This might need a big refactor / redesign of the strategy.
*  [ ] Complete error messages: add insufficient funds, out of gas, etc.
*  [ ] Add typesafety, refactor and cleanup (see todos)

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [x] Prefix PR title with `[WIP]` if necessary.
*   [x] Prefix PR title with bracketed package name(s) corresponding to the changed package(s). For example: `[sol-cov] Fixed bug`.
*   [ ] Add tests to cover changes as needed.
*   [ ] Update documentation as needed.
*   [ ] Add new entries to the relevant CHANGELOG.jsons.
