### PR TITLE
Adapt to Bloxy API change

### DIFF
--- a/packages/pipeline/src/data_sources/bloxy/index.ts
+++ b/packages/pipeline/src/data_sources/bloxy/index.ts
@@ -6,7 +6,7 @@ import { logUtils } from '@0x/utils';
 // URL to use for getting dex trades from Bloxy.
 export const BLOXY_DEX_TRADES_URL = 'https://bloxy.info/api/dex/trades';
 // Number of trades to get at once. Must be less than or equal to MAX_OFFSET.
-const TRADES_PER_QUERY = 10000;
+const TRADES_PER_QUERY = 100000;
 // Maximum offset supported by the Bloxy API.
 const MAX_OFFSET = 100000;
 // Buffer to subtract from offset. This means we will request some trades twice

--- a/packages/pipeline/src/data_sources/bloxy/index.ts
+++ b/packages/pipeline/src/data_sources/bloxy/index.ts
@@ -12,16 +12,11 @@ const MAX_OFFSET = 100000;
 // Buffer to subtract from offset. This means we will request some trades twice
 // but we have less chance on missing out on any data.
 const OFFSET_BUFFER = 1000;
-// Maximum number of days supported by the Bloxy API.
-const MAX_DAYS = 30;
 // Buffer used for comparing the last seen timestamp to the last returned
 // timestamp. Increasing this reduces chances of data loss but also creates more
 // redundancy and can impact performance.
 // tslint:disable-next-line:custom-no-magic-numbers
 const LAST_SEEN_TIMESTAMP_BUFFER_MS = 1000 * 60 * 30; // 30 minutes
-
-// tslint:disable-next-line:custom-no-magic-numbers
-const millisecondsPerDay = 1000 * 60 * 60 * 24; // ms/d = ms/s * s/m * m/h * h/d
 
 export interface BloxyTrade {
     tx_hash: string;
@@ -87,9 +82,6 @@ export class BloxySource {
     private async _scrapeAllDexTradesAsync(lastSeenTimestamp: number): Promise<BloxyTrade[]> {
         let allTrades: BloxyTrade[] = [];
 
-        // Clamp numberOfDays so that it is always between 1 and MAX_DAYS (inclusive)
-        const numberOfDays = R.clamp(1, MAX_DAYS, getDaysSinceTimestamp(lastSeenTimestamp));
-
         // Keep getting trades until we hit one of the following conditions:
         //
         //  1. Offset hits MAX_OFFSET (we can't go back any further).
@@ -98,7 +90,7 @@ export class BloxySource {
         //     some buffer).
         //
         for (let offset = 0; offset <= MAX_OFFSET; offset += TRADES_PER_QUERY - OFFSET_BUFFER) {
-            const trades = await this._getTradesWithOffsetAsync(numberOfDays, offset);
+            const trades = await this._getTradesWithOffsetAsync(lastSeenTimestamp, offset);
             if (trades.length === 0) {
                 // There are no more trades left for the days we are querying.
                 // This means we are done.
@@ -118,11 +110,12 @@ export class BloxySource {
         return allTrades;
     }
 
-    private async _getTradesWithOffsetAsync(numberOfDays: number, offset: number): Promise<BloxyTrade[]> {
+    private async _getTradesWithOffsetAsync(lastSeenTimestamp: number, offset: number): Promise<BloxyTrade[]> {
         const resp = await axios.get<BloxyTradeResponse>(BLOXY_DEX_TRADES_URL, {
             params: {
                 key: this._apiKey,
-                days: numberOfDays,
+                from_date: dateToISO8601ExtendedCalendarDateFormat(new Date(lastSeenTimestamp)),
+                till_date: dateToISO8601ExtendedCalendarDateFormat(new Date()),
                 limit: TRADES_PER_QUERY,
                 offset,
             },
@@ -134,10 +127,8 @@ export class BloxySource {
     }
 }
 
-// Computes the number of days between the given timestamp and the current
-// timestamp (rounded up).
-function getDaysSinceTimestamp(timestamp: number): number {
-    const msSinceTimestamp = Date.now() - timestamp;
-    const daysSinceTimestamp = msSinceTimestamp / millisecondsPerDay;
-    return Math.ceil(daysSinceTimestamp);
+// Converts a Date object to the format like 'YYYY-MM-DD', which is expected by
+// the Bloxy API for its from_date and till_date parameters.
+function dateToISO8601ExtendedCalendarDateFormat(date: Date): string {
+    return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
 }


### PR DESCRIPTION
## Description

We were using the `days` parameter, but that's no longer available in
the API, so our fetching of previous days (before "today") was broken.

This change gets rid of the concept of "days", and uses the API's new
`from_date` and `till_date` parameters to fetch previous days' trades.

The change to the query in `getLastSeenTimestampAsync()` was necessary
because it was returning a string (despite the `as Array<{ tx_timestamp:
number }>` cast), which was later causing problems trying to pass that
value into `new Date()`.  It worked before because we were doing some
math operations on it (multiplying it by some numbers), so coercion was
saving us.  With the change from a raw query to a `typeorm` call, the
`numberToBigIntTransformer` specified in the `DexTrade` entity is now
doing the proper type conversion for us.

The new `MAX_DAYS` constant in `pull_competing_dex_trades.ts` is
necessary in order to avoid trying to pull data all the way back to 1969
:D, which induces the API to return an HTTP 503.

<!--- Describe your changes in detail -->

## Testing instructions

```
PKG=@0x/pipeline yarn build
node packages/pipeline/lib/src/scripts/pull_competing_dex_trades.js
```
If your database is empty, the script will take a little while.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->
