### PR TITLE
Add tx.origin to TEC approvals

### DIFF
--- a/contracts/coordinator/contracts/src/MixinCoordinatorApprovalVerifier.sol
+++ b/contracts/coordinator/contracts/src/MixinCoordinatorApprovalVerifier.sol
@@ -43,11 +43,13 @@ contract MixinCoordinatorApprovalVerifier is
     /// @dev Validates that the 0x transaction has been approved by all of the feeRecipients
     ///      that correspond to each order in the transaction's Exchange calldata.
     /// @param transaction 0x transaction containing salt, signerAddress, and data.
+    /// @param txOrigin Required signer of Ethereum transaction calling this function.
     /// @param transactionSignature Proof that the transaction has been signed by the signer.
     /// @param approvalExpirationTimeSeconds Array of expiration times in seconds for which each corresponding approval signature expires.
     /// @param approvalSignatures Array of signatures that correspond to the feeRecipients of each order in the transaction's Exchange calldata.
     function assertValidCoordinatorApprovals(
         LibZeroExTransaction.ZeroExTransaction memory transaction,
+        address txOrigin,
         bytes memory transactionSignature,
         uint256[] memory approvalExpirationTimeSeconds,
         bytes[] memory approvalSignatures
@@ -64,6 +66,7 @@ contract MixinCoordinatorApprovalVerifier is
             assertValidTransactionOrdersApproval(
                 transaction,
                 orders,
+                txOrigin,
                 transactionSignature,
                 approvalExpirationTimeSeconds,
                 approvalSignatures
@@ -74,12 +77,14 @@ contract MixinCoordinatorApprovalVerifier is
     /// @dev Validates that the feeRecipients of a batch of order have approved a 0x transaction.
     /// @param transaction 0x transaction containing salt, signerAddress, and data.
     /// @param orders Array of order structs containing order specifications.
+    /// @param txOrigin Required signer of Ethereum transaction calling this function.
     /// @param transactionSignature Proof that the transaction has been signed by the signer.
     /// @param approvalExpirationTimeSeconds Array of expiration times in seconds for which each corresponding approval signature expires.
     /// @param approvalSignatures Array of signatures that correspond to the feeRecipients of each order.
     function assertValidTransactionOrdersApproval(
         LibZeroExTransaction.ZeroExTransaction memory transaction,
         LibOrder.Order[] memory orders,
+        address txOrigin,
         bytes memory transactionSignature,
         uint256[] memory approvalExpirationTimeSeconds,
         bytes[] memory approvalSignatures
@@ -87,6 +92,12 @@ contract MixinCoordinatorApprovalVerifier is
         public
         view
     {
+        // Verify that Ethereum tx signer is the same as the approved txOrigin
+        require(
+            tx.origin == txOrigin,
+            "INVALID_SENDER"
+        );
+
         // Hash 0x transaction
         bytes32 transactionHash = getTransactionHash(transaction);
 
@@ -98,6 +109,7 @@ contract MixinCoordinatorApprovalVerifier is
             // Create approval message
             uint256 currentApprovalExpirationTimeSeconds = approvalExpirationTimeSeconds[i];
             CoordinatorApproval memory approval = CoordinatorApproval({
+                txOrigin: txOrigin,
                 transactionHash: transactionHash,
                 transactionSignature: transactionSignature,
                 approvalExpirationTimeSeconds: currentApprovalExpirationTimeSeconds
@@ -117,6 +129,9 @@ contract MixinCoordinatorApprovalVerifier is
             // Add approval signer to list of signers
             approvalSignerAddresses = approvalSignerAddresses.append(approvalSignerAddress);
         }
+    
+        // Ethereum transaction signer gives implicit signature of approval
+        approvalSignerAddresses = approvalSignerAddresses.append(tx.origin);
         
         uint256 ordersLength = orders.length;
         for (uint256 i = 0; i < ordersLength; i++) {
@@ -124,25 +139,13 @@ contract MixinCoordinatorApprovalVerifier is
             if (orders[i].senderAddress == address(0)) {
                 continue;
             }
-            
-            // Ethereum transaction signer gives implicit signature of approval
-            address approverAddress = orders[i].feeRecipientAddress;
-            if (approverAddress == tx.origin) {
-                approvalSignerAddresses = approvalSignerAddresses.append(tx.origin);
-                continue;
-            }
 
             // Ensure feeRecipient of order has approved this 0x transaction
+            address approverAddress = orders[i].feeRecipientAddress;
             bool isOrderApproved = approvalSignerAddresses.contains(approverAddress);
             require(
                 isOrderApproved,
                 "INVALID_APPROVAL_SIGNATURE"
-            );
-
-            // The Ethereum transaction signer must be the 0x transaction signer or an approver of the 0x transaction
-            require(
-                transaction.signerAddress == tx.origin || approvalSignerAddresses.contains(tx.origin),
-                "INVALID_SENDER"
             );
         }
     }

--- a/contracts/coordinator/contracts/src/MixinCoordinatorApprovalVerifier.sol
+++ b/contracts/coordinator/contracts/src/MixinCoordinatorApprovalVerifier.sol
@@ -105,7 +105,7 @@ contract MixinCoordinatorApprovalVerifier is
         address[] memory approvalSignerAddresses = new address[](0);
 
         uint256 signaturesLength = approvalSignatures.length;
-        for (uint256 i = 0; i < signaturesLength; i++) {
+        for (uint256 i = 0; i != signaturesLength; i++) {
             // Create approval message
             uint256 currentApprovalExpirationTimeSeconds = approvalExpirationTimeSeconds[i];
             CoordinatorApproval memory approval = CoordinatorApproval({
@@ -134,7 +134,7 @@ contract MixinCoordinatorApprovalVerifier is
         approvalSignerAddresses = approvalSignerAddresses.append(tx.origin);
         
         uint256 ordersLength = orders.length;
-        for (uint256 i = 0; i < ordersLength; i++) {
+        for (uint256 i = 0; i != ordersLength; i++) {
             // Do not check approval if the order's senderAddress is null
             if (orders[i].senderAddress == address(0)) {
                 continue;

--- a/contracts/coordinator/contracts/src/MixinCoordinatorApprovalVerifier.sol
+++ b/contracts/coordinator/contracts/src/MixinCoordinatorApprovalVerifier.sol
@@ -95,7 +95,7 @@ contract MixinCoordinatorApprovalVerifier is
         // Verify that Ethereum tx signer is the same as the approved txOrigin
         require(
             tx.origin == txOrigin,
-            "INVALID_SENDER"
+            "INVALID_ORIGIN"
         );
 
         // Hash 0x transaction

--- a/contracts/coordinator/contracts/src/MixinCoordinatorCore.sol
+++ b/contracts/coordinator/contracts/src/MixinCoordinatorCore.sol
@@ -32,11 +32,13 @@ contract MixinCoordinatorCore is
 {
     /// @dev Executes a 0x transaction that has been signed by the feeRecipients that correspond to each order in the transaction's Exchange calldata.
     /// @param transaction 0x transaction containing salt, signerAddress, and data.
+    /// @param txOrigin Required signer of Ethereum transaction calling this function.
     /// @param transactionSignature Proof that the transaction has been signed by the signer.
     /// @param approvalExpirationTimeSeconds Array of expiration times in seconds for which each corresponding approval signature expires.
     /// @param approvalSignatures Array of signatures that correspond to the feeRecipients of each order in the transaction's Exchange calldata.
     function executeTransaction(
         LibZeroExTransaction.ZeroExTransaction memory transaction,
+        address txOrigin,
         bytes memory transactionSignature,
         uint256[] memory approvalExpirationTimeSeconds,
         bytes[] memory approvalSignatures
@@ -46,6 +48,7 @@ contract MixinCoordinatorCore is
         // Validate that the 0x transaction has been approves by each feeRecipient
         assertValidCoordinatorApprovals(
             transaction,
+            txOrigin,
             transactionSignature,
             approvalExpirationTimeSeconds,
             approvalSignatures

--- a/contracts/coordinator/contracts/src/interfaces/ICoordinatorApprovalVerifier.sol
+++ b/contracts/coordinator/contracts/src/interfaces/ICoordinatorApprovalVerifier.sol
@@ -28,11 +28,13 @@ contract ICoordinatorApprovalVerifier {
     /// @dev Validates that the 0x transaction has been approved by all of the feeRecipients
     ///      that correspond to each order in the transaction's Exchange calldata.
     /// @param transaction 0x transaction containing salt, signerAddress, and data.
+    /// @param txOrigin Required signer of Ethereum transaction calling this function.
     /// @param transactionSignature Proof that the transaction has been signed by the signer.
     /// @param approvalExpirationTimeSeconds Array of expiration times in seconds for which each corresponding approval signature expires.
     /// @param approvalSignatures Array of signatures that correspond to the feeRecipients of each order in the transaction's Exchange calldata.
     function assertValidCoordinatorApprovals(
         LibZeroExTransaction.ZeroExTransaction memory transaction,
+        address txOrigin,
         bytes memory transactionSignature,
         uint256[] memory approvalExpirationTimeSeconds,
         bytes[] memory approvalSignatures
@@ -43,12 +45,14 @@ contract ICoordinatorApprovalVerifier {
     /// @dev Validates that the feeRecipients of a batch of order have approved a 0x transaction.
     /// @param transaction 0x transaction containing salt, signerAddress, and data.
     /// @param orders Array of order structs containing order specifications.
+    /// @param txOrigin Required signer of Ethereum transaction calling this function.
     /// @param transactionSignature Proof that the transaction has been signed by the signer.
     /// @param approvalExpirationTimeSeconds Array of expiration times in seconds for which each corresponding approval signature expires.
     /// @param approvalSignatures Array of signatures that correspond to the feeRecipients of each order.
     function assertValidTransactionOrdersApproval(
         LibZeroExTransaction.ZeroExTransaction memory transaction,
         LibOrder.Order[] memory orders,
+        address txOrigin,
         bytes memory transactionSignature,
         uint256[] memory approvalExpirationTimeSeconds,
         bytes[] memory approvalSignatures

--- a/contracts/coordinator/contracts/src/interfaces/ICoordinatorCore.sol
+++ b/contracts/coordinator/contracts/src/interfaces/ICoordinatorCore.sol
@@ -26,11 +26,13 @@ contract ICoordinatorCore {
 
     /// @dev Executes a 0x transaction that has been signed by the feeRecipients that correspond to each order in the transaction's Exchange calldata.
     /// @param transaction 0x transaction containing salt, signerAddress, and data.
+    /// @param txOrigin Required signer of Ethereum transaction calling this function.
     /// @param transactionSignature Proof that the transaction has been signed by the signer.
     /// @param approvalExpirationTimeSeconds Array of expiration times in seconds for which each corresponding approval signature expires.
     /// @param approvalSignatures Array of signatures that correspond to the feeRecipients of each order in the transaction's Exchange calldata.
     function executeTransaction(
         LibZeroExTransaction.ZeroExTransaction memory transaction,
+        address txOrigin,
         bytes memory transactionSignature,
         uint256[] memory approvalExpirationTimeSeconds,
         bytes[] memory approvalSignatures

--- a/contracts/coordinator/contracts/src/libs/LibCoordinatorApproval.sol
+++ b/contracts/coordinator/contracts/src/libs/LibCoordinatorApproval.sol
@@ -25,13 +25,14 @@ contract LibCoordinatorApproval is
     LibEIP712Domain
 {
     // Hash for the EIP712 Coordinator approval message
-    bytes32 constant internal EIP712_COORDINATOR_APPROVAL_SCHEMA_HASH = keccak256(abi.encodePacked(
-        "CoordinatorApproval(",
-        "bytes32 transactionHash,",
-        "bytes transactionSignature,",
-        "uint256 approvalExpirationTimeSeconds",
-        ")"
-    ));
+    // keccak256(abi.encodePacked(
+    //     "CoordinatorApproval(",
+    //     "bytes32 transactionHash,",
+    //     "bytes transactionSignature,",
+    //     "uint256 approvalExpirationTimeSeconds",
+    //     ")"
+    // ));
+    bytes32 constant internal EIP712_COORDINATOR_APPROVAL_SCHEMA_HASH = 0x9f6a55727f39e17015e248e6457fbf0b18270e56c53093ff432d3db5703e191e;
 
     struct CoordinatorApproval {
         bytes32 transactionHash;                // EIP712 hash of the transaction, using the domain separator of this contract.
@@ -60,8 +61,7 @@ contract LibCoordinatorApproval is
         returns (bytes32 result)
     {
         bytes32 schemaHash = EIP712_COORDINATOR_APPROVAL_SCHEMA_HASH;
-        bytes32 transactionSignatureHash = keccak256(approval.transactionSignature);
-        // TODO(abandeali1): optimize by loading from memory in assembly
+        bytes memory transactionSignature = approval.transactionSignature;
         bytes32 transactionHash = approval.transactionHash;
         uint256 approvalExpirationTimeSeconds = approval.approvalExpirationTimeSeconds;
 
@@ -74,6 +74,9 @@ contract LibCoordinatorApproval is
         // ));
 
         assembly {
+            // Compute hash of transaction signature
+            let transactionSignatureHash := keccak256(add(transactionSignature, 32), mload(transactionSignature))
+        
             // Load free memory pointer
             let memPtr := mload(64)
 

--- a/contracts/coordinator/contracts/src/libs/LibCoordinatorApproval.sol
+++ b/contracts/coordinator/contracts/src/libs/LibCoordinatorApproval.sol
@@ -27,14 +27,16 @@ contract LibCoordinatorApproval is
     // Hash for the EIP712 Coordinator approval message
     // keccak256(abi.encodePacked(
     //     "CoordinatorApproval(",
+    //     "address txOrigin,",
     //     "bytes32 transactionHash,",
     //     "bytes transactionSignature,",
     //     "uint256 approvalExpirationTimeSeconds",
     //     ")"
     // ));
-    bytes32 constant internal EIP712_COORDINATOR_APPROVAL_SCHEMA_HASH = 0x9f6a55727f39e17015e248e6457fbf0b18270e56c53093ff432d3db5703e191e;
+    bytes32 constant internal EIP712_COORDINATOR_APPROVAL_SCHEMA_HASH = 0x2fbcdbaa76bc7589916958ae919dfbef04d23f6bbf26de6ff317b32c6cc01e05;
 
     struct CoordinatorApproval {
+        address txOrigin;                       // Required signer of Ethereum transaction that is submitting approval.
         bytes32 transactionHash;                // EIP712 hash of the transaction, using the domain separator of this contract.
         bytes transactionSignature;             // Signature of the 0x transaction.
         uint256 approvalExpirationTimeSeconds;  // Timestamp in seconds for which the signature expires.
@@ -62,6 +64,7 @@ contract LibCoordinatorApproval is
     {
         bytes32 schemaHash = EIP712_COORDINATOR_APPROVAL_SCHEMA_HASH;
         bytes memory transactionSignature = approval.transactionSignature;
+        address txOrigin = approval.txOrigin;
         bytes32 transactionHash = approval.transactionHash;
         uint256 approvalExpirationTimeSeconds = approval.approvalExpirationTimeSeconds;
 
@@ -80,12 +83,13 @@ contract LibCoordinatorApproval is
             // Load free memory pointer
             let memPtr := mload(64)
 
-            mstore(memPtr, schemaHash)                              // hash of schema
-            mstore(add(memPtr, 32), transactionHash)                // transactionHash
-            mstore(add(memPtr, 64), transactionSignatureHash)       // transactionSignatureHash
-            mstore(add(memPtr, 96), approvalExpirationTimeSeconds)  // approvalExpirationTimeSeconds
+            mstore(memPtr, schemaHash)                               // hash of schema
+            mstore(add(memPtr, 32), txOrigin)                        // txOrigin
+            mstore(add(memPtr, 64), transactionHash)                 // transactionHash
+            mstore(add(memPtr, 96), transactionSignatureHash)        // transactionSignatureHash
+            mstore(add(memPtr, 128), approvalExpirationTimeSeconds)  // approvalExpirationTimeSeconds
             // Compute hash
-            result := keccak256(memPtr, 128)
+            result := keccak256(memPtr, 160)
         }
         return result;
     }

--- a/contracts/coordinator/contracts/src/libs/LibZeroExTransaction.sol
+++ b/contracts/coordinator/contracts/src/libs/LibZeroExTransaction.sol
@@ -25,13 +25,13 @@ contract LibZeroExTransaction is
     LibEIP712Domain
 {
     // Hash for the EIP712 0x transaction schema
-    //  keccak256(abi.encodePacked(
-    //     "ZeroExTransaction(",
-    //     "uint256 salt,",
-    //     "address signerAddress,",
-    //     "bytes data",
-    //     ")"
-    //  ));
+    // keccak256(abi.encodePacked(
+    //    "ZeroExTransaction(",
+    //    "uint256 salt,",
+    //    "address signerAddress,",
+    //    "bytes data",
+    //    ")"
+    // ));
     bytes32 constant internal EIP712_ZEROEX_TRANSACTION_SCHEMA_HASH = 0x213c6f636f3ea94e701c0adf9b2624aa45a6c694f9a292c094f9a81c24b5df4c;
 
     struct ZeroExTransaction {

--- a/contracts/coordinator/contracts/src/libs/LibZeroExTransaction.sol
+++ b/contracts/coordinator/contracts/src/libs/LibZeroExTransaction.sol
@@ -25,13 +25,14 @@ contract LibZeroExTransaction is
     LibEIP712Domain
 {
     // Hash for the EIP712 0x transaction schema
-    bytes32 constant internal EIP712_ZEROEX_TRANSACTION_SCHEMA_HASH = keccak256(abi.encodePacked(
-        "ZeroExTransaction(",
-        "uint256 salt,",
-        "address signerAddress,",
-        "bytes data",
-        ")"
-    ));
+    //  keccak256(abi.encodePacked(
+    //     "ZeroExTransaction(",
+    //     "uint256 salt,",
+    //     "address signerAddress,",
+    //     "bytes data",
+    //     ")"
+    //  ));
+    bytes32 constant internal EIP712_ZEROEX_TRANSACTION_SCHEMA_HASH = 0x213c6f636f3ea94e701c0adf9b2624aa45a6c694f9a292c094f9a81c24b5df4c;
 
     struct ZeroExTransaction {
         uint256 salt;           // Arbitrary number to ensure uniqueness of transaction hash.
@@ -61,8 +62,7 @@ contract LibZeroExTransaction is
         returns (bytes32 result)
     {
         bytes32 schemaHash = EIP712_ZEROEX_TRANSACTION_SCHEMA_HASH;
-        bytes32 dataHash = keccak256(transaction.data);
-        // TODO(abandeali1): optimize by loading from memory in assembly
+        bytes memory data = transaction.data;
         uint256 salt = transaction.salt;
         address signerAddress = transaction.signerAddress;
 
@@ -75,6 +75,9 @@ contract LibZeroExTransaction is
         // ));
 
         assembly {
+            // Compute hash of data
+            let dataHash := keccak256(add(data, 32), mload(data))
+    
             // Load free memory pointer
             let memPtr := mload(64)
 

--- a/contracts/coordinator/test/coordinator.ts
+++ b/contracts/coordinator/test/coordinator.ts
@@ -517,3 +517,4 @@ describe('Coordinator tests', () => {
         });
     });
 });
+// tslint:disable:max-file-line-count

--- a/contracts/coordinator/test/coordinator.ts
+++ b/contracts/coordinator/test/coordinator.ts
@@ -277,7 +277,7 @@ describe('Coordinator tests', () => {
                         [approval.signature],
                         { from: owner },
                     ),
-                    RevertReason.InvalidSender,
+                    RevertReason.InvalidOrigin,
                 );
             });
         }
@@ -426,7 +426,7 @@ describe('Coordinator tests', () => {
                         [approval.signature],
                         { from: owner },
                     ),
-                    RevertReason.InvalidSender,
+                    RevertReason.InvalidOrigin,
                 );
             });
         }

--- a/contracts/coordinator/test/coordinator.ts
+++ b/contracts/coordinator/test/coordinator.ts
@@ -126,10 +126,15 @@ describe('Coordinator tests', () => {
                 const transaction = takerTransactionFactory.newSignedTransaction(data);
                 const currentTimestamp = await getLatestBlockTimestampAsync();
                 const approvalExpirationTimeSeconds = new BigNumber(currentTimestamp).plus(constants.TIME_BUFFER);
-                const approval = approvalFactory.newSignedApproval(transaction, approvalExpirationTimeSeconds);
+                const approval = approvalFactory.newSignedApproval(
+                    transaction,
+                    takerAddress,
+                    approvalExpirationTimeSeconds,
+                );
                 const transactionReceipt = await web3Wrapper.awaitTransactionSuccessAsync(
                     await coordinatorContract.executeTransaction.sendTransactionAsync(
                         transaction,
+                        takerAddress,
                         transaction.signature,
                         [approvalExpirationTimeSeconds],
                         [approval.signature],
@@ -161,6 +166,7 @@ describe('Coordinator tests', () => {
                 const transactionReceipt = await web3Wrapper.awaitTransactionSuccessAsync(
                     await coordinatorContract.executeTransaction.sendTransactionAsync(
                         transaction,
+                        feeRecipientAddress,
                         transaction.signature,
                         [],
                         [],
@@ -192,6 +198,7 @@ describe('Coordinator tests', () => {
                 await expectTransactionFailedAsync(
                     coordinatorContract.executeTransaction.sendTransactionAsync(
                         transaction,
+                        takerAddress,
                         transaction.signature,
                         [],
                         [],
@@ -209,11 +216,16 @@ describe('Coordinator tests', () => {
                 const transaction = takerTransactionFactory.newSignedTransaction(data);
                 const currentTimestamp = await getLatestBlockTimestampAsync();
                 const approvalExpirationTimeSeconds = new BigNumber(currentTimestamp).plus(constants.TIME_BUFFER);
-                const approval = approvalFactory.newSignedApproval(transaction, approvalExpirationTimeSeconds);
+                const approval = approvalFactory.newSignedApproval(
+                    transaction,
+                    takerAddress,
+                    approvalExpirationTimeSeconds,
+                );
                 const signature = `${approval.signature.slice(0, 4)}FFFFFFFF${approval.signature.slice(12)}`;
                 await expectTransactionFailedAsync(
                     coordinatorContract.executeTransaction.sendTransactionAsync(
                         transaction,
+                        takerAddress,
                         transaction.signature,
                         [approvalExpirationTimeSeconds],
                         [signature],
@@ -228,10 +240,15 @@ describe('Coordinator tests', () => {
                 const transaction = takerTransactionFactory.newSignedTransaction(data);
                 const currentTimestamp = await getLatestBlockTimestampAsync();
                 const approvalExpirationTimeSeconds = new BigNumber(currentTimestamp).minus(constants.TIME_BUFFER);
-                const approval = approvalFactory.newSignedApproval(transaction, approvalExpirationTimeSeconds);
+                const approval = approvalFactory.newSignedApproval(
+                    transaction,
+                    takerAddress,
+                    approvalExpirationTimeSeconds,
+                );
                 await expectTransactionFailedAsync(
                     coordinatorContract.executeTransaction.sendTransactionAsync(
                         transaction,
+                        takerAddress,
                         transaction.signature,
                         [approvalExpirationTimeSeconds],
                         [approval.signature],
@@ -246,10 +263,15 @@ describe('Coordinator tests', () => {
                 const transaction = takerTransactionFactory.newSignedTransaction(data);
                 const currentTimestamp = await getLatestBlockTimestampAsync();
                 const approvalExpirationTimeSeconds = new BigNumber(currentTimestamp).plus(constants.TIME_BUFFER);
-                const approval = approvalFactory.newSignedApproval(transaction, approvalExpirationTimeSeconds);
+                const approval = approvalFactory.newSignedApproval(
+                    transaction,
+                    takerAddress,
+                    approvalExpirationTimeSeconds,
+                );
                 await expectTransactionFailedAsync(
                     coordinatorContract.executeTransaction.sendTransactionAsync(
                         transaction,
+                        takerAddress,
                         transaction.signature,
                         [approvalExpirationTimeSeconds],
                         [approval.signature],
@@ -268,10 +290,15 @@ describe('Coordinator tests', () => {
                 const transaction = takerTransactionFactory.newSignedTransaction(data);
                 const currentTimestamp = await getLatestBlockTimestampAsync();
                 const approvalExpirationTimeSeconds = new BigNumber(currentTimestamp).plus(constants.TIME_BUFFER);
-                const approval = approvalFactory.newSignedApproval(transaction, approvalExpirationTimeSeconds);
+                const approval = approvalFactory.newSignedApproval(
+                    transaction,
+                    takerAddress,
+                    approvalExpirationTimeSeconds,
+                );
                 const transactionReceipt = await web3Wrapper.awaitTransactionSuccessAsync(
                     await coordinatorContract.executeTransaction.sendTransactionAsync(
                         transaction,
+                        takerAddress,
                         transaction.signature,
                         [approvalExpirationTimeSeconds],
                         [approval.signature],
@@ -305,6 +332,7 @@ describe('Coordinator tests', () => {
                 const transactionReceipt = await web3Wrapper.awaitTransactionSuccessAsync(
                     await coordinatorContract.executeTransaction.sendTransactionAsync(
                         transaction,
+                        feeRecipientAddress,
                         transaction.signature,
                         [],
                         [],
@@ -337,11 +365,16 @@ describe('Coordinator tests', () => {
                 const transaction = takerTransactionFactory.newSignedTransaction(data);
                 const currentTimestamp = await getLatestBlockTimestampAsync();
                 const approvalExpirationTimeSeconds = new BigNumber(currentTimestamp).plus(constants.TIME_BUFFER);
-                const approval = approvalFactory.newSignedApproval(transaction, approvalExpirationTimeSeconds);
+                const approval = approvalFactory.newSignedApproval(
+                    transaction,
+                    takerAddress,
+                    approvalExpirationTimeSeconds,
+                );
                 const signature = `${approval.signature.slice(0, 4)}FFFFFFFF${approval.signature.slice(12)}`;
                 await expectTransactionFailedAsync(
                     coordinatorContract.executeTransaction.sendTransactionAsync(
                         transaction,
+                        takerAddress,
                         transaction.signature,
                         [approvalExpirationTimeSeconds],
                         [signature],
@@ -356,10 +389,15 @@ describe('Coordinator tests', () => {
                 const transaction = takerTransactionFactory.newSignedTransaction(data);
                 const currentTimestamp = await getLatestBlockTimestampAsync();
                 const approvalExpirationTimeSeconds = new BigNumber(currentTimestamp).minus(constants.TIME_BUFFER);
-                const approval = approvalFactory.newSignedApproval(transaction, approvalExpirationTimeSeconds);
+                const approval = approvalFactory.newSignedApproval(
+                    transaction,
+                    takerAddress,
+                    approvalExpirationTimeSeconds,
+                );
                 await expectTransactionFailedAsync(
                     coordinatorContract.executeTransaction.sendTransactionAsync(
                         transaction,
+                        takerAddress,
                         transaction.signature,
                         [approvalExpirationTimeSeconds],
                         [approval.signature],
@@ -374,10 +412,15 @@ describe('Coordinator tests', () => {
                 const transaction = takerTransactionFactory.newSignedTransaction(data);
                 const currentTimestamp = await getLatestBlockTimestampAsync();
                 const approvalExpirationTimeSeconds = new BigNumber(currentTimestamp).plus(constants.TIME_BUFFER);
-                const approval = approvalFactory.newSignedApproval(transaction, approvalExpirationTimeSeconds);
+                const approval = approvalFactory.newSignedApproval(
+                    transaction,
+                    takerAddress,
+                    approvalExpirationTimeSeconds,
+                );
                 await expectTransactionFailedAsync(
                     coordinatorContract.executeTransaction.sendTransactionAsync(
                         transaction,
+                        takerAddress,
                         transaction.signature,
                         [approvalExpirationTimeSeconds],
                         [approval.signature],
@@ -396,6 +439,7 @@ describe('Coordinator tests', () => {
             const transactionReceipt = await web3Wrapper.awaitTransactionSuccessAsync(
                 await coordinatorContract.executeTransaction.sendTransactionAsync(
                     transaction,
+                    makerAddress,
                     transaction.signature,
                     [],
                     [],
@@ -423,6 +467,7 @@ describe('Coordinator tests', () => {
             const transactionReceipt = await web3Wrapper.awaitTransactionSuccessAsync(
                 await coordinatorContract.executeTransaction.sendTransactionAsync(
                     transaction,
+                    makerAddress,
                     transaction.signature,
                     [],
                     [],
@@ -452,6 +497,7 @@ describe('Coordinator tests', () => {
             const transactionReceipt = await web3Wrapper.awaitTransactionSuccessAsync(
                 await coordinatorContract.executeTransaction.sendTransactionAsync(
                     transaction,
+                    makerAddress,
                     transaction.signature,
                     [],
                     [],

--- a/contracts/coordinator/test/libs.ts
+++ b/contracts/coordinator/test/libs.ts
@@ -52,12 +52,18 @@ describe('Libs tests', () => {
                 signature: '0x5678',
             };
             const approvalExpirationTimeSeconds = new BigNumber(0);
+            const txOrigin = constants.NULL_ADDRESS;
             const approval = {
+                txOrigin,
                 transactionHash: hashUtils.getTransactionHashHex(signedTx),
                 transactionSignature: signedTx.signature,
                 approvalExpirationTimeSeconds,
             };
-            const expectedApprovalHash = hashUtils.getApprovalHashHex(signedTx, approvalExpirationTimeSeconds);
+            const expectedApprovalHash = hashUtils.getApprovalHashHex(
+                signedTx,
+                txOrigin,
+                approvalExpirationTimeSeconds,
+            );
             const approvalHash = await testLibs.publicGetCoordinatorApprovalHash.callAsync(approval);
             expect(expectedApprovalHash).to.eq(approvalHash);
         });

--- a/contracts/coordinator/test/mixins.ts
+++ b/contracts/coordinator/test/mixins.ts
@@ -362,7 +362,7 @@ describe('Mixins tests', () => {
                         [approval.signature],
                         { from: approvalSignerAddress2 },
                     ),
-                    RevertReason.InvalidSender,
+                    RevertReason.InvalidOrigin,
                 );
                 expectContractCallFailedAsync(
                     mixins.assertValidCoordinatorApprovals.callAsync(
@@ -373,7 +373,7 @@ describe('Mixins tests', () => {
                         [approval.signature],
                         { from: approvalSignerAddress2 },
                     ),
-                    RevertReason.InvalidSender,
+                    RevertReason.InvalidOrigin,
                 );
             });
         }
@@ -576,7 +576,7 @@ describe('Mixins tests', () => {
                         [approval2.signature],
                         { from: approvalSignerAddress1 },
                     ),
-                    RevertReason.InvalidSender,
+                    RevertReason.InvalidOrigin,
                 );
                 expectContractCallFailedAsync(
                     mixins.assertValidCoordinatorApprovals.callAsync(
@@ -587,7 +587,7 @@ describe('Mixins tests', () => {
                         [approval2.signature],
                         { from: approvalSignerAddress1 },
                     ),
-                    RevertReason.InvalidSender,
+                    RevertReason.InvalidOrigin,
                 );
             });
             it(`Should revert: function=${fnName} caller=tx_signer, senderAddress=[verifier,verifier], feeRecipient=[approver1, approver1], approval_sig=[], expiration=[]`, async () => {
@@ -828,7 +828,7 @@ describe('Mixins tests', () => {
                         [approval1.signature],
                         { from: approvalSignerAddress2 },
                     ),
-                    RevertReason.InvalidSender,
+                    RevertReason.InvalidOrigin,
                 );
                 expectContractCallFailedAsync(
                     mixins.assertValidCoordinatorApprovals.callAsync(
@@ -839,7 +839,7 @@ describe('Mixins tests', () => {
                         [approval1.signature],
                         { from: approvalSignerAddress2 },
                     ),
-                    RevertReason.InvalidSender,
+                    RevertReason.InvalidOrigin,
                 );
             });
         }

--- a/contracts/coordinator/test/mixins.ts
+++ b/contracts/coordinator/test/mixins.ts
@@ -137,10 +137,15 @@ describe('Mixins tests', () => {
                 const transaction = transactionFactory.newSignedCoordinatorTransaction(data);
                 const currentTimestamp = await getLatestBlockTimestampAsync();
                 const approvalExpirationTimeSeconds = new BigNumber(currentTimestamp).plus(constants.TIME_BUFFER);
-                const approval = approvalFactory1.newSignedApproval(transaction, approvalExpirationTimeSeconds);
+                const approval = approvalFactory1.newSignedApproval(
+                    transaction,
+                    transactionSignerAddress,
+                    approvalExpirationTimeSeconds,
+                );
                 await mixins.assertValidTransactionOrdersApproval.callAsync(
                     transaction,
                     orders,
+                    transactionSignerAddress,
                     transaction.signature,
                     [approvalExpirationTimeSeconds],
                     [approval.signature],
@@ -148,6 +153,7 @@ describe('Mixins tests', () => {
                 );
                 await mixins.assertValidCoordinatorApprovals.callAsync(
                     transaction,
+                    transactionSignerAddress,
                     transaction.signature,
                     [approvalExpirationTimeSeconds],
                     [approval.signature],
@@ -164,10 +170,15 @@ describe('Mixins tests', () => {
                 const transaction = transactionFactory.newSignedCoordinatorTransaction(data);
                 const currentTimestamp = await getLatestBlockTimestampAsync();
                 const approvalExpirationTimeSeconds = new BigNumber(currentTimestamp).plus(constants.TIME_BUFFER);
-                const approval = approvalFactory1.newSignedApproval(transaction, approvalExpirationTimeSeconds);
+                const approval = approvalFactory1.newSignedApproval(
+                    transaction,
+                    transactionSignerAddress,
+                    approvalExpirationTimeSeconds,
+                );
                 await mixins.assertValidTransactionOrdersApproval.callAsync(
                     transaction,
                     orders,
+                    transactionSignerAddress,
                     transaction.signature,
                     [approvalExpirationTimeSeconds],
                     [approval.signature],
@@ -175,6 +186,7 @@ describe('Mixins tests', () => {
                 );
                 await mixins.assertValidCoordinatorApprovals.callAsync(
                     transaction,
+                    transactionSignerAddress,
                     transaction.signature,
                     [approvalExpirationTimeSeconds],
                     [approval.signature],
@@ -188,14 +200,22 @@ describe('Mixins tests', () => {
                 await mixins.assertValidTransactionOrdersApproval.callAsync(
                     transaction,
                     orders,
+                    approvalSignerAddress1,
                     transaction.signature,
                     [],
                     [],
                     { from: approvalSignerAddress1 },
                 );
-                await mixins.assertValidCoordinatorApprovals.callAsync(transaction, transaction.signature, [], [], {
-                    from: approvalSignerAddress1,
-                });
+                await mixins.assertValidCoordinatorApprovals.callAsync(
+                    transaction,
+                    approvalSignerAddress1,
+                    transaction.signature,
+                    [],
+                    [],
+                    {
+                        from: approvalSignerAddress1,
+                    },
+                );
             });
             it(`Should be successful: function=${fnName}, caller=approver1, senderAddress=[verifier], approval_sig=[approver1], expiration=[invalid]`, async () => {
                 const orders = [defaultOrder];
@@ -203,10 +223,15 @@ describe('Mixins tests', () => {
                 const transaction = transactionFactory.newSignedCoordinatorTransaction(data);
                 const currentTimestamp = await getLatestBlockTimestampAsync();
                 const approvalExpirationTimeSeconds = new BigNumber(currentTimestamp).plus(constants.TIME_BUFFER);
-                const approval = approvalFactory1.newSignedApproval(transaction, approvalExpirationTimeSeconds);
+                const approval = approvalFactory1.newSignedApproval(
+                    transaction,
+                    transactionSignerAddress,
+                    approvalExpirationTimeSeconds,
+                );
                 await mixins.assertValidTransactionOrdersApproval.callAsync(
                     transaction,
                     orders,
+                    approvalSignerAddress1,
                     transaction.signature,
                     [approvalExpirationTimeSeconds],
                     [approval.signature],
@@ -214,6 +239,7 @@ describe('Mixins tests', () => {
                 );
                 await mixins.assertValidCoordinatorApprovals.callAsync(
                     transaction,
+                    approvalSignerAddress1,
                     transaction.signature,
                     [approvalExpirationTimeSeconds],
                     [approval.signature],
@@ -227,14 +253,22 @@ describe('Mixins tests', () => {
                 await mixins.assertValidTransactionOrdersApproval.callAsync(
                     transaction,
                     orders,
+                    approvalSignerAddress1,
                     transaction.signature,
                     [],
                     [],
                     { from: approvalSignerAddress1 },
                 );
-                await mixins.assertValidCoordinatorApprovals.callAsync(transaction, transaction.signature, [], [], {
-                    from: approvalSignerAddress1,
-                });
+                await mixins.assertValidCoordinatorApprovals.callAsync(
+                    transaction,
+                    approvalSignerAddress1,
+                    transaction.signature,
+                    [],
+                    [],
+                    {
+                        from: approvalSignerAddress1,
+                    },
+                );
             });
             it(`Should revert: function=${fnName}, caller=tx_signer, senderAddress=[verifier], approval_sig=[invalid], expiration=[valid]`, async () => {
                 const orders = [defaultOrder];
@@ -242,12 +276,17 @@ describe('Mixins tests', () => {
                 const transaction = transactionFactory.newSignedCoordinatorTransaction(data);
                 const currentTimestamp = await getLatestBlockTimestampAsync();
                 const approvalExpirationTimeSeconds = new BigNumber(currentTimestamp).plus(constants.TIME_BUFFER);
-                const approval = approvalFactory1.newSignedApproval(transaction, approvalExpirationTimeSeconds);
+                const approval = approvalFactory1.newSignedApproval(
+                    transaction,
+                    transactionSignerAddress,
+                    approvalExpirationTimeSeconds,
+                );
                 const signature = `${approval.signature.slice(0, 4)}FFFFFFFF${approval.signature.slice(12)}`;
                 expectContractCallFailedAsync(
                     mixins.assertValidTransactionOrdersApproval.callAsync(
                         transaction,
                         orders,
+                        transactionSignerAddress,
                         transaction.signature,
                         [approvalExpirationTimeSeconds],
                         [signature],
@@ -258,6 +297,7 @@ describe('Mixins tests', () => {
                 expectContractCallFailedAsync(
                     mixins.assertValidCoordinatorApprovals.callAsync(
                         transaction,
+                        transactionSignerAddress,
                         transaction.signature,
                         [approvalExpirationTimeSeconds],
                         [signature],
@@ -272,11 +312,16 @@ describe('Mixins tests', () => {
                 const transaction = transactionFactory.newSignedCoordinatorTransaction(data);
                 const currentTimestamp = await getLatestBlockTimestampAsync();
                 const approvalExpirationTimeSeconds = new BigNumber(currentTimestamp).minus(constants.TIME_BUFFER);
-                const approval = approvalFactory1.newSignedApproval(transaction, approvalExpirationTimeSeconds);
+                const approval = approvalFactory1.newSignedApproval(
+                    transaction,
+                    transactionSignerAddress,
+                    approvalExpirationTimeSeconds,
+                );
                 expectContractCallFailedAsync(
                     mixins.assertValidTransactionOrdersApproval.callAsync(
                         transaction,
                         orders,
+                        transactionSignerAddress,
                         transaction.signature,
                         [approvalExpirationTimeSeconds],
                         [approval.signature],
@@ -287,6 +332,7 @@ describe('Mixins tests', () => {
                 expectContractCallFailedAsync(
                     mixins.assertValidCoordinatorApprovals.callAsync(
                         transaction,
+                        transactionSignerAddress,
                         transaction.signature,
                         [approvalExpirationTimeSeconds],
                         [approval.signature],
@@ -301,11 +347,16 @@ describe('Mixins tests', () => {
                 const transaction = transactionFactory.newSignedCoordinatorTransaction(data);
                 const currentTimestamp = await getLatestBlockTimestampAsync();
                 const approvalExpirationTimeSeconds = new BigNumber(currentTimestamp).plus(constants.TIME_BUFFER);
-                const approval = approvalFactory1.newSignedApproval(transaction, approvalExpirationTimeSeconds);
+                const approval = approvalFactory1.newSignedApproval(
+                    transaction,
+                    transactionSignerAddress,
+                    approvalExpirationTimeSeconds,
+                );
                 expectContractCallFailedAsync(
                     mixins.assertValidTransactionOrdersApproval.callAsync(
                         transaction,
                         orders,
+                        transactionSignerAddress,
                         transaction.signature,
                         [approvalExpirationTimeSeconds],
                         [approval.signature],
@@ -316,6 +367,7 @@ describe('Mixins tests', () => {
                 expectContractCallFailedAsync(
                     mixins.assertValidCoordinatorApprovals.callAsync(
                         transaction,
+                        transactionSignerAddress,
                         transaction.signature,
                         [approvalExpirationTimeSeconds],
                         [approval.signature],
@@ -338,10 +390,15 @@ describe('Mixins tests', () => {
                 const transaction = transactionFactory.newSignedCoordinatorTransaction(data);
                 const currentTimestamp = await getLatestBlockTimestampAsync();
                 const approvalExpirationTimeSeconds = new BigNumber(currentTimestamp).plus(constants.TIME_BUFFER);
-                const approval = approvalFactory1.newSignedApproval(transaction, approvalExpirationTimeSeconds);
+                const approval = approvalFactory1.newSignedApproval(
+                    transaction,
+                    transactionSignerAddress,
+                    approvalExpirationTimeSeconds,
+                );
                 await mixins.assertValidTransactionOrdersApproval.callAsync(
                     transaction,
                     orders,
+                    transactionSignerAddress,
                     transaction.signature,
                     [approvalExpirationTimeSeconds],
                     [approval.signature],
@@ -349,6 +406,7 @@ describe('Mixins tests', () => {
                 );
                 await mixins.assertValidCoordinatorApprovals.callAsync(
                     transaction,
+                    transactionSignerAddress,
                     transaction.signature,
                     [approvalExpirationTimeSeconds],
                     [approval.signature],
@@ -364,10 +422,15 @@ describe('Mixins tests', () => {
                 const transaction = transactionFactory.newSignedCoordinatorTransaction(data);
                 const currentTimestamp = await getLatestBlockTimestampAsync();
                 const approvalExpirationTimeSeconds = new BigNumber(currentTimestamp).plus(constants.TIME_BUFFER);
-                const approval = approvalFactory1.newSignedApproval(transaction, approvalExpirationTimeSeconds);
+                const approval = approvalFactory1.newSignedApproval(
+                    transaction,
+                    transactionSignerAddress,
+                    approvalExpirationTimeSeconds,
+                );
                 await mixins.assertValidTransactionOrdersApproval.callAsync(
                     transaction,
                     orders,
+                    transactionSignerAddress,
                     transaction.signature,
                     [approvalExpirationTimeSeconds],
                     [approval.signature],
@@ -375,6 +438,7 @@ describe('Mixins tests', () => {
                 );
                 await mixins.assertValidCoordinatorApprovals.callAsync(
                     transaction,
+                    transactionSignerAddress,
                     transaction.signature,
                     [approvalExpirationTimeSeconds],
                     [approval.signature],
@@ -391,14 +455,20 @@ describe('Mixins tests', () => {
                 await mixins.assertValidTransactionOrdersApproval.callAsync(
                     transaction,
                     orders,
+                    transactionSignerAddress,
                     transaction.signature,
                     [],
                     [],
                     { from: transactionSignerAddress },
                 );
-                await mixins.assertValidCoordinatorApprovals.callAsync(transaction, transaction.signature, [], [], {
-                    from: transactionSignerAddress,
-                });
+                await mixins.assertValidCoordinatorApprovals.callAsync(
+                    transaction,
+                    transactionSignerAddress,
+                    transaction.signature,
+                    [],
+                    [],
+                    { from: transactionSignerAddress },
+                );
             });
             it(`Should be successful: function=${fnName} caller=tx_signer, senderAddress=[verifier,null], feeRecipient=[approver1,approver1], approval_sig=[approver1], expiration=[valid]`, async () => {
                 const orders = [defaultOrder, { ...defaultOrder, senderAddress: devConstants.NULL_ADDRESS }];
@@ -406,10 +476,15 @@ describe('Mixins tests', () => {
                 const transaction = transactionFactory.newSignedCoordinatorTransaction(data);
                 const currentTimestamp = await getLatestBlockTimestampAsync();
                 const approvalExpirationTimeSeconds = new BigNumber(currentTimestamp).plus(constants.TIME_BUFFER);
-                const approval = approvalFactory1.newSignedApproval(transaction, approvalExpirationTimeSeconds);
+                const approval = approvalFactory1.newSignedApproval(
+                    transaction,
+                    transactionSignerAddress,
+                    approvalExpirationTimeSeconds,
+                );
                 await mixins.assertValidTransactionOrdersApproval.callAsync(
                     transaction,
                     orders,
+                    transactionSignerAddress,
                     transaction.signature,
                     [approvalExpirationTimeSeconds],
                     [approval.signature],
@@ -417,6 +492,7 @@ describe('Mixins tests', () => {
                 );
                 await mixins.assertValidCoordinatorApprovals.callAsync(
                     transaction,
+                    transactionSignerAddress,
                     transaction.signature,
                     [approvalExpirationTimeSeconds],
                     [approval.signature],
@@ -429,11 +505,20 @@ describe('Mixins tests', () => {
                 const transaction = transactionFactory.newSignedCoordinatorTransaction(data);
                 const currentTimestamp = await getLatestBlockTimestampAsync();
                 const approvalExpirationTimeSeconds = new BigNumber(currentTimestamp).plus(constants.TIME_BUFFER);
-                const approval1 = approvalFactory1.newSignedApproval(transaction, approvalExpirationTimeSeconds);
-                const approval2 = approvalFactory2.newSignedApproval(transaction, approvalExpirationTimeSeconds);
+                const approval1 = approvalFactory1.newSignedApproval(
+                    transaction,
+                    transactionSignerAddress,
+                    approvalExpirationTimeSeconds,
+                );
+                const approval2 = approvalFactory2.newSignedApproval(
+                    transaction,
+                    transactionSignerAddress,
+                    approvalExpirationTimeSeconds,
+                );
                 await mixins.assertValidTransactionOrdersApproval.callAsync(
                     transaction,
                     orders,
+                    transactionSignerAddress,
                     transaction.signature,
                     [approvalExpirationTimeSeconds, approvalExpirationTimeSeconds],
                     [approval1.signature, approval2.signature],
@@ -441,6 +526,7 @@ describe('Mixins tests', () => {
                 );
                 await mixins.assertValidCoordinatorApprovals.callAsync(
                     transaction,
+                    transactionSignerAddress,
                     transaction.signature,
                     [approvalExpirationTimeSeconds, approvalExpirationTimeSeconds],
                     [approval1.signature, approval2.signature],
@@ -454,36 +540,54 @@ describe('Mixins tests', () => {
                 await mixins.assertValidTransactionOrdersApproval.callAsync(
                     transaction,
                     orders,
+                    approvalSignerAddress1,
                     transaction.signature,
                     [],
                     [],
                     { from: approvalSignerAddress1 },
                 );
-                await mixins.assertValidCoordinatorApprovals.callAsync(transaction, transaction.signature, [], [], {
-                    from: approvalSignerAddress1,
-                });
+                await mixins.assertValidCoordinatorApprovals.callAsync(
+                    transaction,
+                    approvalSignerAddress1,
+                    transaction.signature,
+                    [],
+                    [],
+                    { from: approvalSignerAddress1 },
+                );
             });
-            it(`Should be successful: function=${fnName} caller=approver1, senderAddress=[verifier,verifier], feeRecipient=[approver1,approver2], approval_sig=[approver2], expiration=[valid]`, async () => {
+            it(`Should revert: function=${fnName} caller=approver1, senderAddress=[verifier,verifier], feeRecipient=[approver1,approver2], approval_sig=[approver2], expiration=[valid]`, async () => {
                 const orders = [defaultOrder, { ...defaultOrder, feeRecipientAddress: approvalSignerAddress2 }];
                 const data = exchangeDataEncoder.encodeOrdersToExchangeData(fnName, orders);
                 const transaction = transactionFactory.newSignedCoordinatorTransaction(data);
                 const currentTimestamp = await getLatestBlockTimestampAsync();
                 const approvalExpirationTimeSeconds = new BigNumber(currentTimestamp).plus(constants.TIME_BUFFER);
-                const approval2 = approvalFactory2.newSignedApproval(transaction, approvalExpirationTimeSeconds);
-                await mixins.assertValidTransactionOrdersApproval.callAsync(
+                const approval2 = approvalFactory2.newSignedApproval(
                     transaction,
-                    orders,
-                    transaction.signature,
-                    [approvalExpirationTimeSeconds],
-                    [approval2.signature],
-                    { from: approvalSignerAddress1 },
+                    transactionSignerAddress,
+                    approvalExpirationTimeSeconds,
                 );
-                await mixins.assertValidCoordinatorApprovals.callAsync(
-                    transaction,
-                    transaction.signature,
-                    [approvalExpirationTimeSeconds],
-                    [approval2.signature],
-                    { from: approvalSignerAddress1 },
+                expectContractCallFailedAsync(
+                    mixins.assertValidTransactionOrdersApproval.callAsync(
+                        transaction,
+                        orders,
+                        transactionSignerAddress,
+                        transaction.signature,
+                        [approvalExpirationTimeSeconds],
+                        [approval2.signature],
+                        { from: approvalSignerAddress1 },
+                    ),
+                    RevertReason.InvalidSender,
+                );
+                expectContractCallFailedAsync(
+                    mixins.assertValidCoordinatorApprovals.callAsync(
+                        transaction,
+                        transactionSignerAddress,
+                        transaction.signature,
+                        [approvalExpirationTimeSeconds],
+                        [approval2.signature],
+                        { from: approvalSignerAddress1 },
+                    ),
+                    RevertReason.InvalidSender,
                 );
             });
             it(`Should revert: function=${fnName} caller=tx_signer, senderAddress=[verifier,verifier], feeRecipient=[approver1, approver1], approval_sig=[], expiration=[]`, async () => {
@@ -494,6 +598,7 @@ describe('Mixins tests', () => {
                     mixins.assertValidTransactionOrdersApproval.callAsync(
                         transaction,
                         orders,
+                        transactionSignerAddress,
                         transaction.signature,
                         [],
                         [],
@@ -502,9 +607,14 @@ describe('Mixins tests', () => {
                     RevertReason.InvalidApprovalSignature,
                 );
                 expectContractCallFailedAsync(
-                    mixins.assertValidCoordinatorApprovals.callAsync(transaction, transaction.signature, [], [], {
-                        from: transactionSignerAddress,
-                    }),
+                    mixins.assertValidCoordinatorApprovals.callAsync(
+                        transaction,
+                        transactionSignerAddress,
+                        transaction.signature,
+                        [],
+                        [],
+                        { from: transactionSignerAddress },
+                    ),
                     RevertReason.InvalidApprovalSignature,
                 );
             });
@@ -514,12 +624,17 @@ describe('Mixins tests', () => {
                 const transaction = transactionFactory.newSignedCoordinatorTransaction(data);
                 const currentTimestamp = await getLatestBlockTimestampAsync();
                 const approvalExpirationTimeSeconds = new BigNumber(currentTimestamp).plus(constants.TIME_BUFFER);
-                const approval = approvalFactory1.newSignedApproval(transaction, approvalExpirationTimeSeconds);
+                const approval = approvalFactory1.newSignedApproval(
+                    transaction,
+                    transactionSignerAddress,
+                    approvalExpirationTimeSeconds,
+                );
                 const signature = `${approval.signature.slice(0, 4)}FFFFFFFF${approval.signature.slice(12)}`;
                 expectContractCallFailedAsync(
                     mixins.assertValidTransactionOrdersApproval.callAsync(
                         transaction,
                         orders,
+                        transactionSignerAddress,
                         transaction.signature,
                         [approvalExpirationTimeSeconds],
                         [signature],
@@ -530,6 +645,7 @@ describe('Mixins tests', () => {
                 expectContractCallFailedAsync(
                     mixins.assertValidCoordinatorApprovals.callAsync(
                         transaction,
+                        transactionSignerAddress,
                         transaction.signature,
                         [approvalExpirationTimeSeconds],
                         [signature],
@@ -544,13 +660,22 @@ describe('Mixins tests', () => {
                 const transaction = transactionFactory.newSignedCoordinatorTransaction(data);
                 const currentTimestamp = await getLatestBlockTimestampAsync();
                 const approvalExpirationTimeSeconds = new BigNumber(currentTimestamp).plus(constants.TIME_BUFFER);
-                const approval1 = approvalFactory1.newSignedApproval(transaction, approvalExpirationTimeSeconds);
-                const approval2 = approvalFactory2.newSignedApproval(transaction, approvalExpirationTimeSeconds);
+                const approval1 = approvalFactory1.newSignedApproval(
+                    transaction,
+                    transactionSignerAddress,
+                    approvalExpirationTimeSeconds,
+                );
+                const approval2 = approvalFactory2.newSignedApproval(
+                    transaction,
+                    transactionSignerAddress,
+                    approvalExpirationTimeSeconds,
+                );
                 const approvalSignature2 = `${approval2.signature.slice(0, 4)}FFFFFFFF${approval2.signature.slice(12)}`;
                 expectContractCallFailedAsync(
                     mixins.assertValidTransactionOrdersApproval.callAsync(
                         transaction,
                         orders,
+                        transactionSignerAddress,
                         transaction.signature,
                         [approvalExpirationTimeSeconds, approvalExpirationTimeSeconds],
                         [approval1.signature, approvalSignature2],
@@ -561,6 +686,7 @@ describe('Mixins tests', () => {
                 expectContractCallFailedAsync(
                     mixins.assertValidCoordinatorApprovals.callAsync(
                         transaction,
+                        transactionSignerAddress,
                         transaction.signature,
                         [approvalExpirationTimeSeconds, approvalExpirationTimeSeconds],
                         [approval1.signature, approvalSignature2],
@@ -575,12 +701,17 @@ describe('Mixins tests', () => {
                 const transaction = transactionFactory.newSignedCoordinatorTransaction(data);
                 const currentTimestamp = await getLatestBlockTimestampAsync();
                 const approvalExpirationTimeSeconds = new BigNumber(currentTimestamp).plus(constants.TIME_BUFFER);
-                const approval2 = approvalFactory2.newSignedApproval(transaction, approvalExpirationTimeSeconds);
+                const approval2 = approvalFactory2.newSignedApproval(
+                    transaction,
+                    transactionSignerAddress,
+                    approvalExpirationTimeSeconds,
+                );
                 const approvalSignature2 = `${approval2.signature.slice(0, 4)}FFFFFFFF${approval2.signature.slice(12)}`;
                 expectContractCallFailedAsync(
                     mixins.assertValidTransactionOrdersApproval.callAsync(
                         transaction,
                         orders,
+                        approvalSignerAddress1,
                         transaction.signature,
                         [approvalExpirationTimeSeconds],
                         [approvalSignature2],
@@ -591,6 +722,7 @@ describe('Mixins tests', () => {
                 expectContractCallFailedAsync(
                     mixins.assertValidCoordinatorApprovals.callAsync(
                         transaction,
+                        approvalSignerAddress1,
                         transaction.signature,
                         [approvalExpirationTimeSeconds],
                         [approvalSignature2],
@@ -606,12 +738,21 @@ describe('Mixins tests', () => {
                 const currentTimestamp = await getLatestBlockTimestampAsync();
                 const approvalExpirationTimeSeconds1 = new BigNumber(currentTimestamp).plus(constants.TIME_BUFFER);
                 const approvalExpirationTimeSeconds2 = new BigNumber(currentTimestamp).minus(constants.TIME_BUFFER);
-                const approval1 = approvalFactory1.newSignedApproval(transaction, approvalExpirationTimeSeconds1);
-                const approval2 = approvalFactory2.newSignedApproval(transaction, approvalExpirationTimeSeconds2);
+                const approval1 = approvalFactory1.newSignedApproval(
+                    transaction,
+                    transactionSignerAddress,
+                    approvalExpirationTimeSeconds1,
+                );
+                const approval2 = approvalFactory2.newSignedApproval(
+                    transaction,
+                    transactionSignerAddress,
+                    approvalExpirationTimeSeconds2,
+                );
                 expectContractCallFailedAsync(
                     mixins.assertValidTransactionOrdersApproval.callAsync(
                         transaction,
                         orders,
+                        transactionSignerAddress,
                         transaction.signature,
                         [approvalExpirationTimeSeconds1, approvalExpirationTimeSeconds2],
                         [approval1.signature, approval2.signature],
@@ -622,6 +763,7 @@ describe('Mixins tests', () => {
                 expectContractCallFailedAsync(
                     mixins.assertValidCoordinatorApprovals.callAsync(
                         transaction,
+                        transactionSignerAddress,
                         transaction.signature,
                         [approvalExpirationTimeSeconds1, approvalExpirationTimeSeconds2],
                         [approval1.signature, approval2.signature],
@@ -636,11 +778,16 @@ describe('Mixins tests', () => {
                 const transaction = transactionFactory.newSignedCoordinatorTransaction(data);
                 const currentTimestamp = await getLatestBlockTimestampAsync();
                 const approvalExpirationTimeSeconds = new BigNumber(currentTimestamp).minus(constants.TIME_BUFFER);
-                const approval2 = approvalFactory2.newSignedApproval(transaction, approvalExpirationTimeSeconds);
+                const approval2 = approvalFactory2.newSignedApproval(
+                    transaction,
+                    transactionSignerAddress,
+                    approvalExpirationTimeSeconds,
+                );
                 expectContractCallFailedAsync(
                     mixins.assertValidTransactionOrdersApproval.callAsync(
                         transaction,
                         orders,
+                        approvalSignerAddress1,
                         transaction.signature,
                         [approvalExpirationTimeSeconds],
                         [approval2.signature],
@@ -651,6 +798,7 @@ describe('Mixins tests', () => {
                 expectContractCallFailedAsync(
                     mixins.assertValidCoordinatorApprovals.callAsync(
                         transaction,
+                        approvalSignerAddress1,
                         transaction.signature,
                         [approvalExpirationTimeSeconds],
                         [approval2.signature],
@@ -665,11 +813,16 @@ describe('Mixins tests', () => {
                 const transaction = transactionFactory.newSignedCoordinatorTransaction(data);
                 const currentTimestamp = await getLatestBlockTimestampAsync();
                 const approvalExpirationTimeSeconds = new BigNumber(currentTimestamp).plus(constants.TIME_BUFFER);
-                const approval1 = approvalFactory1.newSignedApproval(transaction, approvalExpirationTimeSeconds);
+                const approval1 = approvalFactory1.newSignedApproval(
+                    transaction,
+                    transactionSignerAddress,
+                    approvalExpirationTimeSeconds,
+                );
                 expectContractCallFailedAsync(
                     mixins.assertValidTransactionOrdersApproval.callAsync(
                         transaction,
                         orders,
+                        transactionSignerAddress,
                         transaction.signature,
                         [approvalExpirationTimeSeconds],
                         [approval1.signature],
@@ -680,6 +833,7 @@ describe('Mixins tests', () => {
                 expectContractCallFailedAsync(
                     mixins.assertValidCoordinatorApprovals.callAsync(
                         transaction,
+                        transactionSignerAddress,
                         transaction.signature,
                         [approvalExpirationTimeSeconds],
                         [approval1.signature],
@@ -695,25 +849,40 @@ describe('Mixins tests', () => {
             const orders = [defaultOrder];
             const data = exchangeDataEncoder.encodeOrdersToExchangeData(constants.CANCEL_ORDERS, orders);
             const transaction = transactionFactory.newSignedCoordinatorTransaction(data);
-            await mixins.assertValidCoordinatorApprovals.callAsync(transaction, transaction.signature, [], [], {
-                from: transactionSignerAddress,
-            });
+            await mixins.assertValidCoordinatorApprovals.callAsync(
+                transaction,
+                transactionSignerAddress,
+                transaction.signature,
+                [],
+                [],
+                { from: transactionSignerAddress },
+            );
         });
         it('should allow the tx signer to call `batchCancelOrders` without approval', async () => {
             const orders = [defaultOrder, defaultOrder];
             const data = exchangeDataEncoder.encodeOrdersToExchangeData(constants.BATCH_CANCEL_ORDERS, orders);
             const transaction = transactionFactory.newSignedCoordinatorTransaction(data);
-            await mixins.assertValidCoordinatorApprovals.callAsync(transaction, transaction.signature, [], [], {
-                from: transactionSignerAddress,
-            });
+            await mixins.assertValidCoordinatorApprovals.callAsync(
+                transaction,
+                transactionSignerAddress,
+                transaction.signature,
+                [],
+                [],
+                { from: transactionSignerAddress },
+            );
         });
         it('should allow the tx signer to call `cancelOrdersUpTo` without approval', async () => {
             const orders: SignedOrder[] = [];
             const data = exchangeDataEncoder.encodeOrdersToExchangeData(constants.CANCEL_ORDERS_UP_TO, orders);
             const transaction = transactionFactory.newSignedCoordinatorTransaction(data);
-            await mixins.assertValidCoordinatorApprovals.callAsync(transaction, transaction.signature, [], [], {
-                from: transactionSignerAddress,
-            });
+            await mixins.assertValidCoordinatorApprovals.callAsync(
+                transaction,
+                transactionSignerAddress,
+                transaction.signature,
+                [],
+                [],
+                { from: transactionSignerAddress },
+            );
         });
     });
 });

--- a/contracts/coordinator/test/utils/approval_factory.ts
+++ b/contracts/coordinator/test/utils/approval_factory.ts
@@ -13,6 +13,7 @@ export class ApprovalFactory {
     }
     public newSignedApproval(
         transaction: SignedZeroExTransaction,
+        txOrigin: string,
         approvalExpirationTimeSeconds: BigNumber,
         signatureType: CoordinatorSignatureType = CoordinatorSignatureType.EthSign,
     ): SignedCoordinatorApproval {
@@ -20,9 +21,14 @@ export class ApprovalFactory {
             ...transaction,
             verifyingContractAddress: this._verifyingContractAddress,
         };
-        const approvalHashBuff = hashUtils.getApprovalHashBuffer(coordinatorTransaction, approvalExpirationTimeSeconds);
+        const approvalHashBuff = hashUtils.getApprovalHashBuffer(
+            coordinatorTransaction,
+            txOrigin,
+            approvalExpirationTimeSeconds,
+        );
         const signatureBuff = signingUtils.signMessage(approvalHashBuff, this._privateKey, signatureType);
         const signedApproval = {
+            txOrigin,
             transaction: coordinatorTransaction,
             approvalExpirationTimeSeconds,
             signature: ethUtil.addHexPrefix(signatureBuff.toString('hex')),

--- a/contracts/coordinator/test/utils/constants.ts
+++ b/contracts/coordinator/test/utils/constants.ts
@@ -6,6 +6,7 @@ export const constants = {
     COORDINATOR_APPROVAL_SCHEMA: {
         name: 'CoordinatorApproval',
         parameters: [
+            { name: 'txOrigin', type: 'address' },
             { name: 'transactionHash', type: 'bytes32' },
             { name: 'transactionSignature', type: 'bytes' },
             { name: 'approvalExpirationTimeSeconds', type: 'uint256' },

--- a/contracts/coordinator/test/utils/hash_utils.ts
+++ b/contracts/coordinator/test/utils/hash_utils.ts
@@ -7,7 +7,11 @@ import * as _ from 'lodash';
 import { constants } from './index';
 
 export const hashUtils = {
-    getApprovalHashBuffer(transaction: SignedZeroExTransaction, approvalExpirationTimeSeconds: BigNumber): Buffer {
+    getApprovalHashBuffer(
+        transaction: SignedZeroExTransaction,
+        txOrigin: string,
+        approvalExpirationTimeSeconds: BigNumber,
+    ): Buffer {
         const domain = {
             name: constants.COORDINATOR_DOMAIN_NAME,
             version: constants.COORDINATOR_DOMAIN_VERSION,
@@ -15,6 +19,7 @@ export const hashUtils = {
         };
         const transactionHash = hashUtils.getTransactionHashHex(transaction);
         const approval = {
+            txOrigin,
             transactionHash,
             transactionSignature: transaction.signature,
             approvalExpirationTimeSeconds: approvalExpirationTimeSeconds.toString(),
@@ -30,9 +35,13 @@ export const hashUtils = {
         const hashBuffer = signTypedDataUtils.generateTypedDataHash(typedData);
         return hashBuffer;
     },
-    getApprovalHashHex(transaction: SignedZeroExTransaction, approvalExpirationTimeSeconds: BigNumber): string {
+    getApprovalHashHex(
+        transaction: SignedZeroExTransaction,
+        txOrigin: string,
+        approvalExpirationTimeSeconds: BigNumber,
+    ): string {
         const hashHex = `0x${hashUtils
-            .getApprovalHashBuffer(transaction, approvalExpirationTimeSeconds)
+            .getApprovalHashBuffer(transaction, txOrigin, approvalExpirationTimeSeconds)
             .toString('hex')}`;
         return hashHex;
     },

--- a/contracts/coordinator/test/utils/types.ts
+++ b/contracts/coordinator/test/utils/types.ts
@@ -3,6 +3,7 @@ import { BigNumber } from '@0x/utils';
 
 export interface CoordinatorApproval {
     transaction: SignedZeroExTransaction;
+    txOrigin: string;
     approvalExpirationTimeSeconds: BigNumber;
 }
 

--- a/contracts/utils/CHANGELOG.json
+++ b/contracts/utils/CHANGELOG.json
@@ -5,6 +5,10 @@
             {
                 "note": "Set evmVersion to byzantium",
                 "pr": 1678
+            },
+            {
+                "note": "Optimize loops in LibAddressArray",
+                "pr": 1668
             }
         ]
     },

--- a/contracts/utils/contracts/src/LibAddressArray.sol
+++ b/contracts/utils/contracts/src/LibAddressArray.sol
@@ -91,15 +91,31 @@ library LibAddressArray {
     function contains(address[] memory addressArray, address target)
         internal
         pure
-        returns (bool)
+        returns (bool success)
     {
-        uint256 length = addressArray.length;
-        for (uint256 i = 0; i < length; i++) {
-            if (addressArray[i] == target) {
-                return true;
+        assembly {
+
+            // Calculate byte length of array
+            let arrayByteLen := mul(mload(addressArray), 32)
+            // Calculate beginning of array contents
+            let arrayContentsStart := add(addressArray, 32)
+
+            // Loop through array
+            for {let i:= 0} lt(i, arrayByteLen) {i := add(i, 32)} {
+
+                // Load array element
+                let arrayElement := mload(add(arrayContentsStart, i))
+
+                // Return true if array element equals target
+                if eq(target, arrayElement) {
+                    // Set success to true
+                    success := 1
+                    // Break loop
+                    i := arrayByteLen
+                }
             }
         }
-        return false;
+        return success;
     }
 
     /// @dev Finds the index of an address within an array.
@@ -109,14 +125,31 @@ library LibAddressArray {
     function indexOf(address[] memory addressArray, address target)
         internal
         pure
-        returns (bool, uint256)
+        returns (bool success, uint256 index)
     {
-        uint256 length = addressArray.length;
-        for (uint256 i = 0; i < length; i++) {
-            if (addressArray[i] == target) {
-                return (true, i);
+        assembly {
+
+            // Calculate byte length of array
+            let arrayByteLen := mul(mload(addressArray), 32)
+            // Calculate beginning of array contents
+            let arrayContentsStart := add(addressArray, 32)
+
+            // Loop through array
+            for {let i:= 0} lt(i, arrayByteLen) {i := add(i, 32)} {
+
+                // Load array element
+                let arrayElement := mload(add(arrayContentsStart, i))
+
+                // Return true if array element equals target
+                if eq(target, arrayElement) {
+                    // Set success and index
+                    success := 1
+                    index := div(i, 32)
+                    // Break loop
+                    i := arrayByteLen
+                }
             }
         }
-        return (false, 0);
+        return (success, index);
     }
 }

--- a/contracts/utils/contracts/src/LibAddressArray.sol
+++ b/contracts/utils/contracts/src/LibAddressArray.sol
@@ -99,19 +99,21 @@ library LibAddressArray {
             let arrayByteLen := mul(mload(addressArray), 32)
             // Calculate beginning of array contents
             let arrayContentsStart := add(addressArray, 32)
+            // Calclulate end of array contents
+            let arrayContentsEnd := add(arrayContentsStart, arrayByteLen)
 
             // Loop through array
-            for {let i:= 0} lt(i, arrayByteLen) {i := add(i, 32)} {
+            for {let i:= arrayContentsStart} lt(i, arrayContentsEnd) {i := add(i, 32)} {
 
                 // Load array element
-                let arrayElement := mload(add(arrayContentsStart, i))
+                let arrayElement := mload(i)
 
                 // Return true if array element equals target
                 if eq(target, arrayElement) {
                     // Set success to true
                     success := 1
                     // Break loop
-                    i := arrayByteLen
+                    i := arrayContentsEnd
                 }
             }
         }
@@ -133,12 +135,14 @@ library LibAddressArray {
             let arrayByteLen := mul(mload(addressArray), 32)
             // Calculate beginning of array contents
             let arrayContentsStart := add(addressArray, 32)
+            // Calclulate end of array contents
+            let arrayContentsEnd := add(arrayContentsStart, arrayByteLen)
 
             // Loop through array
-            for {let i:= 0} lt(i, arrayByteLen) {i := add(i, 32)} {
+            for {let i:= arrayContentsStart} lt(i, arrayContentsEnd) {i := add(i, 32)} {
 
                 // Load array element
-                let arrayElement := mload(add(arrayContentsStart, i))
+                let arrayElement := mload(i)
 
                 // Return true if array element equals target
                 if eq(target, arrayElement) {
@@ -146,7 +150,7 @@ library LibAddressArray {
                     success := 1
                     index := div(i, 32)
                     // Break loop
-                    i := arrayByteLen
+                    i := arrayContentsEnd
                 }
             }
         }

--- a/packages/types/CHANGELOG.json
+++ b/packages/types/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "2.2.0",
+        "changes": [
+            {
+                "note": "Add `InvalidOrigin` revert reason",
+                "pr": 1668
+            }
+        ]
+    },
+    {
         "timestamp": 1551220833,
         "version": "2.1.1",
         "changes": [

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -273,6 +273,7 @@ export enum RevertReason {
     ToLessThanLengthRequired = 'TO_LESS_THAN_LENGTH_REQUIRED',
     InvalidApprovalSignature = 'INVALID_APPROVAL_SIGNATURE',
     ApprovalExpired = 'APPROVAL_EXPIRED',
+    InvalidOrigin = 'INVALID_ORIGIN',
 }
 
 export enum StatusCodes {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13473,15 +13473,6 @@ react-dom@^16.3.2:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-dom@^16.4.2:
-  version "16.8.3"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.3.tgz#ae236029e66210783ac81999d3015dfc475b9c32"
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.13.3"
-
 react-dom@^16.5.2:
   version "16.5.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.5.2.tgz#b69ee47aa20bab5327b2b9d7c1fe2a30f2cfa9d7"
@@ -13539,8 +13530,8 @@ react-highlight@0xproject/react-highlight#react-peer-deps:
   dependencies:
     highlight.js "^9.11.0"
     highlightjs-solidity "^1.0.5"
-    react "^16.5.2"
-    react-dom "^16.5.2"
+    react "^16.4.2"
+    react-dom "^16.4.2"
 
 react-hot-loader@^4.3.3:
   version "4.3.4"
@@ -13784,15 +13775,6 @@ react@^16.3.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
-
-react@^16.4.2:
-  version "16.8.3"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.8.3.tgz#c6f988a2ce895375de216edcfaedd6b9a76451d9"
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.13.3"
 
 react@^16.5.2:
   version "16.5.2"
@@ -14663,13 +14645,6 @@ schedule@^0.5.0:
   version "0.5.0"
   resolved "https://registry.npmjs.org/schedule/-/schedule-0.5.0.tgz#c128fffa0b402488b08b55ae74bb9df55cc29cc8"
   dependencies:
-    object-assign "^4.1.1"
-
-scheduler@^0.13.3:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.3.tgz#bed3c5850f62ea9c716a4d781f9daeb9b2a58896"
-  dependencies:
-    loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
 schema-utils@^0.4.4:


### PR DESCRIPTION
## Description

- Adds a `txOrigin` field to the Coordinator approval message. The transaction must be executed by this address. This prevent's a user's transaction from being front-runned when it is intended to be used in conjunction with external smart contract calls.
- Optimizes transaction and approval hashing

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
