### PR TITLE
fix: remove getApproved check from OrderValidator

### DIFF
--- a/packages/contracts/CHANGELOG.json
+++ b/packages/contracts/CHANGELOG.json
@@ -1,5 +1,15 @@
 [
     {
+        "name": "OrderValidator",
+        "version": "1.0.1",
+        "changes": [
+            {
+                "note": "remove `getApproved` check from ERC721 approval query",
+                "pr": 1149
+            }
+        ]
+    },
+    {
         "name": "Forwarder",
         "version": "1.1.0",
         "changes": [

--- a/packages/contracts/contracts/extensions/OrderValidator/OrderValidator.sol
+++ b/packages/contracts/contracts/extensions/OrderValidator/OrderValidator.sol
@@ -148,7 +148,7 @@ contract OrderValidator {
             balance = target == owner ? 1 : 0;
 
             // Check if ERC721Proxy is approved to spend tokenId
-            bool isApproved = IERC721Token(token).isApprovedForAll(target, assetProxy) || IERC721Token(token).getApproved(tokenId) == assetProxy;
+            bool isApproved = IERC721Token(token).isApprovedForAll(target, assetProxy);
             
             // Set alowance to 1 if ERC721Proxy is approved to spend tokenId
             allowance = isApproved ? 1 : 0;

--- a/packages/contracts/test/extensions/order_validator.ts
+++ b/packages/contracts/test/extensions/order_validator.ts
@@ -198,7 +198,7 @@ describe('OrderValidator', () => {
                 );
                 expect(newAllowance).to.be.bignumber.equal(ERC721_ALLOWANCE);
             });
-            it('should return an allowance of 1 when ERC721Proxy is approved for specific tokenId', async () => {
+            it('should return an allowance of 0 when ERC721Proxy is approved for specific tokenId', async () => {
                 await web3Wrapper.awaitTransactionSuccessAsync(
                     await erc721Token.mint.sendTransactionAsync(makerAddress, tokenId),
                     constants.AWAIT_TRANSACTION_MINED_MS,
@@ -213,7 +213,7 @@ describe('OrderValidator', () => {
                     makerAddress,
                     erc721AssetData,
                 );
-                expect(newAllowance).to.be.bignumber.equal(ERC721_ALLOWANCE);
+                expect(newAllowance).to.be.bignumber.equal(constants.ZERO_AMOUNT);
             });
         });
     });
@@ -248,8 +248,9 @@ describe('OrderValidator', () => {
                 await erc721Token.mint.sendTransactionAsync(makerAddress, tokenId),
                 constants.AWAIT_TRANSACTION_MINED_MS,
             );
+            const isApproved = true;
             await web3Wrapper.awaitTransactionSuccessAsync(
-                await erc721Token.approve.sendTransactionAsync(erc721Proxy.address, tokenId, {
+                await erc721Token.setApprovalForAll.sendTransactionAsync(erc721Proxy.address, isApproved, {
                     from: makerAddress,
                 }),
                 constants.AWAIT_TRANSACTION_MINED_MS,
@@ -311,8 +312,9 @@ describe('OrderValidator', () => {
                 await erc721Token.mint.sendTransactionAsync(takerAddress, tokenId),
                 constants.AWAIT_TRANSACTION_MINED_MS,
             );
+            const isApproved = true;
             await web3Wrapper.awaitTransactionSuccessAsync(
-                await erc721Token.approve.sendTransactionAsync(erc721Proxy.address, tokenId, {
+                await erc721Token.setApprovalForAll.sendTransactionAsync(erc721Proxy.address, isApproved, {
                     from: takerAddress,
                 }),
                 constants.AWAIT_TRANSACTION_MINED_MS,
@@ -465,8 +467,9 @@ describe('OrderValidator', () => {
                 await erc721Token.mint.sendTransactionAsync(takerAddress, tokenId),
                 constants.AWAIT_TRANSACTION_MINED_MS,
             );
+            const isApproved = true;
             await web3Wrapper.awaitTransactionSuccessAsync(
-                await erc721Token.approve.sendTransactionAsync(erc721Proxy.address, tokenId, {
+                await erc721Token.setApprovalForAll.sendTransactionAsync(erc721Proxy.address, isApproved, {
                     from: takerAddress,
                 }),
                 constants.AWAIT_TRANSACTION_MINED_MS,


### PR DESCRIPTION
## Description

Using `getApproved` isn't reliable since the approval is removed after a single transfer. Therefore, we no longer consider it to be a valid allowance for batch validating orders.

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefix PR title with `[WIP]` if necessary.
*   [ ] Prefix PR title with bracketed package name(s) corresponding to the changed package(s). For example: `[sol-cov] Fixed bug`.
*   [ ] Add tests to cover changes as needed.
*   [ ] Update documentation as needed.
*   [ ] Add new entries to the relevant CHANGELOG.jsons.
