### PR TITLE
[order_utils.py] lazy load contract artifacts

### DIFF
--- a/python-packages/order_utils/src/zero_ex/order_utils/__init__.py
+++ b/python-packages/order_utils/src/zero_ex/order_utils/__init__.py
@@ -34,13 +34,21 @@ from zero_ex.json_schemas import assert_valid
 class _Constants:
     """Static data used by order utilities."""
 
-    contract_name_to_abi = {
-        "Exchange": json.loads(
-            resource_string(
-                "zero_ex.contract_artifacts", "artifacts/Exchange.json"
-            )
-        )["compilerOutput"]["abi"]
-    }
+    _contract_name_to_abi: Dict[str, Dict] = {}
+
+    @classmethod
+    def contract_name_to_abi(cls, contract_name: str) -> Dict:
+        """Load from disk the ABI for the given contract."""
+        try:
+            return cls._contract_name_to_abi[contract_name]
+        except KeyError:
+            cls._contract_name_to_abi[contract_name] = json.loads(
+                resource_string(
+                    "zero_ex.contract_artifacts",
+                    f"artifacts/{contract_name}.json",
+                )
+            )["compilerOutput"]["abi"]
+            return cls._contract_name_to_abi[contract_name]
 
     network_to_exchange_addr: Dict[str, str] = {
         "1": "0x4f833a24e1f95d70f028921e27040ca56e09ab0b",
@@ -233,7 +241,7 @@ def is_valid_signature(
     # false positive from pylint: disable=no-member
     contract: datatypes.Contract = web3_instance.eth.contract(
         address=to_checksum_address(contract_address),
-        abi=_Constants.contract_name_to_abi["Exchange"],
+        abi=_Constants.contract_name_to_abi("Exchange"),
     )
     try:
         return (

--- a/python-packages/order_utils/src/zero_ex/order_utils/__init__.py
+++ b/python-packages/order_utils/src/zero_ex/order_utils/__init__.py
@@ -34,11 +34,16 @@ from zero_ex.json_schemas import assert_valid
 class _Constants:
     """Static data used by order utilities."""
 
-    _contract_name_to_abi: Dict[str, Dict] = {}
+    _contract_name_to_abi: Dict[str, Dict] = {}  # class data, not instance
 
     @classmethod
     def contract_name_to_abi(cls, contract_name: str) -> Dict:
-        """Load from disk the ABI for the given contract."""
+        """Return the ABI for the given contract name.
+
+        First tries to get data from the class level storage
+        `_contract_name_to_abi`.  If it's not there, loads it from disk, stores
+        it in the class data (for the next caller), and then returns it.
+        """
         try:
             return cls._contract_name_to_abi[contract_name]
         except KeyError:


### PR DESCRIPTION
## Description

Don't load contract artifacts until they're actually asked for, and then cache them for the next call.

This fixes a problem with documentation generation on readthedocs.io in that it generates the docs without actually installing the packages, but because it wasn't actually installing them then the data files (artifacts) weren't available, so the process was failing.  In any case, such lazy loading is desirable anyways, so I'm glad to have the impetus to do this.

## Testing instructions

`./setup.py test`, which is integrated with CI.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [x] Prefix PR title with `[WIP]` if necessary.
*   [x] Prefix PR title with bracketed package name(s) corresponding to the changed package(s). For example: `[sol-cov] Fixed bug`.
*   [x] Add tests to cover changes as needed.
*   [x] Update documentation as needed.
*   [x] Add new entries to the relevant CHANGELOG.jsons.
