### PR TITLE
[asset-buyer] Fix test (assetData string)

### DIFF
--- a/packages/asset-buyer/src/asset_buyer.ts
+++ b/packages/asset-buyer/src/asset_buyer.ts
@@ -193,6 +193,7 @@ export class AssetBuyer {
     ): Promise<LiquidityForAssetData> {
         const shouldForceOrderRefresh =
             options.shouldForceOrderRefresh !== undefined ? options.shouldForceOrderRefresh : false;
+        assert.isString('assetData', assetData);
         assetDataUtils.decodeAssetDataOrThrow(assetData);
         assert.isBoolean('options.shouldForceOrderRefresh', shouldForceOrderRefresh);
 


### PR DESCRIPTION
## Description

Per suggestion in PR ( https://github.com/0xProject/0x-monorepo/pull/1512#discussion_r248506087 ), I called `validateAssetDataOrThrow` to validate an assetData parameter, instead of just doing a `assert.isString('assetData', assetData);`.

But -- `validateAssetDataOrThrow` expects the input to be a string -- it calls `.slice` on it.  The test I had was sending in `false` and the code was throwing when it tried to call `.split`.  

So, now we ensure it's a string before we call the `validateAssetDataOrThrow`

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
