### PR TITLE
fix(order_utils.py): validate order w/json schema

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,6 +6,7 @@ lib
 /packages/contract-artifacts/artifacts
 /python-packages/order_utils/src/zero_ex/contract_artifacts/artifacts
 /packages/json-schemas/schemas
+/python-packages/order_utils/src/zero_ex/json_schemas/schemas
 /packages/metacoin/src/contract_wrappers
 /packages/metacoin/artifacts
 /packages/sra-spec/public/

--- a/python-packages/order_utils/setup.py
+++ b/python-packages/order_utils/setup.py
@@ -184,6 +184,7 @@ setup(
     package_data={
         "zero_ex.order_utils": ["py.typed"],
         "zero_ex.contract_artifacts": ["artifacts/*"],
+        "zero_ex.json_schemas": ["schemas/*"],
     },
     package_dir={"": "src"},
     license="Apache 2.0",

--- a/python-packages/order_utils/setup.py
+++ b/python-packages/order_utils/setup.py
@@ -159,7 +159,7 @@ setup(
     install_requires=[
         "eth-abi",
         "eth_utils",
-        "ethereum",
+        "jsonschema",
         "mypy_extensions",
         "web3",
     ],

--- a/python-packages/order_utils/src/index.rst
+++ b/python-packages/order_utils/src/index.rst
@@ -22,6 +22,9 @@ See source for class properties.  Sphinx does not easily generate class property
 
 .. autoclass:: zero_ex.order_utils.asset_data_utils.ERC721AssetData
 
+.. automodule:: zero_ex.json_schemas
+   :members:
+
 Indices and tables
 ==================
 

--- a/python-packages/order_utils/src/zero_ex/json_schemas/__init__.py
+++ b/python-packages/order_utils/src/zero_ex/json_schemas/__init__.py
@@ -1,0 +1,61 @@
+"""JSON schemas and associated utilities."""
+
+from os import path
+import json
+from typing import Mapping
+
+from pkg_resources import resource_string
+import jsonschema
+
+
+def assert_valid(data: Mapping, schema_id: str) -> None:
+    """Validate the given `data` against the specified `schema`.
+
+    :param data: Python dictionary to be validated as a JSON object.
+    :param schema_id: id property of the JSON schema to validate against.  Must
+        be one of those listed in `the 0x JSON schema files
+        <https://github.com/0xProject/0x-monorepo/tree/development/packages/json-schemas/schemas>`_.
+
+    Raises an exception if validation fails.
+
+    >>> assert_valid(
+    ...     {'v': 27, 'r': '0x'+'f'*64, 's': '0x'+'f'*64},
+    ...     '/ECSignature',
+    ... )
+    """
+    # noqa
+    class LocalRefResolver(jsonschema.RefResolver):
+        """Resolve package-local JSON schema id's."""
+
+        def __init__(self):
+            self.ref_to_file = {
+                "/addressSchema": "address_schema.json",
+                "/hexSchema": "hex_schema.json",
+                "/orderSchema": "order_schema.json",
+                "/wholeNumberSchema": "whole_number_schema.json",
+                "/ECSignature": "ec_signature_schema.json",
+                "/ecSignatureParameterSchema": (
+                    "ec_signature_parameter_schema.json" + ""
+                ),
+            }
+            jsonschema.RefResolver.__init__(self, "", "")
+
+        def resolve_from_url(self, url):
+            """Resolve the given URL."""
+            ref = url.replace("file://", "")
+            if ref in self.ref_to_file:
+                return json.loads(
+                    resource_string(
+                        "zero_ex.json_schemas",
+                        f"schemas/{self.ref_to_file[ref]}",
+                    )
+                )
+            raise jsonschema.ValidationError(
+                f"Unknown ref '{ref}'. "
+                + f"Known refs: {list(self.ref_to_file.keys())}."
+            )
+
+    resolver = LocalRefResolver()
+    jsonschema.validate(
+        data, resolver.resolve_from_url(schema_id), resolver=resolver
+    )

--- a/python-packages/order_utils/src/zero_ex/json_schemas/schemas
+++ b/python-packages/order_utils/src/zero_ex/json_schemas/schemas
@@ -1,0 +1,1 @@
+../../../../../packages/json-schemas/schemas/

--- a/python-packages/order_utils/stubs/jsonschema/__init__.pyi
+++ b/python-packages/order_utils/stubs/jsonschema/__init__.pyi
@@ -1,0 +1,5 @@
+from typing import Any, Dict
+
+class RefResolver: pass
+
+def validate(instance: Any, schema: Dict, cls=None, *args, **kwargs) -> None: pass

--- a/python-packages/order_utils/test/test_generate_order_hash_hex.py
+++ b/python-packages/order_utils/test/test_generate_order_hash_hex.py
@@ -1,10 +1,6 @@
 """Test zero_ex.order_utils.get_order_hash_hex()."""
 
-from zero_ex.order_utils import (
-    generate_order_hash_hex,
-    make_empty_order,
-    _Constants,
-)
+from zero_ex.order_utils import generate_order_hash_hex, make_empty_order
 
 
 def test_get_order_hash_hex__empty_order():
@@ -12,7 +8,5 @@ def test_get_order_hash_hex__empty_order():
     expected_hash_hex = (
         "faa49b35faeb9197e9c3ba7a52075e6dad19739549f153b77dfcf59408a4b422"
     )
-    actual_hash_hex = generate_order_hash_hex(
-        make_empty_order(), _Constants.null_address
-    )
+    actual_hash_hex = generate_order_hash_hex(make_empty_order())
     assert actual_hash_hex == expected_hash_hex


### PR DESCRIPTION
## Description

Added a JSON schema Python module, and changed `generate_order_hash_hex()` to use it to validate the order.

In order to conform to the schema, though, had to rename quite a few fields, from snake case to camel.

## Testing instructions

`./setup.py test && ./setup.py lint && ./setup.py build_sphinx && tox`
All but the `tox` part is integrated with CI.
<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [x] Prefix PR title with `[WIP]` if necessary.
*   [x] Prefix PR title with bracketed package name(s) corresponding to the changed package(s). For example: `[sol-cov] Fixed bug`.
*   [x] Add tests to cover changes as needed.
*   [x] Update documentation as needed.
*   [x] Add new entries to the relevant CHANGELOG.jsons.
