### PR TITLE
Fix hang in Python CI test runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,7 +201,7 @@ jobs:
         steps:
             - checkout
             - run: sudo chown -R circleci:circleci /usr/local/bin
-            - run: sudo chown -R circleci:circleci /usr/local/lib/python3.7/site-packages
+            - run: sudo chown -R circleci:circleci /usr/local/lib/python3.7
             - restore_cache:
                   key: deps9-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
             - run:
@@ -249,7 +249,7 @@ jobs:
         steps:
             - checkout
             - run: sudo chown -R circleci:circleci /usr/local/bin
-            - run: sudo chown -R circleci:circleci /usr/local/lib/python3.7/site-packages
+            - run: sudo chown -R circleci:circleci /usr/local/lib/python3.7
             - restore_cache:
                   key: deps9-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
             - run:
@@ -277,7 +277,7 @@ jobs:
         steps:
             - checkout
             - run: sudo chown -R circleci:circleci /usr/local/bin
-            - run: sudo chown -R circleci:circleci /usr/local/lib/python3.7/site-packages
+            - run: sudo chown -R circleci:circleci /usr/local/lib/python3.7
             - restore_cache:
                   key: deps9-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
             - run:


### PR DESCRIPTION
## Description

Runs of `static-tests-python` were hanging in CircleCI, as reported by @LogvinovLeon and @xianny, with the final output looking like this:

```
Successfully built 0x-contract-addresses
Installing collected packages: 0x-contract-addresses
  Found existing installation: 0x-contract-addresses 2.0.0
    Uninstalling 0x-contract-addresses-2.0.0:
```

I ssh'd to the CI machine, and reproduced the hang at the terminal.  Interestingly, when I got impatient and hit Ctrl+C to get my prompt back, I got a relevant error traceback:

```    Uninstalling 0x-contract-addresses-2.0.0:
^CCleaning up...
Removed build tracker '/tmp/pip-req-tracker-oqtgj3rz'
Operation cancelled by user
Exception information:
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/pip/_internal/utils/temp_dir.py", line 130, in create
    os.mkdir(path)
PermissionError: [Errno 13] Permission denied: '/usr/local/lib/python3.7/.%44488ckages'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/pip/_internal/cli/base_command.py", line 176, in main
    status = self.run(options, args)
  File "/usr/local/lib/python3.7/site-packages/pip/_internal/commands/install.py", line 393, in run
    use_user_site=options.use_user_site,
  File "/usr/local/lib/python3.7/site-packages/pip/_internal/req/__init__.py", line 50, in install_given_reqs
    auto_confirm=True
  File "/usr/local/lib/python3.7/site-packages/pip/_internal/req/req_install.py", line 823, in uninstall
    uninstalled_pathset.remove(auto_confirm, verbose)
  File "/usr/local/lib/python3.7/site-packages/pip/_internal/req/req_uninstall.py", line 265, in remove
    new_path = self._stash(path)
  File "/usr/local/lib/python3.7/site-packages/pip/_internal/req/req_uninstall.py", line 242, in _stash
    best.create()
  File "/usr/local/lib/python3.7/site-packages/pip/_internal/utils/temp_dir.py", line 130, in create
    os.mkdir(path)
KeyboardInterrupt
```

I know that existing pip installation processes had required us to `chown -R circleci:circleci /usr/local/lib/python3.7/site-packages`, to facilitate package installations, so I went ahead and expanded that to one level higher (just `python3.7`) and the problem went away.

## Testing instructions

CI

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Prefix PR title with `[WIP]` if necessary.
-   [x] Add tests to cover changes as needed.
-   [x] Update documentation as needed.
-   [x] Add new entries to the relevant CHANGELOG.jsons.
