### PR TITLE
[utils] account for undefined errors in promisify, not only null (and fix instant in Opera)

### DIFF
--- a/packages/utils/CHANGELOG.json
+++ b/packages/utils/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "3.0.0",
+        "changes": [
+            {
+                "note": "Make `promisify` resolve when the callback error is undefined.",
+                "pr": 1501
+            }
+        ]
+    },
+    {
         "version": "2.1.1",
         "changes": [
             {

--- a/packages/utils/src/promisify.ts
+++ b/packages/utils/src/promisify.ts
@@ -10,7 +10,7 @@ export function promisify<T>(originalFn: (...args: any[]) => void, thisArg?: any
     const promisifiedFunction = async (...callArgs: any[]): Promise<T> => {
         return new Promise<T>((resolve, reject) => {
             const callback = (err: Error | null, data?: T) => {
-                _.isNull(err) ? resolve(data) : reject(err);
+                _.isNull(err) || _.isUndefined(err) ? resolve(data) : reject(err);
             };
             originalFn.apply(thisArg, [...callArgs, callback]);
         });


### PR DESCRIPTION
## Description

The provider injected by the Android opera browser has a `sendAsync` method that returns (undefined, result) instead of (null, result). This was tripping up the code in this diff and breaking instant in Opera.

Strictly speaking, this is a breaking change so I changed the version to 3.0.0, but I think keeping it as v2 would also be acceptable. 

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [ ] Prefix PR title with `[WIP]` if necessary.
*   [ ] Add tests to cover changes as needed.
*   [ ] Update documentation as needed.
*   [ ] Add new entries to the relevant CHANGELOG.jsons.
