### PR TITLE
Warn instead of error on incompatible version

### DIFF
--- a/packages/sol-tracing-utils/CHANGELOG.json
+++ b/packages/sol-tracing-utils/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "6.0.5",
+        "changes": [
+            {
+                "note": "Skip unparseable contracts instead of erring",
+                "pr": 1649
+            }
+        ]
+    },
+    {
         "timestamp": 1551130135,
         "version": "6.0.4",
         "changes": [

--- a/packages/sol-tracing-utils/src/artifact_adapters/truffle_artifact_adapter.ts
+++ b/packages/sol-tracing-utils/src/artifact_adapters/truffle_artifact_adapter.ts
@@ -1,4 +1,5 @@
 import { Compiler, CompilerOptions } from '@0x/sol-compiler';
+import { logUtils } from '@0x/utils';
 import * as fs from 'fs';
 import * as glob from 'glob';
 import * as path from 'path';
@@ -77,11 +78,12 @@ export class TruffleArtifactAdapter extends AbstractArtifactAdapter {
             const artifact = JSON.parse(fs.readFileSync(artifactFileName).toString());
             const compilerVersion = artifact.compiler.version;
             if (!compilerVersion.startsWith(this._solcVersion)) {
-                throw new Error(
+                logUtils.warn(
                     `${artifact.contractName} was compiled with solidity ${compilerVersion} but specified version is ${
                         this._solcVersion
-                    } making it impossible to process traces`,
+                    } making it impossible to process traces. Skipping...`
                 );
+                continue;
             }
         }
     }


### PR DESCRIPTION
https://github.com/0xProject/dev-tools-truffle-example/issues/4#issuecomment-467566232

## Description

I have a mix of sol-compiler and truffle artifacts in my truffle's artifact directory. I want the sol-compiler artifacts there so that `truffle migrate` and `truffle test` can easily use them. They are working well for that, but now that I'm trying to wire up sol-trace, I'm getting errors.

## Testing instructions

1. Convert a sol-compiler artifact to a truffle artifact that looks like this: https://gist.github.com/WyseNynja/e08f7d1faf5ebd82367d5893d1753548
2. Add it to your truffle contract build directory for a simple repo like https://github.com/0xProject/dev-tools-truffle-example
3. Try to run `yarn trace` 

## Types of changes

 * Bug fix (non-breaking change which fixes an issue)

## Checklist:

-   [x] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
