### PR TITLE
[instant] Fix push to history issue on second full render of instant

### DIFF
--- a/packages/instant/src/components/standard_sliding_panel.tsx
+++ b/packages/instant/src/components/standard_sliding_panel.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { SlideAnimationState, StandardSlidingPanelContent, StandardSlidingPanelSettings } from '../types';
+import { StandardSlidingPanelContent, StandardSlidingPanelSettings } from '../types';
 
 import { InstallWalletPanelContent } from './install_wallet_panel_content';
 import { SlidingPanel } from './sliding_panel';

--- a/packages/instant/src/index.umd.ts
+++ b/packages/instant/src/index.umd.ts
@@ -89,11 +89,10 @@ export const render = (config: ZeroExInstantConfig, selector: string = DEFAULT_Z
     // If the integrator defined a popstate handler, save it to __zeroExInstantIntegratorsPopStateHandler
     // unless we have already done so on a previous render.
     const anyWindow = window as any;
-    if (window.onpopstate && !anyWindow.__zeroExInstantIntegratorsPopStateHandler) {
-        anyWindow.__zeroExInstantIntegratorsPopStateHandler = window.onpopstate.bind(window);
-    } else {
-        anyWindow.__zeroExInstantIntegratorsPopStateHandler = util.boundNoop;
-    }
+    const popStateExistsAndNotSetPreviously = window.onpopstate && !anyWindow.__zeroExInstantIntegratorsPopStateHandler;
+    anyWindow.__zeroExInstantIntegratorsPopStateHandler = popStateExistsAndNotSetPreviously
+        ? anyWindow.onpopstate.bind(window)
+        : util.boundNoop;
     const onPopStateHandler = (e: PopStateEvent) => {
         anyWindow.__zeroExInstantIntegratorsPopStateHandler(e);
         const newState = e.state;

--- a/packages/instant/src/index.umd.ts
+++ b/packages/instant/src/index.umd.ts
@@ -91,10 +91,11 @@ export const render = (config: ZeroExInstantConfig, selector: string = DEFAULT_Z
     const anyWindow = window as any;
     if (window.onpopstate && !anyWindow.__zeroExInstantIntegratorsPopStateHandler) {
         anyWindow.__zeroExInstantIntegratorsPopStateHandler = window.onpopstate.bind(window);
+    } else {
+        anyWindow.__zeroExInstantIntegratorsPopStateHandler = util.boundNoop;
     }
-    const integratorsOnPopStateHandler = anyWindow.__zeroExInstantIntegratorsPopStateHandler || util.boundNoop;
     const onPopStateHandler = (e: PopStateEvent) => {
-        integratorsOnPopStateHandler(e);
+        anyWindow.__zeroExInstantIntegratorsPopStateHandler(e);
         const newState = e.state;
         if (newState && newState.zeroExInstantShowing) {
             // We have returned to a history state that expects instant to be rendered.

--- a/packages/instant/src/redux/analytics_middleware.ts
+++ b/packages/instant/src/redux/analytics_middleware.ts
@@ -3,7 +3,7 @@ import * as _ from 'lodash';
 import { Middleware } from 'redux';
 
 import { ETH_DECIMALS } from '../constants';
-import { Account, AccountState, StandardSlidingPanelContent } from '../types';
+import { AccountState, StandardSlidingPanelContent } from '../types';
 import { analytics } from '../util/analytics';
 
 import { Action, ActionTypes } from './actions';


### PR DESCRIPTION
This fixes

```
Uncaught DOMException: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
    at d (https://localhost:3000/zrxinstant.js:37:329752)
    at window.onpopstate (https://localhost:3000/zrxinstant.js:37:331654)
    at window.onpopstate (https://localhost:3000/zrxinstant.js:37:331588)
```

That can occur if:
1. No onpopstate is defined. 
2. Instant is rendered "manually" (not through navigating history) twice in a row. 

Basically we were calling an old version of `removeInstant` which had a closure around an old DOM node that had been deleted because we were mistakenly setting our own `onpopstate` as the "intergrator's" `onpopstate` on the second render... which resulted in us calling the `removeInstant` from the first render...

## Description

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefix PR title with `[WIP]` if necessary.
*   [ ] Add tests to cover changes as needed.
*   [ ] Update documentation as needed.
*   [ ] Add new entries to the relevant CHANGELOG.jsons.
