### PR TITLE
[instant] Change input to number input, and simplify ScalingInput

### DIFF
--- a/packages/instant/src/components/scaling_amount_input.tsx
+++ b/packages/instant/src/components/scaling_amount_input.tsx
@@ -58,6 +58,7 @@ export class ScalingAmountInput extends React.Component<ScalingAmountInputProps,
         const { textLengthThreshold, fontColor, maxFontSizePx, onFontSizeChange } = this.props;
         return (
             <ScalingInput
+                type="number"
                 maxFontSizePx={maxFontSizePx}
                 textLengthThreshold={textLengthThreshold}
                 onFontSizeChange={onFontSizeChange}

--- a/packages/instant/src/components/scaling_input.tsx
+++ b/packages/instant/src/components/scaling_input.tsx
@@ -135,6 +135,7 @@ export class ScalingInput extends React.Component<ScalingInputProps, ScalingInpu
         const phase = ScalingInput.getPhaseFromProps(this.props);
         return (
             <Input
+                type="number"
                 ref={this._inputRef as any}
                 fontColor={fontColor}
                 onChange={onChange}

--- a/packages/instant/src/components/ui/input.tsx
+++ b/packages/instant/src/components/ui/input.tsx
@@ -32,9 +32,9 @@ export const Input =
             color: ${props => props.theme[props.fontColor || 'white']} !important;
             opacity: 0.5 !important;
         }
-        &::-webkit-outer-spin-button, &::-webkit-inner-spin-button { 
-            -webkit-appearance: none; 
-            margin: 0; 
+        &::-webkit-outer-spin-button, &::-webkit-inner-spin-button {
+            -webkit-appearance: none;
+            margin: 0;
           }
     }
 `;

--- a/packages/instant/src/components/ui/input.tsx
+++ b/packages/instant/src/components/ui/input.tsx
@@ -32,6 +32,10 @@ export const Input =
             color: ${props => props.theme[props.fontColor || 'white']} !important;
             opacity: 0.5 !important;
         }
+        &::-webkit-outer-spin-button, &::-webkit-inner-spin-button { 
+            -webkit-appearance: none; 
+            margin: 0; 
+          }
     }
 `;
 

--- a/packages/instant/src/components/ui/input.tsx
+++ b/packages/instant/src/components/ui/input.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { ColorOption, styled } from '../../style/theme';
 
-export interface InputProps {
+export interface InputProps extends React.HTMLAttributes<HTMLInputElement> {
     tabIndex?: number;
     className?: string;
     value?: string;


### PR DESCRIPTION
## Description

As discussed, adding type="number" does make the numeric keyboard appear on mobile, however it also causes some problems around the `onChange` event. Namely, it will allow you type in "1", "1.", "1.0" but will only trigger `onChange` for "1" and "1.0".

The final solution which I'm quite happy with is to just simplify the ScalingInput logic to measure everything in "ch" instead of moving between "ch" and "px" as before, and simply leaving enough room for the decimal at all times.

The only improvement we may want to add is that this "padding" is present at all time. It isn't very noticeable, but it should be pretty easy to make the text fit *perfectly* for when we have a decimal. We will always have to leave padding for when there is no decimal. On the other hand, I like the consistency of having some padding at all times as it leaves some room for the cursor.

**Scaling is BETTER NOW. People can buy SPANK!**

**Before: horrible SPANK buying experience**
<img width="361" alt="screen shot 2018-12-13 at 1 18 32 pm" src="https://user-images.githubusercontent.com/3066135/49968130-c4ec9f00-fed9-11e8-858e-55a7f722ebfc.png">

**Now: #flawless**
<img width="359" alt="screen shot 2018-12-13 at 1 19 09 pm" src="https://user-images.githubusercontent.com/3066135/49968137-ca49e980-fed9-11e8-9697-1119822d7de4.png">


## Testing instructions

http://0x-instant-dogfood.s3-website-us-east-1.amazonaws.com/

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefix PR title with `[WIP]` if necessary.
*   [ ] Add tests to cover changes as needed.
*   [ ] Update documentation as needed.
*   [ ] Add new entries to the relevant CHANGELOG.jsons.
