### PR TITLE
Cheaper Mutex/Reentrancy Lock

### DIFF
--- a/contracts/exchange/CHANGELOG.json
+++ b/contracts/exchange/CHANGELOG.json
@@ -15,7 +15,8 @@
                 "pr": 1682
             },
             {
-                "note": "Use new/cheaper reentrancy guard/mutex"
+                "note": "Use new/cheaper reentrancy guard/mutex",
+                "pr": 1699
             }
         ]
     },

--- a/contracts/exchange/CHANGELOG.json
+++ b/contracts/exchange/CHANGELOG.json
@@ -13,6 +13,9 @@
             {
                 "note": "Upgrade contracts to Solidity 0.5.5",
                 "pr": 1682
+            },
+            {
+                "note": "Use new/cheaper reentrancy guard/mutex"
             }
         ]
     },

--- a/contracts/exchange/contracts/test/ReentrantERC20Token.sol
+++ b/contracts/exchange/contracts/test/ReentrantERC20Token.sol
@@ -22,18 +22,17 @@ pragma experimental ABIEncoderV2;
 import "@0x/contracts-utils/contracts/src/LibBytes.sol";
 import "@0x/contracts-erc20/contracts/src/ERC20Token.sol";
 import "@0x/contracts-erc20/contracts/src/interfaces/IERC20Token.sol";
-import "../src/interfaces/IExchange.sol";
-import "../src/interfaces/IAssetProxy.sol";
 import "@0x/contracts-exchange-libs/contracts/src/LibOrder.sol";
+import "../src/interfaces/IExchange.sol";
 
 
-// solhint-disable no-unused-vars
+// solhint-disable no-unused-vars, not-rely-on-time
 contract ReentrantERC20Token is
     ERC20Token
 {
     using LibBytes for bytes;
 
-    uint8 constant BATCH_SIZE = 3;
+    uint8 internal constant BATCH_SIZE = 3;
 
     // solhint-disable-next-line var-name-mixedcase
     IExchange internal EXCHANGE;
@@ -69,7 +68,7 @@ contract ReentrantERC20Token is
     function setReentrantFunction(
         uint8 _currentFunctionId
     )
-        public
+        external
     {
         currentFunctionId = _currentFunctionId;
     }
@@ -224,7 +223,8 @@ contract ReentrantERC20Token is
     function _createMatchedOrders()
         internal
         view
-        returns (LibOrder.Order[2] memory orders) {
+        returns (LibOrder.Order[2] memory orders)
+    {
 
         LibOrder.Order[] memory _orders = _createOrders(2);
         orders[0] = _orders[0];

--- a/contracts/exchange/contracts/test/ReentrantERC20Token.sol
+++ b/contracts/exchange/contracts/test/ReentrantERC20Token.sol
@@ -193,8 +193,7 @@ contract ReentrantERC20Token is
         return true;
     }
 
-    /// @dev Create valid test orders where the maker is set to this contract
-    ///      to succeed in cancel* calls.
+    /// @dev Create valid test orders where the maker is set to this contract.
     function createOrders(
         uint8 count
     )

--- a/contracts/exchange/contracts/test/ReentrantERC20Token.sol
+++ b/contracts/exchange/contracts/test/ReentrantERC20Token.sol
@@ -27,6 +27,9 @@ import "../src/interfaces/IExchange.sol";
 
 
 // solhint-disable no-unused-vars, not-rely-on-time
+// @dev Because reentrancy is lazily evaluated, after all reentrant calls have
+//      been made, all attacks should be crafted to succeed for the reentrancy
+///     to be properly detected.
 contract ReentrantERC20Token is
     ERC20Token
 {

--- a/contracts/exchange/test/core.ts
+++ b/contracts/exchange/test/core.ts
@@ -123,7 +123,7 @@ describe('Exchange core', () => {
             artifacts.ReentrantERC20Token,
             provider,
             txDefaults,
-            exchange.address
+            exchange.address,
         );
         // Configure ERC20Proxy
         await web3Wrapper.awaitTransactionSuccessAsync(
@@ -221,7 +221,7 @@ describe('Exchange core', () => {
                 const description = `should not allow fillOrder to reenter the Exchange contract via ${functionName}`;
                 it(description, async () => {
                     signedOrder = await orderFactory.newSignedOrderAsync({
-                        makerAssetData: await assetDataUtils.encodeERC20AssetData(reentrantErc20Token.address)
+                        makerAssetData: await assetDataUtils.encodeERC20AssetData(reentrantErc20Token.address),
                     });
                     await reentrantErc20Token.setReentrantFunction.sendTransactionAsync(
                         functionId,

--- a/contracts/exchange/test/core.ts
+++ b/contracts/exchange/test/core.ts
@@ -222,13 +222,21 @@ describe('Exchange core', () => {
                     signedOrder = await orderFactory.newSignedOrderAsync({
                         makerAssetData: assetDataUtils.encodeERC20AssetData(reentrantErc20Token.address),
                     });
+                    const attackerOrders = await Promise.all([
+                        orderFactory.newSignedOrderAsync({salt: new BigNumber(1)}),
+                        orderFactory.newSignedOrderAsync({salt: new BigNumber(2)}),
+                    ]);
                     await web3Wrapper.awaitTransactionSuccessAsync(
-                        await reentrantErc20Token.setCurrentFunction.sendTransactionAsync(functionId),
+                        await reentrantErc20Token.setUpUsTheBomb.sendTransactionAsync(
+                            functionId,
+                            attackerOrders,
+                            _.map(attackerOrders, o => o.signature)
+                        ),
                         constants.AWAIT_TRANSACTION_MINED_MS,
                     );
                     await expectTransactionFailedAsync(
                         exchangeWrapper.fillOrderAsync(signedOrder, takerAddress),
-                        RevertReason.TransferFailed,
+                        RevertReason.ReentrancyIllegal,
                     );
                 });
             });

--- a/contracts/exchange/test/core.ts
+++ b/contracts/exchange/test/core.ts
@@ -223,12 +223,10 @@ describe('Exchange core', () => {
                     signedOrder = await orderFactory.newSignedOrderAsync({
                         makerAssetData: await assetDataUtils.encodeERC20AssetData(reentrantErc20Token.address),
                     });
-                    await reentrantErc20Token.setReentrantFunction.sendTransactionAsync(
-                        functionId,
-                    );
+                    await reentrantErc20Token.setReentrantFunction.sendTransactionAsync(functionId);
                     await expectTransactionFailedAsync(
                         exchangeWrapper.fillOrderAsync(signedOrder, takerAddress),
-                            RevertReason.ReentrancyIllegal,
+                        RevertReason.ReentrancyIllegal,
                     );
                 });
             });

--- a/contracts/exchange/test/match_orders.ts
+++ b/contracts/exchange/test/match_orders.ts
@@ -576,12 +576,12 @@ describe('matchOrders', () => {
                         feeRecipientAddress: feeRecipientAddressRight,
                     });
                     await web3Wrapper.awaitTransactionSuccessAsync(
-                        await reentrantErc20Token.setCurrentFunction.sendTransactionAsync(functionId),
+                        await reentrantErc20Token.setReentrantFunction.sendTransactionAsync(functionId),
                         constants.AWAIT_TRANSACTION_MINED_MS,
                     );
                     await expectTransactionFailedAsync(
                         exchangeWrapper.matchOrdersAsync(signedOrderLeft, signedOrderRight, takerAddress),
-                        RevertReason.TransferFailed,
+                        RevertReason.ReentrancyIllegal,
                     );
                 });
             });

--- a/contracts/exchange/test/wrapper.ts
+++ b/contracts/exchange/test/wrapper.ts
@@ -143,12 +143,12 @@ describe('Exchange wrappers', () => {
                         makerAssetData: assetDataUtils.encodeERC20AssetData(reentrantErc20Token.address),
                     });
                     await web3Wrapper.awaitTransactionSuccessAsync(
-                        await reentrantErc20Token.setCurrentFunction.sendTransactionAsync(functionId),
+                        await reentrantErc20Token.setReentrantFunction.sendTransactionAsync(functionId),
                         constants.AWAIT_TRANSACTION_MINED_MS,
                     );
                     await expectTransactionFailedAsync(
                         exchangeWrapper.fillOrKillOrderAsync(signedOrder, takerAddress),
-                        RevertReason.TransferFailed,
+                        RevertReason.ReentrancyIllegal,
                     );
                 });
             });
@@ -234,7 +234,7 @@ describe('Exchange wrappers', () => {
                         makerAssetData: assetDataUtils.encodeERC20AssetData(reentrantErc20Token.address),
                     });
                     await web3Wrapper.awaitTransactionSuccessAsync(
-                        await reentrantErc20Token.setCurrentFunction.sendTransactionAsync(functionId),
+                        await reentrantErc20Token.setReentrantFunction.sendTransactionAsync(functionId),
                         constants.AWAIT_TRANSACTION_MINED_MS,
                     );
                     await exchangeWrapper.fillOrderNoThrowAsync(signedOrder, takerAddress);
@@ -453,12 +453,12 @@ describe('Exchange wrappers', () => {
                             makerAssetData: assetDataUtils.encodeERC20AssetData(reentrantErc20Token.address),
                         });
                         await web3Wrapper.awaitTransactionSuccessAsync(
-                            await reentrantErc20Token.setCurrentFunction.sendTransactionAsync(functionId),
+                            await reentrantErc20Token.setReentrantFunction.sendTransactionAsync(functionId),
                             constants.AWAIT_TRANSACTION_MINED_MS,
                         );
                         await expectTransactionFailedAsync(
                             exchangeWrapper.batchFillOrdersAsync([signedOrder], takerAddress),
-                            RevertReason.TransferFailed,
+                            RevertReason.ReentrancyIllegal,
                         );
                     });
                 });
@@ -522,12 +522,12 @@ describe('Exchange wrappers', () => {
                             makerAssetData: assetDataUtils.encodeERC20AssetData(reentrantErc20Token.address),
                         });
                         await web3Wrapper.awaitTransactionSuccessAsync(
-                            await reentrantErc20Token.setCurrentFunction.sendTransactionAsync(functionId),
+                            await reentrantErc20Token.setReentrantFunction.sendTransactionAsync(functionId),
                             constants.AWAIT_TRANSACTION_MINED_MS,
                         );
                         await expectTransactionFailedAsync(
                             exchangeWrapper.batchFillOrKillOrdersAsync([signedOrder], takerAddress),
-                            RevertReason.TransferFailed,
+                            RevertReason.ReentrancyIllegal,
                         );
                     });
                 });
@@ -608,7 +608,7 @@ describe('Exchange wrappers', () => {
                             makerAssetData: assetDataUtils.encodeERC20AssetData(reentrantErc20Token.address),
                         });
                         await web3Wrapper.awaitTransactionSuccessAsync(
-                            await reentrantErc20Token.setCurrentFunction.sendTransactionAsync(functionId),
+                            await reentrantErc20Token.setReentrantFunction.sendTransactionAsync(functionId),
                             constants.AWAIT_TRANSACTION_MINED_MS,
                         );
                         await exchangeWrapper.batchFillOrdersNoThrowAsync([signedOrder], takerAddress);
@@ -740,14 +740,14 @@ describe('Exchange wrappers', () => {
                             makerAssetData: assetDataUtils.encodeERC20AssetData(reentrantErc20Token.address),
                         });
                         await web3Wrapper.awaitTransactionSuccessAsync(
-                            await reentrantErc20Token.setCurrentFunction.sendTransactionAsync(functionId),
+                            await reentrantErc20Token.setReentrantFunction.sendTransactionAsync(functionId),
                             constants.AWAIT_TRANSACTION_MINED_MS,
                         );
                         await expectTransactionFailedAsync(
                             exchangeWrapper.marketSellOrdersAsync([signedOrder], takerAddress, {
                                 takerAssetFillAmount: signedOrder.takerAssetAmount,
                             }),
-                            RevertReason.TransferFailed,
+                            RevertReason.ReentrancyIllegal,
                         );
                     });
                 });
@@ -854,7 +854,7 @@ describe('Exchange wrappers', () => {
                             makerAssetData: assetDataUtils.encodeERC20AssetData(reentrantErc20Token.address),
                         });
                         await web3Wrapper.awaitTransactionSuccessAsync(
-                            await reentrantErc20Token.setCurrentFunction.sendTransactionAsync(functionId),
+                            await reentrantErc20Token.setReentrantFunction.sendTransactionAsync(functionId),
                             constants.AWAIT_TRANSACTION_MINED_MS,
                         );
                         await exchangeWrapper.marketSellOrdersNoThrowAsync([signedOrder], takerAddress, {
@@ -1001,14 +1001,14 @@ describe('Exchange wrappers', () => {
                             makerAssetData: assetDataUtils.encodeERC20AssetData(reentrantErc20Token.address),
                         });
                         await web3Wrapper.awaitTransactionSuccessAsync(
-                            await reentrantErc20Token.setCurrentFunction.sendTransactionAsync(functionId),
+                            await reentrantErc20Token.setReentrantFunction.sendTransactionAsync(functionId),
                             constants.AWAIT_TRANSACTION_MINED_MS,
                         );
                         await expectTransactionFailedAsync(
                             exchangeWrapper.marketBuyOrdersAsync([signedOrder], takerAddress, {
                                 makerAssetFillAmount: signedOrder.makerAssetAmount,
                             }),
-                            RevertReason.TransferFailed,
+                            RevertReason.ReentrancyIllegal,
                         );
                     });
                 });
@@ -1113,7 +1113,7 @@ describe('Exchange wrappers', () => {
                             makerAssetData: assetDataUtils.encodeERC20AssetData(reentrantErc20Token.address),
                         });
                         await web3Wrapper.awaitTransactionSuccessAsync(
-                            await reentrantErc20Token.setCurrentFunction.sendTransactionAsync(functionId),
+                            await reentrantErc20Token.setReentrantFunction.sendTransactionAsync(functionId),
                             constants.AWAIT_TRANSACTION_MINED_MS,
                         );
                         await exchangeWrapper.marketBuyOrdersNoThrowAsync([signedOrder], takerAddress, {

--- a/contracts/utils/CHANGELOG.json
+++ b/contracts/utils/CHANGELOG.json
@@ -17,6 +17,9 @@
             {
                 "note": "Added Address.sol with test for whether or not an address is a contract",
                 "pr": 1657
+            },
+            {
+                "note": "Change ReentrancyGuard implementation to cheaper one"
             }
         ]
     },

--- a/contracts/utils/CHANGELOG.json
+++ b/contracts/utils/CHANGELOG.json
@@ -19,7 +19,8 @@
                 "pr": 1657
             },
             {
-                "note": "Change ReentrancyGuard implementation to cheaper one"
+                "note": "Change ReentrancyGuard implementation to cheaper one",
+                "pr": 1699
             }
         ]
     },

--- a/contracts/utils/contracts/src/ReentrancyGuard.sol
+++ b/contracts/utils/contracts/src/ReentrancyGuard.sol
@@ -21,25 +21,23 @@ pragma solidity ^0.5.5;
 
 contract ReentrancyGuard {
 
-    // Locked state of mutex
-    bool private locked = false;
+    // Mutex counter.
+    // Starts at 1 and increases whenever a nonReentrant function is called.
+    uint256 private reentrancyGuardCounter = 1;
 
-    /// @dev Functions with this modifer cannot be reentered. The mutex will be locked
-    ///      before function execution and unlocked after.
+    /// @dev Functions with this modifer cannot be reentered.
     modifier nonReentrant() {
-        // Ensure mutex is unlocked
+        // Increment the counter.
+        reentrancyGuardCounter += 1;
+        // Remember the current counter value.
+        uint256 localCounter = reentrancyGuardCounter;
+        // Call the function.
+        _;
+        // If the counter value is different from what we remember,
+        // the function was called more than once.
         require(
-            !locked,
+            localCounter == reentrancyGuardCounter,
             "REENTRANCY_ILLEGAL"
         );
-
-        // Lock mutex before function call
-        locked = true;
-
-        // Perform function call
-        _;
-
-        // Unlock mutex after function call
-        locked = false;
     }
 }

--- a/contracts/utils/contracts/src/ReentrancyGuard.sol
+++ b/contracts/utils/contracts/src/ReentrancyGuard.sol
@@ -27,10 +27,8 @@ contract ReentrancyGuard {
 
     /// @dev Functions with this modifer cannot be reentered.
     modifier nonReentrant() {
-        // Increment the counter.
-        reentrancyGuardCounter += 1;
-        // Remember the current counter value.
-        uint256 localCounter = reentrancyGuardCounter;
+        // Increment and remember the current counter value.
+        uint256 localCounter = ++reentrancyGuardCounter;
         // Call the function.
         _;
         // If the counter value is different from what we remember,


### PR DESCRIPTION
## Description


Replaces our current contract reentrancy guard with [a cheaper version](https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/utils/ReentrancyGuard.sol) that only does one SSTORE per call.

Our current implementation would have played well with [EIP-1087](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1087.md)/[EIP-1283](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1283.md), but those have been nixed for Constantinople.

#### Technical Details and Testing Impact 
This new implementation "lazily," detects reentrancy, only reverting when the penultimate reentrant call returns. 

This meant reentrancy tests that relied on immediate detection of the reentrancy had to be reworked to perform valid (non-failing) calls, because a failing call would revert the second `reentrancyGuard` state change, so no reentrancy would be detected. Reentrancy tests written for new `nonReentrant` functions need to take this into account.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature (non-breaking change which adds functionality)

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
