### PR TITLE
[3.0] Only test contract-related packages in circleci.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,6 @@
+# NOTE: We're only focusing on contracts in the 3.0 branch currently, so
+# we only run certain jobs  until we're ready to reconcile other packages.
+
 version: 2
 
 jobs:
@@ -20,6 +23,28 @@ jobs:
             - setup_remote_docker
             - run: yarn build:ci:no_website
             - run: yarn build:ts
+            - save_cache:
+                  key: repo-{{ .Environment.CIRCLE_SHA1 }}
+                  paths:
+                      - ~/repo
+    build-3.0:
+        resource_class: medium+
+        docker:
+            - image: circleci/node:9-browsers
+        environment:
+            CONTRACTS_COMMIT_HASH: '9ed05f5'
+        working_directory: ~/repo
+        steps:
+            - checkout
+            - run: echo 'export PATH=$HOME/CIRCLE_PROJECT_REPONAME/node_modules/.bin:$PATH' >> $BASH_ENV
+            - run:
+                  name: install-yarn
+                  command: sudo npm install --global yarn@1.9.4
+            - run:
+                  name: yarn
+                  command: yarn --frozen-lockfile --ignore-engines install || yarn --frozen-lockfile --ignore-engines install
+            - setup_remote_docker
+            - run: yarn build:contracts
             - save_cache:
                   key: repo-{{ .Environment.CIRCLE_SHA1 }}
                   paths:
@@ -195,6 +220,81 @@ jobs:
                   key: coverage-web3-wrapper-{{ .Environment.CIRCLE_SHA1 }}
                   paths:
                       - ~/repo/packages/web3-wrapper/coverage/lcov.info
+    test-rest-3.0:
+        docker:
+            - image: circleci/node:9-browsers
+        working_directory: ~/repo
+        steps:
+            - restore_cache:
+                  keys:
+                      - repo-{{ .Environment.CIRCLE_SHA1 }}
+            - run: yarn wsrun test:circleci @0x/contracts-test-utils
+            - run: yarn wsrun test:circleci @0x/abi-gen
+            - run: yarn wsrun test:circleci @0x/assert
+            - run: yarn wsrun test:circleci @0x/base-contract
+            - run: yarn wsrun test:circleci @0x/connect
+            - run: yarn wsrun test:circleci @0x/contract-wrappers
+            - run: yarn wsrun test:circleci @0x/dev-utils
+            - run: yarn wsrun test:circleci @0x/json-schemas
+            - run: yarn wsrun test:circleci @0x/order-utils
+            - run: yarn wsrun test:circleci @0x/sol-compiler
+            - run: yarn wsrun test:circleci @0x/sol-tracing-utils
+            - run: yarn wsrun test:circleci @0x/sol-doc
+            - run: yarn wsrun test:circleci @0x/subproviders
+            - run: yarn wsrun test:circleci @0x/web3-wrapper
+            - run: yarn wsrun test:circleci @0x/utils
+            - save_cache:
+                  key: coverage-abi-gen-{{ .Environment.CIRCLE_SHA1 }}
+                  paths:
+                      - ~/repo/packages/abi-gen/coverage/lcov.info
+            - save_cache:
+                  key: coverage-assert-{{ .Environment.CIRCLE_SHA1 }}
+                  paths:
+                      - ~/repo/packages/assert/coverage/lcov.info
+            - save_cache:
+                  key: coverage-base-contract-{{ .Environment.CIRCLE_SHA1 }}
+                  paths:
+                      - ~/repo/packages/base-contract/coverage/lcov.info
+            - save_cache:
+                  key: coverage-connect-{{ .Environment.CIRCLE_SHA1 }}
+                  paths:
+                      - ~/repo/packages/connect/coverage/lcov.info
+            - save_cache:
+                  key: coverage-contract-wrappers-{{ .Environment.CIRCLE_SHA1 }}
+                  paths:
+                      - ~/repo/packages/contract-wrappers/coverage/lcov.info
+            - save_cache:
+                  key: coverage-dev-utils-{{ .Environment.CIRCLE_SHA1 }}
+                  paths:
+                      - ~/repo/packages/dev-utils/coverage/lcov.info
+            - save_cache:
+                  key: coverage-json-schemas-{{ .Environment.CIRCLE_SHA1 }}
+                  paths:
+                      - ~/repo/packages/json-schemas/coverage/lcov.info
+            - save_cache:
+                  key: coverage-order-utils-{{ .Environment.CIRCLE_SHA1 }}
+                  paths:
+                      - ~/repo/packages/order-utils/coverage/lcov.info
+            - save_cache:
+                  key: coverage-sol-compiler-{{ .Environment.CIRCLE_SHA1 }}
+                  paths:
+                      - ~/repo/packages/sol-compiler/coverage/lcov.info
+            - save_cache:
+                  key: coverage-sol-tracing-utils-{{ .Environment.CIRCLE_SHA1 }}
+                  paths:
+                      - ~/repo/packages/sol-tracing-utils/coverage/lcov.info
+            - save_cache:
+                  key: coverage-sol-doc-{{ .Environment.CIRCLE_SHA1 }}
+                  paths:
+                      - ~/repo/packages/sol-doc/coverage/lcov.info
+            - save_cache:
+                  key: coverage-subproviders-{{ .Environment.CIRCLE_SHA1 }}
+                  paths:
+                      - ~/repo/packages/subproviders/coverage/lcov.info
+            - save_cache:
+                  key: coverage-web3-wrapper-{{ .Environment.CIRCLE_SHA1 }}
+                  paths:
+                      - ~/repo/packages/web3-wrapper/coverage/lcov.info
     test-python:
         working_directory: ~/repo
         docker:
@@ -304,6 +404,17 @@ jobs:
             - run: yarn deps_versions:ci
             - run: cd packages/0x.js && yarn build:umd:prod
             - run: yarn bundlewatch
+    static-tests-3.0:
+        working_directory: ~/repo
+        docker:
+            - image: circleci/node:9-browsers
+        steps:
+            - restore_cache:
+                  keys:
+                      - repo-{{ .Environment.CIRCLE_SHA1 }}
+            - run: yarn lerna run lint
+            - run: yarn prettier:ci
+            - run: yarn deps_versions:ci
     submit-coverage:
         docker:
             - image: circleci/node:9-browsers
@@ -379,42 +490,98 @@ jobs:
                   keys:
                       - coverage-python-order-utils-{{ .Environment.CIRCLE_SHA1 }}
             - run: yarn report_coverage
+    submit-coverage-3.0:
+        docker:
+            - image: circleci/node:9-browsers
+        working_directory: ~/repo
+        steps:
+            - restore_cache:
+                  keys:
+                      - repo-{{ .Environment.CIRCLE_SHA1 }}
+            - restore_cache:
+                  keys:
+                      - coverage-abi-gen-{{ .Environment.CIRCLE_SHA1 }}
+            - restore_cache:
+                  keys:
+                      - coverage-assert-{{ .Environment.CIRCLE_SHA1 }}
+            - restore_cache:
+                  keys:
+                      - coverage-base-contract-{{ .Environment.CIRCLE_SHA1 }}
+            - restore_cache:
+                  keys:
+                      - coverage-connect-{{ .Environment.CIRCLE_SHA1 }}
+            - restore_cache:
+                  keys:
+                      - coverage-contract-wrappers-{{ .Environment.CIRCLE_SHA1 }}
+            - restore_cache:
+                  keys:
+                      - coverage-dev-utils-{{ .Environment.CIRCLE_SHA1 }}
+            - restore_cache:
+                  keys:
+                      - coverage-json-schemas-{{ .Environment.CIRCLE_SHA1 }}
+            - restore_cache:
+                  keys:
+                      - coverage-order-utils-{{ .Environment.CIRCLE_SHA1 }}
+            - restore_cache:
+                  keys:
+                      - coverage-sol-compiler-{{ .Environment.CIRCLE_SHA1 }}
+            - restore_cache:
+                  keys:
+                      - coverage-sol-tracing-utils-{{ .Environment.CIRCLE_SHA1 }}
+            - restore_cache:
+                  keys:
+                      - coverage-sol-doc-{{ .Environment.CIRCLE_SHA1 }}
+            - restore_cache:
+                  keys:
+                      - coverage-subproviders-{{ .Environment.CIRCLE_SHA1 }}
+            - restore_cache:
+                  keys:
+                      - coverage-web3-wrapper-{{ .Environment.CIRCLE_SHA1 }}
+            - restore_cache:
+                  keys:
+                      - coverage-contracts-{{ .Environment.CIRCLE_SHA1 }}
+            - run: yarn report_coverage
 workflows:
     version: 2
     main:
         jobs:
-            - build
-            - build-website:
-                  requires:
-                      - build
+            - build-3.0
+            # Disabled for 3.0
+            # - build-website:
+            #       requires:
+            #           - build
             - test-contracts-ganache:
                   requires:
-                      - build
+                      - build-3.0
             - test-contracts-geth:
                   requires:
-                      - build
-            - test-pipeline:
+                      - build-3.0
+            # Disabled for 3.0
+            # - test-pipeline:
+            #       requires:
+            #           - build-3.0
+            - test-rest-3.0:
                   requires:
-                      - build
-            - test-rest:
+                      - build-3.0
+            - static-tests-3.0:
                   requires:
-                      - build
-            - static-tests:
+                      - build-3.0
+            # Disabled for 3.0
+            # - test-publish:
+            #       requires:
+            #           - build-3.0
+            # Disabled for 3.0
+            # - test-doc-generation:
+            #       requires:
+            #           - build-3.0
+            - submit-coverage-3.0:
                   requires:
-                      - build
-            - test-publish:
-                  requires:
-                      - build
-            - test-doc-generation:
-                  requires:
-                      - build
-            - submit-coverage:
-                  requires:
-                      - test-rest
-                      - test-python
-            - static-tests-python:
-                  requires:
-                      - test-python
-            - test-python
+                      - test-rest-3.0
+            # Disabled for 3.0
+            # - static-tests-python:
+            #       requires:
+            #           - test-python
+            # Disabled for 3.0
+            # - test-python
             # skip python tox run for now, as we don't yet have multiple test environments to support.
             #- test-rest-python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,7 +232,6 @@ jobs:
             - run: yarn wsrun test:circleci @0x/abi-gen
             - run: yarn wsrun test:circleci @0x/assert
             - run: yarn wsrun test:circleci @0x/base-contract
-            - run: yarn wsrun test:circleci @0x/connect
             - run: yarn wsrun test:circleci @0x/contract-wrappers
             - run: yarn wsrun test:circleci @0x/dev-utils
             - run: yarn wsrun test:circleci @0x/json-schemas
@@ -255,10 +254,6 @@ jobs:
                   key: coverage-base-contract-{{ .Environment.CIRCLE_SHA1 }}
                   paths:
                       - ~/repo/packages/base-contract/coverage/lcov.info
-            - save_cache:
-                  key: coverage-connect-{{ .Environment.CIRCLE_SHA1 }}
-                  paths:
-                      - ~/repo/packages/connect/coverage/lcov.info
             - save_cache:
                   key: coverage-contract-wrappers-{{ .Environment.CIRCLE_SHA1 }}
                   paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ jobs:
                   command: yarn --frozen-lockfile --ignore-engines install || yarn --frozen-lockfile --ignore-engines install
             - setup_remote_docker
             - run: yarn build:contracts
+            - run: PKG='@0x/monorepo-scripts' yarn build
             - save_cache:
                   key: repo-{{ .Environment.CIRCLE_SHA1 }}
                   paths:
@@ -238,7 +239,6 @@ jobs:
             - run: yarn wsrun test:circleci @0x/order-utils
             - run: yarn wsrun test:circleci @0x/sol-compiler
             - run: yarn wsrun test:circleci @0x/sol-tracing-utils
-            - run: yarn wsrun test:circleci @0x/sol-doc
             - run: yarn wsrun test:circleci @0x/subproviders
             - run: yarn wsrun test:circleci @0x/web3-wrapper
             - run: yarn wsrun test:circleci @0x/utils
@@ -278,10 +278,6 @@ jobs:
                   key: coverage-sol-tracing-utils-{{ .Environment.CIRCLE_SHA1 }}
                   paths:
                       - ~/repo/packages/sol-tracing-utils/coverage/lcov.info
-            - save_cache:
-                  key: coverage-sol-doc-{{ .Environment.CIRCLE_SHA1 }}
-                  paths:
-                      - ~/repo/packages/sol-doc/coverage/lcov.info
             - save_cache:
                   key: coverage-subproviders-{{ .Environment.CIRCLE_SHA1 }}
                   paths:
@@ -523,9 +519,6 @@ jobs:
             - restore_cache:
                   keys:
                       - coverage-sol-tracing-utils-{{ .Environment.CIRCLE_SHA1 }}
-            - restore_cache:
-                  keys:
-                      - coverage-sol-doc-{{ .Environment.CIRCLE_SHA1 }}
             - restore_cache:
                   keys:
                       - coverage-subproviders-{{ .Environment.CIRCLE_SHA1 }}

--- a/contracts/utils/CHANGELOG.json
+++ b/contracts/utils/CHANGELOG.json
@@ -34,17 +34,12 @@
                 "pr": 1657
             },
             {
-<<<<<<< HEAD
                 "note": "Add unit tests for `LibAddressArray`",
                 "pr": 1712
             },
             {
                 "note": "Fix `LibAddressArray.indexOf` returning incorrect index.",
                 "pr": 1712
-=======
-                "note": "Change ReentrancyGuard implementation to cheaper one",
-                "pr": 1699
->>>>>>> Update PRs in changelogs.
             }
         ],
         "timestamp": 1553091633


### PR DESCRIPTION
## Description
The `3.0` branch is contract-focused right now and will introduce breaking changes to a lot of ancillary packages (e.g., `@0x/instant`). The current circleci suite of tests all depend on `build:ci:no_website`, which is bound to fail in `3.0`, which means circleci would give us no meaningful signals on this branch. This updates the circleci config to only build and test contract-related packages.

Note: `test-contracts-geth` still fails, just like in development, but it's still included because it should start working once we update our geth fork.

This also fixes a minor merge artifact from the the `development` rebase.
 
## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
