### PR TITLE
Fix block fetch error if block not found

### DIFF
--- a/packages/contract-wrappers/src/contract_wrappers/contract_wrapper.ts
+++ b/packages/contract-wrappers/src/contract_wrappers/contract_wrapper.ts
@@ -195,6 +195,7 @@ export abstract class ContractWrapper {
             this._onLogStateChanged.bind(this, isRemoved),
         );
     }
+    // This method only exists in order to comply with the expected interface of Blockstream's constructor
     private async _getBlockOrNullAsync(): Promise<BlockWithoutTransactionData | null> {
         const blockIfExists = await this._web3Wrapper.getBlockIfExistsAsync.bind(this._web3Wrapper);
         if (_.isUndefined(blockIfExists)) {

--- a/packages/contract-wrappers/test/subscription_test.ts
+++ b/packages/contract-wrappers/test/subscription_test.ts
@@ -61,7 +61,7 @@ describe('SubscriptionTest', () => {
                     callback,
                 );
                 stubs = [
-                    Sinon.stub((contractWrappers as any)._web3Wrapper, 'getBlockAsync').throws(
+                    Sinon.stub((contractWrappers as any)._web3Wrapper, 'getBlockIfExistsAsync').throws(
                         new Error('JSON RPC error'),
                     ),
                 ];

--- a/packages/contracts/test/multisig/multi_sig_with_time_lock.ts
+++ b/packages/contracts/test/multisig/multi_sig_with_time_lock.ts
@@ -269,7 +269,10 @@ describe('MultiSigWalletWithTimeLock', () => {
                 expect(confirmRes.logs).to.have.length(2);
 
                 const blockNum = await web3Wrapper.getBlockNumberAsync();
-                const blockInfo = await web3Wrapper.getBlockAsync(blockNum);
+                const blockInfo = await web3Wrapper.getBlockIfExistsAsync(blockNum);
+                if (_.isUndefined(blockInfo)) {
+                    throw new Error(`Unexpectedly failed to fetch block at #${blockNum}`);
+                }
                 const timestamp = new BigNumber(blockInfo.timestamp);
                 const confirmationTimeBigNum = new BigNumber(await multiSig.confirmationTimes.callAsync(txId));
 

--- a/packages/contracts/test/utils/block_timestamp.ts
+++ b/packages/contracts/test/utils/block_timestamp.ts
@@ -35,6 +35,9 @@ export async function increaseTimeAndMineBlockAsync(seconds: number): Promise<nu
  * @returns a new Promise which will resolve with the timestamp in seconds.
  */
 export async function getLatestBlockTimestampAsync(): Promise<number> {
-    const currentBlock = await web3Wrapper.getBlockAsync('latest');
-    return currentBlock.timestamp;
+    const currentBlockIfExists = await web3Wrapper.getBlockIfExistsAsync('latest');
+    if (_.isUndefined(currentBlockIfExists)) {
+        throw new Error(`Unable to fetch latest block.`);
+    }
+    return currentBlockIfExists.timestamp;
 }

--- a/packages/order-watcher/src/order_watcher/event_watcher.ts
+++ b/packages/order-watcher/src/order_watcher/event_watcher.ts
@@ -82,6 +82,7 @@ export class EventWatcher {
             this._onLogStateChangedAsync.bind(this, callback, isRemoved),
         );
     }
+    // This method only exists in order to comply with the expected interface of Blockstream's constructor
     private async _getBlockOrNullAsync(): Promise<BlockWithoutTransactionData | null> {
         const blockIfExists = await this._web3Wrapper.getBlockIfExistsAsync.bind(this._web3Wrapper);
         if (_.isUndefined(blockIfExists)) {

--- a/packages/web3-wrapper/CHANGELOG.json
+++ b/packages/web3-wrapper/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "3.0.0",
+        "changes": [
+            {
+                "note":
+                    "Rename `getBlockAsync` to `getBlockIfExistsAsync` and rather then throw if the requested block wasn't found, return undefined."
+            }
+        ]
+    },
+    {
         "version": "2.0.3",
         "changes": [
             {

--- a/packages/web3-wrapper/CHANGELOG.json
+++ b/packages/web3-wrapper/CHANGELOG.json
@@ -4,7 +4,8 @@
         "changes": [
             {
                 "note":
-                    "Rename `getBlockAsync` to `getBlockIfExistsAsync` and rather then throw if the requested block wasn't found, return undefined."
+                    "Rename `getBlockAsync` to `getBlockIfExistsAsync` and rather then throw if the requested block wasn't found, return undefined.",
+                "pr": 1082
             }
         ]
     },

--- a/packages/web3-wrapper/src/web3_wrapper.ts
+++ b/packages/web3-wrapper/src/web3_wrapper.ts
@@ -330,6 +330,7 @@ export class Web3Wrapper {
      * Fetch a specific Ethereum block without transaction data
      * @param blockParam The block you wish to fetch (blockHash, blockNumber or blockLiteral)
      * @returns The requested block without transaction data, or undefined if block was not found
+     * (e.g the node isn't fully synced, there was a block re-org and the requested block was uncles, etc...)
      */
     public async getBlockIfExistsAsync(
         blockParam: string | BlockParam,

--- a/packages/web3-wrapper/src/web3_wrapper.ts
+++ b/packages/web3-wrapper/src/web3_wrapper.ts
@@ -329,23 +329,28 @@ export class Web3Wrapper {
     /**
      * Fetch a specific Ethereum block without transaction data
      * @param blockParam The block you wish to fetch (blockHash, blockNumber or blockLiteral)
-     * @returns The requested block without transaction data
+     * @returns The requested block without transaction data, or undefined if block was not found
      */
-    public async getBlockAsync(blockParam: string | BlockParam): Promise<BlockWithoutTransactionData> {
+    public async getBlockIfExistsAsync(
+        blockParam: string | BlockParam,
+    ): Promise<BlockWithoutTransactionData | undefined> {
         Web3Wrapper._assertBlockParamOrString(blockParam);
         const encodedBlockParam = marshaller.marshalBlockParam(blockParam);
         const method = utils.isHexStrict(blockParam) ? 'eth_getBlockByHash' : 'eth_getBlockByNumber';
         const shouldIncludeTransactionData = false;
-        const blockWithoutTransactionDataWithHexValues = await this._sendRawPayloadAsync<
+        const blockWithoutTransactionDataWithHexValuesOrNull = await this._sendRawPayloadAsync<
             BlockWithoutTransactionDataRPC
         >({
             method,
             params: [encodedBlockParam, shouldIncludeTransactionData],
         });
-        const blockWithoutTransactionData = marshaller.unmarshalIntoBlockWithoutTransactionData(
-            blockWithoutTransactionDataWithHexValues,
-        );
-        return blockWithoutTransactionData;
+        let blockWithoutTransactionDataIfExists;
+        if (!_.isNull(blockWithoutTransactionDataWithHexValuesOrNull)) {
+            blockWithoutTransactionDataIfExists = marshaller.unmarshalIntoBlockWithoutTransactionData(
+                blockWithoutTransactionDataWithHexValuesOrNull,
+            );
+        }
+        return blockWithoutTransactionDataIfExists;
     }
     /**
      * Fetch a specific Ethereum block with transaction data
@@ -376,8 +381,11 @@ export class Web3Wrapper {
      */
     public async getBlockTimestampAsync(blockParam: string | BlockParam): Promise<number> {
         Web3Wrapper._assertBlockParamOrString(blockParam);
-        const { timestamp } = await this.getBlockAsync(blockParam);
-        return timestamp;
+        const blockIfExists = await this.getBlockIfExistsAsync(blockParam);
+        if (_.isUndefined(blockIfExists)) {
+            throw new Error(`Failed to fetch block with blockParam: ${JSON.stringify(blockParam)}`);
+        }
+        return blockIfExists.timestamp;
     }
     /**
      * Retrieve the user addresses available through the backing provider

--- a/packages/web3-wrapper/test/web3_wrapper_test.ts
+++ b/packages/web3-wrapper/test/web3_wrapper_test.ts
@@ -85,28 +85,40 @@ describe('Web3Wrapper tests', () => {
             expect(typeof blockNumber).to.be.equal('number');
         });
     });
-    describe('#getBlockAsync', () => {
+    describe('#getBlockIfExistsAsync', () => {
         it('gets block when supplied a valid BlockParamLiteral value', async () => {
             const blockParamLiteral = BlockParamLiteral.Earliest;
-            const block = await web3Wrapper.getBlockAsync(blockParamLiteral);
-            expect(block.number).to.be.equal(0);
-            expect(utils.isBigNumber(block.difficulty)).to.equal(true);
-            expect(_.isNumber(block.gasLimit)).to.equal(true);
+            const blockIfExists = await web3Wrapper.getBlockIfExistsAsync(blockParamLiteral);
+            if (_.isUndefined(blockIfExists)) {
+                throw new Error('Expected block to exist');
+            }
+            expect(blockIfExists.number).to.be.equal(0);
+            expect(utils.isBigNumber(blockIfExists.difficulty)).to.equal(true);
+            expect(_.isNumber(blockIfExists.gasLimit)).to.equal(true);
         });
         it('gets block when supplied a block number', async () => {
             const blockParamLiteral = 0;
-            const block = await web3Wrapper.getBlockAsync(blockParamLiteral);
-            expect(block.number).to.be.equal(0);
+            const blockIfExists = await web3Wrapper.getBlockIfExistsAsync(blockParamLiteral);
+            if (_.isUndefined(blockIfExists)) {
+                throw new Error('Expected block to exist');
+            }
+            expect(blockIfExists.number).to.be.equal(0);
         });
         it('gets block when supplied a block hash', async () => {
             const blockParamLiteral = 0;
-            const block = await web3Wrapper.getBlockAsync(blockParamLiteral);
-            const sameBlock = await web3Wrapper.getBlockAsync(block.hash as string);
-            expect(sameBlock.number).to.be.equal(0);
+            const blockIfExists = await web3Wrapper.getBlockIfExistsAsync(blockParamLiteral);
+            if (_.isUndefined(blockIfExists)) {
+                throw new Error('Expected block to exist');
+            }
+            const sameBlockIfExists = await web3Wrapper.getBlockIfExistsAsync(blockIfExists.hash as string);
+            if (_.isUndefined(sameBlockIfExists)) {
+                throw new Error('Expected block to exist');
+            }
+            expect(sameBlockIfExists.number).to.be.equal(0);
         });
         it('should throw if supplied invalid blockParam value', async () => {
             const invalidBlockParam = 'deadbeef';
-            expect(web3Wrapper.getBlockAsync(invalidBlockParam)).to.eventually.to.be.rejected();
+            expect(web3Wrapper.getBlockIfExistsAsync(invalidBlockParam)).to.eventually.to.be.rejected();
         });
     });
     describe('#getBlockWithTransactionDataAsync', () => {


### PR DESCRIPTION
## Description

Currently `web3Wrapper.getBlockAsync` throws:

```
TypeError: Cannot read property 'difficulty' of null
```

If the request for a particular block fails. A block request could fail if a node isn't fully synced, or if it's become uncle'd, among other reasons. The Ethereum JSON RPC spec specified returning `null` for requests where the block cannot be found.

This PR therefore renames `getBlockAsync` to  `getBlockIfExistsAsync` and returns `undefined` (in-line with our codebase conventions) if the block was not found. 

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefix PR title with `[WIP]` if necessary.
*   [ ] Prefix PR title with bracketed package name(s) corresponding to the changed package(s). For example: `[sol-cov] Fixed bug`.
*   [ ] Add tests to cover changes as needed.
*   [ ] Update documentation as needed.
*   [ ] Add new entries to the relevant CHANGELOG.jsons.
