### PR TITLE
don't publish tsconfig.json

### DIFF
--- a/packages/typescript-typings/.npmignore
+++ b/packages/typescript-typings/.npmignore
@@ -2,3 +2,4 @@
 yarn-error.log
 /scripts/
 /lib/monorepo_scripts/
+tsconfig.json


### PR DESCRIPTION
As far as I'm aware, it's bad practice to push the tsconfig.json file to npm.

The reason I noticed was because of a lint warning - "File '../../tsconfig' does not exist." - in VSCode.