### PR TITLE
Remove yarn install command from circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,6 @@ jobs:
             - checkout
             - run: echo 'export PATH=$HOME/CIRCLE_PROJECT_REPONAME/node_modules/.bin:$PATH' >> $BASH_ENV
             - run:
-                  name: install-yarn
-                  command: sudo npm install --global yarn@1.9.4
-            - run:
                   name: yarn
                   command: yarn --frozen-lockfile --ignore-engines install || yarn --frozen-lockfile --ignore-engines install
             - setup_remote_docker


### PR DESCRIPTION
## Description

An attempt to fix the intermittent `Yarn: Permission Denied` errors we see on CircleCI

https://discuss.circleci.com/t/yarn-permission-denied/20160

The fix I decided to apply was to remove the part of our circleCI script that installs yarn and instead opts for using the version of yarn that ships with the node image. I found that that version of yarn that ships with the image that we use is yarn v1.5.1. Despite the low version CI seemed to execute fine (besides the SharedArrayBuffer error we've been seeing)

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
