### PR TITLE
Add migration to fix exchange events primary keys

### DIFF
--- a/packages/pipeline/migrations/1549479172800-AddTxHashToExchangeEventPrimaryKey.ts
+++ b/packages/pipeline/migrations/1549479172800-AddTxHashToExchangeEventPrimaryKey.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+const tableNames = ['exchange_cancel_events', 'exchange_cancel_up_to_events', 'exchange_fill_events'];
+
+const oldPrimaryColumns = ['contract_address', 'log_index', 'block_number'];
+
+const newPrimaryColumns = ['transaction_hash'];
+
+async function updatePrimaryKeysAsync(queryRunner: QueryRunner, columnNames: string[]): Promise<void> {
+    for (const tableName of tableNames) {
+        const table = await queryRunner.getTable(`raw.${tableName}`);
+        if (table === undefined) {
+            throw new Error(`Couldn't get table 'raw.${tableName}'`);
+        }
+        const columns = [];
+        for (const columnName of columnNames) {
+            const column = table.findColumnByName(columnName);
+            if (column === undefined) {
+                throw new Error(`Couldn't get column '${columnName}' from table 'raw.${tableName}'`);
+            }
+            columns.push(column);
+        }
+        await queryRunner.updatePrimaryKeys(table, columns);
+    }
+}
+
+export class AddTxHashToExchangeEventPrimaryKey1549479172800 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await updatePrimaryKeysAsync(queryRunner, oldPrimaryColumns.concat(newPrimaryColumns));
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await updatePrimaryKeysAsync(queryRunner, oldPrimaryColumns);
+    }
+}

--- a/packages/pipeline/migrations/1549499426238-AddTxHashToERC20ApprovalEventPrimaryKey.ts
+++ b/packages/pipeline/migrations/1549499426238-AddTxHashToERC20ApprovalEventPrimaryKey.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+const oldPrimaryColumns = ['token_address', 'log_index', 'block_number'];
+
+const newPrimaryColumns = ['transaction_hash'];
+
+async function updatePrimaryKeysAsync(queryRunner: QueryRunner, columnNames: string[]): Promise<void> {
+    const table = await queryRunner.getTable(`raw.erc20_approval_events`);
+    if (table === undefined) {
+        throw new Error(`Couldn't get table 'raw.erc20_approval_events'`);
+    }
+    const columns = [];
+    for (const columnName of columnNames) {
+        const column = table.findColumnByName(columnName);
+        if (column === undefined) {
+            throw new Error(`Couldn't get column '${columnName}' from table 'raw.erc20_approval_events'`);
+        }
+        columns.push(column);
+    }
+    await queryRunner.updatePrimaryKeys(table, columns);
+}
+
+export class AddTxHashToERC20ApprovalEventPrimaryKey1549499426238 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await updatePrimaryKeysAsync(queryRunner, oldPrimaryColumns.concat(newPrimaryColumns));
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await updatePrimaryKeysAsync(queryRunner, oldPrimaryColumns);
+    }
+}

--- a/packages/pipeline/src/entities/erc20_approval_event.ts
+++ b/packages/pipeline/src/entities/erc20_approval_event.ts
@@ -15,7 +15,7 @@ export class ERC20ApprovalEvent {
     @Column({ name: 'raw_data' })
     public rawData!: string;
 
-    @Column({ name: 'transaction_hash' })
+    @PrimaryColumn({ name: 'transaction_hash' })
     public transactionHash!: string;
     @Column({ name: 'owner_address' })
     public ownerAddress!: string;

--- a/packages/pipeline/src/entities/exchange_cancel_event.ts
+++ b/packages/pipeline/src/entities/exchange_cancel_event.ts
@@ -15,7 +15,7 @@ export class ExchangeCancelEvent {
     @Column({ name: 'raw_data' })
     public rawData!: string;
 
-    @Column({ name: 'transaction_hash' })
+    @PrimaryColumn({ name: 'transaction_hash' })
     public transactionHash!: string;
     @Column({ name: 'maker_address' })
     public makerAddress!: string;

--- a/packages/pipeline/src/entities/exchange_cancel_up_to_event.ts
+++ b/packages/pipeline/src/entities/exchange_cancel_up_to_event.ts
@@ -15,7 +15,7 @@ export class ExchangeCancelUpToEvent {
     @Column({ name: 'raw_data' })
     public rawData!: string;
 
-    @Column({ name: 'transaction_hash' })
+    @PrimaryColumn({ name: 'transaction_hash' })
     public transactionHash!: string;
     @Column({ name: 'maker_address' })
     public makerAddress!: string;

--- a/packages/pipeline/src/entities/exchange_fill_event.ts
+++ b/packages/pipeline/src/entities/exchange_fill_event.ts
@@ -16,7 +16,7 @@ export class ExchangeFillEvent {
     @Column({ name: 'raw_data' })
     public rawData!: string;
 
-    @Column({ name: 'transaction_hash' })
+    @PrimaryColumn({ name: 'transaction_hash' })
     public transactionHash!: string;
     @Column({ name: 'maker_address' })
     public makerAddress!: string;

--- a/packages/pipeline/src/scripts/pull_exchange_events.ts
+++ b/packages/pipeline/src/scripts/pull_exchange_events.ts
@@ -119,7 +119,12 @@ async function saveIndividuallyWithFallbackAsync<T extends ExchangeEvent>(
         try {
             // First try an insert.
             await repository.insert(event);
-        } catch {
+        } catch (err) {
+            if (err.message.includes('duplicate key value violates unique constraint')) {
+                logUtils.log("Ignore the preceeding INSERT failure; it's not unexpected");
+            } else {
+                throw err;
+            }
             // If it fails, assume it was a primary key constraint error and try
             // doing an update instead.
             // Note(albrow): Unfortunately the `as any` hack here seems

--- a/packages/pipeline/src/scripts/pull_exchange_events.ts
+++ b/packages/pipeline/src/scripts/pull_exchange_events.ts
@@ -132,6 +132,7 @@ async function saveIndividuallyWithFallbackAsync<T extends ExchangeEvent>(
                     contractAddress: event.contractAddress,
                     blockNumber: event.blockNumber,
                     logIndex: event.logIndex,
+                    transactionHash: event.transactionHash,
                 } as any,
                 event as any,
             );

--- a/packages/pipeline/src/scripts/pull_exchange_events.ts
+++ b/packages/pipeline/src/scripts/pull_exchange_events.ts
@@ -112,7 +112,7 @@ async function saveIndividuallyWithFallbackAsync<T extends ExchangeEvent>(
     events: T[],
 ): Promise<void> {
     // Note(albrow): This is a temporary hack because `save` is not working as
-    // documented and is causing a foreign key constraint violation. Hopefully
+    // documented and is causing a primary key constraint violation. Hopefully
     // can remove later because this "poor man's upsert" implementation operates
     // on one event at a time and is therefore much slower.
     for (const event of events) {
@@ -120,7 +120,7 @@ async function saveIndividuallyWithFallbackAsync<T extends ExchangeEvent>(
             // First try an insert.
             await repository.insert(event);
         } catch {
-            // If it fails, assume it was a foreign key constraint error and try
+            // If it fails, assume it was a primary key constraint error and try
             // doing an update instead.
             // Note(albrow): Unfortunately the `as any` hack here seems
             // required. I can't figure out how to convince the type-checker


### PR DESCRIPTION
## Description

It was noticed that the `pull_exchange_events.ts` script is regularly failing with the message `error: duplicate key value violates unique constraint "PK_79d3b54710830426f998cd6263b"`, repeated for each of the tables into which it inserts.  This change is to fix that error.

A new migration script will add `transaction_hash` to (or remove it from, for revert) the set of columns that comprise the primary key.

## Testing instructions

With local DB running as described in README,
```
yarn build
yarn migrate:run
psql --username=postgres --password --host=localhost --command="\d raw.exchange_cancel_events"
```
entering `postgres` for the password, and visually confirm that the `PRIMARY KEY` line includes `transaction_hash`.
Repeat `psql` command for other tables, replacing `exchange_cancel_events` with `exchange_cancel_up_to_events`, and subsequently with `exchange_fill_events`, confirming the `PRIMARY KEY` for each.

To test revert:
```
yarn migrate:revert
```
Then run the same `psql` commands, confirming that `PRIMARY KEY` does *not* contain `transaction_hash`.


## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Prefix PR title with `[WIP]` if necessary.
-   [x] Add tests to cover changes as needed.
-   [x] Update documentation as needed.
-   [x] Add new entries to the relevant CHANGELOG.jsons.
