### PR TITLE
[order_utils.py] Feature/schema resolver cache

### DIFF
--- a/python-packages/order_utils/src/zero_ex/json_schemas/__init__.py
+++ b/python-packages/order_utils/src/zero_ex/json_schemas/__init__.py
@@ -8,11 +8,11 @@ from pkg_resources import resource_string
 import jsonschema
 
 
-class LocalRefResolver(jsonschema.RefResolver):
+class _LocalRefResolver(jsonschema.RefResolver):
     """Resolve package-local JSON schema id's."""
 
     def __init__(self):
-        """Initialize a new LocalRefResolver instance."""
+        """Initialize a new instance."""
         self.ref_to_file = {
             "/addressSchema": "address_schema.json",
             "/hexSchema": "hex_schema.json",
@@ -32,7 +32,7 @@ class LocalRefResolver(jsonschema.RefResolver):
         :param url: a string representing the URL of the JSON schema to fetch.
         :returns: a string representing the deserialized JSON schema
         :raises jsonschema.ValidationError: when the resource associated with
-                                            `url` does not exist.
+                   `url` does not exist.
         """
         ref = url.replace("file://", "")
         if ref in self.ref_to_file:
@@ -47,10 +47,10 @@ class LocalRefResolver(jsonschema.RefResolver):
         )
 
 
-# Instantiate the `LocalRefResolver()` only once so that `assert_valid()` can
+# Instantiate the `_LocalRefResolver()` only once so that `assert_valid()` can
 # perform multiple schema validations without reading from disk the schema
 # every time.
-LOCAL_RESOLVER = LocalRefResolver()
+_LOCAL_RESOLVER = _LocalRefResolver()
 
 
 def assert_valid(data: Mapping, schema_id: str) -> None:
@@ -70,5 +70,5 @@ def assert_valid(data: Mapping, schema_id: str) -> None:
     """
     # noqa
 
-    _, schema = LOCAL_RESOLVER.resolve(schema_id)
-    jsonschema.validate(data, schema, resolver=LOCAL_RESOLVER)
+    _, schema = _LOCAL_RESOLVER.resolve(schema_id)
+    jsonschema.validate(data, schema, resolver=_LOCAL_RESOLVER)

--- a/python-packages/order_utils/src/zero_ex/json_schemas/__init__.py
+++ b/python-packages/order_utils/src/zero_ex/json_schemas/__init__.py
@@ -12,6 +12,7 @@ class LocalRefResolver(jsonschema.RefResolver):
     """Resolve package-local JSON schema id's."""
 
     def __init__(self):
+        """Initialize a new LocalRefResolver instance."""
         self.ref_to_file = {
             "/addressSchema": "address_schema.json",
             "/hexSchema": "hex_schema.json",
@@ -30,7 +31,8 @@ class LocalRefResolver(jsonschema.RefResolver):
 
         :param url: a string representing the URL of the JSON schema to fetch.
         :returns: a string representing the deserialized JSON schema
-        :raises jsonschema.ValidationError: when the resource associated with `url` does not exist.
+        :raises jsonschema.ValidationError: when the resource associated with
+                                            `url` does not exist.
         """
         ref = url.replace("file://", "")
         if ref in self.ref_to_file:
@@ -45,8 +47,9 @@ class LocalRefResolver(jsonschema.RefResolver):
         )
 
 
-# Instantiate the `LocalRefResolver()` only once so that `assert_valid()` can perform multiple schema validations without
-# reading from disk the schema every time.
+# Instantiate the `LocalRefResolver()` only once so that `assert_valid()` can
+# perform multiple schema validations without reading from disk the schema
+# every time.
 LOCAL_RESOLVER = LocalRefResolver()
 
 

--- a/python-packages/order_utils/stubs/jsonschema/__init__.pyi
+++ b/python-packages/order_utils/stubs/jsonschema/__init__.pyi
@@ -1,5 +1,11 @@
-from typing import Any, Dict
+from typing import Any, Dict, Tuple
 
-class RefResolver: pass
+
+class RefResolver:
+    def resolve(self, url: str) -> Tuple[str, Dict]:
+        ...
+
+
+class ValidationError(Exception): pass
 
 def validate(instance: Any, schema: Dict, cls=None, *args, **kwargs) -> None: pass

--- a/python-packages/order_utils/test/test_doctest.py
+++ b/python-packages/order_utils/test/test_doctest.py
@@ -2,16 +2,17 @@
 
 from doctest import testmod
 import pkgutil
+import importlib
 
 import zero_ex
 
 
 def test_all_doctests():
     """Gather zero_ex.* modules and doctest them."""
-    for (importer, modname, _) in pkgutil.walk_packages(
+    for (_, modname, _) in pkgutil.walk_packages(
         path=zero_ex.__path__, prefix="zero_ex."
     ):
-        module = importer.find_module(modname).load_module(modname)
+        module = importlib.import_module(modname)
         print(module)
         (failure_count, _) = testmod(module)
         assert failure_count == 0

--- a/python-packages/order_utils/test/test_doctest.py
+++ b/python-packages/order_utils/test/test_doctest.py
@@ -8,13 +8,7 @@ import zero_ex
 
 
 def test_all_doctests():
-    """Gather zero_ex.* modules and doctest them.
-
-    NOTE: we now use `importlib` instead of `imp` because `imp` is deprecated
-    and also `load_module()` will reload modules that are already loaded,
-    causing tests to faily non-deterministically.
-    Ref https://bit.ly/2zwgyrZ
-    """
+    """Gather zero_ex.* modules and doctest them."""
     for (_, modname, _) in pkgutil.walk_packages(
         path=zero_ex.__path__, prefix="zero_ex."
     ):

--- a/python-packages/order_utils/test/test_doctest.py
+++ b/python-packages/order_utils/test/test_doctest.py
@@ -8,7 +8,13 @@ import zero_ex
 
 
 def test_all_doctests():
-    """Gather zero_ex.* modules and doctest them."""
+    """Gather zero_ex.* modules and doctest them.
+
+    NOTE: we now use `importlib` instead of `imp` because `imp` is deprecated
+    and also `load_module()` will reload modules that are already loaded,
+    causing tests to faily non-deterministically.
+    Ref https://bit.ly/2zwgyrZ
+    """
     for (_, modname, _) in pkgutil.walk_packages(
         path=zero_ex.__path__, prefix="zero_ex."
     ):

--- a/python-packages/order_utils/test/test_json_schemas.py
+++ b/python-packages/order_utils/test/test_json_schemas.py
@@ -2,14 +2,22 @@
 
 
 from zero_ex.order_utils import make_empty_order
-from zero_ex.json_schemas import LOCAL_RESOLVER, assert_valid
+from zero_ex.json_schemas import _LOCAL_RESOLVER, assert_valid
 
 
 def test_assert_valid_caches_resources():
-    """Test that the JSON ref resolver in `assert_valid()` caches resources"""
-    LOCAL_RESOLVER._remote_cache.cache_clear()
+    """Test that the JSON ref resolver in `assert_valid()` caches resources
+
+    In order to test the cache we much access the private class of
+    `json_schemas` and reset the LRU cache on `_LocalRefResolver`.
+    For this to happen, we need to disable errror `W0212`
+    on _LOCAL_RESOLVER
+    """
+    _LOCAL_RESOLVER._remote_cache.cache_clear()  # pylint: disable=W0212
 
     assert_valid(make_empty_order(), "/orderSchema")
-    cache_info = LOCAL_RESOLVER._remote_cache.cache_info()
+    cache_info = (
+        _LOCAL_RESOLVER._remote_cache.cache_info()  # pylint: disable=W0212
+    )
     assert cache_info.currsize == 4
     assert cache_info.hits == 10

--- a/python-packages/order_utils/test/test_json_schemas.py
+++ b/python-packages/order_utils/test/test_json_schemas.py
@@ -1,0 +1,15 @@
+"""Tests of zero_ex.json_schemas"""
+
+
+from zero_ex.order_utils import make_empty_order
+from zero_ex.json_schemas import LOCAL_RESOLVER, assert_valid
+
+
+def test_assert_valid_caches_resources():
+    """Test that the JSON ref resolver in `assert_valid()` caches resources"""
+    LOCAL_RESOLVER._remote_cache.cache_clear()
+
+    assert_valid(make_empty_order(), "/orderSchema")
+    cache_info = LOCAL_RESOLVER._remote_cache.cache_info()
+    assert cache_info.currsize == 4
+    assert cache_info.hits == 10


### PR DESCRIPTION
## Description

This PR is a proposed solution for https://github.com/0xProject/0x-monorepo/issues/1316

## Testing instructions
- Perform regression on schema validation logic

## Types of changes

- Extracts `LocalRefResolver()` to the module level
- Creates an instance variable `LOCAL_RESOLVER` that is called by `assert_valid()`
- Changes the method that the resolver uses to fetch the JSON schema: from `resolve_from_url` I changed it to `resolve`, because the latter uses a LRU cache.
- Added `signedOrderSchema` to the `LocalRefResolver()` IDs.
- Added some new unit tests for my work
- Changed the unit test that runs all docstrings to use `importlib` causes my new test to fail sporadically. This is because the old  `load_module()` will also reload modules that are already loaded. Aside from this, `load_module()` is also deprecated in Python 3.4

## Checklist:

*   [x] Prefix PR title with `[WIP]` if necessary.
*   [x] Prefix PR title with bracketed package name(s) corresponding to the changed package(s). For example: `[sol-cov] Fixed bug`.
*   [x] Add tests to cover changes as needed.
*   [x] Update documentation as needed.
*   [ ] Add new entries to the relevant CHANGELOG.jsons.
