### PR TITLE
Pin Launch Kit version in test-python CI task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,7 +200,7 @@ jobs:
         docker:
             - image: circleci/python
             - image: 0xorg/ganache-cli:2.2.2
-            - image: 0xorg/launch-kit-ci
+            - image: 0xorg/launch-kit-ci:0.0.1
               command: |
                   yarn start:ts -p 3000:3000
         steps:


### PR DESCRIPTION
## Description

Pin Launch Kit version in test-python CI task.

Fixes CI run plaguing everyone.

I republished the launch-kit-ci docker image earlier, updating the latest tag, to fix a bug experienced in the old version, and it broke the development branch test runs.  A code update, and an unpinning, will come from a WiP PR soon, but until it does we should pin the old test code to the Launch Kit version it was always running on (and passing).

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->
