### PR TITLE
Use correct error message for division by zero

### DIFF
--- a/packages/contracts/test/exchange/internal.ts
+++ b/packages/contracts/test/exchange/internal.ts
@@ -67,9 +67,7 @@ describe('Exchange core internal functions', () => {
         overflowErrorForSendTransaction = new Error(
             await getRevertReasonOrErrorMessageForSendTransactionAsync(RevertReason.Uint256Overflow),
         );
-        divisionByZeroErrorForCall = new Error(
-            await getRevertReasonOrErrorMessageForSendTransactionAsync(RevertReason.DivisionByZero),
-        );
+        divisionByZeroErrorForCall = new Error(RevertReason.DivisionByZero);
         invalidOpcodeErrorForCall = new Error(await getInvalidOpcodeErrorMessageForCallAsync());
     });
     // Note(albrow): Don't forget to add beforeEach and afterEach calls to reset


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR fixes a bug introduced in https://github.com/0xProject/0x-monorepo/pull/1005.

When there is a revert reason, both Geth and Ganache return an error message which includes that revert reason. The exact error messages differ, so the approach we have been using for months is to check if the expected error message is contained in the actual error message.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

Start the devnet and then run:

```
PKG=contracts TEST_PROVIDER=geth yarn test
```

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefix PR title with `[WIP]` if necessary.
*   [ ] Prefix PR title with bracketed package name(s) corresponding to the changed package(s). For example: `[sol-cov] Fixed bug`.
*   [ ] Add tests to cover changes as needed.
*   [ ] Update documentation as needed.
*   [ ] Add new entries to the relevant CHANGELOG.jsons.
