### PR TITLE
upgrade to ddex api v3

### DIFF
--- a/packages/pipeline/migrations/1547153875669-UpdateDDexAPIToV3.ts
+++ b/packages/pipeline/migrations/1547153875669-UpdateDDexAPIToV3.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UpdateDDexAPIToV31547153875669 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`
+        UPDATE raw.token_orderbook_snapshots
+        SET quote_asset_symbol='WETH'
+        WHERE quote_asset_symbol='ETH' AND
+        source='ddex';
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`
+        UPDATE raw.token_orderbook_snapshots
+        SET quote_asset_symbol='ETH'
+        WHERE quote_asset_symbol='WETH' AND
+        source='ddex';
+        `);
+    }
+}

--- a/packages/pipeline/src/data_sources/ddex/index.ts
+++ b/packages/pipeline/src/data_sources/ddex/index.ts
@@ -1,6 +1,6 @@
 import { fetchAsync, logUtils } from '@0x/utils';
 
-const DDEX_BASE_URL = 'https://api.ddex.io/v2';
+const DDEX_BASE_URL = 'https://api.ddex.io/v3';
 const ACTIVE_MARKETS_URL = `${DDEX_BASE_URL}/markets`;
 const NO_AGGREGATION_LEVEL = 3; // See https://docs.ddex.io/#get-orderbook
 const ORDERBOOK_ENDPOINT = `/orderbook?level=${NO_AGGREGATION_LEVEL}`;
@@ -23,7 +23,6 @@ export interface DdexMarket {
     baseTokenDecimals: number;
     baseTokenAddress: string;
     minOrderSize: string;
-    maxOrderSize: string;
     pricePrecision: number;
     priceDecimals: number;
     amountDecimals: number;

--- a/packages/pipeline/src/parsers/ddex_orders/index.ts
+++ b/packages/pipeline/src/parsers/ddex_orders/index.ts
@@ -58,14 +58,12 @@ export function parseDdexOrder(
     tokenOrder.orderType = orderType;
     tokenOrder.price = price;
 
-    // ddex currently confuses quote and base assets.
-    // We switch them here to maintain our internal consistency.
-    tokenOrder.baseAssetSymbol = ddexMarket.quoteToken;
-    tokenOrder.baseAssetAddress = ddexMarket.quoteTokenAddress;
+    tokenOrder.baseAssetSymbol = ddexMarket.baseToken;
+    tokenOrder.baseAssetAddress = ddexMarket.baseTokenAddress;
     tokenOrder.baseVolume = amount;
 
-    tokenOrder.quoteAssetSymbol = ddexMarket.baseToken;
-    tokenOrder.quoteAssetAddress = ddexMarket.baseTokenAddress;
+    tokenOrder.quoteAssetSymbol = ddexMarket.quoteToken;
+    tokenOrder.quoteAssetAddress = ddexMarket.quoteTokenAddress;
     tokenOrder.quoteVolume = price.times(amount);
     return tokenOrder;
 }

--- a/packages/pipeline/test/parsers/ddex_orders/index_test.ts
+++ b/packages/pipeline/test/parsers/ddex_orders/index_test.ts
@@ -25,7 +25,6 @@ describe('ddex_orders', () => {
                 baseTokenDecimals: 2,
                 baseTokenAddress: '0xb45df06e38540a675fdb5b598abf2c0dbe9d6b81',
                 minOrderSize: '0.1',
-                maxOrderSize: '1000',
                 pricePrecision: 1,
                 priceDecimals: 1,
                 amountDecimals: 0,
@@ -39,14 +38,12 @@ describe('ddex_orders', () => {
             expected.observedTimestamp = observedTimestamp;
             expected.orderType = OrderType.Bid;
             expected.price = new BigNumber(0.5);
-            // ddex currently confuses base and quote assets.
-            // Switch them to maintain our internal consistency.
-            expected.baseAssetSymbol = 'ABC';
-            expected.baseAssetAddress = '0x0000000000000000000000000000000000000000';
-            expected.baseVolume = new BigNumber(10);
-            expected.quoteAssetSymbol = 'DEF';
-            expected.quoteAssetAddress = '0xb45df06e38540a675fdb5b598abf2c0dbe9d6b81';
+            expected.quoteAssetSymbol = 'ABC';
+            expected.quoteAssetAddress = '0x0000000000000000000000000000000000000000';
             expected.quoteVolume = new BigNumber(5);
+            expected.baseAssetSymbol = 'DEF';
+            expected.baseAssetAddress = '0xb45df06e38540a675fdb5b598abf2c0dbe9d6b81';
+            expected.baseVolume = new BigNumber(10);
 
             const actual = parseDdexOrder(ddexMarket, observedTimestamp, orderType, source, ddexOrder);
             expect(actual).deep.equal(expected);


### PR DESCRIPTION
## Description

DDex script breaking because v2 no longer supported. Upgraded to v3. 
[Changelog](https://docs.ddex.io/#changelog)
Relevant:
* switched base and quote tokens
* removed maxOrderSize

Please review and confirm that `tokenOrder.baseVolume` and `tokenOrder.quoteVolume` are calculated correctly here.

## Testing instructions

`yarn test`

or

`yarn build && node lib/src/scripts/pull_ddex_orderbook_snapshots.js`

<img width="940" alt="screen shot 2019-01-10 at 12 05 04 pm" src="https://user-images.githubusercontent.com/8582774/50994040-04ee7400-14d0-11e9-8707-649cd3ab5c19.png">


## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [x] Prefix PR title with `[WIP]` if necessary.
*   [x] Add tests to cover changes as needed.
*   [x] Update documentation as needed.
*   [x] Add new entries to the relevant CHANGELOG.jsons.
