### PR TITLE
[WIP] Feature/local key provider

### DIFF
--- a/python-packages/local_key_http_provider/src/zero_ex/__init__.py
+++ b/python-packages/local_key_http_provider/src/zero_ex/__init__.py
@@ -1,0 +1,2 @@
+"""0x Python API."""
+__import__("pkg_resources").declare_namespace(__name__)

--- a/python-packages/local_key_http_provider/src/zero_ex/local_key_http_provider/provider.py
+++ b/python-packages/local_key_http_provider/src/zero_ex/local_key_http_provider/provider.py
@@ -1,0 +1,55 @@
+"""A Web3 provider for interacting with a hosted node with a local private key."""
+from web3 import Web3, HTTPProvider
+from web3.middleware import construct_sign_and_send_raw_middleware
+from eth_account.messages import defunct_hash_message
+from hexbytes import HexBytes
+
+
+class LocalKeyHTTPProvider(HTTPProvider):
+    """
+    This provider intercepts all "eth-sign" requests to always sign messages via
+    a local private key and includes a middleware that captures transactions,
+    signs them, and sends them as raw transactions.
+    """
+    __name__ = "LocalKeyHTTPProvider"
+
+    def __init__(self, rpc_url, private_key):
+        """Create an instance of a Web3 http provider with a private key.
+
+        Keyword arguments:
+        rpc_url - - string of the URL of the Web3 service
+        private_key - - hex bytes or hex string of private key for signing transactions
+            (must be convertible to `HexBytes`)
+        """
+        super(LocalKeyHTTPProvider, self).__init__(rpc_url)
+        self._private_key = private_key
+        self._web3_instance = Web3(self)
+        self._web3_instance.middleware_stack.add(
+            construct_sign_and_send_raw_middleware(private_key)
+        )
+
+    def account(self):
+        """Get the account address as a hexstr"""
+        return self._web3_instance.eth.account.privateKeyToAccount(  # pylint: disable=no-member
+            self._private_key
+        ).lower()
+
+    def make_request(self, method, params):
+        """Intercept "eth-sign" requests to always sign messages with the local private key.
+        Messages are always signed via the signHash method in eth-account.
+
+        Implementation of the signHash method:
+        https://github.com/ethereum/eth-account/blob/692943d3bdbc3e05aa88cfc9444890b79e3922e1/eth_account/account.py#L333
+        """
+        if method == "eth_sign":
+            msg_hash_hexbytes = defunct_hash_message(HexBytes(params[1]))
+            ec_signature = self._web3_instance.eth.account.signHash(  # pylint: disable=no-member
+                msg_hash_hexbytes,
+                private_key=self._private_key,
+            )
+            return {"result": ec_signature.signature}
+        return super(LocalKeyHTTPProvider, self).make_request(method, params)
+
+    def web3(self):
+        """Get the web3 instance of this provider"""
+        return self._web3_instance

--- a/python-packages/local_key_http_provider/test/__init__.py
+++ b/python-packages/local_key_http_provider/test/__init__.py
@@ -1,0 +1,1 @@
+"""Tests of zero_x.local_key_http_provider."""

--- a/python-packages/local_key_http_provider/test/test_local_key_http_provider.py
+++ b/python-packages/local_key_http_provider/test/test_local_key_http_provider.py
@@ -1,0 +1,22 @@
+"""Tests of 0x.local_key_provider."""
+
+from eth_utils import to_checksum_address
+from zero_ex import local_key_http_provider, order_utils
+from zero_ex.contract_addresses import NETWORK_TO_ADDRESSES, NetworkId
+
+
+def test_local_key_provider__sign_order():
+    """Test signing order with local_key_provider"""
+    PRIVATE_KEY = "f2f48ee19680706196e2e339e5da3491186e0c4c5030670656b0e0164837257d"
+    WEB3_RPC_URL = 'https://kovan.infura.io/v3/e2c067d9717e492091d1f1d7a2ec55aa'
+
+    exchange = NETWORK_TO_ADDRESSES[NetworkId.KOVAN].exchange
+    order = order_utils.make_empty_order()
+    order_hash = order_utils.generate_order_hash_hex(order, exchange)
+    provider = local_key_http_provider(WEB3_RPC_URL, PRIVATE_KEY)
+    order_utils.assert_is_provider(provider, "provider")
+    signature = order_utils.sign_hash(
+        provider, to_checksum_address(provider.account), order_hash)
+    order_utils.assert_is_hex_string(signature, "signature")
+    order_utils.is_valid_signature(
+        provider, order_hash, signature, provider.account)


### PR DESCRIPTION
## Description
A Web3 provider for interacting with a hosted node with a local private key.  

## Testing instructions
Work in progress

## Types of changes
New feature - Adding a python package that includes a web3 provider that intercepts all "eth-sign" requests to always sign messages via a local private key. Also includes a middleware that captures transactions, signs them, and sends them as raw transactions.

## Checklist:
-   [x] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
