### PR TITLE
Bump prettier version to ^1.13.4 for Atom compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
         "lcov-result-merger": "^3.0.0",
         "lerna": "^3.0.0-beta.25",
         "npm-run-all": "^4.1.2",
-        "prettier": "^1.11.1",
+        "prettier": "^1.13.4",
         "source-map-support": "^0.5.6",
         "typescript": "3.0.1",
         "wsrun": "^2.2.0"


### PR DESCRIPTION
## Description

Bump `prettier` version for compatibility with `prettier-atom`. I got this error msg when I tried it for the first time:

```
Your Prettier version is not compatible with prettier-atom. Prettier must be >= 1.13.4
```

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [x] Prefix PR title with `[WIP]` if necessary.
*   [x] Add tests to cover changes as needed.
*   [x] Update documentation as needed.
*   [x] Add new entries to the relevant CHANGELOG.jsons.
