### PR TITLE
Enable cryptokitties data from nonfungible.com

### DIFF
--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -29,7 +29,6 @@
     "devDependencies": {
         "@0x/tslint-config": "^3.0.0",
         "@types/axios": "^0.14.0",
-        "@types/lodash": "4.14.104",
         "@types/ramda": "^0.25.38",
         "chai": "^4.0.1",
         "chai-as-promised": "^7.1.0",
@@ -58,7 +57,6 @@
         "bottleneck": "^2.13.2",
         "dockerode": "^2.5.7",
         "ethereum-types": "^2.1.0",
-        "lodash": "^4.17.11",
         "pg": "^7.5.0",
         "prettier": "^1.16.3",
         "ramda": "^0.25.0",

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -29,6 +29,7 @@
     "devDependencies": {
         "@0x/tslint-config": "^3.0.0",
         "@types/axios": "^0.14.0",
+        "@types/lodash": "4.14.104",
         "@types/ramda": "^0.25.38",
         "chai": "^4.0.1",
         "chai-as-promised": "^7.1.0",
@@ -57,6 +58,7 @@
         "bottleneck": "^2.13.2",
         "dockerode": "^2.5.7",
         "ethereum-types": "^2.1.0",
+        "lodash": "^4.17.11",
         "pg": "^7.5.0",
         "prettier": "^1.16.3",
         "ramda": "^0.25.0",

--- a/packages/pipeline/src/data_sources/nonfungible_dot_com/index.ts
+++ b/packages/pipeline/src/data_sources/nonfungible_dot_com/index.ts
@@ -42,7 +42,7 @@ export interface NonfungibleDotComTradeResponse {
     transactionHash: string;
     blockNumber: number;
     logIndex: number;
-    blockTimestamp: string;
+    blockTimestamp: string | number; // string from API, number from initial dump
     assetId: string;
     assetDescriptor: string;
     nftAddress: string;
@@ -152,6 +152,10 @@ export async function getTradesAsync(
         );
         for (const tradeFromApi of tradesFromApi) {
             ensureNonNull(tradeFromApi);
+
+            // convert date from "2019-03-06T17:36:24.000Z" to unix epoch integer
+            const msPerSec = 1000;
+            tradeFromApi.blockTimestamp = Math.floor(new Date(tradeFromApi.blockTimestamp).valueOf() / msPerSec);
 
             if (tradeFromApi.blockNumber <= blockNumberStop) {
                 blockNumber = blockNumberStop;

--- a/packages/pipeline/src/scripts/partition_nonfungible_dot_com_dump.ts
+++ b/packages/pipeline/src/scripts/partition_nonfungible_dot_com_dump.ts
@@ -33,14 +33,15 @@ import {
 (() => {
     const publisher = process.argv[2];
 
-    const sourceJson: NonfungibleDotComHistoryResponse = JSON.parse(
-        readFileSync(`sales_summary_${publisher}.json`).toString(),
-    );
+    const inputFilename = `sales_summary_${publisher}.json`;
+    logUtils.log(`Reading input file ${inputFilename}`);
+    const sourceJson: NonfungibleDotComHistoryResponse = JSON.parse(readFileSync(inputFilename).toString());
 
-    const chunks: NonfungibleDotComTradeResponse[][] = splitEvery(S3_CHUNK_SIZES[publisher], sourceJson.data);
+    const chunkSize = S3_CHUNK_SIZES[publisher];
+    logUtils.log(`Splitting data into chunks of ${chunkSize} trades each`);
+    const chunks: NonfungibleDotComTradeResponse[][] = splitEvery(chunkSize, sourceJson.data);
 
-    logUtils.log(`${chunks.length} chunks`);
-
+    logUtils.log(`Writing ${chunks.length} chunks to disk`);
     for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex++) {
         writeFileSync(`sales_summary_${publisher}${chunkIndex}.json`, JSON.stringify(chunks[chunkIndex]));
     }

--- a/packages/pipeline/src/scripts/partition_nonfungible_dot_com_dump.ts
+++ b/packages/pipeline/src/scripts/partition_nonfungible_dot_com_dump.ts
@@ -1,0 +1,47 @@
+/**
+ * Needed because we store the initial dump of trades in S3, and some projects
+ * (namely cryptokitties) have dumps that are too big to be transferred easily
+ * as one big file to and from S3.  This script breaks apart a dump file into a
+ * set of files containing segments of the data.  The number of segments is
+ * based on S3_CHUNK_SIZES specified for each project, or "publisher" in their
+ * parlance, in ../../data_sources/nonfungible_dot_com/index.ts.
+ *
+ * Usage: $ node partition_nonfungible_dot_com_dump.ts publisher
+ * Example: $ node partition_nonfungible_dot_com_dump.ts cryptokitties
+ *
+ * Expects a to find on disk a data file named
+ * `sales_summary_${publisher}.json`, as emailed by Daniel of nonfungible.com.
+ *
+ * Writes to disk a set of files named `sales_summary_${publisher}${N}.json`.
+ *
+ * Probably need to use `node` with --max-old-space-size=1024 or maybe
+ * even more.
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+
+import { chunk } from 'lodash';
+
+import { logUtils } from '@0x/utils';
+
+import {
+    NonfungibleDotComHistoryResponse,
+    NonfungibleDotComTradeResponse,
+    S3_CHUNK_SIZES,
+} from '../data_sources/nonfungible_dot_com';
+
+(() => {
+    const publisher = process.argv[2];
+
+    const sourceJson: NonfungibleDotComHistoryResponse = JSON.parse(
+        readFileSync(`sales_summary_${publisher}.json`).toString(),
+    );
+
+    const chunks: NonfungibleDotComTradeResponse[][] = chunk(sourceJson.data, S3_CHUNK_SIZES[publisher]);
+
+    logUtils.log(`${chunks.length} chunks`);
+
+    for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex++) {
+        writeFileSync(`sales_summary_${publisher}${chunkIndex}.json`, JSON.stringify(chunks[chunkIndex]));
+    }
+})();

--- a/packages/pipeline/src/scripts/partition_nonfungible_dot_com_dump.ts
+++ b/packages/pipeline/src/scripts/partition_nonfungible_dot_com_dump.ts
@@ -20,7 +20,7 @@
 
 import { readFileSync, writeFileSync } from 'fs';
 
-import { chunk } from 'lodash';
+import { splitEvery } from 'ramda';
 
 import { logUtils } from '@0x/utils';
 
@@ -37,7 +37,7 @@ import {
         readFileSync(`sales_summary_${publisher}.json`).toString(),
     );
 
-    const chunks: NonfungibleDotComTradeResponse[][] = chunk(sourceJson.data, S3_CHUNK_SIZES[publisher]);
+    const chunks: NonfungibleDotComTradeResponse[][] = splitEvery(S3_CHUNK_SIZES[publisher], sourceJson.data);
 
     logUtils.log(`${chunks.length} chunks`);
 


### PR DESCRIPTION
## Description

Recall that nonfungible.com sent us an initial data dump so that we wouldn't have to pull *every*thing from the API.  And recall that we're storing that initial dump on S3.  Finally, recall that the cryptokitties data was particularly voluminous (~1GB), which doesn't easily transfer to and from S3.

These changes provide a CLI script to partition that data (or any such data from nonfungible.com) into a set of smaller files; and a scraping script that seamlessly recombines those partitions for loading into the database.

## Testing instructions

After building the `pipeline` component and setting `ZEROEX_DATA_PIPELINE_DB_URL` appropriately,
`node --max-old-space-size=8192 lib/src/scripts/pull_nonfungible_dot_com_trades.js`

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature (non-breaking change which adds functionality)

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Prefix PR title with `[WIP]` if necessary.
-   [x] Add tests to cover changes as needed.
-   [x] Update documentation as needed.
-   [x] Add new entries to the relevant CHANGELOG.jsons.
