### PR TITLE
fix(order_utils.py): work aroud pylint bug

### DIFF
--- a/python-packages/order_utils/setup.py
+++ b/python-packages/order_utils/setup.py
@@ -187,7 +187,8 @@ setup(
             "mypy_extensions",
             "pycodestyle",
             "pydocstyle",
-            "pylint",
+            "pylint<=2.1.1",  # version pinned until resolution of
+            # https://github.com/PyCQA/pylint/issues/2612
             "pytest",
             "sphinx",
             "tox",


### PR DESCRIPTION
## Description

Fix error in runs of `static-tests-python`.  Apparently there's a bug in the new version of pylint that was released yesterday, which [I've reported](https://github.com/PyCQA/pylint/issues/2612).  While we await the fix for that, this PR pins pylint to the previous version.

## Testing instructions

Watch CI :smile: 

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [x] Prefix PR title with `[WIP]` if necessary.
*   [x] Prefix PR title with bracketed package name(s) corresponding to the changed package(s). For example: `[sol-cov] Fixed bug`.
*   [x] Add tests to cover changes as needed.
*   [x] Update documentation as needed.
*   [x] Add new entries to the relevant CHANGELOG.jsons.
