### PR TITLE
Fix RadarRelay timestamps

### DIFF
--- a/packages/pipeline/src/entities/sra_order_observed_timestamp.ts
+++ b/packages/pipeline/src/entities/sra_order_observed_timestamp.ts
@@ -22,11 +22,11 @@ export class SraOrdersObservedTimeStamp {
  * current time.
  * @param order The order to generate a timestamp for.
  */
-export function createObservedTimestampForOrder(order: SraOrder): SraOrdersObservedTimeStamp {
+export function createObservedTimestampForOrder(order: SraOrder, observedTimestamp: number): SraOrdersObservedTimeStamp {
     const observed = new SraOrdersObservedTimeStamp();
     observed.exchangeAddress = order.exchangeAddress;
     observed.orderHashHex = order.orderHashHex;
     observed.sourceUrl = order.sourceUrl;
-    observed.observedTimestamp = Date.now();
+    observed.observedTimestamp = observedTimestamp;
     return observed;
 }

--- a/packages/pipeline/src/scripts/pull_radar_relay_orders.ts
+++ b/packages/pipeline/src/scripts/pull_radar_relay_orders.ts
@@ -33,11 +33,12 @@ async function getOrderbookAsync(): Promise<void> {
     // Save all the orders and update the observed time stamps in a single
     // transaction.
     console.log('Saving orders and updating timestamps...');
+    const observedTimestamp = Date.now();
     await connection.transaction(async (manager: EntityManager): Promise<void> => {
         for (const order of orders) {
             await manager.save(SraOrder, order);
-            const observedTimestamp = createObservedTimestampForOrder(order);
-            await manager.save(observedTimestamp);
+            const orderObservation = createObservedTimestampForOrder(order, observedTimestamp);
+            await manager.save(orderObservation);
         }
     });
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR changes the timestamps used when scraping RadarRelay order books. Now we use the same timestamp for each pull instead of using a different timestamp for each order.

Thanks to @wakkadojo. I just cherry-picked this fix from https://github.com/0xProject/0x-monorepo/pull/1378.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefix PR title with `[WIP]` if necessary.
*   [ ] Add tests to cover changes as needed.
*   [ ] Update documentation as needed.
*   [ ] Add new entries to the relevant CHANGELOG.jsons.
