### PR TITLE
Track idex Orderbook Snapshots

### DIFF
--- a/packages/pipeline/src/data_sources/idex/index.ts
+++ b/packages/pipeline/src/data_sources/idex/index.ts
@@ -1,0 +1,85 @@
+import { fetchAsync, logUtils } from '@0x/utils';
+
+const IDEX_BASE_URL = 'https://api.idex.market';
+const MARKETS_URL = `${IDEX_BASE_URL}/returnTicker`;
+const ORDERBOOK_URL = `${IDEX_BASE_URL}/returnOrderBook`;
+const MAX_ORDER_COUNT = 100; // Maximum based on https://github.com/AuroraDAO/idex-api-docs#returnorderbook
+export const IDEX_SOURCE = 'idex';
+
+export interface IdexMarketsResponse {
+    [marketName: string]: IdexMarket;
+}
+
+export interface IdexMarket {
+    last: string;
+    high: string;
+    low: string;
+    lowestAsk: string;
+    highestBid: string;
+    percentChange: string;
+    baseVolume: string;
+    quoteVolume: string;
+}
+
+export interface IdexOrderbook {
+    asks: IdexOrder[];
+    bids: IdexOrder[];
+}
+
+export interface IdexOrder {
+    price: string;
+    amount: string;
+    total: string;
+    orderHash: string;
+    params: IdexOrderParam;
+}
+
+export interface IdexOrderParam {
+    tokenBuy: string;
+    buySymbol: string;
+    buyPrecision: number;
+    amountBuy: string;
+    tokenSell: string;
+    sellSymbol: string;
+    sellPrecision: number;
+    amountSell: string;
+    expires: number;
+    nonce: number;
+    user: string;
+}
+
+// tslint:disable:prefer-function-over-method
+// ^ Keep consistency with other sources and help logical organization
+export class IdexSource {
+    /**
+     * Call Idex API to find out which markets they are maintaining orderbooks for.
+     */
+    public async getMarketsAsync(): Promise<string[]> {
+        logUtils.log('Getting all IDEX markets');
+        const params = { method: 'POST' };
+        const resp = await fetchAsync(MARKETS_URL, params);
+        const respJson: IdexMarketsResponse = await resp.json();
+        const markets: string[] = Object.keys(respJson);
+        logUtils.log(`Got ${markets.length} markets.`);
+        return markets;
+    }
+
+    /**
+     * Retrieve orderbook from Idex API for a given market.
+     * @param marketId String identifying the market we want data for. Eg. 'REP_AUG'
+     */
+    public async getMarketOrderbookAsync(marketId: string): Promise<IdexOrderbook> {
+        logUtils.log(`${marketId}: Retrieving orderbook.`);
+        const params = {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                market: marketId,
+                count: MAX_ORDER_COUNT,
+            }),
+        };
+        const resp = await fetchAsync(ORDERBOOK_URL, params);
+        const respJson: IdexOrderbook = await resp.json();
+        return respJson;
+    }
+}

--- a/packages/pipeline/src/parsers/idex_orders/index.ts
+++ b/packages/pipeline/src/parsers/idex_orders/index.ts
@@ -1,0 +1,89 @@
+import { BigNumber } from '@0x/utils';
+import * as R from 'ramda';
+
+import { IdexOrder, IdexOrderbook, IdexOrderParam } from '../../data_sources/idex';
+import { TokenOrderbookSnapshot as TokenOrder } from '../../entities';
+import { OrderType } from '../../types';
+
+/**
+ * Marque function of this file.
+ * 1) Takes in orders from an orderbook,
+ * 2) Aggregates them by price point,
+ * 3) Parses them into entities which are then saved into the database.
+ * @param idexOrderbook raw orderbook that we pull from the Idex API.
+ * @param observedTimestamp Time at which the orders for the market were pulled.
+ * @param source The exchange where these orders are placed. In this case 'idex'.
+ */
+export function parseIdexOrders(idexOrderbook: IdexOrderbook, observedTimestamp: number, source: string): TokenOrder[] {
+    const aggregatedBids = aggregateOrders(idexOrderbook.bids);
+    // Any of the bid orders' params will work
+    const idexBidOrder = idexOrderbook.bids[0];
+    const parsedBids =
+        aggregatedBids.length > 0
+            ? aggregatedBids.map(order => parseIdexOrder(idexBidOrder.params, observedTimestamp, 'bid', source, order))
+            : [];
+
+    const aggregatedAsks = aggregateOrders(idexOrderbook.asks);
+    // Any of the ask orders' params will work
+    const idexAskOrder = idexOrderbook.asks[0];
+    const parsedAsks =
+        aggregatedAsks.length > 0
+            ? aggregatedAsks.map(order => parseIdexOrder(idexAskOrder.params, observedTimestamp, 'ask', source, order))
+            : [];
+    return parsedBids.concat(parsedAsks);
+}
+
+/**
+ * Aggregates orders by price point for consistency with other exchanges.
+ * The Idex API returns a breakdown of individual orders at each price point.
+ * Other exchanges only give total amount at each price point.
+ * Returns an array of <price, amount> tuples.
+ * @param idexOrders A list of Idex orders awaiting aggregation.
+ */
+export function aggregateOrders(idexOrders: IdexOrder[]): Array<[string, BigNumber]> {
+    const sumAmount = (acc: BigNumber, order: IdexOrder): BigNumber => acc.plus(order.amount);
+    const aggregatedPricePoints = R.reduceBy(sumAmount, new BigNumber(0), R.prop('price'), idexOrders);
+    return Object.entries(aggregatedPricePoints);
+}
+
+/**
+ * Parse a single aggregated Idex order in order to form a tokenOrder entity
+ * which can be saved into the database.
+ * @param idexOrderParam An object containing information about the market where these
+ * trades have been placed.
+ * @param observedTimestamp The time when the API response returned back to us.
+ * @param orderType 'bid' or 'ask' enum.
+ * @param source Exchange where these orders were placed.
+ * @param idexOrder A <price, amount> tuple which we will convert to volume-basis.
+ */
+export function parseIdexOrder(
+    idexOrderParam: IdexOrderParam,
+    observedTimestamp: number,
+    orderType: OrderType,
+    source: string,
+    idexOrder: [string, BigNumber],
+): TokenOrder {
+    const tokenOrder = new TokenOrder();
+    const price = new BigNumber(idexOrder[0]);
+    const amount = idexOrder[1];
+
+    tokenOrder.source = source;
+    tokenOrder.observedTimestamp = observedTimestamp;
+    tokenOrder.orderType = orderType;
+    tokenOrder.price = price;
+    tokenOrder.baseVolume = amount;
+    tokenOrder.quoteVolume = price.times(amount);
+
+    if (orderType === 'bid') {
+        tokenOrder.baseAssetSymbol = idexOrderParam.buySymbol;
+        tokenOrder.baseAssetAddress = idexOrderParam.tokenBuy;
+        tokenOrder.quoteAssetSymbol = idexOrderParam.sellSymbol;
+        tokenOrder.quoteAssetAddress = idexOrderParam.tokenSell;
+    } else {
+        tokenOrder.baseAssetSymbol = idexOrderParam.sellSymbol;
+        tokenOrder.baseAssetAddress = idexOrderParam.tokenSell;
+        tokenOrder.quoteAssetSymbol = idexOrderParam.buySymbol;
+        tokenOrder.quoteAssetAddress = idexOrderParam.tokenBuy;
+    }
+    return tokenOrder;
+}

--- a/packages/pipeline/src/scripts/pull_idex_orderbook_snapshots.ts
+++ b/packages/pipeline/src/scripts/pull_idex_orderbook_snapshots.ts
@@ -1,0 +1,60 @@
+import { logUtils } from '@0x/utils';
+import * as R from 'ramda';
+import { Connection, ConnectionOptions, createConnection } from 'typeorm';
+
+import { IDEX_SOURCE, IdexSource } from '../data_sources/idex';
+import { TokenOrderbookSnapshot as TokenOrder } from '../entities';
+import * as ormConfig from '../ormconfig';
+import { parseIdexOrders } from '../parsers/idex_orders';
+import { handleError } from '../utils';
+
+// Number of orders to save at once.
+const BATCH_SAVE_SIZE = 1000;
+
+// Number of markets to retrieve orderbooks for at once.
+const MARKET_ORDERBOOK_REQUEST_BATCH_SIZE = 100;
+
+// Delay between market orderbook requests.
+const MILLISEC_MARKET_ORDERBOOK_REQUEST_DELAY = 2000;
+
+let connection: Connection;
+
+(async () => {
+    connection = await createConnection(ormConfig as ConnectionOptions);
+    const idexSource = new IdexSource();
+    const markets = await idexSource.getMarketsAsync();
+    for (const marketsChunk of R.splitEvery(MARKET_ORDERBOOK_REQUEST_BATCH_SIZE, markets)) {
+        await Promise.all(
+            marketsChunk.map(async (marketId: string) => getAndSaveMarketOrderbook(idexSource, marketId)),
+        );
+        await new Promise<void>(resolve => setTimeout(resolve, MILLISEC_MARKET_ORDERBOOK_REQUEST_DELAY));
+    }
+    process.exit(0);
+})().catch(handleError);
+
+/**
+ * Retrieve orderbook from Idex API for a given market. Parse orders and insert
+ * them into our database.
+ * @param idexSource Data source which can query Idex API.
+ * @param marketId String representing market of interest, eg. 'ETH_TIC'.
+ */
+async function getAndSaveMarketOrderbook(idexSource: IdexSource, marketId: string): Promise<void> {
+    const orderBook = await idexSource.getMarketOrderbookAsync(marketId);
+    const observedTimestamp = Date.now();
+
+    if (!R.has('bids', orderBook) || !R.has('asks', orderBook)) {
+        logUtils.warn(`${marketId}: Orderbook faulty.`);
+        return;
+    }
+
+    logUtils.log(`${marketId}: Parsing orders.`);
+    const orders = parseIdexOrders(orderBook, observedTimestamp, IDEX_SOURCE);
+
+    if (orders.length > 0) {
+        logUtils.log(`${marketId}: Saving ${orders.length} orders.`);
+        const TokenOrderRepository = connection.getRepository(TokenOrder);
+        await TokenOrderRepository.save(orders, { chunk: Math.ceil(orders.length / BATCH_SAVE_SIZE) });
+    } else {
+        logUtils.log(`${marketId}: 0 orders to save.`);
+    }
+}

--- a/packages/pipeline/test/parsers/idex_orders/index_test.ts
+++ b/packages/pipeline/test/parsers/idex_orders/index_test.ts
@@ -1,0 +1,120 @@
+import { BigNumber } from '@0x/utils';
+import * as chai from 'chai';
+import 'mocha';
+
+import { IdexOrder, IdexOrderParam } from '../../../src/data_sources/idex';
+import { TokenOrderbookSnapshot as TokenOrder } from '../../../src/entities';
+import { aggregateOrders, parseIdexOrder } from '../../../src/parsers/idex_orders';
+import { OrderType } from '../../../src/types';
+import { chaiSetup } from '../../utils/chai_setup';
+
+chaiSetup.configure();
+const expect = chai.expect;
+
+// tslint:disable:custom-no-magic-numbers
+describe('idex_orders', () => {
+    describe('aggregateOrders', () => {
+        it('aggregates orders by price point', () => {
+            const emptyOrderParam: IdexOrderParam = {
+                tokenBuy: '',
+                buySymbol: '',
+                buyPrecision: 2,
+                amountBuy: '',
+                tokenSell: '',
+                sellSymbol: '',
+                sellPrecision: 2,
+                amountSell: '',
+                expires: 100000,
+                nonce: 1,
+                user: '',
+            };
+            const input = [
+                { price: '1', amount: '20', orderHash: 'testtest', total: '20', params: emptyOrderParam },
+                { price: '1', amount: '30', orderHash: 'testone', total: '30', params: emptyOrderParam },
+                { price: '2', amount: '100', orderHash: 'testtwo', total: '200', params: emptyOrderParam },
+            ];
+            const expected = [['1', new BigNumber(50)], ['2', new BigNumber(100)]];
+            const actual = aggregateOrders(input);
+            expect(actual).deep.equal(expected);
+        });
+
+        it('handles empty orders gracefully', () => {
+            const input: IdexOrder[] = [];
+            const expected: Array<[string, BigNumber]> = [];
+            const actual = aggregateOrders(input);
+            expect(actual).deep.equal(expected);
+        });
+    });
+
+    describe('parseIdexOrder', () => {
+        // for market listed as 'DEF_ABC'.
+        it('correctly converts bid type idexOrder to TokenOrder entity', () => {
+            const idexOrder: [string, BigNumber] = ['0.5', new BigNumber(10)];
+            const idexOrderParam: IdexOrderParam = {
+                tokenBuy: '0x0000000000000000000000000000000000000000',
+                buySymbol: 'ABC',
+                buyPrecision: 2,
+                amountBuy: '10',
+                tokenSell: '0xb45df06e38540a675fdb5b598abf2c0dbe9d6b81',
+                sellSymbol: 'DEF',
+                sellPrecision: 2,
+                amountSell: '5',
+                expires: Date.now() + 100000,
+                nonce: 1,
+                user: '0x212345667543456435324564345643453453333',
+            };
+            const observedTimestamp: number = Date.now();
+            const orderType: OrderType = 'bid';
+            const source: string = 'idex';
+
+            const expected = new TokenOrder();
+            expected.source = 'idex';
+            expected.observedTimestamp = observedTimestamp;
+            expected.orderType = 'bid';
+            expected.price = new BigNumber(0.5);
+            expected.baseAssetSymbol = 'ABC';
+            expected.baseAssetAddress = '0x0000000000000000000000000000000000000000';
+            expected.baseVolume = new BigNumber(10);
+            expected.quoteAssetSymbol = 'DEF';
+            expected.quoteAssetAddress = '0xb45df06e38540a675fdb5b598abf2c0dbe9d6b81';
+            expected.quoteVolume = new BigNumber(5);
+
+            const actual = parseIdexOrder(idexOrderParam, observedTimestamp, orderType, source, idexOrder);
+            expect(actual).deep.equal(expected);
+        });
+        it('correctly converts ask type idexOrder to TokenOrder entity', () => {
+            const idexOrder: [string, BigNumber] = ['0.5', new BigNumber(10)];
+            const idexOrderParam: IdexOrderParam = {
+                tokenBuy: '0xb45df06e38540a675fdb5b598abf2c0dbe9d6b81',
+                buySymbol: 'DEF',
+                buyPrecision: 2,
+                amountBuy: '5',
+                tokenSell: '0x0000000000000000000000000000000000000000',
+                sellSymbol: 'ABC',
+                sellPrecision: 2,
+                amountSell: '10',
+                expires: Date.now() + 100000,
+                nonce: 1,
+                user: '0x212345667543456435324564345643453453333',
+            };
+            const observedTimestamp: number = Date.now();
+            const orderType: OrderType = 'ask';
+            const source: string = 'idex';
+
+            const expected = new TokenOrder();
+            expected.source = 'idex';
+            expected.observedTimestamp = observedTimestamp;
+            expected.orderType = 'ask';
+            expected.price = new BigNumber(0.5);
+            expected.baseAssetSymbol = 'ABC';
+            expected.baseAssetAddress = '0x0000000000000000000000000000000000000000';
+            expected.baseVolume = new BigNumber(10);
+            expected.quoteAssetSymbol = 'DEF';
+            expected.quoteAssetAddress = '0xb45df06e38540a675fdb5b598abf2c0dbe9d6b81';
+            expected.quoteVolume = new BigNumber(5);
+
+            const actual = parseIdexOrder(idexOrderParam, observedTimestamp, orderType, source, idexOrder);
+            expect(actual).deep.equal(expected);
+        });
+    });
+});


### PR DESCRIPTION
## Description
This change implements functionality for pulling orderbook snapshots from the idex API.

## Testing instructions
Standard testing via docker set up and `yarn test`. You can verify that the DB is filled with idex data.

## Types of changes
New functionality

## Checklist:

*   [ ] Prefix PR title with `[WIP]` if necessary.
*   [ x] Add tests to cover changes as needed.
*   [ ] Update documentation as needed.
*   [ ] Add new entries to the relevant CHANGELOG.jsons.
