### PR TITLE
[instant] Don't report localhost errors to Rollbar

### DIFF
--- a/packages/instant/package.json
+++ b/packages/instant/package.json
@@ -10,7 +10,7 @@
     "scripts": {
         "build": "webpack --mode production",
         "build:ci": "yarn build",
-        "dev": "webpack-dev-server --mode development",
+        "dev": "dotenv webpack-dev-server -- --mode development",
         "lint": "tslint --format stylish --project .",
         "test": "jest",
         "test:coverage": "jest --coverage",
@@ -24,10 +24,7 @@
     },
     "config": {
         "postpublish": {
-            "assets": [
-                "packages/instant/umd/instant.js",
-                "packages/instant/umd/instant.js.map"
-            ]
+            "assets": ["packages/instant/umd/instant.js", "packages/instant/umd/instant.js.map"]
         }
     },
     "repository": {

--- a/packages/instant/src/constants.ts
+++ b/packages/instant/src/constants.ts
@@ -15,6 +15,7 @@ export const GWEI_IN_WEI = new BigNumber(1000000000);
 export const ONE_SECOND_MS = 1000;
 export const ONE_MINUTE_MS = ONE_SECOND_MS * 60;
 export const GIT_SHA = process.env.GIT_SHA;
+export const NODE_ENV = process.env.NODE_ENV;
 export const NPM_PACKAGE_VERSION = process.env.NPM_PACKAGE_VERSION;
 export const ACCOUNT_UPDATE_INTERVAL_TIME_MS = ONE_SECOND_MS * 5;
 export const BUY_QUOTE_UPDATE_INTERVAL_TIME_MS = ONE_SECOND_MS * 15;
@@ -28,14 +29,12 @@ export const HEAP_ENABLED = process.env.HEAP_ENABLED;
 export const COINBASE_API_BASE_URL = 'https://api.coinbase.com/v2';
 export const PROGRESS_STALL_AT_WIDTH = '95%';
 export const PROGRESS_FINISH_ANIMATION_TIME_MS = 200;
-export const HOST_DOMAINS = [
+export const HOST_DOMAINS_EXTERNAL = [
     '0x-instant-staging.s3-website-us-east-1.amazonaws.com',
     '0x-instant-dogfood.s3-website-us-east-1.amazonaws.com',
-    'localhost',
-    '127.0.0.1',
-    '0.0.0.0',
     'instant.0xproject.com',
 ];
+export const HOST_DOMAINS_LOCAL = ['localhost', '127.0.0.1', '0.0.0.0'];
 export const ROLLBAR_CLIENT_TOKEN = process.env.ROLLBAR_CLIENT_TOKEN;
 export const ROLLBAR_ENABLED = process.env.ROLLBAR_ENABLED;
 export const INSTANT_DISCHARGE_TARGET = process.env.INSTANT_DISCHARGE_TARGET as

--- a/packages/instant/src/util/analytics.ts
+++ b/packages/instant/src/util/analytics.ts
@@ -2,7 +2,7 @@ import { BuyQuote } from '@0x/asset-buyer';
 import { BigNumber } from '@0x/utils';
 import * as _ from 'lodash';
 
-import { GIT_SHA, HEAP_ENABLED, INSTANT_DISCHARGE_TARGET, NPM_PACKAGE_VERSION } from '../constants';
+import { GIT_SHA, HEAP_ENABLED, INSTANT_DISCHARGE_TARGET, NODE_ENV, NPM_PACKAGE_VERSION } from '../constants';
 import {
     AffiliateInfo,
     Asset,
@@ -156,7 +156,7 @@ export const analytics = {
             affiliateFeePercent,
             selectedAssetName: selectedAsset ? selectedAsset.metaData.name : 'none',
             selectedAssetData: selectedAsset ? selectedAsset.assetData : 'none',
-            instantEnvironment: INSTANT_DISCHARGE_TARGET || `Local ${process.env.NODE_ENV}`,
+            instantEnvironment: INSTANT_DISCHARGE_TARGET || `Local ${NODE_ENV}`,
         };
         return eventOptions;
     },

--- a/packages/instant/src/util/error_reporter.ts
+++ b/packages/instant/src/util/error_reporter.ts
@@ -29,7 +29,6 @@ let rollbar: any;
 export const setupRollbar = (): any => {
     if (_.isUndefined(rollbar) && ROLLBAR_CLIENT_TOKEN && ROLLBAR_ENABLED) {
         const hostDomains = getRollbarHostDomains();
-        console.log('hostDomains', hostDomains);
         rollbar = new Rollbar({
             accessToken: ROLLBAR_CLIENT_TOKEN,
             captureUncaught: true,

--- a/packages/instant/src/util/error_reporter.ts
+++ b/packages/instant/src/util/error_reporter.ts
@@ -1,17 +1,35 @@
 import { logUtils } from '@0x/utils';
 import * as _ from 'lodash';
 
-import { GIT_SHA, HOST_DOMAINS, INSTANT_DISCHARGE_TARGET, ROLLBAR_CLIENT_TOKEN, ROLLBAR_ENABLED } from '../constants';
+import {
+    GIT_SHA,
+    HOST_DOMAINS_EXTERNAL,
+    HOST_DOMAINS_LOCAL,
+    INSTANT_DISCHARGE_TARGET,
+    NODE_ENV,
+    ROLLBAR_CLIENT_TOKEN,
+    ROLLBAR_ENABLED,
+} from '../constants';
 
 // Import version of Rollbar designed for embedded components
 // See https://docs.rollbar.com/docs/using-rollbarjs-inside-an-embedded-component
 // tslint:disable-next-line:no-var-requires
 const Rollbar = require('rollbar/dist/rollbar.noconflict.umd');
 
+const getRollbarHostDomains = (): string[] => {
+    if (NODE_ENV === 'development') {
+        return HOST_DOMAINS_EXTERNAL.concat(HOST_DOMAINS_LOCAL);
+    } else {
+        return HOST_DOMAINS_EXTERNAL;
+    }
+};
+
 let rollbar: any;
 // Configures rollbar and sets up error catching
 export const setupRollbar = (): any => {
     if (_.isUndefined(rollbar) && ROLLBAR_CLIENT_TOKEN && ROLLBAR_ENABLED) {
+        const hostDomains = getRollbarHostDomains();
+        console.log('hostDomains', hostDomains);
         rollbar = new Rollbar({
             accessToken: ROLLBAR_CLIENT_TOKEN,
             captureUncaught: true,
@@ -20,7 +38,7 @@ export const setupRollbar = (): any => {
             itemsPerMinute: 10,
             maxItems: 500,
             payload: {
-                environment: INSTANT_DISCHARGE_TARGET || `Local ${process.env.NODE_ENV}`,
+                environment: INSTANT_DISCHARGE_TARGET || `Local ${NODE_ENV}`,
                 client: {
                     javascript: {
                         source_map_enabled: true,
@@ -29,7 +47,7 @@ export const setupRollbar = (): any => {
                     },
                 },
             },
-            hostWhiteList: HOST_DOMAINS,
+            hostWhiteList: hostDomains,
             uncaughtErrorLevel: 'error',
             ignoredMessages: [
                 // Errors from the third-party scripts


### PR DESCRIPTION
## Description

If an error was coming from a `localhost` script, we were reporting it to Rollbar.  This should fix that and not allow it if we're using a production build.

## Testing instructions

Here's how I tested this:

* Created an embed page with the dogfood instant.js, with the following code in the index:

```
      window.setTimeout(() => {
        throw new Error("Manual trigger prod localhost error");
      }, 8000);
```

* Saw that this error in `setTimeout` was reported to Rollbar

* Deployed this new change to dogfood

* Saw that this error in `setTimeout` was now not reported to Rollbar anymore

In both situations, I confirmed that the magic number `0€` still reported to Rollbar correctly, to ensure Rollbar was still configured properly

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefix PR title with `[WIP]` if necessary.
*   [ ] Add tests to cover changes as needed.
*   [ ] Update documentation as needed.
*   [ ] Add new entries to the relevant CHANGELOG.jsons.
