### PR TITLE
[instant] Close Instant on "back" and re-open instant on "forward by default. Provide option to disable.

### DIFF
--- a/packages/instant/public/index.html
+++ b/packages/instant/public/index.html
@@ -128,8 +128,10 @@
             availableAssetDatas: availableAssetDatasString ? JSON.parse(availableAssetDatasString) : undefined,
             defaultSelectedAssetData: queryParams.getQueryParamValue('defaultSelectedAssetData'),
             affiliateInfo: affiliateInfoOverride,
+
         }
         const renderOptions = Object.assign({}, renderOptionsDefaults, removeUndefined(renderOptionsOverrides));
+        window.onpopstate = () => console.log('Integrators onpopstate called');
         zeroExInstant.render(renderOptions);
     </script>
 </body>

--- a/packages/instant/public/index.html
+++ b/packages/instant/public/index.html
@@ -128,7 +128,7 @@
             availableAssetDatas: availableAssetDatasString ? JSON.parse(availableAssetDatasString) : undefined,
             defaultSelectedAssetData: queryParams.getQueryParamValue('defaultSelectedAssetData'),
             affiliateInfo: affiliateInfoOverride,
-
+            shouldDisablePushToHistory: !!queryParams.getQueryParamValue('shouldDisablePushToHistory'),
         }
         const renderOptions = Object.assign({}, renderOptionsDefaults, removeUndefined(renderOptionsOverrides));
         window.onpopstate = () => console.log('Integrators onpopstate called');

--- a/packages/instant/src/index.umd.ts
+++ b/packages/instant/src/index.umd.ts
@@ -53,14 +53,19 @@ export const render = (config: ZeroExInstantConfig, selector: string = DEFAULT_Z
         injectedDiv.setAttribute('id', INJECTED_DIV_ID);
         injectedDiv.setAttribute('class', INJECTED_DIV_CLASS);
         appendTo.appendChild(injectedDiv);
-        const removeFromDom = () => appendTo.removeChild(injectedDiv);
+        const closeInstant = () => {
+            if (config.onClose) {
+                config.onClose();
+            }
+            appendTo.removeChild(injectedDiv);
+        };
         const instantOverlayProps = {
             ...config,
             // If we are using the history API, just go back to close
-            onClose: () => (config.shouldDisablePushToHistory ? removeFromDom() : window.history.back()),
+            onClose: () => (config.shouldDisablePushToHistory ? closeInstant() : window.history.back()),
         };
         ReactDOM.render(React.createElement(ZeroExInstantOverlay, instantOverlayProps), injectedDiv);
-        return removeFromDom;
+        return closeInstant;
     };
     if (config.shouldDisablePushToHistory) {
         renderInstant();
@@ -83,9 +88,6 @@ export const render = (config: ZeroExInstantConfig, selector: string = DEFAULT_Z
             } else {
                 // User pressed back, so close instant.
                 removeInstant();
-                if (!_.isUndefined(config.onClose)) {
-                    config.onClose();
-                }
             }
         };
     }

--- a/packages/instant/src/index.umd.ts
+++ b/packages/instant/src/index.umd.ts
@@ -41,7 +41,7 @@ export const render = (config: ZeroExInstantConfig, selector: string = DEFAULT_Z
         assert.isWeb3Provider('props.provider', config.provider);
     }
     assert.isString('selector', selector);
-    // Render instant and return a callback that allows you to close it.
+    // Render instant and return a callback that allows you to remove it from the DOM.
     const renderInstant = () => {
         const appendToIfExists = document.querySelector(selector);
         assert.assert(!_.isNull(appendToIfExists), `Could not find div with selector: ${selector}`);
@@ -50,21 +50,21 @@ export const render = (config: ZeroExInstantConfig, selector: string = DEFAULT_Z
         injectedDiv.setAttribute('id', INJECTED_DIV_ID);
         injectedDiv.setAttribute('class', INJECTED_DIV_CLASS);
         appendTo.appendChild(injectedDiv);
-        const close = () => appendTo.removeChild(injectedDiv);
+        const removeFromDom = () => appendTo.removeChild(injectedDiv);
         const instantOverlayProps = {
             ...config,
             // If we are using the history API, just go back to close
-            onClose: () => (config.shouldDisablePushToHistory ? close() : window.history.back()),
+            onClose: () => (config.shouldDisablePushToHistory ? removeFromDom() : window.history.back()),
         };
         ReactDOM.render(React.createElement(ZeroExInstantOverlay, instantOverlayProps), injectedDiv);
-        return close;
+        return removeFromDom;
     };
     if (config.shouldDisablePushToHistory) {
         renderInstant();
     } else {
         // Before we render, push to history saying that instant is showing for this part of the history.
         window.history.pushState({ zeroExInstantShowing: true }, '0x Instant');
-        let closeInstant = renderInstant();
+        let removeInstant = renderInstant();
 
         let prevOnPopState = util.boundNoop;
         if (window.onpopstate) {
@@ -76,10 +76,10 @@ export const render = (config: ZeroExInstantConfig, selector: string = DEFAULT_Z
             // e.state represents the new state
             if (e.state && e.state.zeroExInstantShowing) {
                 // The user pressed fowards, so re-render instant.
-                closeInstant = renderInstant();
+                removeInstant = renderInstant();
             } else {
                 // User pressed back, so close instant.
-                closeInstant();
+                removeInstant();
                 if (!_.isUndefined(config.onClose)) {
                     config.onClose();
                 }

--- a/packages/instant/src/index.umd.ts
+++ b/packages/instant/src/index.umd.ts
@@ -7,34 +7,38 @@ import { ZeroExInstantOverlay, ZeroExInstantOverlayProps } from './index';
 import { assert } from './util/assert';
 import { util } from './util/util';
 
-export const render = (props: ZeroExInstantOverlayProps, selector: string = DEFAULT_ZERO_EX_CONTAINER_SELECTOR) => {
-    assert.isValidOrderSource('orderSource', props.orderSource);
-    if (!_.isUndefined(props.defaultSelectedAssetData)) {
-        assert.isHexString('defaultSelectedAssetData', props.defaultSelectedAssetData);
+export interface ZeroExInstantConfig extends ZeroExInstantOverlayProps {
+    shouldUseHistoryApi?: boolean;
+}
+
+export const render = (config: ZeroExInstantConfig, selector: string = DEFAULT_ZERO_EX_CONTAINER_SELECTOR) => {
+    assert.isValidOrderSource('orderSource', config.orderSource);
+    if (!_.isUndefined(config.defaultSelectedAssetData)) {
+        assert.isHexString('defaultSelectedAssetData', config.defaultSelectedAssetData);
     }
-    if (!_.isUndefined(props.additionalAssetMetaDataMap)) {
-        assert.isValidAssetMetaDataMap('props.additionalAssetMetaDataMap', props.additionalAssetMetaDataMap);
+    if (!_.isUndefined(config.additionalAssetMetaDataMap)) {
+        assert.isValidAssetMetaDataMap('props.additionalAssetMetaDataMap', config.additionalAssetMetaDataMap);
     }
-    if (!_.isUndefined(props.defaultAssetBuyAmount)) {
-        assert.isNumber('props.defaultAssetBuyAmount', props.defaultAssetBuyAmount);
+    if (!_.isUndefined(config.defaultAssetBuyAmount)) {
+        assert.isNumber('props.defaultAssetBuyAmount', config.defaultAssetBuyAmount);
     }
-    if (!_.isUndefined(props.networkId)) {
-        assert.isNumber('props.networkId', props.networkId);
+    if (!_.isUndefined(config.networkId)) {
+        assert.isNumber('props.networkId', config.networkId);
     }
-    if (!_.isUndefined(props.availableAssetDatas)) {
-        assert.areValidAssetDatas('availableAssetDatas', props.availableAssetDatas);
+    if (!_.isUndefined(config.availableAssetDatas)) {
+        assert.areValidAssetDatas('availableAssetDatas', config.availableAssetDatas);
     }
-    if (!_.isUndefined(props.onClose)) {
-        assert.isFunction('props.onClose', props.onClose);
+    if (!_.isUndefined(config.onClose)) {
+        assert.isFunction('props.onClose', config.onClose);
     }
-    if (!_.isUndefined(props.zIndex)) {
-        assert.isNumber('props.zIndex', props.zIndex);
+    if (!_.isUndefined(config.zIndex)) {
+        assert.isNumber('props.zIndex', config.zIndex);
     }
-    if (!_.isUndefined(props.affiliateInfo)) {
-        assert.isValidAffiliateInfo('props.affiliateInfo', props.affiliateInfo);
+    if (!_.isUndefined(config.affiliateInfo)) {
+        assert.isValidAffiliateInfo('props.affiliateInfo', config.affiliateInfo);
     }
-    if (!_.isUndefined(props.provider)) {
-        assert.isWeb3Provider('props.provider', props.provider);
+    if (!_.isUndefined(config.provider)) {
+        assert.isWeb3Provider('props.provider', config.provider);
     }
     assert.isString('selector', selector);
     // Render instant and return a callback that allows you to close it.
@@ -47,7 +51,7 @@ export const render = (props: ZeroExInstantOverlayProps, selector: string = DEFA
         injectedDiv.setAttribute('class', INJECTED_DIV_CLASS);
         appendTo.appendChild(injectedDiv);
         const instantOverlayProps = {
-            ...props,
+            ...config,
             onClose: () => window.history.back(),
         };
         ReactDOM.render(React.createElement(ZeroExInstantOverlay, instantOverlayProps), injectedDiv);
@@ -73,8 +77,8 @@ export const render = (props: ZeroExInstantOverlayProps, selector: string = DEFA
             // User pressed back, so close instant.
             closeInstant();
             delete window.onpopstate;
-            if (!_.isUndefined(props.onClose)) {
-                props.onClose();
+            if (!_.isUndefined(config.onClose)) {
+                config.onClose();
             }
         }
     };

--- a/packages/instant/src/index.umd.ts
+++ b/packages/instant/src/index.umd.ts
@@ -17,28 +17,31 @@ export const render = (config: ZeroExInstantConfig, selector: string = DEFAULT_Z
         assert.isHexString('defaultSelectedAssetData', config.defaultSelectedAssetData);
     }
     if (!_.isUndefined(config.additionalAssetMetaDataMap)) {
-        assert.isValidAssetMetaDataMap('props.additionalAssetMetaDataMap', config.additionalAssetMetaDataMap);
+        assert.isValidAssetMetaDataMap('additionalAssetMetaDataMap', config.additionalAssetMetaDataMap);
     }
     if (!_.isUndefined(config.defaultAssetBuyAmount)) {
-        assert.isNumber('props.defaultAssetBuyAmount', config.defaultAssetBuyAmount);
+        assert.isNumber('defaultAssetBuyAmount', config.defaultAssetBuyAmount);
     }
     if (!_.isUndefined(config.networkId)) {
-        assert.isNumber('props.networkId', config.networkId);
+        assert.isNumber('networkId', config.networkId);
     }
     if (!_.isUndefined(config.availableAssetDatas)) {
         assert.areValidAssetDatas('availableAssetDatas', config.availableAssetDatas);
     }
     if (!_.isUndefined(config.onClose)) {
-        assert.isFunction('props.onClose', config.onClose);
+        assert.isFunction('onClose', config.onClose);
     }
     if (!_.isUndefined(config.zIndex)) {
-        assert.isNumber('props.zIndex', config.zIndex);
+        assert.isNumber('zIndex', config.zIndex);
     }
     if (!_.isUndefined(config.affiliateInfo)) {
-        assert.isValidAffiliateInfo('props.affiliateInfo', config.affiliateInfo);
+        assert.isValidAffiliateInfo('affiliateInfo', config.affiliateInfo);
     }
     if (!_.isUndefined(config.provider)) {
-        assert.isWeb3Provider('props.provider', config.provider);
+        assert.isWeb3Provider('provider', config.provider);
+    }
+    if (!_.isUndefined(config.shouldDisablePushToHistory)) {
+        assert.isBoolean('shouldDisablePushToHistory', config.shouldDisablePushToHistory);
     }
     assert.isString('selector', selector);
     // Render instant and return a callback that allows you to remove it from the DOM.


### PR DESCRIPTION
## Description

- Changes the `render` method such that it calls `pushState` before it renders. This allows the user to press "back" without us having to worry about them leaving the page. 
- Listens to `window.onpopstate` to know when to open and close instant when the feature is not disabled. When user presses back, instant is removed from the DOM. When he presses forward again, instant is re-rendered.
- Calls `history.back` instead of directly moving instant from the DOM when the closing "X" is pressed.
- Add `shouldDisablePushToHistory` to disable the above behavior. 

Worth noting that this works jankily with the hot reloading in webpack-dev-server, and so we might want to disable it by default.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefix PR title with `[WIP]` if necessary.
*   [ ] Prefix PR title with bracketed package name(s) corresponding to the changed package(s). For example: `[sol-cov] Fixed bug`.
*   [ ] Add tests to cover changes as needed.
*   [ ] Update documentation as needed.
*   [ ] Add new entries to the relevant CHANGELOG.jsons.
