### PR TITLE
Fix error where object could be undefined given an approval event

### DIFF
--- a/packages/order-watcher/CHANGELOG.json
+++ b/packages/order-watcher/CHANGELOG.json
@@ -5,6 +5,9 @@
             {
                 "note": "Update websocket from ^1.0.25 to ^1.0.26",
                 "pr": 1685
+            },
+            {
+                "note": "Fix issue where ERC721 Approval events could cause a lookup on undefined object"
             }
         ]
     },

--- a/packages/order-watcher/CHANGELOG.json
+++ b/packages/order-watcher/CHANGELOG.json
@@ -7,7 +7,8 @@
                 "pr": 1685
             },
             {
-                "note": "Fix issue where ERC721 Approval events could cause a lookup on undefined object"
+                "note": "Fix issue where ERC721 Approval events could cause a lookup on undefined object",
+                "pr": 1692
             }
         ]
     },

--- a/packages/order-watcher/src/order_watcher/dependent_order_hashes_tracker.ts
+++ b/packages/order-watcher/src/order_watcher/dependent_order_hashes_tracker.ts
@@ -37,9 +37,15 @@ export class DependentOrderHashesTracker {
         this._zrxTokenAddress = zrxTokenAddress;
     }
     public getDependentOrderHashesByERC721ByMaker(makerAddress: string, tokenAddress: string): string[] {
-        const orderHashSets = _.values(
-            this._orderHashesByERC721AddressByTokenIdByMakerAddress[makerAddress][tokenAddress],
-        );
+        let orderHashSets: Array<Set<string>> = [];
+        if (
+            this._orderHashesByERC721AddressByTokenIdByMakerAddress[makerAddress] &&
+            this._orderHashesByERC721AddressByTokenIdByMakerAddress[makerAddress][tokenAddress]
+        ) {
+            orderHashSets = _.values(
+                this._orderHashesByERC721AddressByTokenIdByMakerAddress[makerAddress][tokenAddress],
+            );
+        }
         const orderHashList = _.reduce(
             orderHashSets,
             (accumulator, orderHashSet) => [...accumulator, ...orderHashSet],

--- a/packages/order-watcher/src/order_watcher/dependent_order_hashes_tracker.ts
+++ b/packages/order-watcher/src/order_watcher/dependent_order_hashes_tracker.ts
@@ -37,15 +37,15 @@ export class DependentOrderHashesTracker {
         this._zrxTokenAddress = zrxTokenAddress;
     }
     public getDependentOrderHashesByERC721ByMaker(makerAddress: string, tokenAddress: string): string[] {
-        let orderHashSets: Array<Set<string>> = [];
         if (
-            this._orderHashesByERC721AddressByTokenIdByMakerAddress[makerAddress] &&
-            this._orderHashesByERC721AddressByTokenIdByMakerAddress[makerAddress][tokenAddress]
+            _.isUndefined(this._orderHashesByERC721AddressByTokenIdByMakerAddress[makerAddress]) ||
+            _.isUndefined(this._orderHashesByERC721AddressByTokenIdByMakerAddress[makerAddress][tokenAddress])
         ) {
-            orderHashSets = _.values(
-                this._orderHashesByERC721AddressByTokenIdByMakerAddress[makerAddress][tokenAddress],
-            );
+            return [];
         }
+        const orderHashSets = _.values(
+            this._orderHashesByERC721AddressByTokenIdByMakerAddress[makerAddress][tokenAddress],
+        );
         const orderHashList = _.reduce(
             orderHashSets,
             (accumulator, orderHashSet) => [...accumulator, ...orderHashSet],

--- a/packages/order-watcher/test/order_watcher_test.ts
+++ b/packages/order-watcher/test/order_watcher_test.ts
@@ -90,6 +90,19 @@ describe('OrderWatcher', () => {
     afterEach(async () => {
         await blockchainLifecycle.revertAsync();
     });
+    describe('DependentOrderHashesTracker', async () => {
+        let makerErc721TokenAddress: string;
+        [makerErc721TokenAddress] = tokenUtils.getDummyERC721TokenAddresses();
+        it('should handle lookups on unknown addresses', async () => {
+            // Regression test
+            // ApprovalForAll events on a token from an untracked address could cause
+            // nested lookups on undefined object
+            // #1550
+            const dependentOrderHashesTracker = (orderWatcher as any)
+                ._dependentOrderHashesTracker as DependentOrderHashesTracker;
+            dependentOrderHashesTracker.getDependentOrderHashesByERC721ByMaker(takerAddress, makerErc721TokenAddress);
+        });
+    });
     describe('#removeOrder', async () => {
         it('should successfully remove existing order', async () => {
             signedOrder = await fillScenarios.createFillableSignedOrderAsync(


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
When tracking ApprovalForAll on ERC721, an untracked address (no orders added as a maker) could cause a lookup on undefined.

Fixed #1550 

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
