### PR TITLE
Changed EDPS endpoint to a 0x AWS one

### DIFF
--- a/packages/pipeline/src/data_sources/dex_prices/index.ts
+++ b/packages/pipeline/src/data_sources/dex_prices/index.ts
@@ -2,7 +2,8 @@ import { fetchAsync } from '@0x/utils';
 import Bottleneck from 'bottleneck';
 
 const ONE_SECOND = 1000;
-const EDPS_BASE_URL = 'http://35.185.219.196:1337';
+const EDPS_BASE_URL = 'http://23.22.220.126:1337';
+const TIMEOUT = 30 * ONE_SECOND;
 
 export type EdpsResponse = EdpsWrapper[];
 
@@ -36,7 +37,7 @@ export class EdpsSource {
      */
     public async getEdpsAsync(direction: string, symbol: string, amount: number): Promise<EdpsWrapper> {
         const edpsUrl = `${EDPS_BASE_URL}/${direction}?amount=${amount}&symbol=${symbol}&decimals=`;
-        const resp = await this._limiter.schedule(() => fetchAsync(edpsUrl));
+        const resp = await this._limiter.schedule(() => fetchAsync(edpsUrl, {}, TIMEOUT));
         const respJson: EdpsResponse = await resp.json();
         const allExchanges: EdpsWrapper = {};
         // The below unwraps the response so we get 1 single EdpsWrapper object

--- a/packages/pipeline/src/data_sources/dex_prices/index.ts
+++ b/packages/pipeline/src/data_sources/dex_prices/index.ts
@@ -3,7 +3,8 @@ import Bottleneck from 'bottleneck';
 
 const ONE_SECOND = 1000;
 const EDPS_BASE_URL = 'http://23.22.220.126:1337';
-const TIMEOUT = 30 * ONE_SECOND;
+// tslint:disable-next-line:custom-no-magic-numbers
+const TIMEOUT = ONE_SECOND * 30;
 
 export type EdpsResponse = EdpsWrapper[];
 

--- a/packages/pipeline/src/scripts/pull_slippage.ts
+++ b/packages/pipeline/src/scripts/pull_slippage.ts
@@ -13,7 +13,7 @@ import { handleError } from '../utils';
 const BATCH_SAVE_SIZE = 1000;
 
 // Max requests to make to API per second;
-const EDPS_MAX_REQUESTS_PER_SECOND = 1;
+const EDPS_MAX_REQUESTS_PER_SECOND = 0.5;
 
 // Maximum requests per second to CryptoCompare
 const CRYPTO_COMPARE_MAX_REQS_PER_SECOND = 60;


### PR DESCRIPTION
## Description

We were previously using an endpoint for Ethereum DEX Prices Service which 0x did not control. This PR changes the endpoint to a service which is hosted in the 0x AWS environment.

In addition, we've increased timeout to 30 seconds + made the bottleneck 2x more aggressive (now max 30 requests per minute) so we don't hit rate-limits for the DEX APIs.

## Testing instructions

```
yarn build
yarn test
node lib/src/scripts/pull_slippage.js
```

## Types of changes

* Fix (non-breaking change which fixes an issue)