### PR TITLE
Allow using Web3Factory in-process Ganache with existing snapshot

### DIFF
--- a/packages/dev-utils/CHANGELOG.json
+++ b/packages/dev-utils/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "2.1.0",
+        "changes": [
+            {
+                "note": "Allow using the Web3Factory in-process Ganache provider with existing DB snapshot",
+                "pr": 1602
+            }
+        ]
+    },
+    {
         "version": "2.0.2",
         "changes": [
             {

--- a/packages/dev-utils/src/web3_factory.ts
+++ b/packages/dev-utils/src/web3_factory.ts
@@ -47,8 +47,11 @@ export const web3Factory = {
                 _.isUndefined(config.shouldThrowErrorsOnGanacheRPCResponse) ||
                 config.shouldThrowErrorsOnGanacheRPCResponse;
             if (!_.isUndefined(config.ganacheDatabasePath)) {
-                // Saving the snapshot to a local db. Ganache requires this directory to exist
-                fs.mkdirSync(config.ganacheDatabasePath);
+                const doesDatabaseAlreadyExist = fs.existsSync(config.ganacheDatabasePath);
+                if (!doesDatabaseAlreadyExist) {
+                    // Working with local DB snapshot. Ganache requires this directory to exist
+                    fs.mkdirSync(config.ganacheDatabasePath);
+                }
             }
             provider.addProvider(
                 new GanacheSubprovider({


### PR DESCRIPTION
## Description

While working on the TEC server, I wanted to use our existing Ganache snapshot as a starting point for my tests. I found out however, that I couldn't pass the Web3Factory an existing snapshot DB path. This PR fixes that.

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
