### PR TITLE
fix(order-utils): remove constants export

### DIFF
--- a/packages/monorepo-scripts/src/doc_gen_configs.ts
+++ b/packages/monorepo-scripts/src/doc_gen_configs.ts
@@ -16,8 +16,14 @@ export const docGenConfigs: DocGenConfigs = {
         Schema:
             'https://github.com/tdegrunt/jsonschema/blob/5c2edd4baba149964aec0f23c87ad12c25a50dfb/lib/index.d.ts#L49',
         Uint8Array: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array',
+        // HACK: CI can handle these without the namespace but some local setups (Jacob) require the namespace prefix
+        //      This is duplicated until we can discover the source of the issue.
         GanacheOpts: 'https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/ganache-core/index.d.ts#L8',
         keystore: 'https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/eth-lightwallet/index.d.ts#L36',
+        'Ganache.GanacheOpts':
+            'https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/ganache-core/index.d.ts#L8',
+        'lightwallet.keystore':
+            'https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/eth-lightwallet/index.d.ts#L36',
     },
     // If a 0x package re-exports an external package, we should add a link to it's exported items here
     EXTERNAL_EXPORT_TO_LINK: {

--- a/packages/order-utils/src/index.ts
+++ b/packages/order-utils/src/index.ts
@@ -18,7 +18,6 @@ export { ExchangeTransferSimulator } from './exchange_transfer_simulator';
 export { BalanceAndProxyAllowanceLazyStore } from './store/balance_and_proxy_allowance_lazy_store';
 export { OrderFilledCancelledLazyStore } from './store/order_filled_cancelled_lazy_store';
 
-export { constants } from './constants';
 export { eip712Utils } from './eip712_utils';
 
 export {


### PR DESCRIPTION
## Description

We don't render object literals in the docs, and no other packages require these constants. Removing them from export.

My local environment requires me to namespace some types in the doc gen project, whereas CI seems fine without the namespace. Duplicated to suit both environments.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefix PR title with `[WIP]` if necessary.
*   [ ] Prefix PR title with bracketed package name(s) corresponding to the changed package(s). For example: `[sol-cov] Fixed bug`.
*   [ ] Add tests to cover changes as needed.
*   [ ] Update documentation as needed.
*   [ ] Add new entries to the relevant CHANGELOG.jsons.
