### PR TITLE
[0x.js] Update uglify plugin to support es6

### DIFF
--- a/packages/0x.js/package.json
+++ b/packages/0x.js/package.json
@@ -17,7 +17,7 @@
     "scripts": {
         "watch_without_deps": "tsc -w",
         "build": "yarn build:all",
-        "build:all": "run-p build:umd:prod build:commonjs; exit 0;",
+        "build:all": "run-p build:umd:prod build:commonjs",
         "lint": "tslint --project . --exclude **/src/generated_contract_wrappers/**/*",
         "test:circleci": "run-s test:coverage",
         "test": "yarn run_mocha",
@@ -70,6 +70,7 @@
         "tslint": "5.11.0",
         "typedoc": "0.12.0",
         "typescript": "3.0.1",
+        "uglifyjs-webpack-plugin": "^1.3.0",
         "webpack": "^3.1.0"
     },
     "dependencies": {

--- a/packages/0x.js/webpack.config.js
+++ b/packages/0x.js/webpack.config.js
@@ -3,6 +3,7 @@
  */
 const _ = require('lodash');
 const webpack = require('webpack');
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const path = require('path');
 const production = process.env.NODE_ENV === 'production';
 
@@ -27,10 +28,16 @@ module.exports = {
     },
     devtool: 'source-map',
     plugins: [
-        new webpack.optimize.UglifyJsPlugin({
-            minimize: true,
+        // TODO: Revert to webpack bundled version with webpack v4.
+        // The v3 series bundled version does not support ES6 and
+        // fails to build.
+        new UglifyJsPlugin({
             sourceMap: true,
-            include: /\.min\.js$/,
+            uglifyOptions: {
+                mangle: {
+                    reserved: ['BigNumber'],
+                },
+            },
         }),
     ],
     module: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13929,6 +13929,19 @@ uglifyjs-webpack-plugin@^1.2.5:
     webpack-sources "^1.1.0"
     worker-farm "^1.5.2"
 
+uglifyjs-webpack-plugin@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.3.0.tgz#75f548160858163a08643e086d5fefe18a5d67de"
+  dependencies:
+    cacache "^10.0.4"
+    find-cache-dir "^1.0.0"
+    schema-utils "^0.4.5"
+    serialize-javascript "^1.4.0"
+    source-map "^0.6.1"
+    uglify-es "^3.3.4"
+    webpack-sources "^1.1.0"
+    worker-farm "^1.5.2"
+
 uid-number@0.0.6, uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"


### PR DESCRIPTION
## Description

* Remove `exit 0` from `0x.j` `build` command
* Change uglifyJS plugin in webpack config to support es6
* This same fix was already applied to `webpack.config.js` in the `website` package

## Testing instructions

```bash
yarn install && PKG=0x.js yarn build
```

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefix PR title with `[WIP]` if necessary.
*   [ ] Prefix PR title with bracketed package name(s) corresponding to the changed package(s). For example: `[sol-cov] Fixed bug`.
*   [ ] Add tests to cover changes as needed.
*   [ ] Update documentation as needed.
*   [ ] Add new entries to the relevant CHANGELOG.jsons.
