### PR TITLE
Fix a bug when TruffleArtifactAdapter was incorrectly parsing the truffle config of the newest version

### DIFF
--- a/packages/sol-tracing-utils/CHANGELOG.json
+++ b/packages/sol-tracing-utils/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "6.0.6",
+        "changes": [
+            {
+                "note": "Fix a bug when `TruffleArtifactAdapter` wasn't parsing solc config in the newest version of trufle",
+                "pr": 1654
+            }
+        ]
+    },
+    {
         "timestamp": 1551220833,
         "version": "6.0.5",
         "changes": [

--- a/packages/sol-tracing-utils/package.json
+++ b/packages/sol-tracing-utils/package.json
@@ -55,6 +55,7 @@
         "ethereumjs-util": "^5.1.1",
         "ethers": "~4.0.4",
         "glob": "^7.1.2",
+        "solc": "^0.5.2",
         "istanbul": "^0.4.5",
         "lodash": "^4.17.11",
         "loglevel": "^1.6.1",

--- a/packages/sol-tracing-utils/src/artifact_adapters/truffle_artifact_adapter.ts
+++ b/packages/sol-tracing-utils/src/artifact_adapters/truffle_artifact_adapter.ts
@@ -82,8 +82,10 @@ export class TruffleArtifactAdapter extends AbstractArtifactAdapter {
     private _getTruffleSolcSettings(): Partial<solc.CompilerSettings> {
         const truffleConfig = this._getTruffleConfig();
         if (!_.isUndefined(truffleConfig.solc)) {
+            // Truffle < 5.0
             return (truffleConfig as any).solc.settings;
         } else if (!_.isUndefined((truffleConfig as any).compilers.solc)) {
+            // Truffle >= 5.0
             return (truffleConfig as any).compilers.solc.settings;
         } else {
             return {};


### PR DESCRIPTION

## Description

Truffle recently released a major new version which changed the format of `truffle-config.json`.
This PR adds support for that new format.
Fixes: https://github.com/0xProject/0x-monorepo/issues/1650

## Testing instructions


## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Prefix PR title with `[WIP]` if necessary.
-   [x] Add tests to cover changes as needed.
-   [x] Update documentation as needed.
-   [x] Add new entries to the relevant CHANGELOG.jsons.
