### PR TITLE
[web3-wrapper] Throws when contract returns null

### DIFF
--- a/packages/web3-wrapper/src/web3_wrapper.ts
+++ b/packages/web3-wrapper/src/web3_wrapper.ts
@@ -533,9 +533,6 @@ export class Web3Wrapper {
             method: 'eth_call',
             params: [callDataHex, marshalledDefaultBlock],
         });
-        if (rawCallResult === '0x') {
-            throw new Error('Contract call failed (returned null)');
-        }
         return rawCallResult;
     }
     /**


### PR DESCRIPTION
## Description

#1240 
#622 

In 0x packages we attempt to validate a contract call by performing an `eth_call`  before submitting a transaction. This is in order to detect any reverts or revert with reasons. For example, an `eth_call` for `cancelOrder`.

```
{id: 3, jsonrpc: "2.0", params: [{to: "0x4530c0483a1633c7a1c97d2c53721caff2caaaaf",…}, "latest"],…}
id: 3
jsonrpc: "2.0"
method: "eth_call"
params: [{to: "0x4530c0483a1633c7a1c97d2c53721caff2caaaaf",…}, "latest"]
0: {to: "0x4530c0483a1633c7a1c97d2c53721caff2caaaaf",…}
data: "0xd46b02c30000000000000000000000000000000000000000000000000000000000000020000000000000000000000000ea95a7a25506c9f70fb7bc50877c435a609353b20000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000166fb3f1e2fc47af3ca74a4f69efc343e30e6685f96b0f11ae1570779c56738be60b56464bc000000000000000000000000000000000000000000000000000000000000018000000000000000000000000000000000000000000000000000000000000001e00000000000000000000000000000000000000000000000000000000000000024f47261b0000000000000000000000000ff67881f8d12f372d91baae9752eb3631ff0ed00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024f47261b0000000000000000000000000c778417e063141139fce010982780140aa0cd5ab00000000000000000000000000000000000000000000000000000000"
from: "0xea95a7a25506c9f70fb7bc50877c435a609353b2"
to: "0x4530c0483a1633c7a1c97d2c53721caff2caaaaf"
1: "latest"
```

0x Exchange cancelOrder has no return value although it may throw a Revert Reason:
```
// Cancel Order + Batch Cancel Order
ORDER_UNFILLABLE
INVALID_SENDER
INVALID_MAKER

// Cancel Orders Up To 
INVALID_NEW_ORDER_EPOCH
```

So a successful return will not contain any data.

Successful Response: 
```
// Gethh Response
{"jsonrpc":"2.0","id":3,"result":"0x"}
// Parity Response
{"jsonrpc":"2.0","id":1,"result":"0x"}
// Ganache Response: 
{"id":1,"jsonrpc":"2.0","result":"0x0"}
```

Whereas error responses look like the following:
```
// Geth
{"jsonrpc":"2.0","id":7,"result":"0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000104f524445525f554e46494c4c41424c4500000000000000000000000000000000"}
// Parity
{"jsonrpc":"2.0","id":4,"error":{"code":-32015,"data":"Reverted 0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000104f524445525f554e46494c4c41424c4500000000000000000000000000000000","message":"VM execution error."}}
// Ganache
{"id":3,"jsonrpc":"2.0","result":"0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000104f524445525f554e46494c4c41424c4500000000000000000000000000000000"}
```

Revert without supplied reason response:
```
// Geth
{"jsonrpc":"2.0","id":2005073035,"error":{"code":-32015,"data":"Reverted 0x","message":"VM execution error."}}
// Parity
{"jsonrpc":"2.0","id":2580139779,"result":"0x"}
// Ganache
{"id":1,"jsonrpc":"2.0","result":"0x0"}
```

By removing this check we may end up with ambiguous results on Geth and Ganache when a revert occurs, since it is not possible to determine if the `0x` response is result of a revert (without reason) or a null return data.

We have contacted Geth developers in removing this ambiguous case in future versions of Geth. Discussion can be [found here](https://ethereum-magicians.org/t/eip-remote-procedure-call-specification/1537/14).

Also contacted Ganache to see if we can agree on a standard `eth_call` response. trufflesuite/ganache-core#222
## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefix PR title with `[WIP]` if necessary.
*   [x] Prefix PR title with bracketed package name(s) corresponding to the changed package(s). For example: `[sol-cov] Fixed bug`.
*   [ ] Add tests to cover changes as needed.
*   [ ] Update documentation as needed.
*   [x] Add new entries to the relevant CHANGELOG.jsons.
