### PR TITLE
[ethereum-types] Add BigNumber[] in ContractEventArg Type Definition

### DIFF
--- a/packages/ethereum-types/src/index.ts
+++ b/packages/ethereum-types/src/index.ts
@@ -238,7 +238,7 @@ export enum AbiType {
     Fallback = 'fallback',
 }
 
-export type ContractEventArg = string | BigNumber | number | boolean;
+export type ContractEventArg = string | BigNumber | BigNumber[] |number | boolean;
 
 export interface DecodedLogArgs {
     [argName: string]: ContractEventArg;

--- a/packages/ethereum-types/src/index.ts
+++ b/packages/ethereum-types/src/index.ts
@@ -238,7 +238,7 @@ export enum AbiType {
     Fallback = 'fallback',
 }
 
-export type ContractEventArg = string | BigNumber | BigNumber[] |number | boolean;
+export type ContractEventArg = any;
 
 export interface DecodedLogArgs {
     [argName: string]: ContractEventArg;


### PR DESCRIPTION
## Description

Currently, my contract has events that take a `uint256` array  (e.g. `emit Transfer(address, address, uint256[])` ) and typescript complains that ContractEventArg does not support this.


<!--- Describe your changes in detail -->

## Testing instructions

Test to transpile using `tsc` after creating wrapper contract with a contract that has a `uint256` array as event argument. 

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefix PR title with `[WIP]` if necessary.
*   [ x ] Prefix PR title with bracketed package name(s) corresponding to the changed package(s). For example: `[sol-cov] Fixed bug`.
*   [ ] Add tests to cover changes as needed.
*   [ ] Update documentation as needed.
*   [ ] Add new entries to the relevant CHANGELOG.jsons.
