### PR TITLE
Fix race condition in CI runs of Python SRA client tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,6 +205,7 @@ jobs:
                   RPC_URL: http://localhost:8545
                   NETWORK_ID: 50
                   WHITELIST_ALL_TOKENS: True
+              command: bash -c "until curl -sfd'{\"method\":\"net_listening\"}' http://localhost:8545 | grep true; do continue; done; forever ts/lib/index.js"
         steps:
             - checkout
             - run: sudo chown -R circleci:circleci /usr/local/bin

--- a/python-packages/sra_client/README.md
+++ b/python-packages/sra_client/README.md
@@ -294,6 +294,40 @@ except ApiException as e:
     print("Exception when calling DefaultApi->get_asset_pairs: %s\n" % e)
 ```
 
+## Contributing
+
+We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
+
+Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
+
+### Install Code and Dependencies
+
+Ensure that you have installed Python >=3.6, Docker, and docker-compose. Then:
+
+```bash
+pip install -e .[dev]
+```
+
+### Test
+
+Tests depend on a running instance of 0x-launch-kit, backed by a Ganache node with the 0x contracts deployed in it. For convenience, a docker-compose file is provided that creates this environment. And a shortcut is provided to interface with that file: `./setup.py start_test_relayer` will start those services. With them running, the tests can be run with `./setup.py test`. When you're done with testing, you can `./setup.py stop_test_relayer`.
+
+### Clean
+
+`./setup.py clean --all`
+
+### Lint
+
+`./setup.py lint`
+
+### Build Documentation
+
+`./setup.py build_sphinx`
+
+### More
+
+See `./setup.py --help-commands` for more info.
+
 ## Documentation for API Endpoints
 
 All URIs are relative to _http://localhost_

--- a/python-packages/sra_client/sra_client/__init__.py
+++ b/python-packages/sra_client/sra_client/__init__.py
@@ -93,7 +93,7 @@ Post an order to an SRA-compliant Relayer.
 ...     jsdict_order_to_struct(example_order), exchange_address)
 >>> example_order["signature"] = sign_hash(
 ...     provider, Web3.toChecksumAddress(maker_address), order_hash)
->>> relayer_api.post_order_with_http_info(  # doctest: +SKIP
+>>> relayer_api.post_order_with_http_info(
 ...     network_id=50, signed_order_schema=example_order)[1]
 200
 
@@ -101,7 +101,7 @@ Get Orders
 -----------
 Get orders from an SRA-compliant Relayer.
 
->>> relayer_api.get_orders()  # doctest: +SKIP
+>>> relayer_api.get_orders()
 {'records': [{'meta_data': {},
               'order': {'exchange_address': '0x48bacb9266a570d521063ef5dd96e61686dbe788',
                         'expiration_time_seconds': '1000000000000000000000',
@@ -121,7 +121,7 @@ Get Order
 ---------
 Get an order by hash from an SRA-compliant Relayer.
 
->>> relayer_api.get_order("0x" + order_hash)  # doctest: +SKIP
+>>> relayer_api.get_order("0x" + order_hash)
 {'meta_data': {},
  'order': {'exchange_address': '0x48bacb9266a570d521063ef5dd96e61686dbe788',
            'expiration_time_seconds': '1000000000000000000000',
@@ -141,7 +141,7 @@ Get Asset Pair
 ---------------
 Get available asset pairs from an SRA-compliant Relayer.
 
->>> relayer_api.get_asset_pairs()  # doctest: +SKIP
+>>> relayer_api.get_asset_pairs()
 {'records': [{'assetDataA': {'assetData': '0xf47261b00000000000000000000000000b1ba0af832d7c05fd64161e0db78e85978e8082',
                              'maxAmount': '115792089237316195423570985008687907853269984665640564039457584007913129639936',
                              'minAmount': '0',
@@ -155,7 +155,7 @@ Get Orderbook
 -------------
 Get the orderbook for the WETH/ZRX asset pair from an SRA-compliant Relayer.
 
->>> relayer_api.get_orderbook(  # doctest: +SKIP
+>>> relayer_api.get_orderbook(
 ...     base_asset_data=weth_asset_data,
 ...     quote_asset_data=zrx_asset_data)
 {'asks': {'records': [{'meta_data': {},

--- a/python-packages/sra_client/test/relayer/docker-compose.yml
+++ b/python-packages/sra_client/test/relayer/docker-compose.yml
@@ -1,0 +1,19 @@
+# Run Launch Kit with Ganache as the backing node
+version: '3'
+services:
+    ganache:
+        image: "0xorg/ganache-cli:2.2.2"
+        ports:
+            - "8545:8545"
+    launchkit:
+        image: "0xorg/launch-kit-ci"
+        depends_on:
+            - ganache
+        ports:
+            - "3000:3000"
+        network_mode: "host" # to connect to ganache
+        environment:
+            - NETWORK_ID=50
+            - RPC_URL=http://localhost:8545
+            - WHITELIST_ALL_TOKENS=True
+        command: bash -c "until curl -sfd'{\"method\":\"net_listening\"}' http://localhost:8545 | grep true; do continue; done; forever ts/lib/index.js"

--- a/python-packages/sra_client/test/test_default_api.py
+++ b/python-packages/sra_client/test/test_default_api.py
@@ -6,13 +6,10 @@ from __future__ import absolute_import
 
 import unittest
 
-import pytest
-
 from sra_client import ApiClient, Configuration
 from sra_client.api import DefaultApi
 
 
-@pytest.mark.skip(reason="Circle CI error launch kit unreachable")
 class TestDefaultApi(unittest.TestCase):
     """DefaultApi unit test stubs"""
 


### PR DESCRIPTION
## Description

Context: Python SRA client tests run against an instance of Launch Kit, and for testing purposes we use Ganache as its backing node.

There was a race condition in having Circle CI start these services:  Sometimes, Launch Kit would start accepting connections, and tests would start running and trying to post orders, but Ganache was not yet up and listening, so the tests would time out and fail.

This PR adds changes to wait for Ganache to answer an API call before starting Launch Kit.

It also re-enables the Python SRA client tests, which were disabled due to them intermittently failing because of this race condition.

Finally, this PR also adds some conveniences for spinning up these services in a local development environment.

In an effort to ensure there's no longer an intermittent issue, I re-ran CI 5 times on my branch before opening this PR.  Previously, I observed the race condition about 6 times out of I think 8 runs (only 2 successes ever), so I'd say 5 clean runs in a row signals that this problem really is resolved.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->