### PR TITLE
Use correct "orderValidator" address in OrderValidatorWrapper constructor

### DIFF
--- a/packages/contract-wrappers/CHANGELOG.json
+++ b/packages/contract-wrappers/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "6.0.1",
+        "changes": [
+            {
+                "note": "Fix OrderValidatorWrapper constructor to use the correct address",
+                "pr": 1568
+            }
+        ]
+    },
+    {
         "version": "6.0.0",
         "changes": [
             {

--- a/packages/contract-wrappers/src/contract_wrappers/order_validator_wrapper.ts
+++ b/packages/contract-wrappers/src/contract_wrappers/order_validator_wrapper.ts
@@ -29,7 +29,7 @@ export class OrderValidatorWrapper extends ContractWrapper {
      */
     constructor(web3Wrapper: Web3Wrapper, networkId: number, address?: string) {
         super(web3Wrapper, networkId);
-        this.address = _.isUndefined(address) ? _getDefaultContractAddresses(networkId).exchange : address;
+        this.address = _.isUndefined(address) ? _getDefaultContractAddresses(networkId).orderValidator : address;
     }
     /**
      * Get an object conforming to OrderAndTraderInfo containing on-chain information of the provided order and address


### PR DESCRIPTION
## Description

`OrderValidatorWrapper` constructor defaults to the `exchange` address instead of the correct `orderValidator` address

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Prefix PR title with `[WIP]` if necessary.
-   [x] Add tests to cover changes as needed.
-   [x] Update documentation as needed.
-   [x] Add new entries to the relevant CHANGELOG.jsons.
