### PR TITLE
[fix] allow devnet rpc to listen on any vhost

### DIFF
--- a/packages/devnet/run.sh
+++ b/packages/devnet/run.sh
@@ -15,6 +15,7 @@ mkdir -p /var/log
     --rpc \
     --rpcaddr '0.0.0.0' \
     --rpcport 8501 \
+    --rpcvhosts '*' \
     --rpcapi 'personal,db,eth,net,web3,txpool,miner,debug' \
     --networkid 50 \
     --gasprice '2000000000' \


### PR DESCRIPTION


## Description

<!--- Describe your changes in detail -->
[this only affects the devnet docker image]

geth's default value for `--rpcvhosts` is `localhost`, which does not work when trying to use the devnet in certain environments such as `docker-compose` or `gitlab-ci`

See [geth's CLI wiki](https://github.com/ethereum/go-ethereum/wiki/Command-Line-Options) for the official documentation on `--rpcvhosts`.
## Testing instructions

Build the docker image locally, and then use/connect to it in a `docker-compose` environment where the vhost of the devnet is *not* localhost.

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Add new entries to the relevant CHANGELOG.jsons.
