### PR TITLE
[@0x/order-watcher] Fix a bug in an order removal when maker token is ZRX

### DIFF
--- a/packages/order-watcher/CHANGELOG.json
+++ b/packages/order-watcher/CHANGELOG.json
@@ -1,5 +1,15 @@
 [
     {
+        "version": "2.2.4",
+        "changes": [
+            {
+                "note":
+                    "Fix the bug when order watcher was throwing an error on order removal when maker token was ZRX",
+                "pr": 1259
+            }
+        ]
+    },
+    {
         "version": "2.2.3",
         "changes": [
             {

--- a/packages/order-watcher/src/order_watcher/dependent_order_hashes_tracker.ts
+++ b/packages/order-watcher/src/order_watcher/dependent_order_hashes_tracker.ts
@@ -89,7 +89,9 @@ export class DependentOrderHashesTracker {
                 (decodedMakerAssetData as ERC721AssetData).tokenId,
             );
         }
-        this._removeFromERC20DependentOrderhashes(signedOrder, this._zrxTokenAddress);
+        if ((decodedMakerAssetData as ERC20AssetData).tokenAddress !== this._zrxTokenAddress) {
+            this._removeFromERC20DependentOrderhashes(signedOrder, this._zrxTokenAddress);
+        }
         this._removeFromMakerDependentOrderhashes(signedOrder);
     }
     private _getDependentOrderHashesByERC20AssetData(makerAddress: string, erc20AssetData: string): string[] {

--- a/packages/order-watcher/src/order_watcher/dependent_order_hashes_tracker.ts
+++ b/packages/order-watcher/src/order_watcher/dependent_order_hashes_tracker.ts
@@ -89,6 +89,7 @@ export class DependentOrderHashesTracker {
                 (decodedMakerAssetData as ERC721AssetData).tokenId,
             );
         }
+        // If makerToken === ZRX then we already removed it and we don't need to remove it again.
         if ((decodedMakerAssetData as ERC20AssetData).tokenAddress !== this._zrxTokenAddress) {
             this._removeFromERC20DependentOrderhashes(signedOrder, this._zrxTokenAddress);
         }


### PR DESCRIPTION
## Description

When we try to remove an order that has makerToken == ZRX we tried to remove ZRX from dependent order hashes twice and it failed.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue) 
## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [x] Prefix PR title with `[WIP]` if necessary.
*   [x] Prefix PR title with bracketed package name(s) corresponding to the changed package(s). For example: `[sol-cov] Fixed bug`.
*   [x] Add tests to cover changes as needed.
*   [x] Update documentation as needed.
*   [x] Add new entries to the relevant CHANGELOG.jsons.
