### PR TITLE
Fix awaitTransactionMinedAsync for new Parity version

### DIFF
--- a/packages/web3-wrapper/CHANGELOG.json
+++ b/packages/web3-wrapper/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "2.0.3",
+        "changes": [
+            {
+                "note":
+                    "Fixes issue #1076 where Parity now returns a placeholder transactionReceipt before the transaction is mined."
+            }
+        ]
+    },
+    {
         "timestamp": 1536142250,
         "version": "2.0.2",
         "changes": [

--- a/packages/web3-wrapper/CHANGELOG.json
+++ b/packages/web3-wrapper/CHANGELOG.json
@@ -4,7 +4,8 @@
         "changes": [
             {
                 "note":
-                    "Fixes issue #1076 where Parity now returns a placeholder transactionReceipt before the transaction is mined."
+                    "Fixes issue #1076 where Parity now returns a placeholder transactionReceipt before the transaction is mined.",
+                "pr": 1079
             }
         ]
     },

--- a/packages/web3-wrapper/src/web3_wrapper.ts
+++ b/packages/web3-wrapper/src/web3_wrapper.ts
@@ -539,7 +539,7 @@ export class Web3Wrapper {
         }
         // Immediately check if the transaction has already been mined.
         let transactionReceipt = await this.getTransactionReceiptAsync(txHash);
-        if (!_.isNull(transactionReceipt)) {
+        if (!_.isNull(transactionReceipt) && !_.isNull(transactionReceipt.blockNumber)) {
             const logsWithDecodedArgs = _.map(
                 transactionReceipt.logs,
                 this.abiDecoder.tryToDecodeLogOrNoop.bind(this.abiDecoder),


### PR DESCRIPTION
## Description

Addressess: https://github.com/0xProject/0x-monorepo/issues/1076 by also checking that the `blockNumber` in the returned `transactionReceipt` is not `null`.

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefix PR title with `[WIP]` if necessary.
*   [ ] Prefix PR title with bracketed package name(s) corresponding to the changed package(s). For example: `[sol-cov] Fixed bug`.
*   [ ] Add tests to cover changes as needed.
*   [ ] Update documentation as needed.
*   [ ] Add new entries to the relevant CHANGELOG.jsons.
