### PR TITLE
[json-schemas] Remove superflous id from relayer api fee recipients json schema

### DIFF
--- a/packages/json-schemas/schemas/relayer_api_fee_recipients_response_schema.ts
+++ b/packages/json-schemas/schemas/relayer_api_fee_recipients_response_schema.ts
@@ -6,7 +6,6 @@ export const relayerApiFeeRecipientsResponseSchema = {
         {
             properties: {
                 records: {
-                    id: '/relayerApiFeeRecipientsSchema',
                     type: 'array',
                     items: { $ref: '/addressSchema' },
                 },


### PR DESCRIPTION
## Description

We use ids for top-level schemas (mostly for the json validator we export). The OpenAPI json schema validator doesn't like to see these ids. In the sra-api json-schema pre-processing logic we remove these ids, but since this one is nested and we only remove ids from top-level objects, it was making the validator fail. I just removed the id on the sub-schema because we never have to reference it directly.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefix PR title with `[WIP]` if necessary.
*   [ ] Prefix PR title with bracketed package name(s) corresponding to the changed package(s). For example: `[sol-cov] Fixed bug`.
*   [ ] Add tests to cover changes as needed.
*   [ ] Update documentation as needed.
*   [ ] Add new entries to the relevant CHANGELOG.jsons.
