### PR TITLE
[ganache]: fix exceeds block gas limit error

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "packages/*"
     ],
     "scripts": {
-        "ganache": "ganache-cli -p 8545 --networkId 50 -m \"${npm_package_config_mnemonic}\"",
+        "ganache": "ganache-cli -p 8545 --gasLimit 10000000 --networkId 50 -m \"${npm_package_config_mnemonic}\"",
         "prettier": "prettier --write '**/*.{ts,tsx,json,md}' --config .prettierrc",
         "prettier:ci": "prettier --list-different '**/*.{ts,tsx,json,md}' --config .prettierrc",
         "report_coverage": "lcov-result-merger './{packages/*/coverage/lcov.info,python-packages/*/.coverage}' | coveralls",


### PR DESCRIPTION
## Description

Run ganache

```
cd 0x-monorepo
yarn ganache
```

Another terminal, run migrate

```
cd packages/migrations
yarn migrate:v2
```

Then you will get these errors.

```
❯ yarn migrate:v2
yarn run v1.12.3
run-s build script:migrate:v2 run−sbuildscript:migrate:v2 tsc -b
$ node ./lib/migrate.js --contracts-version 2.0.0
{ message: 'Exceeds block gas limit',
  code: -32000,
  data:
   { stack: 'r: Exceeds block gas limit\n    at StateManager.queueTransaction (/Users/akagi201/Documents/src/github.com/0xProject/0x-monorepo/node_modules/ganache-cli/build/cli.node.js:149:69564)\n    at s.eth_sendTransaction (/Users/akagi201/Documents/src/github.com/0xProject/0x-monorepo/node_modules/ganache-cli/build/cli.node.js:149:81687)\n    at s.handleRequest (/Users/akagi201/Documents/src/github.com/0xProject/0x-monorepo/node_modules/ganache-cli/build/cli.node.js:149:78847)\n    at a (/Users/akagi201/Documents/src/github.com/0xProject/0x-monorepo/node_modules/ganache-cli/build/cli.node.js:149:225418)\n    at c.handleRequest (/Users/akagi201/Documents/src/github.com/0xProject/0x-monorepo/node_modules/ganache-cli/build/cli.node.js:149:85837)\n    at a (/Users/akagi201/Documents/src/github.com/0xProject/0x-monorepo/node_modules/ganache-cli/build/cli.node.js:149:225418)\n    at o.d.handleRequest (/Users/akagi201/Documents/src/github.com/0xProject/0x-monorepo/node_modules/ganache-cli/build/cli.node.js:149:90270)\n    at o.handleRequest (/Users/akagi201/Documents/src/github.com/0xProject/0x-monorepo/node_modules/ganache-cli/build/cli.node.js:149:97049)\n    at a (/Users/akagi201/Documents/src/github.com/0xProject/0x-monorepo/node_modules/ganache-cli/build/cli.node.js:149:225418)\n    at f.handleRequest (/Users/akagi201/Documents/src/github.com/0xProject/0x-monorepo/node_modules/ganache-cli/build/cli.node.js:149:86274)\n    at a (/Users/akagi201/Documents/src/github.com/0xProject/0x-monorepo/node_modules/ganache-cli/build/cli.node.js:149:225418)\n    at c.handleRequest (/Users/akagi201/Documents/src/github.com/0xProject/0x-monorepo/node_modules/ganache-cli/build/cli.node.js:149:87427)\n    at a (/Users/akagi201/Documents/src/github.com/0xProject/0x-monorepo/node_modules/ganache-cli/build/cli.node.js:149:225418)\n    at s._handleAsync (/Users/akagi201/Documents/src/github.com/0xProject/0x-monorepo/node_modules/ganache-cli/build/cli.node.js:149:225454)\n    at Timeout._onTimeout (/Users/akagi201/Documents/src/github.com/0xProject/0x-monorepo/node_modules/ganache-cli/build/cli.node.js:149:224879)\n    at ontimeout (timers.js:466:11)\n    at tryOnTimeout (timers.js:304:5)\n    at Timer.listOnTimeout (timers.js:267:5)',
     name: 'r' } }
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
ERROR: "script:migrate:v2" exited with 1.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

## Testing instructions

Step 1

```
yarn ganache
```

Step 2.

Another terminal.

```
cd packages/migrations
yarn migrate:v2
```

It will succeed.

## Types of changes

* Bug fix (non-breaking change which fixes an issue)

