### PR TITLE
fix(web3-wrapper): Make getTransactionByHashAsync return the correct type

### DIFF
--- a/packages/web3-wrapper/src/web3_wrapper.ts
+++ b/packages/web3-wrapper/src/web3_wrapper.ts
@@ -23,7 +23,13 @@ import {
 import * as _ from 'lodash';
 
 import { marshaller } from './marshaller';
-import { BlockWithoutTransactionDataRPC, BlockWithTransactionDataRPC, NodeType, Web3WrapperErrors } from './types';
+import {
+    BlockWithoutTransactionDataRPC,
+    BlockWithTransactionDataRPC,
+    NodeType,
+    Web3WrapperErrors,
+    TransactionRPC,
+} from './types';
 import { utils } from './utils';
 
 const BASE_TEN = 10;
@@ -228,10 +234,11 @@ export class Web3Wrapper {
      */
     public async getTransactionByHashAsync(txHash: string): Promise<Transaction> {
         assert.isHexString('txHash', txHash);
-        const transaction = await this.sendRawPayloadAsync<Transaction>({
+        const transactionRpc = await this.sendRawPayloadAsync<TransactionRPC>({
             method: 'eth_getTransactionByHash',
             params: [txHash],
         });
+        const transaction = marshaller.unmarshalTransaction(transactionRpc);
         return transaction;
     }
     /**


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR fixes a bug. Because we were not calling `unmarshalTransaction`, the return value of `getTransactionByHashAsync` did not line up with its type definition. The fields were not getting parsed (e.g. `gasPrice` was a `string` instead of a `BigNumber`).

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefix PR title with `[WIP]` if necessary.
*   [ ] Prefix PR title with bracketed package name(s) corresponding to the changed package(s). For example: `[sol-cov] Fixed bug`.
*   [ ] Add tests to cover changes as needed.
*   [ ] Update documentation as needed.
*   [ ] Add new entries to the relevant CHANGELOG.jsons.
