### PR TITLE
Fix race-condition in Order-watcher

### DIFF
--- a/packages/order-watcher/CHANGELOG.json
+++ b/packages/order-watcher/CHANGELOG.json
@@ -9,6 +9,10 @@
             {
                 "note": "Fix issue where ERC721 Approval events could cause a lookup on undefined object",
                 "pr": 1692
+            },
+            {
+                "note": "Fix race-condition bugs due to async event callbacks modifying shared state",
+                "pr": 1718
             }
         ]
     },

--- a/packages/order-watcher/package.json
+++ b/packages/order-watcher/package.json
@@ -81,6 +81,7 @@
         "ethereumjs-blockstream": "6.0.0",
         "ethers": "~4.0.4",
         "lodash": "^4.17.11",
+        "semaphore-async-await": "^1.5.1",
         "websocket": "^1.0.26"
     },
     "publishConfig": {

--- a/packages/order-watcher/src/order_watcher/order_watcher.ts
+++ b/packages/order-watcher/src/order_watcher/order_watcher.ts
@@ -42,6 +42,7 @@ import {
     ZeroExProvider,
 } from 'ethereum-types';
 import * as _ from 'lodash';
+import { Lock } from 'semaphore-async-await';
 
 import { orderWatcherPartialConfigSchema } from '../schemas/order_watcher_partial_config_schema';
 import { OnOrderStateChangeCallback, OrderWatcherConfig, OrderWatcherError } from '../types';
@@ -84,6 +85,7 @@ export class OrderWatcher {
     private readonly _dependentOrderHashesTracker: DependentOrderHashesTracker;
     private readonly _orderStateByOrderHashCache: OrderStateByOrderHash = {};
     private readonly _orderByOrderHash: OrderByOrderHash = {};
+    private readonly _orderByOrderHashLock = new Lock();
     private readonly _eventWatcher: EventWatcher;
     private readonly _provider: ZeroExProvider;
     private readonly _collisionResistantAbiDecoder: CollisionResistanceAbiDecoder;
@@ -196,10 +198,12 @@ export class OrderWatcher {
             throw new Error(OrderWatcherError.SubscriptionAlreadyPresent);
         }
         this._callbackIfExists = callback;
-        this._eventWatcher.subscribe(this._onEventWatcherCallbackAsync.bind(this));
-        this._expirationWatcher.subscribe(this._onOrderExpired.bind(this));
+        this._eventWatcher.subscribe(
+            this._addLockToCallbackAsync.bind(this, this._onEventWatcherCallbackAsync.bind(this)),
+        );
+        this._expirationWatcher.subscribe(this._addLockToCallbackAsync.bind(this, this._onOrderExpired.bind(this)));
         this._cleanupJobIntervalIdIfExists = intervalUtils.setAsyncExcludingInterval(
-            this._cleanupAsync.bind(this),
+            this._addLockToCallbackAsync.bind(this, this._cleanupAsync.bind(this)),
             this._cleanupJobInterval,
             (err: Error) => {
                 this.unsubscribe();
@@ -228,6 +232,17 @@ export class OrderWatcher {
         return {
             orderCount: _.size(this._orderByOrderHash),
         };
+    }
+    private async _addLockToCallbackAsync(cbAsync: any, ...params: any[]): Promise<void> {
+        await this._orderByOrderHashLock.acquire();
+        try {
+            await cbAsync(...params);
+            await this._orderByOrderHashLock.release();
+        } catch (err) {
+            // Make sure to releasee the lock if an error is thrown
+            await this._orderByOrderHashLock.release();
+            throw err;
+        }
     }
     private async _cleanupAsync(): Promise<void> {
         for (const orderHash of _.keys(this._orderByOrderHash)) {

--- a/packages/order-watcher/src/order_watcher/order_watcher.ts
+++ b/packages/order-watcher/src/order_watcher/order_watcher.ts
@@ -85,7 +85,7 @@ export class OrderWatcher {
     private readonly _dependentOrderHashesTracker: DependentOrderHashesTracker;
     private readonly _orderStateByOrderHashCache: OrderStateByOrderHash = {};
     private readonly _orderByOrderHash: OrderByOrderHash = {};
-    private readonly _orderByOrderHashLock = new Lock();
+    private readonly _lock = new Lock();
     private readonly _eventWatcher: EventWatcher;
     private readonly _provider: ZeroExProvider;
     private readonly _collisionResistantAbiDecoder: CollisionResistanceAbiDecoder;
@@ -234,13 +234,13 @@ export class OrderWatcher {
         };
     }
     private async _addLockToCallbackAsync(cbAsync: any, ...params: any[]): Promise<void> {
-        await this._orderByOrderHashLock.acquire();
+        await this._lock.acquire();
         try {
             await cbAsync(...params);
-            await this._orderByOrderHashLock.release();
+            await this._lock.release();
         } catch (err) {
             // Make sure to releasee the lock if an error is thrown
-            await this._orderByOrderHashLock.release();
+            await this._lock.release();
             throw err;
         }
     }
@@ -508,4 +508,4 @@ export class OrderWatcher {
             this._callbackIfExists(null, orderState);
         }
     }
-}
+} // tslint:disable:max-file-line-count

--- a/packages/order-watcher/test/order_watcher_test.ts
+++ b/packages/order-watcher/test/order_watcher_test.ts
@@ -175,10 +175,14 @@ describe('OrderWatcher', () => {
         });
     });
     describe('tests with cleanup', async () => {
+        beforeEach(async () => {
+            await blockchainLifecycle.startAsync();
+        });
         afterEach(async () => {
             orderWatcher.unsubscribe();
             const orderHash = orderHashUtils.getOrderHashHex(signedOrder);
             orderWatcher.removeOrder(orderHash);
+            await blockchainLifecycle.revertAsync();
         });
         it('should emit orderStateInvalid when makerAddress allowance set to 0 for watched order', (done: DoneCallback) => {
             (async () => {


### PR DESCRIPTION
## Description

Intermittent failures were reported by an order-watcher user (https://github.com/0xProject/0x-monorepo/issues/1710)

It turns out we have several async event callbacks that are modifying a shared piece of state, and that removals from this data structure can cause other callbacks to malfunction. 

This PR adds a semaphore around each of the async event callbacks so that the shared data structures they all use won't be modified during their execution. This allows them to assume that it won't be modified by another process. 

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
