### PR TITLE
[instant] Reset svg style

### DIFF
--- a/packages/instant/src/components/css_reset.tsx
+++ b/packages/instant/src/components/css_reset.tsx
@@ -16,7 +16,7 @@ export const CSSReset = createGlobalStyle`
         input, ins, keygen, kbd, label, legend, li, map, mark, menu, meter, nav,
         noscript, object, ol, optgroup, option, output, p, param, pre, progress,
         q, rp, rt, ruby, samp, section, select, small, span, strong, sub, sup,
-        table, tbody, td, textarea, tfoot, th, thead, time, tr, ul, var, video {
+        table, tbody, td, textarea, tfoot, th, thead, time, tr, ul, var, video, svg {
             background: transparent;
             border: 0;
             font-size: 100%;


### PR DESCRIPTION
## Description

Etherscan has a global SVG style which messes up the look of instant

## Testing instructions

Added the following:

```
+++ b/packages/instant/public/index.html
@@ -31,6 +31,10 @@
                 height: 100vh;
                 background-color: rgba(0, 0, 0, 0.2);
             }
+
+            svg {
+                margin-bottom: -0.4375rem;
+            }
         </style>
     </head>

```

W/o this commit, looks messed up like on Etherscan.  Fixed w/ this commit


## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
