### PR TITLE
[website] Don't show placeholder text on contact page

### DIFF
--- a/packages/website/ts/@next/components/modals/input.tsx
+++ b/packages/website/ts/@next/components/modals/input.tsx
@@ -29,7 +29,7 @@ export const Input = React.forwardRef((props: InputProps, ref?: React.Ref<HTMLIn
     return (
         <InputWrapper {...props}>
             <Label htmlFor={id}>{label}</Label>
-            <StyledInput as={componentType} ref={ref} id={id} placeholder={label} isErrors={isErrors} {...props} />
+            <StyledInput as={componentType} ref={ref} id={id} isErrors={isErrors} {...props} />
             {isErrors && <Error>{errorMessage}</Error>}
         </InputWrapper>
     );


### PR DESCRIPTION
## Description

Don't show placeholder text on contact form on the website

I looked through the code, and from what I can see, the contact form is the only code that sends in a  `label` prop on the `Input` component, so it seems safe to remove using the `label` value as placeholder text here

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefix PR title with `[WIP]` if necessary.
*   [ ] Add tests to cover changes as needed.
*   [ ] Update documentation as needed.
*   [ ] Add new entries to the relevant CHANGELOG.jsons.
