### PR TITLE
Fix yarn command in monorepo-scripts

### DIFF
--- a/packages/monorepo-scripts/README.md
+++ b/packages/monorepo-scripts/README.md
@@ -17,7 +17,7 @@ This repository contains a few helpful scripts for working with this mono repo.
 In order to reduce the size of this repo, we try and use the same versions of dependencies between packages. To make it easier to discover version discrepancies between packages, you can run:
 
 ```bash
-yarn scripts:deps_versions
+yarn script:deps_versions
 ```
 
 This will list out any dependencies that differ in versions between packages.


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Don't hate me, this is a very small change, but (1) it was bugging me to know that the command doesn't work and (2) I wanted to go through the contributor guide.

```bash
yarn scripts:deps_versions
```

The solution was to replace `scripts` with `script`:

```bash
yarn script:deps_versions
```

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Prefix PR title with `[WIP]` if necessary.
-   [x] Add tests to cover changes as needed.
-   [x] Update documentation as needed.
-   [x] Add new entries to the relevant CHANGELOG.jsons.
