### PR TITLE
[instant] Add buy events to instant

### DIFF
--- a/packages/instant/src/components/buy_button.tsx
+++ b/packages/instant/src/components/buy_button.tsx
@@ -74,7 +74,7 @@ export class BuyButton extends React.Component<BuyButtonProps> {
                 takerAddress: accountAddress,
                 gasPrice: gasInfo.gasPriceInWei,
             });
-            analytics.trackBuyTxSubmitted();
+            analytics.trackBuyTxSubmitted(txHash);
         } catch (e) {
             if (e instanceof Error) {
                 if (e.message === AssetBuyerError.SignatureRequestDenied) {
@@ -95,14 +95,14 @@ export class BuyButton extends React.Component<BuyButtonProps> {
         try {
             await web3Wrapper.awaitTransactionSuccessAsync(txHash);
         } catch (e) {
-            analytics.trackBuyTxFailed();
+            analytics.trackBuyTxFailed(txHash);
             if (e instanceof Error && e.message.startsWith(WEB_3_WRAPPER_TRANSACTION_FAILED_ERROR_MSG_PREFIX)) {
                 this.props.onBuyFailure(buyQuote, txHash);
                 return;
             }
             throw e;
         }
-        analytics.trackBuyTxSucceeded();
+        analytics.trackBuyTxSucceeded(txHash);
         this.props.onBuySuccess(buyQuote, txHash);
     };
 }

--- a/packages/instant/src/util/analytics.ts
+++ b/packages/instant/src/util/analytics.ts
@@ -133,23 +133,20 @@ export const analytics = {
         trackingEventFnWithPayload(EventNames.BUY_TX_SUBMITTED)({
             ...buyQuoteEventProperties(buyQuote),
             txHash,
-            startTimeUnix,
-            expectedEndTimeUnix,
+            expectedTxTimeMs: expectedEndTimeUnix - startTimeUnix,
         }),
     trackBuyTxSucceeded: (buyQuote: BuyQuote, txHash: string, startTimeUnix: number, expectedEndTimeUnix: number) =>
         trackingEventFnWithPayload(EventNames.BUY_TX_SUCCEEDED)({
             ...buyQuoteEventProperties(buyQuote),
             txHash,
-            startTimeUnix,
-            expectedEndTimeUnix,
-            actualEndTimeUnix: new Date().getTime(),
+            expectedTxTimeMs: expectedEndTimeUnix - startTimeUnix,
+            actualTxTimeMs: new Date().getTime() - startTimeUnix,
         }),
     trackBuyTxFailed: (buyQuote: BuyQuote, txHash: string, startTimeUnix: number, expectedEndTimeUnix: number) =>
         trackingEventFnWithPayload(EventNames.BUY_TX_FAILED)({
             ...buyQuoteEventProperties(buyQuote),
             txHash,
-            startTimeUnix,
-            expectedEndTimeUnix,
-            actualEndTimeUnix: new Date().getTime(),
+            expectedTxTimeMs: expectedEndTimeUnix - startTimeUnix,
+            actualTxTimeMs: new Date().getTime() - startTimeUnix,
         }),
 };

--- a/packages/instant/src/util/analytics.ts
+++ b/packages/instant/src/util/analytics.ts
@@ -78,7 +78,7 @@ export const analytics = {
     trackBuyStarted: trackingEventFnWithoutPayload(EventNames.BUY_STARTED),
     trackBuySignatureDenied: trackingEventFnWithoutPayload(EventNames.BUY_SIGNATURE_DENIED),
     trackBuySimulationFailed: trackingEventFnWithoutPayload(EventNames.BUY_SIMULATION_FAILED),
-    trackBuyTxSubmitted: trackingEventFnWithoutPayload(EventNames.BUY_TX_SUBMITTED),
-    trackBuyTxSucceeded: trackingEventFnWithoutPayload(EventNames.BUY_TX_SUCCEEDED),
-    trackBuyTxFailed: trackingEventFnWithoutPayload(EventNames.BUY_TX_FAILED),
+    trackBuyTxSubmitted: (txHash: string) => trackingEventFnWithPayload(EventNames.BUY_TX_SUBMITTED)({ txHash }),
+    trackBuyTxSucceeded: (txHash: string) => trackingEventFnWithPayload(EventNames.BUY_TX_SUCCEEDED)({ txHash }),
+    trackBuyTxFailed: (txHash: string) => trackingEventFnWithPayload(EventNames.BUY_TX_FAILED)({ txHash }),
 };

--- a/packages/instant/src/util/analytics.ts
+++ b/packages/instant/src/util/analytics.ts
@@ -18,6 +18,13 @@ enum EventNames {
     ACCOUNT_UNLOCK_REQUESTED = 'Account - Unlock Requested',
     ACCOUNT_UNLOCK_DENIED = 'Account - Unlock Denied',
     ACCOUNT_ADDRESS_CHANGED = 'Account - Address Changed',
+    BUY_NOT_ENOUGH_ETH = 'Buy - Not Enough Eth',
+    BUY_STARTED = 'Buy - Started',
+    BUY_SIGNATURE_DENIED = 'Buy - Signature Denied',
+    BUY_SIMULATION_FAILED = 'Buy - Simulation Failed',
+    BUY_TX_SUBMITTED = 'Buy - Tx Submitted',
+    BUY_TX_SUCCEEDED = 'Buy - Tx Succeeded',
+    BUY_TX_FAILED = 'Buy - Tx Failed',
 }
 const track = (eventName: EventNames, eventProperties: EventProperties = {}): void => {
     evaluateIfEnabled(() => {
@@ -67,4 +74,11 @@ export const analytics = {
     trackAccountUnlockDenied: trackingEventFnWithoutPayload(EventNames.ACCOUNT_UNLOCK_DENIED),
     trackAccountAddressChanged: (address: string) =>
         trackingEventFnWithPayload(EventNames.ACCOUNT_ADDRESS_CHANGED)({ address }),
+    trackBuyNotEnoughEth: trackingEventFnWithoutPayload(EventNames.BUY_NOT_ENOUGH_ETH),
+    trackBuyStarted: trackingEventFnWithoutPayload(EventNames.BUY_STARTED),
+    trackBuySignatureDenied: trackingEventFnWithoutPayload(EventNames.BUY_SIGNATURE_DENIED),
+    trackBuySimulationFailed: trackingEventFnWithoutPayload(EventNames.BUY_SIMULATION_FAILED),
+    trackBuyTxSubmitted: trackingEventFnWithoutPayload(EventNames.BUY_TX_SUBMITTED),
+    trackBuyTxSucceeded: trackingEventFnWithoutPayload(EventNames.BUY_TX_SUCCEEDED),
+    trackBuyTxFailed: trackingEventFnWithoutPayload(EventNames.BUY_TX_FAILED),
 };

--- a/packages/instant/src/util/analytics.ts
+++ b/packages/instant/src/util/analytics.ts
@@ -47,7 +47,6 @@ function trackingEventFnWithPayload(eventName: EventNames): (eventProperties: Ev
 }
 
 const buyQuoteEventProperties = (buyQuote: BuyQuote) => {
-    const assetData = buyQuote.assetData.toString();
     const assetBuyAmount = buyQuote.assetBuyAmount.toString();
     const assetEthAmount = buyQuote.worstCaseQuoteInfo.assetEthAmount.toString();
     const feeEthAmount = buyQuote.worstCaseQuoteInfo.feeEthAmount.toString();
@@ -55,7 +54,6 @@ const buyQuoteEventProperties = (buyQuote: BuyQuote) => {
     const feePercentage = !_.isUndefined(buyQuote.feePercentage) ? buyQuote.feePercentage.toString() : 0;
     const hasFeeOrders = !_.isEmpty(buyQuote.feeOrders) ? 'true' : 'false';
     return {
-        assetData,
         assetBuyAmount,
         assetEthAmount,
         feeEthAmount,
@@ -104,10 +102,27 @@ export const analytics = {
         trackingEventFnWithPayload(EventNames.BUY_SIGNATURE_DENIED)(buyQuoteEventProperties(buyQuote)),
     trackBuySimulationFailed: (buyQuote: BuyQuote) =>
         trackingEventFnWithPayload(EventNames.BUY_SIMULATION_FAILED)(buyQuoteEventProperties(buyQuote)),
-    trackBuyTxSubmitted: (buyQuote: BuyQuote, txHash: string) =>
-        trackingEventFnWithPayload(EventNames.BUY_TX_SUBMITTED)({ ...buyQuoteEventProperties(buyQuote), txHash }),
-    trackBuyTxSucceeded: (buyQuote: BuyQuote, txHash: string) =>
-        trackingEventFnWithPayload(EventNames.BUY_TX_SUCCEEDED)({ ...buyQuoteEventProperties(buyQuote), txHash }),
-    trackBuyTxFailed: (buyQuote: BuyQuote, txHash: string) =>
-        trackingEventFnWithPayload(EventNames.BUY_TX_FAILED)({ ...buyQuoteEventProperties(buyQuote), txHash }),
+    trackBuyTxSubmitted: (buyQuote: BuyQuote, txHash: string, startTimeUnix: number, expectedEndTimeUnix: number) =>
+        trackingEventFnWithPayload(EventNames.BUY_TX_SUBMITTED)({
+            ...buyQuoteEventProperties(buyQuote),
+            txHash,
+            startTimeUnix,
+            expectedEndTimeUnix,
+        }),
+    trackBuyTxSucceeded: (buyQuote: BuyQuote, txHash: string, startTimeUnix: number, expectedEndTimeUnix: number) =>
+        trackingEventFnWithPayload(EventNames.BUY_TX_SUCCEEDED)({
+            ...buyQuoteEventProperties(buyQuote),
+            txHash,
+            startTimeUnix,
+            expectedEndTimeUnix,
+            actualEndTimeUnix: new Date().getTime(),
+        }),
+    trackBuyTxFailed: (buyQuote: BuyQuote, txHash: string, startTimeUnix: number, expectedEndTimeUnix: number) =>
+        trackingEventFnWithPayload(EventNames.BUY_TX_FAILED)({
+            ...buyQuoteEventProperties(buyQuote),
+            txHash,
+            startTimeUnix,
+            expectedEndTimeUnix,
+            actualEndTimeUnix: new Date().getTime(),
+        }),
 };

--- a/packages/instant/src/util/analytics.ts
+++ b/packages/instant/src/util/analytics.ts
@@ -1,3 +1,6 @@
+import { BuyQuote } from '@0x/asset-buyer';
+import * as _ from 'lodash';
+
 import { EventProperties, heapUtil } from './heap';
 
 let isDisabled = false;
@@ -43,6 +46,25 @@ function trackingEventFnWithPayload(eventName: EventNames): (eventProperties: Ev
     };
 }
 
+const buyQuoteEventProperties = (buyQuote: BuyQuote) => {
+    const assetData = buyQuote.assetData.toString();
+    const assetBuyAmount = buyQuote.assetBuyAmount.toString();
+    const assetEthAmount = buyQuote.worstCaseQuoteInfo.assetEthAmount.toString();
+    const feeEthAmount = buyQuote.worstCaseQuoteInfo.feeEthAmount.toString();
+    const totalEthAmount = buyQuote.worstCaseQuoteInfo.totalEthAmount.toString();
+    const feePercentage = !_.isUndefined(buyQuote.feePercentage) ? buyQuote.feePercentage.toString() : 0;
+    const hasFeeOrders = !_.isEmpty(buyQuote.feeOrders) ? 'true' : 'false';
+    return {
+        assetData,
+        assetBuyAmount,
+        assetEthAmount,
+        feeEthAmount,
+        totalEthAmount,
+        feePercentage,
+        hasFeeOrders,
+    };
+};
+
 export interface AnalyticsUserOptions {
     lastKnownEthAddress?: string;
     ethBalanceInUnitAmount?: string;
@@ -74,11 +96,18 @@ export const analytics = {
     trackAccountUnlockDenied: trackingEventFnWithoutPayload(EventNames.ACCOUNT_UNLOCK_DENIED),
     trackAccountAddressChanged: (address: string) =>
         trackingEventFnWithPayload(EventNames.ACCOUNT_ADDRESS_CHANGED)({ address }),
-    trackBuyNotEnoughEth: trackingEventFnWithoutPayload(EventNames.BUY_NOT_ENOUGH_ETH),
-    trackBuyStarted: trackingEventFnWithoutPayload(EventNames.BUY_STARTED),
-    trackBuySignatureDenied: trackingEventFnWithoutPayload(EventNames.BUY_SIGNATURE_DENIED),
-    trackBuySimulationFailed: trackingEventFnWithoutPayload(EventNames.BUY_SIMULATION_FAILED),
-    trackBuyTxSubmitted: (txHash: string) => trackingEventFnWithPayload(EventNames.BUY_TX_SUBMITTED)({ txHash }),
-    trackBuyTxSucceeded: (txHash: string) => trackingEventFnWithPayload(EventNames.BUY_TX_SUCCEEDED)({ txHash }),
-    trackBuyTxFailed: (txHash: string) => trackingEventFnWithPayload(EventNames.BUY_TX_FAILED)({ txHash }),
+    trackBuyNotEnoughEth: (buyQuote: BuyQuote) =>
+        trackingEventFnWithPayload(EventNames.BUY_NOT_ENOUGH_ETH)(buyQuoteEventProperties(buyQuote)),
+    trackBuyStarted: (buyQuote: BuyQuote) =>
+        trackingEventFnWithPayload(EventNames.BUY_STARTED)(buyQuoteEventProperties(buyQuote)),
+    trackBuySignatureDenied: (buyQuote: BuyQuote) =>
+        trackingEventFnWithPayload(EventNames.BUY_SIGNATURE_DENIED)(buyQuoteEventProperties(buyQuote)),
+    trackBuySimulationFailed: (buyQuote: BuyQuote) =>
+        trackingEventFnWithPayload(EventNames.BUY_SIMULATION_FAILED)(buyQuoteEventProperties(buyQuote)),
+    trackBuyTxSubmitted: (buyQuote: BuyQuote, txHash: string) =>
+        trackingEventFnWithPayload(EventNames.BUY_TX_SUBMITTED)({ ...buyQuoteEventProperties(buyQuote), txHash }),
+    trackBuyTxSucceeded: (buyQuote: BuyQuote, txHash: string) =>
+        trackingEventFnWithPayload(EventNames.BUY_TX_SUCCEEDED)({ ...buyQuoteEventProperties(buyQuote), txHash }),
+    trackBuyTxFailed: (buyQuote: BuyQuote, txHash: string) =>
+        trackingEventFnWithPayload(EventNames.BUY_TX_FAILED)({ ...buyQuoteEventProperties(buyQuote), txHash }),
 };


### PR DESCRIPTION
## Description

Adds the following events:

```
    BUY_NOT_ENOUGH_ETH = 'Buy - Not Enough Eth',
    BUY_STARTED = 'Buy - Started',
    BUY_SIGNATURE_DENIED = 'Buy - Signature Denied',
    BUY_SIMULATION_FAILED = 'Buy - Simulation Failed',
    BUY_TX_SUBMITTED = 'Buy - Tx Submitted',
    BUY_TX_SUCCEEDED = 'Buy - Tx Succeeded',
    BUY_TX_FAILED = 'Buy - Tx Failed',
```

Each event has the following properties attached: `assetData`, `assetBuyAmount`, `assetEthAmount`, `feeEthAmount`, `totalEthAmount`, `feePercentage`, `hasFeeOrders`,

Each transaction related event also has a property `txHash` attached.

## Testing instructions

* Heap live tracking

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature (non-breaking change which adds functionality)

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefix PR title with `[WIP]` if necessary.
*   [ ] Add tests to cover changes as needed.
*   [ ] Update documentation as needed.
*   [ ] Add new entries to the relevant CHANGELOG.jsons.
