### PR TITLE
Fix a bug when combining sol-compiler settings from different sources

### DIFF
--- a/packages/sol-compiler/CHANGELOG.json
+++ b/packages/sol-compiler/CHANGELOG.json
@@ -1,5 +1,13 @@
 [
     {
+        "version": "3.1.1",
+        "changes": [
+            {
+                "note": "Fix a bug when combining compilerSettings from different sources",
+            }
+        ]
+    },
+    {
         "version": "3.1.0",
         "changes": [
             {

--- a/packages/sol-compiler/CHANGELOG.json
+++ b/packages/sol-compiler/CHANGELOG.json
@@ -4,6 +4,7 @@
         "changes": [
             {
                 "note": "Fix a bug when combining compilerSettings from different sources",
+                "pr": 1652
             }
         ]
     },

--- a/packages/sol-compiler/src/compiler.ts
+++ b/packages/sol-compiler/src/compiler.ts
@@ -107,7 +107,11 @@ export class Compiler {
         assert.doesConformToSchema('compiler.json', config, compilerOptionsSchema);
         this._contractsDir = path.resolve(passedOpts.contractsDir || config.contractsDir || DEFAULT_CONTRACTS_DIR);
         this._solcVersionIfExists = passedOpts.solcVersion || config.solcVersion;
-        this._compilerSettings = passedOpts.compilerSettings || config.compilerSettings || DEFAULT_COMPILER_SETTINGS;
+        this._compilerSettings = {
+            ...DEFAULT_COMPILER_SETTINGS,
+            ...config.compilerSettings,
+            ...passedOpts.compilerSettings,
+        };
         this._artifactsDir = passedOpts.artifactsDir || config.artifactsDir || DEFAULT_ARTIFACTS_DIR;
         this._specifiedContracts = passedOpts.contracts || config.contracts || ALL_CONTRACTS_IDENTIFIER;
         this._useDockerisedSolc =


### PR DESCRIPTION
## Description

If the user specifies some compiler settings in `compier.json` but doesn't specify the outputSelection - solidity produces 0 output.

This PR changes the way we merge the default configs in, so it should work.

FIxes https://github.com/0xProject/0x-monorepo/issues/1645

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Prefix PR title with `[WIP]` if necessary.
-   [x] Add tests to cover changes as needed.
-   [x] Update documentation as needed.
-   [x] Add new entries to the relevant CHANGELOG.jsons.
