### PR TITLE
[order-watcher] Public function getWatchCounts

### DIFF
--- a/packages/order-watcher/CHANGELOG.json
+++ b/packages/order-watcher/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "2.1.2",
+        "changes": [
+            {
+                "note": "Added getWatchCounts function"
+            }
+        ],
+        "timestamp": 1538836030
+    },
+    {
         "version": "2.1.1",
         "changes": [
             {

--- a/packages/order-watcher/src/order_watcher/order_watcher.ts
+++ b/packages/order-watcher/src/order_watcher/order_watcher.ts
@@ -213,6 +213,10 @@ export class OrderWatcher {
         this._expirationWatcher.unsubscribe();
         intervalUtils.clearAsyncExcludingInterval(this._cleanupJobIntervalIdIfExists);
     }
+    /**
+     * Gets number of orderHashes currently being watched by the order watcher instance.
+     * @returns {number}
+     */
     public getWatchCount(): number {
         return _.size(this._orderByOrderHash);
     }

--- a/packages/order-watcher/src/order_watcher/order_watcher.ts
+++ b/packages/order-watcher/src/order_watcher/order_watcher.ts
@@ -213,6 +213,9 @@ export class OrderWatcher {
         this._expirationWatcher.unsubscribe();
         intervalUtils.clearAsyncExcludingInterval(this._cleanupJobIntervalIdIfExists);
     }
+    public getWatchCount(): number {
+        return _.size(this._orderByOrderHash);
+    }
     private async _cleanupAsync(): Promise<void> {
         for (const orderHash of _.keys(this._orderByOrderHash)) {
             this._cleanupOrderRelatedState(orderHash);

--- a/packages/order-watcher/test/order_watcher_test.ts
+++ b/packages/order-watcher/test/order_watcher_test.ts
@@ -140,6 +140,23 @@ describe('OrderWatcher', () => {
             expect(() => orderWatcher.subscribe(_.noop.bind(_))).to.throw(OrderWatcherError.SubscriptionAlreadyPresent);
         });
     });
+    describe('#getWatchCount', async () => {
+        it('should increment and decrement order counts', async() => {
+            signedOrder = await fillScenarios.createFillableSignedOrderAsync(
+                makerAssetData,
+                takerAssetData,
+                makerAddress,
+                takerAddress,
+                fillableAmount,
+            );
+            const orderHash = orderHashUtils.getOrderHashHex(signedOrder);
+            expect(orderWatcher.getWatchCount()).to.be.eq(0);
+            await orderWatcher.addOrderAsync(signedOrder);
+            expect(orderWatcher.getWatchCount()).to.be.eq(1);
+            orderWatcher.removeOrder(orderHash);
+            expect(orderWatcher.getWatchCount()).to.be.eq(0);
+        });
+    });
     describe('tests with cleanup', async () => {
         afterEach(async () => {
             orderWatcher.unsubscribe();


### PR DESCRIPTION
## Description

Added public function to get order watcher counts so I can effectively scale order watcher instances based on watch loads.

## Testing instructions

Function added to test suite, no real changes as it reads in internal property that is assumed properly maintained.

## Types of changes

Added function for getWatchCounts in order watcher and one test.

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefix PR title with `[WIP]` if necessary.
*   [X ] Prefix PR title with bracketed package name(s) corresponding to the changed package(s). For example: `[sol-cov] Fixed bug`.
*   [X ] Add tests to cover changes as needed.
*   [X] Update documentation as needed.
*   [X ] Add new entries to the relevant CHANGELOG.jsons.
