### PR TITLE
[order-utils] Add signature verification and cancellation check to validateFillOrderThrowIfInvalidAsync

### DIFF
--- a/packages/contract-wrappers/CHANGELOG.json
+++ b/packages/contract-wrappers/CHANGELOG.json
@@ -1,5 +1,15 @@
 [
     {
+        "version": "2.0.3",
+        "changes": [
+            {
+                "note":
+                    "Validate order signature and order cancel state in Exchange Wrapper `validateOrderFillableOrThrowAsync`",
+                "pr": 1101
+            }
+        ]
+    },
+    {
         "version": "2.0.2",
         "changes": [
             {

--- a/packages/contract-wrappers/src/contract_wrappers/exchange_wrapper.ts
+++ b/packages/contract-wrappers/src/contract_wrappers/exchange_wrapper.ts
@@ -1124,6 +1124,7 @@ export class ExchangeWrapper extends ContractWrapper {
         const orderValidationUtils = new OrderValidationUtils(filledCancelledFetcher);
         await orderValidationUtils.validateOrderFillableOrThrowAsync(
             exchangeTradeSimulator,
+            this._web3Wrapper.getProvider(),
             signedOrder,
             this.getZRXAssetData(),
             expectedFillTakerTokenAmountIfExists,

--- a/packages/ethereum-types/src/index.ts
+++ b/packages/ethereum-types/src/index.ts
@@ -1,3 +1,4 @@
+// tslint:disable:max-file-line-count
 import { BigNumber } from 'bignumber.js';
 
 export type JSONRPCErrorCallback = (err: Error | null, result?: JSONRPCResponsePayload) => void;

--- a/packages/order-utils/CHANGELOG.json
+++ b/packages/order-utils/CHANGELOG.json
@@ -14,6 +14,14 @@
             {
                 "note": "Rename `ecSignOrderHashAsync` to `ecSignHashAsync` removing `SignerType` parameter.",
                 "pr": 1102
+            },
+            {
+                "note": "Validate order signature and order cancel state in `validateOrderFillableOrThrowAsync`",
+                "pr": 1101
+            },
+            {
+                "note": "Validate order cancel state in `validateFillOrderThrowIfInvalidAsync`",
+                "pr": 1101
             }
         ]
     },

--- a/packages/order-utils/src/order_validation_utils.ts
+++ b/packages/order-utils/src/order_validation_utils.ts
@@ -106,7 +106,7 @@ export class OrderValidationUtils {
                 TransferType.Fee,
             );
         } catch (err) {
-            throw new Error(RevertReason.TransferFailed);
+            throw new Error(`${RevertReason.TransferFailed} ${err.message}`);
         }
     }
     private static async _validateSignatureIsValidOrThrowAsync(

--- a/packages/order-utils/test/order_state_utils_test.ts
+++ b/packages/order-utils/test/order_state_utils_test.ts
@@ -2,11 +2,10 @@ import { BigNumber } from '@0xproject/utils';
 import * as chai from 'chai';
 import 'mocha';
 
-import { AbstractBalanceAndProxyAllowanceFetcher } from '../src/abstract/abstract_balance_and_proxy_allowance_fetcher';
-import { AbstractOrderFilledCancelledFetcher } from '../src/abstract/abstract_order_filled_cancelled_fetcher';
 import { OrderStateUtils } from '../src/order_state_utils';
 
 import { chaiSetup } from './utils/chai_setup';
+import { buildMockBalanceFetcher, buildMockOrderFilledFetcher } from './utils/mock_fetchers';
 import { testOrderFactory } from './utils/test_order_factory';
 
 chaiSetup.configure();
@@ -14,34 +13,6 @@ const expect = chai.expect;
 
 describe('OrderStateUtils', () => {
     describe('#getOpenOrderStateAsync', () => {
-        const buildMockBalanceFetcher = (takerBalance: BigNumber): AbstractBalanceAndProxyAllowanceFetcher => {
-            const balanceFetcher = {
-                async getBalanceAsync(_assetData: string, _userAddress: string): Promise<BigNumber> {
-                    return takerBalance;
-                },
-                async getProxyAllowanceAsync(_assetData: string, _userAddress: string): Promise<BigNumber> {
-                    return takerBalance;
-                },
-            };
-            return balanceFetcher;
-        };
-        const buildMockOrderFilledFetcher = (
-            filledAmount: BigNumber = new BigNumber(0),
-            cancelled: boolean = false,
-        ): AbstractOrderFilledCancelledFetcher => {
-            const orderFetcher = {
-                async getFilledTakerAmountAsync(_orderHash: string): Promise<BigNumber> {
-                    return filledAmount;
-                },
-                async isOrderCancelledAsync(_orderHash: string): Promise<boolean> {
-                    return cancelled;
-                },
-                getZRXAssetData(): string {
-                    return '';
-                },
-            };
-            return orderFetcher;
-        };
         it('should have valid order state if order can be fully filled with small maker amount', async () => {
             const makerAssetAmount = new BigNumber(10);
             const takerAssetAmount = new BigNumber(10000000000000000);

--- a/packages/order-utils/test/utils/mock_fetchers.ts
+++ b/packages/order-utils/test/utils/mock_fetchers.ts
@@ -1,0 +1,34 @@
+import { BigNumber } from '@0xproject/utils';
+
+import { AbstractBalanceAndProxyAllowanceFetcher } from '../../src/abstract/abstract_balance_and_proxy_allowance_fetcher';
+import { AbstractOrderFilledCancelledFetcher } from '../../src/abstract/abstract_order_filled_cancelled_fetcher';
+
+export const buildMockBalanceFetcher = (takerBalance: BigNumber): AbstractBalanceAndProxyAllowanceFetcher => {
+    const balanceFetcher = {
+        async getBalanceAsync(_assetData: string, _userAddress: string): Promise<BigNumber> {
+            return takerBalance;
+        },
+        async getProxyAllowanceAsync(_assetData: string, _userAddress: string): Promise<BigNumber> {
+            return takerBalance;
+        },
+    };
+    return balanceFetcher;
+};
+
+export const buildMockOrderFilledFetcher = (
+    filledAmount: BigNumber = new BigNumber(0),
+    cancelled: boolean = false,
+): AbstractOrderFilledCancelledFetcher => {
+    const orderFetcher = {
+        async getFilledTakerAmountAsync(_orderHash: string): Promise<BigNumber> {
+            return filledAmount;
+        },
+        async isOrderCancelledAsync(_orderHash: string): Promise<boolean> {
+            return cancelled;
+        },
+        getZRXAssetData(): string {
+            return '';
+        },
+    };
+    return orderFetcher;
+};

--- a/packages/types/CHANGELOG.json
+++ b/packages/types/CHANGELOG.json
@@ -9,6 +9,10 @@
             {
                 "note": "Added `ZeroExTransaction` type for Exchange executeTransaction",
                 "pr": 1102
+            },
+            {
+                "note": "Add `RevertReason.OrderCancelled`",
+                "pr": 1101
             }
         ]
     },

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -171,6 +171,7 @@ export interface ERC721AssetData {
 // TODO: DRY. These should be extracted from contract code.
 export enum RevertReason {
     OrderUnfillable = 'ORDER_UNFILLABLE',
+    OrderCancelled = 'ORDER_CANCELLED',
     InvalidMaker = 'INVALID_MAKER',
     InvalidTaker = 'INVALID_TAKER',
     InvalidSender = 'INVALID_SENDER',


### PR DESCRIPTION

## Description

OrderValidationUtils `validateOrderFillableOrThrowAsync ` does not check if an order has been cancelled on chain.

Update this function to also be consistent with other functions in this utility by also checking the signature of the order.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [x] Prefix PR title with `[WIP]` if necessary.
*   [x] Prefix PR title with bracketed package name(s) corresponding to the changed package(s). For example: `[sol-cov] Fixed bug`.
*   [x] Add tests to cover changes as needed.
*   [ ] Update documentation as needed.
*   [x] Add new entries to the relevant CHANGELOG.jsons.
