### PR TITLE
Add WS endpoint to devnode

### DIFF
--- a/packages/devnet/Dockerfile
+++ b/packages/devnet/Dockerfile
@@ -20,6 +20,7 @@ COPY run.sh .
 RUN /geth --datadir node0/ init genesis.json
 
 EXPOSE 8501
+EXPOSE 8546
 EXPOSE 30310
 
 ENTRYPOINT ./run.sh

--- a/packages/devnet/README.md
+++ b/packages/devnet/README.md
@@ -18,14 +18,17 @@ docker build -t 0x-devnet .
 To start the network, run:
 
 ```
-docker run -it --rm -p 8501:8501 0x-devnet
+docker run -it --rm -p 8501:8501 -p 8546:8546 0x-devnet
 ```
 
 Depending on your OS and how you installed docker, you may need to prefix any
 docker commands with `sudo`.
 
-The Docker container exposes the JSON RPC API at port 8501, and this is the
+The Docker container exposes the HTTP JSON RPC API at port 8501, and this is the
 primary way you are expected to interact with the devnet. The following
+endpoints are supported: `personal,db,eth,net,web3,txpool,miner,debug`.
+
+It also exposes the WS JSON RPC API at port 8546. The following
 endpoints are supported: `personal,db,eth,net,web3,txpool,miner,debug`.
 
 You can stop the network with `docker stop` and it will automatically clean up

--- a/packages/devnet/run.sh
+++ b/packages/devnet/run.sh
@@ -17,6 +17,11 @@ mkdir -p /var/log
     --rpcport 8501 \
     --rpcvhosts '*' \
     --rpcapi 'personal,db,eth,net,web3,txpool,miner,debug' \
+    --ws \
+    --wsaddr 0.0.0.0 \
+    --wsport 8546 \
+    --wsorigins '*' \
+    --wsapi 'personal,db,eth,net,web3,txpool,miner,debug' \
     --networkid 50 \
     --gasprice '2000000000' \
     --targetgaslimit '0x4c4b400000' \


### PR DESCRIPTION
## Description

Truffle uses `eth_subscribe` that only works with Geth over `WebSocket`. This PR adds a `WS` endpoint to `devnode`.

I need it to fix our dev tools truffle example. https://github.com/0xProject/dev-tools-truffle-example/issues/5
For now it just hangs on `eth_subscribe`.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature (non-breaking change which adds functionality)

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Prefix PR title with `[WIP]` if necessary.
-   [x] Add tests to cover changes as needed.
-   [x] Update documentation as needed.
-   [x] Add new entries to the relevant CHANGELOG.jsons.
