### PR TITLE
Fix `value` and `gasPrice` precision bug by returning them as BigNumbers

### DIFF
--- a/packages/web3-wrapper/CHANGELOG.json
+++ b/packages/web3-wrapper/CHANGELOG.json
@@ -1,5 +1,13 @@
 [
     {
+        "version": "3.2.0",
+        "changes": [
+            {
+                "note": "Return `value` and `gasPrice` as BigNumbers to avoid loss of precision errors"
+            }
+        ]
+    },
+    {
         "version": "3.1.6",
         "changes": [
             {

--- a/packages/web3-wrapper/CHANGELOG.json
+++ b/packages/web3-wrapper/CHANGELOG.json
@@ -3,7 +3,8 @@
         "version": "3.2.0",
         "changes": [
             {
-                "note": "Return `value` and `gasPrice` as BigNumbers to avoid loss of precision errors"
+                "note": "Return `value` and `gasPrice` as BigNumbers to avoid loss of precision errors",
+                "pr": 1402
             }
         ]
     },

--- a/packages/web3-wrapper/src/marshaller.ts
+++ b/packages/web3-wrapper/src/marshaller.ts
@@ -1,4 +1,4 @@
-import { addressUtils, BigNumber } from '@0x/utils';
+import { addressUtils } from '@0x/utils';
 import {
     BlockParam,
     BlockParamLiteral,
@@ -122,7 +122,9 @@ export const marshaller = {
             ...txDataRpc,
             value: !_.isUndefined(txDataRpc.value) ? utils.convertAmountToBigNumber(txDataRpc.value) : undefined,
             gas: !_.isUndefined(txDataRpc.gas) ? utils.convertHexToNumber(txDataRpc.gas) : undefined,
-            gasPrice: !_.isUndefined(txDataRpc.gasPrice) ? utils.convertAmountToBigNumber(txDataRpc.gasPrice) : undefined,
+            gasPrice: !_.isUndefined(txDataRpc.gasPrice)
+                ? utils.convertAmountToBigNumber(txDataRpc.gasPrice)
+                : undefined,
             nonce: !_.isUndefined(txDataRpc.nonce) ? utils.convertHexToNumber(txDataRpc.nonce) : undefined,
         };
         return txData;

--- a/packages/web3-wrapper/src/marshaller.ts
+++ b/packages/web3-wrapper/src/marshaller.ts
@@ -123,7 +123,7 @@ export const marshaller = {
             value: !_.isUndefined(txDataRpc.value) ? utils.convertAmountToBigNumber(txDataRpc.value) : undefined,
             gas: !_.isUndefined(txDataRpc.gas) ? utils.convertHexToNumber(txDataRpc.gas) : undefined,
             gasPrice: !_.isUndefined(txDataRpc.gasPrice) ? utils.convertAmountToBigNumber(txDataRpc.gasPrice) : undefined,
-            nonce: !_.isUndefined(txDataRpc.nonce) ? utils.convertHexToNumber(txDataRpc.nonce) : undefined, , , , , , , ,
+            nonce: !_.isUndefined(txDataRpc.nonce) ? utils.convertHexToNumber(txDataRpc.nonce) : undefined,
         };
         return txData;
     },

--- a/packages/web3-wrapper/src/marshaller.ts
+++ b/packages/web3-wrapper/src/marshaller.ts
@@ -1,4 +1,4 @@
-import { addressUtils } from '@0x/utils';
+import { addressUtils, BigNumber } from '@0x/utils';
 import {
     BlockParam,
     BlockParamLiteral,
@@ -120,10 +120,10 @@ export const marshaller = {
         }
         const txData = {
             ...txDataRpc,
-            value: !_.isUndefined(txDataRpc.value) ? utils.convertHexToNumber(txDataRpc.value) : undefined,
+            value: !_.isUndefined(txDataRpc.value) ? utils.convertAmountToBigNumber(txDataRpc.value) : undefined,
             gas: !_.isUndefined(txDataRpc.gas) ? utils.convertHexToNumber(txDataRpc.gas) : undefined,
-            gasPrice: !_.isUndefined(txDataRpc.gasPrice) ? utils.convertHexToNumber(txDataRpc.gasPrice) : undefined,
-            nonce: !_.isUndefined(txDataRpc.nonce) ? utils.convertHexToNumber(txDataRpc.nonce) : undefined,
+            gasPrice: !_.isUndefined(txDataRpc.gasPrice) ? utils.convertAmountToBigNumber(txDataRpc.gasPrice) : undefined,
+            nonce: !_.isUndefined(txDataRpc.nonce) ? utils.convertHexToNumber(txDataRpc.nonce) : undefined, , , , , , , ,
         };
         return txData;
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2008,6 +2008,10 @@ aes-js@^0.2.3:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-0.2.4.tgz#94b881ab717286d015fa219e08fb66709dda5a3d"
 
+aes-js@^3.1.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-3.1.2.tgz#db9aabde85d5caabbfc0d4f2a4446960f627146a"
+
 agent-base@4, agent-base@^4.1.0, agent-base@~4.2.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.1.tgz#d89e5999f797875674c07d87f260fc41e83e8ca9"
@@ -3466,7 +3470,7 @@ bs-logger@0.x:
   dependencies:
     fast-json-stable-stringify "^2.0.0"
 
-bs58@=4.0.1:
+bs58@=4.0.1, bs58@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
   dependencies:
@@ -3488,6 +3492,14 @@ bs58check@^1.0.8:
   dependencies:
     bs58 "^3.1.0"
     create-hash "^1.1.0"
+
+bs58check@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/bs58check/-/bs58check-2.1.2.tgz#53b018291228d82a5aa08e7d796fdafda54aebfc"
+  dependencies:
+    bs58 "^4.0.0"
+    create-hash "^1.1.0"
+    safe-buffer "^5.1.2"
 
 bser@^2.0.0:
   version "2.0.0"
@@ -6163,6 +6175,19 @@ ethereumjs-wallet@0.6.0:
     utf8 "^2.1.1"
     uuid "^2.0.1"
 
+ethereumjs-wallet@~0.6.0:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/ethereumjs-wallet/-/ethereumjs-wallet-0.6.2.tgz#67244b6af3e8113b53d709124b25477b64aeccda"
+  dependencies:
+    aes-js "^3.1.1"
+    bs58check "^2.1.2"
+    ethereumjs-util "^5.2.0"
+    hdkey "^1.0.0"
+    safe-buffer "^5.1.2"
+    scrypt.js "^0.2.0"
+    utf8 "^3.0.0"
+    uuid "^3.3.2"
+
 ethers@~4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.4.tgz#d3f85e8b27f4b59537e06526439b0fb15b44dc65"
@@ -7000,7 +7025,7 @@ ganache-core@0xProject/ganache-core#monorepo-dep:
     ethereumjs-tx "0xProject/ethereumjs-tx#fake-tx-include-signature-by-default"
     ethereumjs-util "^5.2.0"
     ethereumjs-vm "2.3.5"
-    ethereumjs-wallet "~0.6.0"
+    ethereumjs-wallet "0.6.0"
     fake-merkle-patricia-tree "~1.0.1"
     heap "~0.2.6"
     js-scrypt "^0.2.0"
@@ -7725,6 +7750,14 @@ hdkey@^0.7.0, hdkey@^0.7.1:
   resolved "https://registry.yarnpkg.com/hdkey/-/hdkey-0.7.1.tgz#caee4be81aa77921e909b8d228dd0f29acaee632"
   dependencies:
     coinstring "^2.0.0"
+    secp256k1 "^3.0.1"
+
+hdkey@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/hdkey/-/hdkey-1.1.0.tgz#e74e7b01d2c47f797fa65d1d839adb7a44639f29"
+  dependencies:
+    coinstring "^2.0.0"
+    safe-buffer "^5.1.1"
     secp256k1 "^3.0.1"
 
 he@1.1.1:
@@ -16143,6 +16176,10 @@ utf8@2.1.1:
 utf8@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/utf8/-/utf8-2.1.2.tgz#1fa0d9270e9be850d9b05027f63519bf46457d96"
+
+utf8@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/utf8/-/utf8-3.0.0.tgz#f052eed1364d696e769ef058b183df88c87f69d1"
 
 util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
## Description

Fixes: https://github.com/0xProject/0x-monorepo/issues/1394

Decided to convert `gasPrice` and `value` to BigNumbers as they can be larger then 2^53-1 (max JS number amount). I did not change `gas`, since the current gas limit per block is ~8,000,000 gas and we could image this will grow, but it's hard to imagine it ever being close to 2^53-1. Happy for anyone to dispute that last claim.

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefix PR title with `[WIP]` if necessary.
*   [ ] Add tests to cover changes as needed.
*   [ ] Update documentation as needed.
*   [ ] Add new entries to the relevant CHANGELOG.jsons.
