### PR TITLE
Hook eth_sendRawTransaction in addition to eth_sendTransaction

### DIFF
--- a/packages/sol-tracing-utils/package.json
+++ b/packages/sol-tracing-utils/package.json
@@ -52,6 +52,7 @@
         "@types/solidity-parser-antlr": "^0.2.0",
         "ethereum-types": "^1.1.6",
         "ethereumjs-util": "^5.1.1",
+        "ethers": "~4.0.4",
         "glob": "^7.1.2",
         "chalk": "^2.3.0",
         "istanbul": "^0.4.5",

--- a/packages/sol-tracing-utils/src/trace_collection_subprovider.ts
+++ b/packages/sol-tracing-utils/src/trace_collection_subprovider.ts
@@ -3,6 +3,7 @@ import { Callback, ErrorCallback, NextCallback, Subprovider } from '@0x/subprovi
 import { logUtils } from '@0x/utils';
 import { CallDataRPC, marshaller, Web3Wrapper } from '@0x/web3-wrapper';
 import { JSONRPCRequestPayload, Provider, TxData } from 'ethereum-types';
+import { utils } from 'ethers';
 import * as _ from 'lodash';
 import { Lock } from 'semaphore-async-await';
 
@@ -92,6 +93,18 @@ export abstract class TraceCollectionSubprovider extends Subprovider {
                         next();
                     } else {
                         const txData = payload.params[0];
+                        next(logAsyncErrors(this._onTransactionSentAsync.bind(this, txData)));
+                    }
+                    return;
+
+                case 'eth_sendRawTransaction':
+                    if (!this._config.shouldCollectTransactionTraces) {
+                        next();
+                    } else {
+                        const txData = utils.parseTransaction(payload.params[0]);
+                        if (txData.to === null) {
+                            txData.to = constants.NEW_CONTRACT;
+                        }
                         next(logAsyncErrors(this._onTransactionSentAsync.bind(this, txData)));
                     }
                     return;


### PR DESCRIPTION
## Description

`TraceCollectionSubprovider` currently traces calls to `eth_sendTransaction`, `eth_call`, and `eth_estimateGas`. This change adds `eth_sendRawTransaction` to that list.

Background:

I was trying out sol-coverage on a new project and the first time I tried it, sol-coverage reported that none of my statements were covered. I looked into it and discovered that it was because my tests were sending all of their transactions with `eth_sendRawTransaction`, which `TraceCollectionSubprovider` wasn't tracing. After making the change in this PR (and the change in 0xProject/0x-monorepo#1583) , my coverage report is as I expected.

## Testing instructions

I don't have an easy-to-reproduce test case prepared. I didn't see existing tests that covered the previous hooks, so it seemed like quite a bit of marginal work to create a test for this. Let me know if that's a blocker.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature (non-breaking change which adds functionality)

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
