### PR TITLE
[instant] Ensure build process receives build arguments

### DIFF
--- a/packages/instant/.dogfood.discharge.json
+++ b/packages/instant/.dogfood.discharge.json
@@ -1,6 +1,6 @@
 {
     "domain": "0x-instant-dogfood",
-    "build_command": "WEBPACK_OUTPUT_PATH=public dotenv yarn build --env.discharge_target=dogfood",
+    "build_command": "WEBPACK_OUTPUT_PATH=public dotenv yarn build -- --env.discharge_target=dogfood",
     "upload_directory": "public",
     "index_key": "index.html",
     "error_key": "index.html",

--- a/packages/instant/.production.discharge.json
+++ b/packages/instant/.production.discharge.json
@@ -1,6 +1,6 @@
 {
     "domain": "instant.0xproject.com",
-    "build_command": "dotenv yarn build --env.discharge_target=production",
+    "build_command": "dotenv yarn build -- --env.discharge_target=production",
     "upload_directory": "umd",
     "index_key": "instant.js",
     "error_key": "404.html",

--- a/packages/instant/.staging.discharge.json
+++ b/packages/instant/.staging.discharge.json
@@ -1,6 +1,6 @@
 {
     "domain": "0x-instant-staging",
-    "build_command": "dotenv WEBPACK_OUTPUT_PATH=public yarn build --env.discharge_target=staging",
+    "build_command": "WEBPACK_OUTPUT_PATH=public dotenv yarn build -- --env.discharge_target=staging",
     "upload_directory": "public",
     "index_key": "index.html",
     "error_key": "index.html",


### PR DESCRIPTION
With the dotenv PR ( https://github.com/0xProject/0x-monorepo/pull/1364  ), we started losing arguments sent into the build process.  This caused the production build to report to the development heap analytics.

See https://github.com/entropitor/dotenv-cli/issues/8

## Description

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefix PR title with `[WIP]` if necessary.
*   [ ] Add tests to cover changes as needed.
*   [ ] Update documentation as needed.
*   [ ] Add new entries to the relevant CHANGELOG.jsons.
