### PR TITLE
[instant] CSS leakage and non-lowercase defaultAssetData fix

### DIFF
--- a/packages/instant/public/external.css
+++ b/packages/instant/public/external.css
@@ -15,6 +15,10 @@ input {
     height: 100px;
 }
 
+input::-webkit-input-placeholder {
+    color: #b4b4b4 !important;
+}
+
 div {
     padding: 3px;
 }

--- a/packages/instant/src/components/ui/input.tsx
+++ b/packages/instant/src/components/ui/input.tsx
@@ -29,8 +29,8 @@ export const Input =
         outline: none;
         border: none;
         &::placeholder {
-            color: ${props => props.theme[props.fontColor || 'white']};
-            opacity: 0.5;
+            color: ${props => props.theme[props.fontColor || 'white']} !important;
+            opacity: 0.5 !important;
         }
     }
 `;

--- a/packages/instant/src/components/zero_ex_instant_provider.tsx
+++ b/packages/instant/src/components/zero_ex_instant_provider.tsx
@@ -60,7 +60,8 @@ export class ZeroExInstantProvider extends React.Component<ZeroExInstantProvider
         );
         // merge the additional additionalAssetMetaDataMap with our default map
         const completeAssetMetaDataMap = {
-            ...props.additionalAssetMetaDataMap,
+            // Make sure the passed in assetDatas are lower case
+            ..._.mapKeys(props.additionalAssetMetaDataMap || {}, (value, key) => key.toLowerCase()),
             ...defaultState.assetMetaDataMap,
         };
         // construct the final state

--- a/packages/instant/src/util/asset.ts
+++ b/packages/instant/src/util/asset.ts
@@ -26,7 +26,7 @@ export const assetUtils = {
             return;
         }
         return {
-            assetData,
+            assetData: assetData.toLowerCase(),
             metaData,
         };
     },
@@ -36,7 +36,7 @@ export const assetUtils = {
         network: Network,
     ): Asset => {
         return {
-            assetData,
+            assetData: assetData.toLowerCase(),
             metaData: assetUtils.getMetaDataOrThrow(assetData, assetMetaDataMap, network),
         };
     },


### PR DESCRIPTION
## Description

We discovered coingecko was using this code to render REP Instant:
```
zeroExInstant.render({
    orderSource: "https://api.radarrelay.com/0x/v2/",
      // Initialization options
      availableAssetDatas: [
        '0xf47261b00000000000000000000000000d8775f648430679a709e98d2b0cb6250d2887ef', // BAT
        '0xf47261b000000000000000000000000089d24a6b4ccb1b6faa2625fe562bdd9a23260359', // DAI
        '0xf47261b0000000000000000000000000e41d2489571d322189246dafa5ebde1f4699f498', // 0x 
        '0xf47261b0000000000000000000000000d26114cd6EE289AccF82350c8d8487fedB8A0C07',// OMG
        '0xf47261b00000000000000000000000001985365e9f78359a9B6AD760e32412f4a445E862',// REP
        '0xf47261b00000000000000000000000008f8221afbb33998d8584a2b05749ba73c37a938a',// REQ
        '0xf47261b000000000000000000000000027054b13b1b798b345b591a4d22e6562d47ea75a',// AST
        '0xf47261b00000000000000000000000009f8f72aa9304c8b593d555f12ef6589cc3a579a2',// MKR
      ],
      defaultSelectedAssetData: assetAddress,
    }, 'body');
```

The assetDatas are not lowercased and this was causing problems when requesting liquidity from radar. 

The CSS fix is more of a patch.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefix PR title with `[WIP]` if necessary.
*   [ ] Add tests to cover changes as needed.
*   [ ] Update documentation as needed.
*   [ ] Add new entries to the relevant CHANGELOG.jsons.
