### PR TITLE
[instant] add stable class name to overlay close button and adjust overlay color

### DIFF
--- a/packages/instant/src/components/ui/overlay.tsx
+++ b/packages/instant/src/components/ui/overlay.tsx
@@ -33,7 +33,7 @@ export const Overlay =
 
 Overlay.defaultProps = {
     zIndex: zIndex.overlayDefault,
-    backgroundColor: generateOverlayBlack(0.9),
+    backgroundColor: generateOverlayBlack(0.7),
 };
 
 Overlay.displayName = 'Overlay';

--- a/packages/instant/src/components/zero_ex_instant_overlay.tsx
+++ b/packages/instant/src/components/zero_ex_instant_overlay.tsx
@@ -21,17 +21,21 @@ export const ZeroExInstantOverlay: React.StatelessComponent<ZeroExInstantOverlay
         <ZeroExInstantProvider {...rest}>
             <Overlay zIndex={zIndex} className={OVERLAY_DIV_CLASS}>
                 <Flex height="100vh">
-                    <Container position="absolute" top="0px" right="0px" display={{ default: 'initial', sm: 'none' }}>
-                        <Container className={OVERLAY_CLOSE_BUTTON_DIV_CLASS}>
-                            <Icon
-                                height={18}
-                                width={18}
-                                color={ColorOption.white}
-                                icon="closeX"
-                                onClick={onClose}
-                                padding="2em 2em"
-                            />
-                        </Container>
+                    <Container
+                        className={OVERLAY_CLOSE_BUTTON_DIV_CLASS}
+                        position="absolute"
+                        top="0px"
+                        right="0px"
+                        display={{ default: 'initial', sm: 'none' }}
+                    >
+                        <Icon
+                            height={18}
+                            width={18}
+                            color={ColorOption.white}
+                            icon="closeX"
+                            onClick={onClose}
+                            padding="2em 2em"
+                        />
                     </Container>
                     <Container
                         width={{ default: 'auto', sm: '100%' }}

--- a/packages/instant/src/components/zero_ex_instant_overlay.tsx
+++ b/packages/instant/src/components/zero_ex_instant_overlay.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { ZeroExInstantContainer } from '../components/zero_ex_instant_container';
-import { MAIN_CONTAINER_DIV_CLASS, OVERLAY_DIV_CLASS } from '../constants';
+import { MAIN_CONTAINER_DIV_CLASS, OVERLAY_CLOSE_BUTTON_DIV_CLASS, OVERLAY_DIV_CLASS } from '../constants';
 import { ColorOption } from '../style/theme';
 
 import { Container } from './ui/container';
@@ -22,14 +22,16 @@ export const ZeroExInstantOverlay: React.StatelessComponent<ZeroExInstantOverlay
             <Overlay zIndex={zIndex} className={OVERLAY_DIV_CLASS}>
                 <Flex height="100vh">
                     <Container position="absolute" top="0px" right="0px" display={{ default: 'initial', sm: 'none' }}>
-                        <Icon
-                            height={18}
-                            width={18}
-                            color={ColorOption.white}
-                            icon="closeX"
-                            onClick={onClose}
-                            padding="2em 2em"
-                        />
+                        <Container className={OVERLAY_CLOSE_BUTTON_DIV_CLASS}>
+                            <Icon
+                                height={18}
+                                width={18}
+                                color={ColorOption.white}
+                                icon="closeX"
+                                onClick={onClose}
+                                padding="2em 2em"
+                            />
+                        </Container>
                     </Container>
                     <Container
                         width={{ default: 'auto', sm: '100%' }}

--- a/packages/instant/src/constants.ts
+++ b/packages/instant/src/constants.ts
@@ -8,6 +8,7 @@ export const DEFAULT_ZERO_EX_CONTAINER_SELECTOR = '#zeroExInstantContainer';
 export const INJECTED_DIV_CLASS = 'zeroExInstantResetRoot';
 export const INJECTED_DIV_ID = 'zeroExInstant';
 export const OVERLAY_DIV_CLASS = 'zeroExInstantOverlay';
+export const OVERLAY_CLOSE_BUTTON_DIV_CLASS = 'zeroExInstantOverlayCloseButton';
 export const MAIN_CONTAINER_DIV_CLASS = 'zeroExInstantMainContainer';
 export const WEB_3_WRAPPER_TRANSACTION_FAILED_ERROR_MSG_PREFIX = 'Transaction failed';
 export const GWEI_IN_WEI = new BigNumber(1000000000);


### PR DESCRIPTION
## Description

* Change overlay alpha from `0.9` to `0.7`
* Give a stable class that integrators can identify the overlay close button with
* This is to address a hack in the instex integration: https://0xinstant.instex.io/ where they are trying to id the close button given the auto-generated `styled-components` class, producing the potential for the instex integration to blow up
* We're seeing more and more integrators hack around our overlay so we should probably give more serious thought to supporting an inline version

## Testing instructions

Observe the class name for the close button

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature (non-breaking change which adds functionality)

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefix PR title with `[WIP]` if necessary.
*   [ ] Add tests to cover changes as needed.
*   [ ] Update documentation as needed.
*   [ ] Add new entries to the relevant CHANGELOG.jsons.
