### PR TITLE
[instant] More aggressive error reporting

### DIFF
--- a/packages/instant/src/util/buy_quote_updater.ts
+++ b/packages/instant/src/util/buy_quote_updater.ts
@@ -38,14 +38,11 @@ export const buyQuoteUpdater = {
         } catch (error) {
             const errorMessage = assetUtils.assetBuyerErrorMessage(asset, error);
 
-            if (_.isUndefined(errorMessage)) {
-                // This is an unknown error, report it to rollbar
-                errorReporter.report(error);
-            }
+            errorReporter.report(error);
+            analytics.trackQuoteError(error.message ? error.message : 'other', baseUnitValue, fetchOrigin);
 
             if (options.dispatchErrors) {
                 dispatch(actions.setQuoteRequestStateFailure());
-                analytics.trackQuoteError(error.message ? error.message : 'other', baseUnitValue, fetchOrigin);
                 errorFlasher.flashNewErrorMessage(dispatch, errorMessage || 'Error fetching price, please try again');
             }
             return;


### PR DESCRIPTION
## Description

Initially, I was trying to be conservative with logging errors, but with the launch I think it'd be good to have more info than less, even if there is some noise.

Before: Any error that we knew could occur (i.e. insufficient liquidity, standard relayer api error), would not be reported to Rollbar
Now: These are all reported to Rollbar

Before: If a quote fetch failed on a _heartbeat_ request, it wasn't logged to heap
Now: These are all reported to heap

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefix PR title with `[WIP]` if necessary.
*   [ ] Add tests to cover changes as needed.
*   [ ] Update documentation as needed.
*   [ ] Add new entries to the relevant CHANGELOG.jsons.
