### PR TITLE
Upgrade to websocket@^1.0.26 to fix broken tests

### DIFF
--- a/packages/connect/CHANGELOG.json
+++ b/packages/connect/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "5.0.3",
+        "changes": [
+            {
+                "note": "Update websocket@^1.0.25 -> websocket@^1.0.26",
+                "pr": 1685
+            }
+        ]
+    },
+    {
         "timestamp": 1551479279,
         "version": "5.0.2",
         "changes": [

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -54,7 +54,7 @@
         "query-string": "^6.0.0",
         "sinon": "^4.0.0",
         "uuid": "^3.3.2",
-        "websocket": "^1.0.25"
+        "websocket": "^1.0.26"
     },
     "devDependencies": {
         "@0x/tslint-config": "^3.0.0",

--- a/packages/order-watcher/CHANGELOG.json
+++ b/packages/order-watcher/CHANGELOG.json
@@ -1,5 +1,13 @@
 [
     {
+        "version": "4.0.4",
+        "changes": [
+            {
+                "note": "Update websocket from ^1.0.25 to ^1.0.26"
+            }
+        ]
+    },
+    {
         "timestamp": 1551479279,
         "version": "4.0.3",
         "changes": [

--- a/packages/order-watcher/CHANGELOG.json
+++ b/packages/order-watcher/CHANGELOG.json
@@ -3,7 +3,8 @@
         "version": "4.0.4",
         "changes": [
             {
-                "note": "Update websocket from ^1.0.25 to ^1.0.26"
+                "note": "Update websocket from ^1.0.25 to ^1.0.26",
+                "pr": 1685
             }
         ]
     },

--- a/packages/order-watcher/package.json
+++ b/packages/order-watcher/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@0x/order-watcher",
-    "version": "4.0.3",
+    "version": "4.0.4",
     "description": "An order watcher daemon that watches for order validity",
     "keywords": [
         "0x",
@@ -81,7 +81,7 @@
         "ethereumjs-blockstream": "6.0.0",
         "ethers": "~4.0.4",
         "lodash": "^4.17.11",
-        "websocket": "^1.0.25"
+        "websocket": "^1.0.26"
     },
     "publishConfig": {
         "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17619,15 +17619,6 @@ websocket@1.0.26:
     typedarray-to-buffer "^3.1.2"
     yaeti "^0.0.6"
 
-websocket@^1.0.25:
-  version "1.0.25"
-  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.25.tgz#998ec790f0a3eacb8b08b50a4350026692a11958"
-  dependencies:
-    debug "^2.2.0"
-    nan "^2.3.3"
-    typedarray-to-buffer "^3.1.2"
-    yaeti "^0.0.6"
-
 "websocket@git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible":
   version "1.0.26"
   resolved "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"


### PR DESCRIPTION
## Description

The `order-watcher` package was sporadically failing tests for me on *clean* installs of the `development` branch. It turns out my version of `yarn` (`1.13.0 arch-linux@5.0.0`) kept pulling  `websocket@1.0.25`, which I discovered has a [masking number calculation bug](https://github.com/theturtle32/WebSocket-Node/blob/d941f975e8ef6b55eafc0ef45996f4198013832c/lib/WebSocketFrame.js#L256) that is fixed in subsequent patches.

I was able to get a corrected version installed and tests passing by upgrading `order-watcher`'s dependency from `websocket@^1.0.25` to `websocket@^1.0.26` AND removing the `websocket@1.0.25` entry in the root `yarn.lock` file (there are two others pointing to `1.0.26` already).

So far I've been the only one who could replicate this issue, probably because I'm on a rolling release distro. 

I don't foresee this minor change having any noticeable impact on working copies.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
