### PR TITLE
Fix inconsistently named constraint in migration

### DIFF
--- a/packages/pipeline/migrations/1550163069315-TokenOrderBookSnapshotsAddMakerAddress.ts
+++ b/packages/pipeline/migrations/1550163069315-TokenOrderBookSnapshotsAddMakerAddress.ts
@@ -36,7 +36,7 @@ export class TokenOrderBookSnapshotsAddMakerAddress1550163069315 implements Migr
                 ALTER TABLE ${TOKEN_ORDERBOOK_SNAPSHOT_TABLE}
                     DROP CONSTRAINT "token_orderbook_snapshots_pkey",
                     DROP COLUMN ${NEW_COLUMN_NAME},
-                    ADD PRIMARY KEY (observed_timestamp, source, order_type, price, base_asset_symbol, quote_asset_symbol);
+                    ADD CONSTRAINT "token_orderbook_snapshots_pkey" PRIMARY KEY (observed_timestamp, source, order_type, price, base_asset_symbol, quote_asset_symbol);
             `);
         } else {
             throw new Error(`Could not find table with name ${TOKEN_ORDERBOOK_SNAPSHOT_TABLE}`);

--- a/packages/pipeline/migrations/1550163069315-TokenOrderBookSnapshotsAddMakerAddress.ts
+++ b/packages/pipeline/migrations/1550163069315-TokenOrderBookSnapshotsAddMakerAddress.ts
@@ -22,7 +22,7 @@ export class TokenOrderBookSnapshotsAddMakerAddress1550163069315 implements Migr
             await queryRunner.query(`
                 ALTER TABLE ${TOKEN_ORDERBOOK_SNAPSHOT_TABLE}
                     DROP CONSTRAINT "token_orderbook_snapshots_pkey",
-                    ADD PRIMARY KEY (observed_timestamp, source, order_type, price, base_asset_symbol, quote_asset_symbol, maker_address);
+                    ADD CONSTRAINT "token_orderbook_snapshots_pkey" PRIMARY KEY (observed_timestamp, source, order_type, price, base_asset_symbol, quote_asset_symbol, maker_address);
             `);
         } else {
             throw new Error(`Could not find table with name ${TOKEN_ORDERBOOK_SNAPSHOT_TABLE}`);

--- a/packages/pipeline/migrations/1550163069315-TokenOrderBookSnapshotsAddMakerAddress.ts
+++ b/packages/pipeline/migrations/1550163069315-TokenOrderBookSnapshotsAddMakerAddress.ts
@@ -21,7 +21,7 @@ export class TokenOrderBookSnapshotsAddMakerAddress1550163069315 implements Migr
             `);
             await queryRunner.query(`
                 ALTER TABLE ${TOKEN_ORDERBOOK_SNAPSHOT_TABLE}
-                    DROP CONSTRAINT "token_orderbook_snapshots_pkey1",
+                    DROP CONSTRAINT "token_orderbook_snapshots_pkey",
                     ADD PRIMARY KEY (observed_timestamp, source, order_type, price, base_asset_symbol, quote_asset_symbol, maker_address);
             `);
         } else {
@@ -32,7 +32,14 @@ export class TokenOrderBookSnapshotsAddMakerAddress1550163069315 implements Migr
     public async down(queryRunner: QueryRunner): Promise<any> {
         const snapshotTable = await queryRunner.getTable(TOKEN_ORDERBOOK_SNAPSHOT_TABLE);
         if (snapshotTable) {
-            await queryRunner.dropColumn(snapshotTable, NEW_COLUMN_NAME);
+            // await queryRunner.dropIndex(snapshotTable, 'token_orderbook_snapshots_pkey');
+            // await queryRunner.dropColumn(snapshotTable, NEW_COLUMN_NAME);
+            await queryRunner.query(`
+                ALTER TABLE ${TOKEN_ORDERBOOK_SNAPSHOT_TABLE}
+                    DROP CONSTRAINT "token_orderbook_snapshots_pkey",
+                    DROP COLUMN ${NEW_COLUMN_NAME},
+                    ADD PRIMARY KEY (observed_timestamp, source, order_type, price, base_asset_symbol, quote_asset_symbol);
+            `);
         } else {
             throw new Error(`Could not find table with name ${TOKEN_ORDERBOOK_SNAPSHOT_TABLE}`);
         }

--- a/packages/pipeline/migrations/1550163069315-TokenOrderBookSnapshotsAddMakerAddress.ts
+++ b/packages/pipeline/migrations/1550163069315-TokenOrderBookSnapshotsAddMakerAddress.ts
@@ -32,8 +32,6 @@ export class TokenOrderBookSnapshotsAddMakerAddress1550163069315 implements Migr
     public async down(queryRunner: QueryRunner): Promise<any> {
         const snapshotTable = await queryRunner.getTable(TOKEN_ORDERBOOK_SNAPSHOT_TABLE);
         if (snapshotTable) {
-            // await queryRunner.dropIndex(snapshotTable, 'token_orderbook_snapshots_pkey');
-            // await queryRunner.dropColumn(snapshotTable, NEW_COLUMN_NAME);
             await queryRunner.query(`
                 ALTER TABLE ${TOKEN_ORDERBOOK_SNAPSHOT_TABLE}
                     DROP CONSTRAINT "token_orderbook_snapshots_pkey",


### PR DESCRIPTION
## Description

In https://github.com/0xProject/0x-monorepo/pull/1612 I broke `test-pipeline`.

This is because when writing the migrations, I looked at the name for the PRIMARY KEY constraint on `raw.token_orderbook_snapshots` on the QA and prod instances, both called `token_orderbook_snapshots_pkey1`. I do not know how those constraints became named that way, but when you run the migration code on a fresh DB instance that constraint ends up being named `token_orderbook_snapshots_pkey`. 

I think the solution here is to stick with `token_orderbook_snapshots_pkey` and manually rename the name of the constraint on QA and prod for consistency.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
