### PR TITLE
Removed default meta tags in public/index.html

### DIFF
--- a/packages/website/public/index.html
+++ b/packages/website/public/index.html
@@ -3,16 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="description" content="An Open Protocol For Decentralized Exchange On The Ethereum Blockchain" />
-        <meta property="og:type" content="website" />
-        <meta property="og:title" content="0x" />
-        <meta
-            property="og:description"
-            content="An Open Protocol For Decentralized Exchange On The Ethereum Blockchain"
-        />
-        <meta property="og:image" content="/images/og_image.png" />
         <meta name="google-site-verification" content="0wu9KbpKgGXUhUboLQw-MGtAHJHQ67rMFQN8KrX5I1s" />
-        <title>0x: The Protocol for Trading Tokens</title>
         <link rel="icon" type="image/png" href="/images/favicon/favicon-2-32x32.png" sizes="32x32" />
         <link rel="icon" type="image/png" href="/images/favicon/favicon-2-16x16.png" sizes="16x16" />
         <link rel="stylesheet" href="/css/material-design-iconic-font.min.css" />


### PR DESCRIPTION
## Description

Appears that we have two of each meta tag between the public/index.html has default meta tags. This may be confusing the google crawler. 

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
