### PR TITLE
Remove optimization from matchOrdersAsync in Exchange wrapper

### DIFF
--- a/packages/contract-wrappers/CHANGELOG.json
+++ b/packages/contract-wrappers/CHANGELOG.json
@@ -7,7 +7,7 @@
                 "pr": 1474
             },
             {
-                "note": "Prevent Exchange `matchOrdersAsync` input parameters being modified",
+                "note": "Remove Exchange `matchOrdersAsync` optimization",
                 "pr": 1514
             }
         ]

--- a/packages/contract-wrappers/src/contract_wrappers/exchange_wrapper.ts
+++ b/packages/contract-wrappers/src/contract_wrappers/exchange_wrapper.ts
@@ -744,19 +744,13 @@ export class ExchangeWrapper extends ContractWrapper {
         ) {
             throw new Error(ExchangeWrapperError.AssetDataMismatch);
         }
-        // Smart contracts assigns the asset data from the left order to the right one so we can save gas on reducing the size of call data
-        const optimizedRightSignedOrder = {
-            ...rightSignedOrder,
-            makerAssetData: '0x',
-            takerAssetData: '0x',
-        };
         const exchangeInstance = await this._getExchangeContractAsync();
         if (orderTransactionOpts.shouldValidate) {
             await exchangeInstance.matchOrders.callAsync(
                 leftSignedOrder,
-                optimizedRightSignedOrder,
+                rightSignedOrder,
                 leftSignedOrder.signature,
-                optimizedRightSignedOrder.signature,
+                rightSignedOrder.signature,
                 {
                     from: normalizedTakerAddress,
                     gas: orderTransactionOpts.gasLimit,
@@ -767,9 +761,9 @@ export class ExchangeWrapper extends ContractWrapper {
         }
         const txHash = await exchangeInstance.matchOrders.sendTransactionAsync(
             leftSignedOrder,
-            optimizedRightSignedOrder,
+            rightSignedOrder,
             leftSignedOrder.signature,
-            optimizedRightSignedOrder.signature,
+            rightSignedOrder.signature,
             {
                 from: normalizedTakerAddress,
                 gas: orderTransactionOpts.gasLimit,


### PR DESCRIPTION
## Description

`matchOrdersAsync` would modify the `rightOrder` object passed in. Subsequent uses of this object would result in unexpected behaviour (invalid signature, different orderHash, different orderInfo).

```typescript
await contractWrappers.exchange.matchOrdersAsync(leftSignedOrder, rightSignedOrder,  matcherAccount);
// rightSignedOrder now has maker/takerAssetData = '0x'
await contractWrappers.exchange.getOrderInfoAsync(rightSignedOrder);
// FILLABLE, 0 since the order hash now differs
```

With the new ABI Encoder we use internally this optimisation is no longer required as the rightOrder will contain a pointer to the leftOrder assetData.

Thanks @arikan for pointing this out.
<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
