### PR TITLE
Store blockTimestamp from NonFungible.com trade in seconds

### DIFF
--- a/packages/pipeline/src/parsers/nonfungible_dot_com/index.ts
+++ b/packages/pipeline/src/parsers/nonfungible_dot_com/index.ts
@@ -28,7 +28,7 @@ export function _parseNonFungibleDotComTrade(
     nonfungibleDotComTrade.assetDescriptor = rawTrade.assetDescriptor;
     nonfungibleDotComTrade.assetId = rawTrade.assetId;
     nonfungibleDotComTrade.blockNumber = rawTrade.blockNumber;
-    nonfungibleDotComTrade.blockTimestamp = new Date(rawTrade.blockTimestamp).getTime();
+    nonfungibleDotComTrade.blockTimestamp = Math.floor(new Date(rawTrade.blockTimestamp).getTime()/1000);
     nonfungibleDotComTrade.buyerAddress = rawTrade.buyer;
     nonfungibleDotComTrade.logIndex = rawTrade.logIndex;
     nonfungibleDotComTrade.marketAddress = rawTrade.marketAddress;


### PR DESCRIPTION
Currently, NonFungible.com API sales are stored as milliseconds - Date.getTime() returns epoch time in milliseconds as opposed to seconds.

## Description

Convert milliseconds to seconds before storage.

## Types of changes

Bug fix

## Checklist:

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
