### PR TITLE
Add the solidity prettier plugin

### DIFF
--- a/contracts/.prettierrc
+++ b/contracts/.prettierrc
@@ -1,0 +1,6 @@
+{
+    "tabWidth": 4,
+    "printWidth": 80,
+    "trailingComma": all,
+    "singleQuote": true
+}

--- a/contracts/examples/contracts/ExchangeWrapper/ExchangeWrapper.sol
+++ b/contracts/examples/contracts/ExchangeWrapper/ExchangeWrapper.sol
@@ -22,16 +22,12 @@ pragma experimental ABIEncoderV2;
 import "@0x/contracts-interfaces/contracts/protocol/Exchange/IExchange.sol";
 import "@0x/contracts-libs/contracts/libs/LibOrder.sol";
 
-
 contract ExchangeWrapper {
-
     // Exchange contract.
     // solhint-disable-next-line var-name-mixedcase
     IExchange internal EXCHANGE;
 
-    constructor (address _exchange)
-        public
-    {
+    constructor(address _exchange) public {
         EXCHANGE = IExchange(_exchange);
     }
 
@@ -44,9 +40,7 @@ contract ExchangeWrapper {
         uint256 targetOrderEpoch,
         uint256 salt,
         bytes makerSignature
-    )
-        external
-    {
+    ) external {
         address makerAddress = msg.sender;
 
         // Encode arguments into byte array.
@@ -56,12 +50,7 @@ contract ExchangeWrapper {
         );
 
         // Call `cancelOrdersUpTo` via `executeTransaction`.
-        EXCHANGE.executeTransaction(
-            salt,
-            makerAddress,
-            data,
-            makerSignature
-        );
+        EXCHANGE.executeTransaction(salt, makerAddress, data, makerSignature);
     }
 
     /// @dev Fills an order using `msg.sender` as the taker.
@@ -76,9 +65,7 @@ contract ExchangeWrapper {
         uint256 salt,
         bytes memory orderSignature,
         bytes memory takerSignature
-    )
-        public
-    {
+    ) public {
         address takerAddress = msg.sender;
 
         // Encode arguments into byte array.
@@ -90,11 +77,6 @@ contract ExchangeWrapper {
         );
 
         // Call `fillOrder` via `executeTransaction`.
-        EXCHANGE.executeTransaction(
-            salt,
-            takerAddress,
-            data,
-            takerSignature
-        );
+        EXCHANGE.executeTransaction(salt, takerAddress, data, takerSignature);
     }
 }

--- a/contracts/examples/contracts/Validator/Validator.sol
+++ b/contracts/examples/contracts/Validator/Validator.sol
@@ -20,18 +20,14 @@ pragma solidity 0.4.24;
 
 import "@0x/contracts-interfaces/contracts/protocol/Exchange/IValidator.sol";
 
-
-contract Validator is 
-    IValidator
-{
-
+contract Validator is IValidator {
     // The single valid signer for this wallet.
     // solhint-disable-next-line var-name-mixedcase
     address internal VALID_SIGNER;
 
     /// @dev constructs a new `Validator` with a single valid signer.
     /// @param validSigner The sole, valid signer.
-    constructor (address validSigner) public {
+    constructor(address validSigner) public {
         VALID_SIGNER = validSigner;
     }
 
@@ -45,11 +41,7 @@ contract Validator is
         bytes32 hash,
         address signerAddress,
         bytes signature
-    )
-        external
-        view
-        returns (bool isValid)
-    {
+    ) external view returns (bool isValid) {
         return (signerAddress == VALID_SIGNER);
     }
     // solhint-enable no-unused-vars

--- a/contracts/examples/contracts/Wallet/Wallet.sol
+++ b/contracts/examples/contracts/Wallet/Wallet.sol
@@ -21,10 +21,7 @@ pragma solidity 0.4.24;
 import "@0x/contracts-interfaces/contracts/protocol/Exchange/IWallet.sol";
 import "@0x/contracts-utils/contracts/utils/LibBytes/LibBytes.sol";
 
-
-contract Wallet is 
-    IWallet
-{
+contract Wallet is IWallet {
     using LibBytes for bytes;
 
     // The owner of this wallet.
@@ -33,7 +30,7 @@ contract Wallet is
 
     /// @dev constructs a new `Wallet` with a single owner.
     /// @param walletOwner The owner of this wallet.
-    constructor (address walletOwner) public {
+    constructor(address walletOwner) public {
         WALLET_OWNER = walletOwner;
     }
 
@@ -42,18 +39,12 @@ contract Wallet is
     /// @param hash Message hash that is signed.
     /// @param eip712Signature Proof of signing.
     /// @return Validity of signature.
-    function isValidSignature(
-        bytes32 hash,
-        bytes eip712Signature
-    )
+    function isValidSignature(bytes32 hash, bytes eip712Signature)
         external
         view
         returns (bool isValid)
     {
-        require(
-            eip712Signature.length == 65,
-            "LENGTH_65_REQUIRED"
-        );
+        require(eip712Signature.length == 65, "LENGTH_65_REQUIRED");
 
         uint8 v = uint8(eip712Signature[0]);
         bytes32 r = eip712Signature.readBytes32(1);

--- a/contracts/examples/contracts/Whitelist/Whitelist.sol
+++ b/contracts/examples/contracts/Whitelist/Whitelist.sol
@@ -23,13 +23,9 @@ import "@0x/contracts-interfaces/contracts/protocol/Exchange/IExchange.sol";
 import "@0x/contracts-libs/contracts/libs/LibOrder.sol";
 import "@0x/contracts-utils/contracts/utils/Ownable/Ownable.sol";
 
-
-contract Whitelist is
-    Ownable
-{
-
+contract Whitelist is Ownable {
     // Mapping of address => whitelist status.
-    mapping (address => bool) public isWhitelisted;
+    mapping(address => bool) public isWhitelisted;
 
     // Exchange contract.
     // solhint-disable var-name-mixedcase
@@ -37,22 +33,20 @@ contract Whitelist is
     bytes internal TX_ORIGIN_SIGNATURE;
     // solhint-enable var-name-mixedcase
 
-    byte constant internal VALIDATOR_SIGNATURE_BYTE = "\x05";
+    byte internal constant VALIDATOR_SIGNATURE_BYTE = "\x05";
 
-    constructor (address _exchange)
-        public
-    {
+    constructor(address _exchange) public {
         EXCHANGE = IExchange(_exchange);
-        TX_ORIGIN_SIGNATURE = abi.encodePacked(address(this), VALIDATOR_SIGNATURE_BYTE);
+        TX_ORIGIN_SIGNATURE = abi.encodePacked(
+            address(this),
+            VALIDATOR_SIGNATURE_BYTE
+        );
     }
 
     /// @dev Adds or removes an address from the whitelist.
     /// @param target Address to add or remove from whitelist.
     /// @param isApproved Whitelist status to assign to address.
-    function updateWhitelistStatus(
-        address target,
-        bool isApproved
-    )
+    function updateWhitelistStatus(address target, bool isApproved)
         external
         onlyOwner
     {
@@ -70,11 +64,7 @@ contract Whitelist is
         bytes32 hash,
         address signerAddress,
         bytes signature
-    )
-        external
-        view
-        returns (bool isValid)
-    {
+    ) external view returns (bool isValid) {
         // solhint-disable-next-line avoid-tx-origin
         return signerAddress == tx.origin;
     }
@@ -93,9 +83,7 @@ contract Whitelist is
         uint256 takerAssetFillAmount,
         uint256 salt,
         bytes memory orderSignature
-    )
-        public
-    {
+    ) public {
         address takerAddress = msg.sender;
 
         // This contract must be the entry point for the transaction.
@@ -106,16 +94,10 @@ contract Whitelist is
         );
 
         // Check if maker is on the whitelist.
-        require(
-            isWhitelisted[order.makerAddress],
-            "MAKER_NOT_WHITELISTED"
-        );
+        require(isWhitelisted[order.makerAddress], "MAKER_NOT_WHITELISTED");
 
         // Check if taker is on the whitelist.
-        require(
-            isWhitelisted[takerAddress],
-            "TAKER_NOT_WHITELISTED"
-        );
+        require(isWhitelisted[takerAddress], "TAKER_NOT_WHITELISTED");
 
         // Encode arguments into byte array.
         bytes memory data = abi.encodeWithSelector(

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "ganache": "ganache-cli -p 8545 --gasLimit 10000000 --networkId 50 -m \"${npm_package_config_mnemonic}\"",
         "prettier": "prettier --write '**/*.{ts,tsx,json,md}' --config .prettierrc",
         "prettier:ci": "prettier --list-different '**/*.{ts,tsx,json,md}' --config .prettierrc",
+        "prettier:contracts": "prettier --write 'contracts/examples/**/*.sol' --config contracts/.prettierrc",
         "report_coverage": "lcov-result-merger './{packages/*/coverage/lcov.info,python-packages/*/.coverage}' | coveralls",
         "test:installation": "node ./packages/monorepo-scripts/lib/test_installation.js",
         "test:installation:local": "IS_LOCAL_PUBLISH=true node ./packages/monorepo-scripts/lib/test_installation.js",
@@ -73,6 +74,7 @@
         "lerna": "^3.0.0-beta.25",
         "npm-run-all": "^4.1.2",
         "prettier": "^1.11.1",
+        "prettier-plugin-solidity": "^1.0.0-alpha.16",
         "source-map-support": "^0.5.6",
         "typescript": "3.0.1",
         "wsrun": "^2.2.0"


### PR DESCRIPTION
See #1486.

This PR adds the solidity plugin for prettier and applies it to some of the contracts. Since there are several differences between the plugin's output and what there was already here, I only updated the contracts under `contracts/examples`; otherwise the number of changes would've been huge.

The plugin is still in development, so any feedback is welcome!