### PR TITLE
Unfix Solidity compiler version except for top level contracts

### DIFF
--- a/contracts/.solhint.json
+++ b/contracts/.solhint.json
@@ -5,6 +5,7 @@
         "avoid-tx-origin": "warn",
         "bracket-align": false,
         "code-complexity": false,
+        "compiler-fixed": false,
         "const-name-snakecase": "error",
         "expression-indent": "error",
         "function-max-lines": false,

--- a/contracts/extensions/contracts/BalanceThresholdFilter/MixinBalanceThresholdFilterCore.sol
+++ b/contracts/extensions/contracts/BalanceThresholdFilter/MixinBalanceThresholdFilterCore.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "@0x/contracts-libs/contracts/libs/LibExchangeSelectors.sol";
 import "@0x/contracts-libs/contracts/libs/LibOrder.sol";

--- a/contracts/extensions/contracts/BalanceThresholdFilter/MixinExchangeCalldata.sol
+++ b/contracts/extensions/contracts/BalanceThresholdFilter/MixinExchangeCalldata.sol
@@ -17,7 +17,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "./mixins/MExchangeCalldata.sol";
 import "@0x/contracts-libs/contracts/libs/LibAddressArray.sol";

--- a/contracts/extensions/contracts/BalanceThresholdFilter/interfaces/IBalanceThresholdFilterCore.sol
+++ b/contracts/extensions/contracts/BalanceThresholdFilter/interfaces/IBalanceThresholdFilterCore.sol
@@ -17,7 +17,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 contract IBalanceThresholdFilterCore {

--- a/contracts/extensions/contracts/BalanceThresholdFilter/interfaces/IThresholdAsset.sol
+++ b/contracts/extensions/contracts/BalanceThresholdFilter/interfaces/IThresholdAsset.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 contract IThresholdAsset {

--- a/contracts/extensions/contracts/BalanceThresholdFilter/mixins/MBalanceThresholdFilterCore.sol
+++ b/contracts/extensions/contracts/BalanceThresholdFilter/mixins/MBalanceThresholdFilterCore.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "@0x/contracts-interfaces/contracts/protocol/Exchange/IExchange.sol";
 import "../interfaces/IThresholdAsset.sol";

--- a/contracts/extensions/contracts/BalanceThresholdFilter/mixins/MExchangeCalldata.sol
+++ b/contracts/extensions/contracts/BalanceThresholdFilter/mixins/MExchangeCalldata.sol
@@ -17,7 +17,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 contract MExchangeCalldata {

--- a/contracts/extensions/contracts/Forwarder/MixinAssets.sol
+++ b/contracts/extensions/contracts/Forwarder/MixinAssets.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "@0x/contracts-utils/contracts/utils/LibBytes/LibBytes.sol";
 import "@0x/contracts-utils/contracts/utils/Ownable/Ownable.sol";

--- a/contracts/extensions/contracts/Forwarder/MixinExchangeWrapper.sol
+++ b/contracts/extensions/contracts/Forwarder/MixinExchangeWrapper.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 pragma experimental ABIEncoderV2;
 
 import "./libs/LibConstants.sol";

--- a/contracts/extensions/contracts/Forwarder/MixinForwarderCore.sol
+++ b/contracts/extensions/contracts/Forwarder/MixinForwarderCore.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 pragma experimental ABIEncoderV2;
 
 import "./libs/LibConstants.sol";

--- a/contracts/extensions/contracts/Forwarder/MixinWeth.sol
+++ b/contracts/extensions/contracts/Forwarder/MixinWeth.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "@0x/contracts-libs/contracts/libs/LibMath.sol";
 import "./libs/LibConstants.sol";

--- a/contracts/extensions/contracts/Forwarder/interfaces/IAssets.sol
+++ b/contracts/extensions/contracts/Forwarder/interfaces/IAssets.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 contract IAssets {

--- a/contracts/extensions/contracts/Forwarder/interfaces/IForwarder.sol
+++ b/contracts/extensions/contracts/Forwarder/interfaces/IForwarder.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 pragma experimental ABIEncoderV2;
 
 import "./IForwarderCore.sol";

--- a/contracts/extensions/contracts/Forwarder/interfaces/IForwarderCore.sol
+++ b/contracts/extensions/contracts/Forwarder/interfaces/IForwarderCore.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 pragma experimental ABIEncoderV2;
 
 import "@0x/contracts-libs/contracts/libs/LibOrder.sol";

--- a/contracts/extensions/contracts/Forwarder/libs/LibConstants.sol
+++ b/contracts/extensions/contracts/Forwarder/libs/LibConstants.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "@0x/contracts-utils/contracts/utils/LibBytes/LibBytes.sol";
 import "@0x/contracts-interfaces/contracts/protocol/Exchange/IExchange.sol";

--- a/contracts/extensions/contracts/Forwarder/libs/LibForwarderErrors.sol
+++ b/contracts/extensions/contracts/Forwarder/libs/LibForwarderErrors.sol
@@ -17,7 +17,7 @@
 */
 
 // solhint-disable
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 /// This contract is intended to serve as a reference, but is not actually used for efficiency reasons.

--- a/contracts/extensions/contracts/Forwarder/mixins/MAssets.sol
+++ b/contracts/extensions/contracts/Forwarder/mixins/MAssets.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "../interfaces/IAssets.sol";
 

--- a/contracts/extensions/contracts/Forwarder/mixins/MExchangeWrapper.sol
+++ b/contracts/extensions/contracts/Forwarder/mixins/MExchangeWrapper.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 pragma experimental ABIEncoderV2;
 
 import "@0x/contracts-libs/contracts/libs/LibOrder.sol";

--- a/contracts/extensions/contracts/Forwarder/mixins/MWeth.sol
+++ b/contracts/extensions/contracts/Forwarder/mixins/MWeth.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 contract MWeth {

--- a/contracts/extensions/contracts/OrderMatcher/MixinAssets.sol
+++ b/contracts/extensions/contracts/OrderMatcher/MixinAssets.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "@0x/contracts-utils/contracts/utils/LibBytes/LibBytes.sol";
 import "@0x/contracts-utils/contracts/utils/Ownable/Ownable.sol";

--- a/contracts/extensions/contracts/OrderMatcher/MixinMatchOrders.sol
+++ b/contracts/extensions/contracts/OrderMatcher/MixinMatchOrders.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 pragma experimental ABIEncoderV2;
 
 import "./libs/LibConstants.sol";

--- a/contracts/extensions/contracts/OrderMatcher/interfaces/IAssets.sol
+++ b/contracts/extensions/contracts/OrderMatcher/interfaces/IAssets.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 contract IAssets {

--- a/contracts/extensions/contracts/OrderMatcher/interfaces/IMatchOrders.sol
+++ b/contracts/extensions/contracts/OrderMatcher/interfaces/IMatchOrders.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 pragma experimental ABIEncoderV2;
 
 import "@0x/contracts-libs/contracts/libs/LibOrder.sol";

--- a/contracts/extensions/contracts/OrderMatcher/interfaces/IOrderMatcher.sol
+++ b/contracts/extensions/contracts/OrderMatcher/interfaces/IOrderMatcher.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "@0x/contract-utils/contracts/utils/Ownable/IOwnable.sol";
 import "./IMatchOrders.sol";

--- a/contracts/extensions/contracts/OrderMatcher/libs/LibConstants.sol
+++ b/contracts/extensions/contracts/OrderMatcher/libs/LibConstants.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "@0x/contracts-interfaces/contracts/protocol/Exchange/IExchange.sol";
 

--- a/contracts/extensions/contracts/OrderMatcher/mixins/MAssets.sol
+++ b/contracts/extensions/contracts/OrderMatcher/mixins/MAssets.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "../interfaces/IAssets.sol";
 

--- a/contracts/interfaces/contracts/protocol/AssetProxy/IAssetData.sol
+++ b/contracts/interfaces/contracts/protocol/AssetProxy/IAssetData.sol
@@ -17,7 +17,7 @@
 */
 
 // solhint-disable
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 pragma experimental ABIEncoderV2;
 
 

--- a/contracts/interfaces/contracts/protocol/AssetProxy/IAssetProxy.sol
+++ b/contracts/interfaces/contracts/protocol/AssetProxy/IAssetProxy.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "./IAuthorizable.sol";
 

--- a/contracts/interfaces/contracts/protocol/AssetProxy/IAuthorizable.sol
+++ b/contracts/interfaces/contracts/protocol/AssetProxy/IAuthorizable.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "@0x/contracts-utils/contracts/utils/Ownable/IOwnable.sol";
 

--- a/contracts/interfaces/contracts/protocol/Exchange/IAssetProxyDispatcher.sol
+++ b/contracts/interfaces/contracts/protocol/Exchange/IAssetProxyDispatcher.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 contract IAssetProxyDispatcher {

--- a/contracts/interfaces/contracts/protocol/Exchange/IExchange.sol
+++ b/contracts/interfaces/contracts/protocol/Exchange/IExchange.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 pragma experimental ABIEncoderV2;
 
 import "./IExchangeCore.sol";

--- a/contracts/interfaces/contracts/protocol/Exchange/IExchangeCore.sol
+++ b/contracts/interfaces/contracts/protocol/Exchange/IExchangeCore.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 pragma experimental ABIEncoderV2;
 
 import "@0x/contracts-libs/contracts/libs/LibOrder.sol";

--- a/contracts/interfaces/contracts/protocol/Exchange/IMatchOrders.sol
+++ b/contracts/interfaces/contracts/protocol/Exchange/IMatchOrders.sol
@@ -15,7 +15,7 @@
   limitations under the License.
 
 */
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 pragma experimental ABIEncoderV2;
 
 import "@0x/contracts-libs/contracts/libs/LibOrder.sol";

--- a/contracts/interfaces/contracts/protocol/Exchange/ISignatureValidator.sol
+++ b/contracts/interfaces/contracts/protocol/Exchange/ISignatureValidator.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 contract ISignatureValidator {

--- a/contracts/interfaces/contracts/protocol/Exchange/ITransactions.sol
+++ b/contracts/interfaces/contracts/protocol/Exchange/ITransactions.sol
@@ -15,7 +15,7 @@
   limitations under the License.
 
 */
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 contract ITransactions {

--- a/contracts/interfaces/contracts/protocol/Exchange/IValidator.sol
+++ b/contracts/interfaces/contracts/protocol/Exchange/IValidator.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 contract IValidator {

--- a/contracts/interfaces/contracts/protocol/Exchange/IWallet.sol
+++ b/contracts/interfaces/contracts/protocol/Exchange/IWallet.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 contract IWallet {

--- a/contracts/interfaces/contracts/protocol/Exchange/IWrapperFunctions.sol
+++ b/contracts/interfaces/contracts/protocol/Exchange/IWrapperFunctions.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 pragma experimental ABIEncoderV2;
 
 import "@0x/contracts-libs/contracts/libs/LibOrder.sol";

--- a/contracts/libs/contracts/libs/LibAbiEncoder.sol
+++ b/contracts/libs/contracts/libs/LibAbiEncoder.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 pragma experimental ABIEncoderV2;
 
 import "./LibOrder.sol";

--- a/contracts/libs/contracts/libs/LibAddressArray.sol
+++ b/contracts/libs/contracts/libs/LibAddressArray.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "@0x/contracts-utils/contracts/utils/LibBytes/LibBytes.sol";
 

--- a/contracts/libs/contracts/libs/LibAssetProxyErrors.sol
+++ b/contracts/libs/contracts/libs/LibAssetProxyErrors.sol
@@ -17,7 +17,7 @@
 */
 
 // solhint-disable
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 /// @dev This contract documents the revert reasons used in the AssetProxy contracts.

--- a/contracts/libs/contracts/libs/LibConstants.sol
+++ b/contracts/libs/contracts/libs/LibConstants.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 // solhint-disable max-line-length

--- a/contracts/libs/contracts/libs/LibEIP712.sol
+++ b/contracts/libs/contracts/libs/LibEIP712.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 contract LibEIP712 {

--- a/contracts/libs/contracts/libs/LibExchangeErrors.sol
+++ b/contracts/libs/contracts/libs/LibExchangeErrors.sol
@@ -17,7 +17,7 @@
 */
 
 // solhint-disable
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 /// @dev This contract documents the revert reasons used in the Exchange contract.

--- a/contracts/libs/contracts/libs/LibExchangeSelectors.sol
+++ b/contracts/libs/contracts/libs/LibExchangeSelectors.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 contract LibExchangeSelectors {

--- a/contracts/libs/contracts/libs/LibFillResults.sol
+++ b/contracts/libs/contracts/libs/LibFillResults.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "@0x/contracts-utils/contracts/utils/SafeMath/SafeMath.sol";
 

--- a/contracts/libs/contracts/libs/LibMath.sol
+++ b/contracts/libs/contracts/libs/LibMath.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "@0x/contracts-utils/contracts/utils/SafeMath/SafeMath.sol";
 

--- a/contracts/libs/contracts/libs/LibOrder.sol
+++ b/contracts/libs/contracts/libs/LibOrder.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "./LibEIP712.sol";
 

--- a/contracts/protocol/contracts/protocol/AssetProxy/MixinAuthorizable.sol
+++ b/contracts/protocol/contracts/protocol/AssetProxy/MixinAuthorizable.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "@0x/contracts-utils/contracts/utils/Ownable/Ownable.sol";
 import "./mixins/MAuthorizable.sol";

--- a/contracts/protocol/contracts/protocol/AssetProxy/mixins/MAuthorizable.sol
+++ b/contracts/protocol/contracts/protocol/AssetProxy/mixins/MAuthorizable.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "@0x/contracts-interfaces/contracts/protocol/AssetProxy/IAuthorizable.sol";
 

--- a/contracts/protocol/contracts/protocol/Exchange/MixinAssetProxyDispatcher.sol
+++ b/contracts/protocol/contracts/protocol/Exchange/MixinAssetProxyDispatcher.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "@0x/contracts-utils/contracts/utils/Ownable/Ownable.sol";
 import "./mixins/MAssetProxyDispatcher.sol";

--- a/contracts/protocol/contracts/protocol/Exchange/MixinExchangeCore.sol
+++ b/contracts/protocol/contracts/protocol/Exchange/MixinExchangeCore.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 pragma experimental ABIEncoderV2;
 
 import "@0x/contracts-utils/contracts/utils/ReentrancyGuard/ReentrancyGuard.sol";

--- a/contracts/protocol/contracts/protocol/Exchange/MixinMatchOrders.sol
+++ b/contracts/protocol/contracts/protocol/Exchange/MixinMatchOrders.sol
@@ -11,7 +11,7 @@
   limitations under the License.
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 pragma experimental ABIEncoderV2;
 
 import "@0x/contracts-utils/contracts/utils/ReentrancyGuard/ReentrancyGuard.sol";

--- a/contracts/protocol/contracts/protocol/Exchange/MixinSignatureValidator.sol
+++ b/contracts/protocol/contracts/protocol/Exchange/MixinSignatureValidator.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "@0x/contracts-utils/contracts/utils/LibBytes/LibBytes.sol";
 import "@0x/contracts-utils/contracts/utils/ReentrancyGuard/ReentrancyGuard.sol";

--- a/contracts/protocol/contracts/protocol/Exchange/MixinTransactions.sol
+++ b/contracts/protocol/contracts/protocol/Exchange/MixinTransactions.sol
@@ -15,7 +15,7 @@
   limitations under the License.
 
 */
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "@0x/contracts-libs/contracts/libs/LibExchangeErrors.sol";
 import "./mixins/MSignatureValidator.sol";

--- a/contracts/protocol/contracts/protocol/Exchange/MixinWrapperFunctions.sol
+++ b/contracts/protocol/contracts/protocol/Exchange/MixinWrapperFunctions.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 pragma experimental ABIEncoderV2;
 
 import "@0x/contracts-utils/contracts/utils/ReentrancyGuard/ReentrancyGuard.sol";

--- a/contracts/protocol/contracts/protocol/Exchange/mixins/MAssetProxyDispatcher.sol
+++ b/contracts/protocol/contracts/protocol/Exchange/mixins/MAssetProxyDispatcher.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "@0x/contracts-interfaces/contracts/protocol/Exchange/IAssetProxyDispatcher.sol";
 

--- a/contracts/protocol/contracts/protocol/Exchange/mixins/MExchangeCore.sol
+++ b/contracts/protocol/contracts/protocol/Exchange/mixins/MExchangeCore.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 pragma experimental ABIEncoderV2;
 
 import "@0x/contracts-libs/contracts/libs/LibOrder.sol";

--- a/contracts/protocol/contracts/protocol/Exchange/mixins/MMatchOrders.sol
+++ b/contracts/protocol/contracts/protocol/Exchange/mixins/MMatchOrders.sol
@@ -15,7 +15,7 @@
   limitations under the License.
 
 */
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 pragma experimental ABIEncoderV2;
 
 import "@0x/contracts-libs/contracts/libs/LibOrder.sol";

--- a/contracts/protocol/contracts/protocol/Exchange/mixins/MSignatureValidator.sol
+++ b/contracts/protocol/contracts/protocol/Exchange/mixins/MSignatureValidator.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "@0x/contracts-interfaces/contracts/protocol/Exchange/ISignatureValidator.sol";
 

--- a/contracts/protocol/contracts/protocol/Exchange/mixins/MTransactions.sol
+++ b/contracts/protocol/contracts/protocol/Exchange/mixins/MTransactions.sol
@@ -15,7 +15,7 @@
   limitations under the License.
 
 */
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "@0x/contracts-interfaces/contracts/protocol/Exchange/ITransactions.sol";
 

--- a/contracts/protocol/contracts/protocol/Exchange/mixins/MWrapperFunctions.sol
+++ b/contracts/protocol/contracts/protocol/Exchange/mixins/MWrapperFunctions.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 pragma experimental ABIEncoderV2;
 
 import "@0x/contracts-libs/contracts/libs/LibOrder.sol";

--- a/contracts/tokens/contracts/tokens/ERC20Token/ERC20Token.sol
+++ b/contracts/tokens/contracts/tokens/ERC20Token/ERC20Token.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "./IERC20Token.sol";
 

--- a/contracts/tokens/contracts/tokens/ERC20Token/IERC20Token.sol
+++ b/contracts/tokens/contracts/tokens/ERC20Token/IERC20Token.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 contract IERC20Token {

--- a/contracts/tokens/contracts/tokens/ERC20Token/MintableERC20Token.sol
+++ b/contracts/tokens/contracts/tokens/ERC20Token/MintableERC20Token.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "@0x/contracts-utils/contracts/utils/SafeMath/SafeMath.sol";
 import "./UnlimitedAllowanceERC20Token.sol";

--- a/contracts/tokens/contracts/tokens/ERC20Token/UnlimitedAllowanceERC20Token.sol
+++ b/contracts/tokens/contracts/tokens/ERC20Token/UnlimitedAllowanceERC20Token.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "../ERC20Token/ERC20Token.sol";
 

--- a/contracts/tokens/contracts/tokens/ERC721Token/ERC721Token.sol
+++ b/contracts/tokens/contracts/tokens/ERC721Token/ERC721Token.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "./IERC721Token.sol";
 import "./IERC721Receiver.sol";

--- a/contracts/tokens/contracts/tokens/ERC721Token/IERC721Receiver.sol
+++ b/contracts/tokens/contracts/tokens/ERC721Token/IERC721Receiver.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 contract IERC721Receiver {

--- a/contracts/tokens/contracts/tokens/ERC721Token/IERC721Token.sol
+++ b/contracts/tokens/contracts/tokens/ERC721Token/IERC721Token.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 contract IERC721Token {

--- a/contracts/tokens/contracts/tokens/ERC721Token/MintableERC721Token.sol
+++ b/contracts/tokens/contracts/tokens/ERC721Token/MintableERC721Token.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "./ERC721Token.sol";
 

--- a/contracts/tokens/contracts/tokens/EtherToken/IEtherToken.sol
+++ b/contracts/tokens/contracts/tokens/EtherToken/IEtherToken.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "../ERC20Token/IERC20Token.sol";
 

--- a/contracts/utils/contracts/utils/LibBytes/LibBytes.sol
+++ b/contracts/utils/contracts/utils/LibBytes/LibBytes.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 library LibBytes {

--- a/contracts/utils/contracts/utils/Ownable/IOwnable.sol
+++ b/contracts/utils/contracts/utils/Ownable/IOwnable.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 contract IOwnable {

--- a/contracts/utils/contracts/utils/Ownable/Ownable.sol
+++ b/contracts/utils/contracts/utils/Ownable/Ownable.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "./IOwnable.sol";
 

--- a/contracts/utils/contracts/utils/ReentrancyGuard/ReentrancyGuard.sol
+++ b/contracts/utils/contracts/utils/ReentrancyGuard/ReentrancyGuard.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 contract ReentrancyGuard {

--- a/contracts/utils/contracts/utils/SafeMath/SafeMath.sol
+++ b/contracts/utils/contracts/utils/SafeMath/SafeMath.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 contract SafeMath {


### PR DESCRIPTION
## Description

This PR unfixes all Solidity compiler versions _except_ for the top level contracts (i.e the contracts that are actually deployed). This is done so that all of the inherited contracts can be used in codebases with higher Solidity versions, which should be helpful for us and external devs going forward.

CC @Recmo @hysz @LogvinovLeon. Let's use this same pattern going forward. It doesn't seem like there's any easy way to add this rule to the linter unfortunately.

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefix PR title with `[WIP]` if necessary.
*   [ ] Add tests to cover changes as needed.
*   [ ] Update documentation as needed.
*   [ ] Add new entries to the relevant CHANGELOG.jsons.
