### PR TITLE
[WIP] [sol-compiler] persist artifacts with only relevant sources

### DIFF
--- a/packages/sol-compiler/src/compiler.ts
+++ b/packages/sol-compiler/src/compiler.ts
@@ -297,6 +297,10 @@ export class Compiler {
     ): Promise<void> {
         const compiledContract = compilerOutput.contracts[contractPath][contractName];
 
+        // need to gather sourceCodes for this artifact, but compilerOutput.sources (the list of contract modules)
+        // contains listings for for every contract compiled during the compiler invocation that compiled the contract
+        // to be persisted, which could include many that are irrelevant to the contract at hand.  So, gather up only
+        // the relevant sources:
         const { sourceCodes, sources } = this._getSourcesWithDependencies(contractPath, compilerOutput.sources);
 
         const contractVersion: ContractVersionData = {
@@ -333,7 +337,7 @@ export class Compiler {
         logUtils.warn(`${contractName} artifact saved!`);
     }
     /**
-     * For the given @param contractPath, populates JSON objects to be used in the ContractArtifact interface's
+     * For the given @param contractPath, populates JSON objects to be used in the ContractVersionData interface's
      * properties `sources` (source code file names mapped to ID numbers) and `sourceCodes` (source code content of
      * contracts) for that contract.  The source code pointed to by contractPath is read and parsed directly (via
      * `this._resolver.resolve().source`), as are its imports, recursively.  The ID numbers for @return `sources` are


### PR DESCRIPTION
## Description
[Fix bug where all source codes are included in each artifact.](https://app.asana.com/0/684263176955174/842516551768097/f)

> @albrow  [8:07 PM]
> Okay as far as I know, the issue first appeared after your PR for compiling contract code in batches: https://github.com/0xProject/0x-monorepo/pull/965
> What appears to be happening is that the “sources” and “sourceCodes” field for each artifact includes *all* the source code for all other contracts. This is making artifact files much much bigger than they need to be.

<!--- Describe your changes in detail -->
I modified the artifact persistence logic to include only the source codes for the target artifact (and its dependencies (recursively)), out of the larger set of compilation outputs, which includes all of the other contracts compiled together in that run of the compiler.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [x] Prefix PR title with `[WIP]` if necessary.
*   [x] Prefix PR title with bracketed package name(s) corresponding to the changed package(s). For example: `[sol-cov] Fixed bug`.
*   [ ] Add tests to cover changes as needed.
*   [ ] Update documentation as needed.
*   [ ] Add new entries to the relevant CHANGELOG.jsons.
