### PR TITLE
[WIP][FFF] Cut the package fat! Part 2: Ethers and Abi-gen-wrappers

### DIFF
--- a/packages/abi-gen-templates/contract.handlebars
+++ b/packages/abi-gen-templates/contract.handlebars
@@ -6,8 +6,7 @@ import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact,
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
-import * as ethers from 'ethers';
-import * as _ from 'lodash';
+import { isUndefined } from 'lodash';
 // tslint:enable:no-unused-variable
 
 {{#if events}}
@@ -46,7 +45,7 @@ export class {{contractName}}Contract extends BaseContract {
         txDefaults: Partial<TxData>,
         {{> typed_params inputs=ctor.inputs}}
     ): Promise<{{contractName}}Contract> {
-        if (_.isUndefined(artifact.compilerOutput)) {
+        if (isUndefined(artifact.compilerOutput)) {
             throw new Error('Compiler output not found in the artifact file');
         }
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
@@ -68,7 +67,8 @@ export class {{contractName}}Contract extends BaseContract {
             [{{> params inputs=ctor.inputs}}],
             BaseContract._bigNumberToString,
         );
-        const iface = new ethers.utils.Interface(abi);
+        return {} as any;
+        {{!-- const iface = new ethersUtils.Interface(abi);
         const deployInfo = iface.deployFunction;
         const txData = deployInfo.encode(bytecode, [{{> params inputs=ctor.inputs}}]);
         const web3Wrapper = new Web3Wrapper(provider);
@@ -82,8 +82,8 @@ export class {{contractName}}Contract extends BaseContract {
         const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
         logUtils.log(`{{contractName}} successfully deployed at ${txReceipt.contractAddress}`);
         const contractInstance = new {{contractName}}Contract(abi, txReceipt.contractAddress as string, provider, txDefaults);
-        contractInstance.constructorArgs = [{{> params inputs=ctor.inputs}}];
-        return contractInstance;
+        contractInstance.constructorArgs = [{{> params inputs=ctor.inputs}}]; --}}
+        {{!-- return contractInstance; --}}
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
         super('{{contractName}}', abi, address, supportedProvider, txDefaults);

--- a/packages/abi-gen-templates/contract.handlebars
+++ b/packages/abi-gen-templates/contract.handlebars
@@ -3,7 +3,7 @@
 // tslint:disable:no-unbound-method
 import { BaseContract } from '@0x/base-contract';
 import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact, DecodedLogArgs, MethodAbi, TxData, TxDataPayable, SupportedProvider } from 'ethereum-types';
-import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
+import { AbiEncoder, BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 import { isUndefined } from 'lodash';
@@ -67,10 +67,8 @@ export class {{contractName}}Contract extends BaseContract {
             [{{> params inputs=ctor.inputs}}],
             BaseContract._bigNumberToString,
         );
-        return {} as any;
-        {{!-- const iface = new ethersUtils.Interface(abi);
-        const deployInfo = iface.deployFunction;
-        const txData = deployInfo.encode(bytecode, [{{> params inputs=ctor.inputs}}]);
+        const encoder = new AbiEncoder.Constructor(constructorAbi);
+        const txData = encoder.encode(bytecode, [{{> params inputs=ctor.inputs}}]);
         const web3Wrapper = new Web3Wrapper(provider);
         const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
             {data: txData},
@@ -82,8 +80,8 @@ export class {{contractName}}Contract extends BaseContract {
         const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
         logUtils.log(`{{contractName}} successfully deployed at ${txReceipt.contractAddress}`);
         const contractInstance = new {{contractName}}Contract(abi, txReceipt.contractAddress as string, provider, txDefaults);
-        contractInstance.constructorArgs = [{{> params inputs=ctor.inputs}}]; --}}
-        {{!-- return contractInstance; --}}
+        contractInstance.constructorArgs = [{{> params inputs=ctor.inputs}}];
+        return contractInstance;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
         super('{{contractName}}', abi, address, supportedProvider, txDefaults);

--- a/packages/abi-gen-templates/partials/callAsync.handlebars
+++ b/packages/abi-gen-templates/partials/callAsync.handlebars
@@ -1,21 +1,13 @@
+functionSignature: '{{this.functionSignature}}',
 async callAsync(
 {{> typed_params inputs=inputs}}
     callData: Partial<CallData> = {},
     defaultBlock?: BlockParam,
 ): Promise<{{> return_type outputs=outputs}}> {
     const self = this as any as {{contractName}}Contract;
-    const encodedData = self._strictEncodeArguments('{{this.functionSignature}}', [{{> params inputs=inputs}}]);
-    const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-        {
-            to: self.address,
-            ...callData,
-            data: encodedData,
-        },
-        self._web3Wrapper.getContractDefaults(),
-    );
-    const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-    BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-    const abiEncoder = self._lookupAbiEncoder('{{this.functionSignature}}');
+    const encodedData = self._strictEncodeArguments(self.{{this.tsName}}.functionSignature, [{{> params inputs=inputs}}]);
+    const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+    const abiEncoder = self._lookupAbiEncoder(self.{{this.tsName}}.functionSignature);
     // tslint:disable boolean-naming
     const result = abiEncoder.strictDecodeReturnValue<{{> return_type outputs=outputs}}>(rawCallResult);
     // tslint:enable boolean-naming

--- a/packages/abi-gen-templates/partials/callAsync.handlebars
+++ b/packages/abi-gen-templates/partials/callAsync.handlebars
@@ -1,13 +1,12 @@
-functionSignature: '{{this.functionSignature}}',
 async callAsync(
 {{> typed_params inputs=inputs}}
     callData: Partial<CallData> = {},
     defaultBlock?: BlockParam,
 ): Promise<{{> return_type outputs=outputs}}> {
     const self = this as any as {{contractName}}Contract;
-    const encodedData = self._strictEncodeArguments(self.{{this.tsName}}.functionSignature, [{{> params inputs=inputs}}]);
+    const encodedData = self._strictEncodeArguments('{{this.functionSignature}}', [{{> params inputs=inputs}}]);
     const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-    const abiEncoder = self._lookupAbiEncoder(self.{{this.tsName}}.functionSignature);
+    const abiEncoder = self._lookupAbiEncoder('{{this.functionSignature}}');
     // tslint:disable boolean-naming
     const result = abiEncoder.strictDecodeReturnValue<{{> return_type outputs=outputs}}>(rawCallResult);
     // tslint:enable boolean-naming

--- a/packages/abi-gen-templates/partials/tx.handlebars
+++ b/packages/abi-gen-templates/partials/tx.handlebars
@@ -9,20 +9,9 @@ public {{this.tsName}} = {
     {{/this.payable}}
     ): Promise<string> {
         const self = this as any as {{contractName}}Contract;
-        const encodedData = self._strictEncodeArguments('{{this.functionSignature}}', [{{> params inputs=inputs}}]);
-        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-            {
-                to: self.address,
-                ...txData,
-                data: encodedData,
-            },
-            self._web3Wrapper.getContractDefaults(),
-            self.{{this.tsName}}.estimateGasAsync.bind(
-                self,
-                {{> params inputs=inputs}}
-            ),
-        );
-        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        const encodedData = self._strictEncodeArguments(self.{{this.tsName}}.functionSignature, [{{> params inputs=inputs}}]);
+        const gasEstimateFunction = self.{{this.tsName}}.estimateGasAsync.bind(self, {{> params inputs=inputs}});
+        const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
         return txHash;
     },
     async estimateGasAsync(
@@ -30,23 +19,15 @@ public {{this.tsName}} = {
         txData: Partial<TxData> = {},
     ): Promise<number> {
         const self = this as any as {{contractName}}Contract;
-        const encodedData = self._strictEncodeArguments('{{this.functionSignature}}', [{{> params inputs=inputs}}]);
-        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-            {
-                to: self.address,
-                ...txData,
-                data: encodedData,
-            },
-            self._web3Wrapper.getContractDefaults(),
-        );
-        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        const encodedData = self._strictEncodeArguments(self.{{this.tsName}}.functionSignature, [{{> params inputs=inputs}}]);
+        const gas = await self._estimateGasAsync(self.address, encodedData, txData);
         return gas;
     },
     getABIEncodedTransactionData(
     {{> typed_params inputs=inputs}}
     ): string {
         const self = this as any as {{contractName}}Contract;
-        const abiEncodedTransactionData = self._strictEncodeArguments('{{this.functionSignature}}', [{{> params inputs=inputs}}]);
+        const abiEncodedTransactionData = self._strictEncodeArguments(self.{{this.tsName}}.functionSignature, [{{> params inputs=inputs}}]);
         return abiEncodedTransactionData;
     },
     {{> callAsync}}

--- a/packages/abi-gen-templates/partials/tx.handlebars
+++ b/packages/abi-gen-templates/partials/tx.handlebars
@@ -9,7 +9,7 @@ public {{this.tsName}} = {
     {{/this.payable}}
     ): Promise<string> {
         const self = this as any as {{contractName}}Contract;
-        const encodedData = self._strictEncodeArguments(self.{{this.tsName}}.functionSignature, [{{> params inputs=inputs}}]);
+        const encodedData = self._strictEncodeArguments('{{this.functionSignature}}', [{{> params inputs=inputs}}]);
         const gasEstimateFunction = self.{{this.tsName}}.estimateGasAsync.bind(self, {{> params inputs=inputs}});
         const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
         return txHash;
@@ -19,7 +19,7 @@ public {{this.tsName}} = {
         txData: Partial<TxData> = {},
     ): Promise<number> {
         const self = this as any as {{contractName}}Contract;
-        const encodedData = self._strictEncodeArguments(self.{{this.tsName}}.functionSignature, [{{> params inputs=inputs}}]);
+        const encodedData = self._strictEncodeArguments('{{this.functionSignature}}', [{{> params inputs=inputs}}]);
         const gas = await self._estimateGasAsync(self.address, encodedData, txData);
         return gas;
     },
@@ -27,7 +27,7 @@ public {{this.tsName}} = {
     {{> typed_params inputs=inputs}}
     ): string {
         const self = this as any as {{contractName}}Contract;
-        const abiEncodedTransactionData = self._strictEncodeArguments(self.{{this.tsName}}.functionSignature, [{{> params inputs=inputs}}]);
+        const abiEncodedTransactionData = self._strictEncodeArguments('{{this.functionSignature}}', [{{> params inputs=inputs}}]);
         return abiEncodedTransactionData;
     },
     {{> callAsync}}

--- a/packages/abi-gen-wrappers/src/generated-wrappers/asset_proxy_owner.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/asset_proxy_owner.ts
@@ -6,8 +6,7 @@ import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact,
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
-import * as ethers from 'ethers';
-import * as _ from 'lodash';
+import { isUndefined } from 'lodash';
 // tslint:enable:no-unused-variable
 
 export type AssetProxyOwnerEventArgs =
@@ -98,6 +97,7 @@ export interface AssetProxyOwnerRequirementChangeEventArgs extends DecodedLogArg
 // tslint:disable-next-line:class-name
 export class AssetProxyOwnerContract extends BaseContract {
     public owners = {
+        functionSignature: 'owners(uint256)',
         async callAsync(
             index_0: BigNumber,
             callData: Partial<CallData> = {},
@@ -105,19 +105,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<string
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('owners(uint256)', [index_0
+            const encodedData = self._strictEncodeArguments(self.owners.functionSignature, [index_0
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('owners(uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.owners.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -131,21 +122,11 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('removeOwner(address)', [owner
+            const encodedData = self._strictEncodeArguments(self.removeOwner.functionSignature, [owner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.removeOwner.estimateGasAsync.bind(
-                    self,
-                    owner
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.removeOwner.estimateGasAsync.bind(self, owner
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -153,27 +134,20 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('removeOwner(address)', [owner
+            const encodedData = self._strictEncodeArguments(self.removeOwner.functionSignature, [owner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             owner: string,
         ): string {
             const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('removeOwner(address)', [owner
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.removeOwner.functionSignature, [owner
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'removeOwner(address)',
         async callAsync(
             owner: string,
             callData: Partial<CallData> = {},
@@ -181,19 +155,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('removeOwner(address)', [owner
+            const encodedData = self._strictEncodeArguments(self.removeOwner.functionSignature, [owner
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('removeOwner(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.removeOwner.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -207,21 +172,11 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('revokeConfirmation(uint256)', [transactionId
+            const encodedData = self._strictEncodeArguments(self.revokeConfirmation.functionSignature, [transactionId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.revokeConfirmation.estimateGasAsync.bind(
-                    self,
-                    transactionId
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.revokeConfirmation.estimateGasAsync.bind(self, transactionId
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -229,27 +184,20 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('revokeConfirmation(uint256)', [transactionId
+            const encodedData = self._strictEncodeArguments(self.revokeConfirmation.functionSignature, [transactionId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             transactionId: BigNumber,
         ): string {
             const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('revokeConfirmation(uint256)', [transactionId
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.revokeConfirmation.functionSignature, [transactionId
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'revokeConfirmation(uint256)',
         async callAsync(
             transactionId: BigNumber,
             callData: Partial<CallData> = {},
@@ -257,19 +205,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('revokeConfirmation(uint256)', [transactionId
+            const encodedData = self._strictEncodeArguments(self.revokeConfirmation.functionSignature, [transactionId
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('revokeConfirmation(uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.revokeConfirmation.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -278,6 +217,7 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
     };
     public isOwner = {
+        functionSignature: 'isOwner(address)',
         async callAsync(
             index_0: string,
             callData: Partial<CallData> = {},
@@ -285,19 +225,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('isOwner(address)', [index_0
+            const encodedData = self._strictEncodeArguments(self.isOwner.functionSignature, [index_0
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('isOwner(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.isOwner.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -306,6 +237,7 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
     };
     public confirmations = {
+        functionSignature: 'confirmations(uint256,address)',
         async callAsync(
             index_0: BigNumber,
             index_1: string,
@@ -314,20 +246,11 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('confirmations(uint256,address)', [index_0,
+            const encodedData = self._strictEncodeArguments(self.confirmations.functionSignature, [index_0,
         index_1
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('confirmations(uint256,address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.confirmations.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -341,21 +264,11 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('executeRemoveAuthorizedAddressAtIndex(uint256)', [transactionId
+            const encodedData = self._strictEncodeArguments(self.executeRemoveAuthorizedAddressAtIndex.functionSignature, [transactionId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.executeRemoveAuthorizedAddressAtIndex.estimateGasAsync.bind(
-                    self,
-                    transactionId
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.executeRemoveAuthorizedAddressAtIndex.estimateGasAsync.bind(self, transactionId
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -363,27 +276,20 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('executeRemoveAuthorizedAddressAtIndex(uint256)', [transactionId
+            const encodedData = self._strictEncodeArguments(self.executeRemoveAuthorizedAddressAtIndex.functionSignature, [transactionId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             transactionId: BigNumber,
         ): string {
             const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('executeRemoveAuthorizedAddressAtIndex(uint256)', [transactionId
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.executeRemoveAuthorizedAddressAtIndex.functionSignature, [transactionId
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'executeRemoveAuthorizedAddressAtIndex(uint256)',
         async callAsync(
             transactionId: BigNumber,
             callData: Partial<CallData> = {},
@@ -391,19 +297,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('executeRemoveAuthorizedAddressAtIndex(uint256)', [transactionId
+            const encodedData = self._strictEncodeArguments(self.executeRemoveAuthorizedAddressAtIndex.functionSignature, [transactionId
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('executeRemoveAuthorizedAddressAtIndex(uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.executeRemoveAuthorizedAddressAtIndex.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -412,24 +309,16 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
     };
     public secondsTimeLocked = {
+        functionSignature: 'secondsTimeLocked()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('secondsTimeLocked()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('secondsTimeLocked()');
+            const encodedData = self._strictEncodeArguments(self.secondsTimeLocked.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.secondsTimeLocked.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -438,6 +327,7 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
     };
     public getTransactionCount = {
+        functionSignature: 'getTransactionCount(bool,bool)',
         async callAsync(
             pending: boolean,
             executed: boolean,
@@ -446,20 +336,11 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('getTransactionCount(bool,bool)', [pending,
+            const encodedData = self._strictEncodeArguments(self.getTransactionCount.functionSignature, [pending,
         executed
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('getTransactionCount(bool,bool)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.getTransactionCount.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -474,23 +355,13 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('registerAssetProxy(address,bool)', [assetProxyContract,
+            const encodedData = self._strictEncodeArguments(self.registerAssetProxy.functionSignature, [assetProxyContract,
     isRegistered
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.registerAssetProxy.estimateGasAsync.bind(
-                    self,
-                    assetProxyContract,
-                    isRegistered
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.registerAssetProxy.estimateGasAsync.bind(self, assetProxyContract,
+    isRegistered
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -499,18 +370,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('registerAssetProxy(address,bool)', [assetProxyContract,
+            const encodedData = self._strictEncodeArguments(self.registerAssetProxy.functionSignature, [assetProxyContract,
     isRegistered
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -518,11 +381,12 @@ export class AssetProxyOwnerContract extends BaseContract {
             isRegistered: boolean,
         ): string {
             const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('registerAssetProxy(address,bool)', [assetProxyContract,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.registerAssetProxy.functionSignature, [assetProxyContract,
     isRegistered
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'registerAssetProxy(address,bool)',
         async callAsync(
             assetProxyContract: string,
             isRegistered: boolean,
@@ -531,20 +395,11 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('registerAssetProxy(address,bool)', [assetProxyContract,
+            const encodedData = self._strictEncodeArguments(self.registerAssetProxy.functionSignature, [assetProxyContract,
         isRegistered
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('registerAssetProxy(address,bool)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.registerAssetProxy.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -558,21 +413,11 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('addOwner(address)', [owner
+            const encodedData = self._strictEncodeArguments(self.addOwner.functionSignature, [owner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.addOwner.estimateGasAsync.bind(
-                    self,
-                    owner
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.addOwner.estimateGasAsync.bind(self, owner
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -580,27 +425,20 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('addOwner(address)', [owner
+            const encodedData = self._strictEncodeArguments(self.addOwner.functionSignature, [owner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             owner: string,
         ): string {
             const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('addOwner(address)', [owner
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.addOwner.functionSignature, [owner
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'addOwner(address)',
         async callAsync(
             owner: string,
             callData: Partial<CallData> = {},
@@ -608,19 +446,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('addOwner(address)', [owner
+            const encodedData = self._strictEncodeArguments(self.addOwner.functionSignature, [owner
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('addOwner(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.addOwner.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -629,6 +458,7 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
     };
     public isConfirmed = {
+        functionSignature: 'isConfirmed(uint256)',
         async callAsync(
             transactionId: BigNumber,
             callData: Partial<CallData> = {},
@@ -636,19 +466,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('isConfirmed(uint256)', [transactionId
+            const encodedData = self._strictEncodeArguments(self.isConfirmed.functionSignature, [transactionId
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('isConfirmed(uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.isConfirmed.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -662,21 +483,11 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('changeTimeLock(uint256)', [_secondsTimeLocked
+            const encodedData = self._strictEncodeArguments(self.changeTimeLock.functionSignature, [_secondsTimeLocked
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.changeTimeLock.estimateGasAsync.bind(
-                    self,
-                    _secondsTimeLocked
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.changeTimeLock.estimateGasAsync.bind(self, _secondsTimeLocked
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -684,27 +495,20 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('changeTimeLock(uint256)', [_secondsTimeLocked
+            const encodedData = self._strictEncodeArguments(self.changeTimeLock.functionSignature, [_secondsTimeLocked
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             _secondsTimeLocked: BigNumber,
         ): string {
             const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('changeTimeLock(uint256)', [_secondsTimeLocked
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.changeTimeLock.functionSignature, [_secondsTimeLocked
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'changeTimeLock(uint256)',
         async callAsync(
             _secondsTimeLocked: BigNumber,
             callData: Partial<CallData> = {},
@@ -712,19 +516,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('changeTimeLock(uint256)', [_secondsTimeLocked
+            const encodedData = self._strictEncodeArguments(self.changeTimeLock.functionSignature, [_secondsTimeLocked
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('changeTimeLock(uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.changeTimeLock.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -733,6 +528,7 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
     };
     public isAssetProxyRegistered = {
+        functionSignature: 'isAssetProxyRegistered(address)',
         async callAsync(
             index_0: string,
             callData: Partial<CallData> = {},
@@ -740,19 +536,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('isAssetProxyRegistered(address)', [index_0
+            const encodedData = self._strictEncodeArguments(self.isAssetProxyRegistered.functionSignature, [index_0
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('isAssetProxyRegistered(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.isAssetProxyRegistered.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -761,6 +548,7 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
     };
     public getConfirmationCount = {
+        functionSignature: 'getConfirmationCount(uint256)',
         async callAsync(
             transactionId: BigNumber,
             callData: Partial<CallData> = {},
@@ -768,19 +556,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('getConfirmationCount(uint256)', [transactionId
+            const encodedData = self._strictEncodeArguments(self.getConfirmationCount.functionSignature, [transactionId
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('getConfirmationCount(uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.getConfirmationCount.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -789,6 +568,7 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
     };
     public transactions = {
+        functionSignature: 'transactions(uint256)',
         async callAsync(
             index_0: BigNumber,
             callData: Partial<CallData> = {},
@@ -796,19 +576,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<[string, BigNumber, string, boolean]
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('transactions(uint256)', [index_0
+            const encodedData = self._strictEncodeArguments(self.transactions.functionSignature, [index_0
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('transactions(uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.transactions.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<[string, BigNumber, string, boolean]
         >(rawCallResult);
@@ -817,24 +588,16 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
     };
     public getOwners = {
+        functionSignature: 'getOwners()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('getOwners()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('getOwners()');
+            const encodedData = self._strictEncodeArguments(self.getOwners.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.getOwners.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string[]
         >(rawCallResult);
@@ -843,6 +606,7 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
     };
     public getTransactionIds = {
+        functionSignature: 'getTransactionIds(uint256,uint256,bool,bool)',
         async callAsync(
             from: BigNumber,
             to: BigNumber,
@@ -853,22 +617,13 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<BigNumber[]
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('getTransactionIds(uint256,uint256,bool,bool)', [from,
+            const encodedData = self._strictEncodeArguments(self.getTransactionIds.functionSignature, [from,
         to,
         pending,
         executed
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('getTransactionIds(uint256,uint256,bool,bool)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.getTransactionIds.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber[]
         >(rawCallResult);
@@ -877,6 +632,7 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
     };
     public getConfirmations = {
+        functionSignature: 'getConfirmations(uint256)',
         async callAsync(
             transactionId: BigNumber,
             callData: Partial<CallData> = {},
@@ -884,19 +640,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<string[]
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('getConfirmations(uint256)', [transactionId
+            const encodedData = self._strictEncodeArguments(self.getConfirmations.functionSignature, [transactionId
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('getConfirmations(uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.getConfirmations.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string[]
         >(rawCallResult);
@@ -905,24 +652,16 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
     };
     public transactionCount = {
+        functionSignature: 'transactionCount()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('transactionCount()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('transactionCount()');
+            const encodedData = self._strictEncodeArguments(self.transactionCount.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.transactionCount.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -936,21 +675,11 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('changeRequirement(uint256)', [_required
+            const encodedData = self._strictEncodeArguments(self.changeRequirement.functionSignature, [_required
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.changeRequirement.estimateGasAsync.bind(
-                    self,
-                    _required
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.changeRequirement.estimateGasAsync.bind(self, _required
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -958,27 +687,20 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('changeRequirement(uint256)', [_required
+            const encodedData = self._strictEncodeArguments(self.changeRequirement.functionSignature, [_required
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             _required: BigNumber,
         ): string {
             const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('changeRequirement(uint256)', [_required
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.changeRequirement.functionSignature, [_required
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'changeRequirement(uint256)',
         async callAsync(
             _required: BigNumber,
             callData: Partial<CallData> = {},
@@ -986,19 +708,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('changeRequirement(uint256)', [_required
+            const encodedData = self._strictEncodeArguments(self.changeRequirement.functionSignature, [_required
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('changeRequirement(uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.changeRequirement.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -1012,21 +725,11 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('confirmTransaction(uint256)', [transactionId
+            const encodedData = self._strictEncodeArguments(self.confirmTransaction.functionSignature, [transactionId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.confirmTransaction.estimateGasAsync.bind(
-                    self,
-                    transactionId
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.confirmTransaction.estimateGasAsync.bind(self, transactionId
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -1034,27 +737,20 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('confirmTransaction(uint256)', [transactionId
+            const encodedData = self._strictEncodeArguments(self.confirmTransaction.functionSignature, [transactionId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             transactionId: BigNumber,
         ): string {
             const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('confirmTransaction(uint256)', [transactionId
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.confirmTransaction.functionSignature, [transactionId
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'confirmTransaction(uint256)',
         async callAsync(
             transactionId: BigNumber,
             callData: Partial<CallData> = {},
@@ -1062,19 +758,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('confirmTransaction(uint256)', [transactionId
+            const encodedData = self._strictEncodeArguments(self.confirmTransaction.functionSignature, [transactionId
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('confirmTransaction(uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.confirmTransaction.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -1090,25 +777,15 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('submitTransaction(address,uint256,bytes)', [destination,
+            const encodedData = self._strictEncodeArguments(self.submitTransaction.functionSignature, [destination,
     value,
     data
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.submitTransaction.estimateGasAsync.bind(
-                    self,
-                    destination,
-                    value,
-                    data
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.submitTransaction.estimateGasAsync.bind(self, destination,
+    value,
+    data
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -1118,19 +795,11 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('submitTransaction(address,uint256,bytes)', [destination,
+            const encodedData = self._strictEncodeArguments(self.submitTransaction.functionSignature, [destination,
     value,
     data
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -1139,12 +808,13 @@ export class AssetProxyOwnerContract extends BaseContract {
             data: string,
         ): string {
             const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('submitTransaction(address,uint256,bytes)', [destination,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.submitTransaction.functionSignature, [destination,
     value,
     data
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'submitTransaction(address,uint256,bytes)',
         async callAsync(
             destination: string,
             value: BigNumber,
@@ -1154,21 +824,12 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('submitTransaction(address,uint256,bytes)', [destination,
+            const encodedData = self._strictEncodeArguments(self.submitTransaction.functionSignature, [destination,
         value,
         data
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('submitTransaction(address,uint256,bytes)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.submitTransaction.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -1177,6 +838,7 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
     };
     public confirmationTimes = {
+        functionSignature: 'confirmationTimes(uint256)',
         async callAsync(
             index_0: BigNumber,
             callData: Partial<CallData> = {},
@@ -1184,19 +846,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('confirmationTimes(uint256)', [index_0
+            const encodedData = self._strictEncodeArguments(self.confirmationTimes.functionSignature, [index_0
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('confirmationTimes(uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.confirmationTimes.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -1205,24 +858,16 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
     };
     public MAX_OWNER_COUNT = {
+        functionSignature: 'MAX_OWNER_COUNT()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('MAX_OWNER_COUNT()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('MAX_OWNER_COUNT()');
+            const encodedData = self._strictEncodeArguments(self.MAX_OWNER_COUNT.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.MAX_OWNER_COUNT.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -1231,24 +876,16 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
     };
     public required = {
+        functionSignature: 'required()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('required()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('required()');
+            const encodedData = self._strictEncodeArguments(self.required.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.required.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -1263,23 +900,13 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('replaceOwner(address,address)', [owner,
+            const encodedData = self._strictEncodeArguments(self.replaceOwner.functionSignature, [owner,
     newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.replaceOwner.estimateGasAsync.bind(
-                    self,
-                    owner,
-                    newOwner
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.replaceOwner.estimateGasAsync.bind(self, owner,
+    newOwner
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -1288,18 +915,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('replaceOwner(address,address)', [owner,
+            const encodedData = self._strictEncodeArguments(self.replaceOwner.functionSignature, [owner,
     newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -1307,11 +926,12 @@ export class AssetProxyOwnerContract extends BaseContract {
             newOwner: string,
         ): string {
             const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('replaceOwner(address,address)', [owner,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.replaceOwner.functionSignature, [owner,
     newOwner
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'replaceOwner(address,address)',
         async callAsync(
             owner: string,
             newOwner: string,
@@ -1320,20 +940,11 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('replaceOwner(address,address)', [owner,
+            const encodedData = self._strictEncodeArguments(self.replaceOwner.functionSignature, [owner,
         newOwner
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('replaceOwner(address,address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.replaceOwner.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -1347,21 +958,11 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('executeTransaction(uint256)', [transactionId
+            const encodedData = self._strictEncodeArguments(self.executeTransaction.functionSignature, [transactionId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.executeTransaction.estimateGasAsync.bind(
-                    self,
-                    transactionId
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.executeTransaction.estimateGasAsync.bind(self, transactionId
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -1369,27 +970,20 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('executeTransaction(uint256)', [transactionId
+            const encodedData = self._strictEncodeArguments(self.executeTransaction.functionSignature, [transactionId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             transactionId: BigNumber,
         ): string {
             const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('executeTransaction(uint256)', [transactionId
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.executeTransaction.functionSignature, [transactionId
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'executeTransaction(uint256)',
         async callAsync(
             transactionId: BigNumber,
             callData: Partial<CallData> = {},
@@ -1397,19 +991,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('executeTransaction(uint256)', [transactionId
+            const encodedData = self._strictEncodeArguments(self.executeTransaction.functionSignature, [transactionId
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('executeTransaction(uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.executeTransaction.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -1426,7 +1011,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             _required: BigNumber,
             _secondsTimeLocked: BigNumber,
     ): Promise<AssetProxyOwnerContract> {
-        if (_.isUndefined(artifact.compilerOutput)) {
+        if (isUndefined(artifact.compilerOutput)) {
             throw new Error('Compiler output not found in the artifact file');
         }
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
@@ -1463,33 +1048,10 @@ _secondsTimeLocked
 ],
             BaseContract._bigNumberToString,
         );
-        const iface = new ethers.utils.Interface(abi);
-        const deployInfo = iface.deployFunction;
-        const txData = deployInfo.encode(bytecode, [_owners,
-_assetProxyContracts,
-_required,
-_secondsTimeLocked
-]);
-        const web3Wrapper = new Web3Wrapper(provider);
-        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-            {data: txData},
-            txDefaults,
-            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
-        );
-        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-        logUtils.log(`transactionHash: ${txHash}`);
-        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
-        logUtils.log(`AssetProxyOwner successfully deployed at ${txReceipt.contractAddress}`);
-        const contractInstance = new AssetProxyOwnerContract(abi, txReceipt.contractAddress as string, provider, txDefaults);
-        contractInstance.constructorArgs = [_owners,
-_assetProxyContracts,
-_required,
-_secondsTimeLocked
-];
-        return contractInstance;
+        return {} as any;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
-        super('AssetProxyOwner', abi, address, providerUtils.standardizeOrThrow(supportedProvider), txDefaults);
+        super('AssetProxyOwner', abi, address, supportedProvider, txDefaults);
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count

--- a/packages/abi-gen-wrappers/src/generated-wrappers/asset_proxy_owner.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/asset_proxy_owner.ts
@@ -97,7 +97,6 @@ export interface AssetProxyOwnerRequirementChangeEventArgs extends DecodedLogArg
 // tslint:disable-next-line:class-name
 export class AssetProxyOwnerContract extends BaseContract {
     public owners = {
-        functionSignature: 'owners(uint256)',
         async callAsync(
             index_0: BigNumber,
             callData: Partial<CallData> = {},
@@ -105,10 +104,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<string
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.owners.functionSignature, [index_0
+            const encodedData = self._strictEncodeArguments('owners(uint256)', [index_0
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.owners.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('owners(uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -122,7 +121,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.removeOwner.functionSignature, [owner
+            const encodedData = self._strictEncodeArguments('removeOwner(address)', [owner
     ]);
             const gasEstimateFunction = self.removeOwner.estimateGasAsync.bind(self, owner
     );
@@ -134,7 +133,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.removeOwner.functionSignature, [owner
+            const encodedData = self._strictEncodeArguments('removeOwner(address)', [owner
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -143,11 +142,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             owner: string,
         ): string {
             const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.removeOwner.functionSignature, [owner
+            const abiEncodedTransactionData = self._strictEncodeArguments('removeOwner(address)', [owner
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'removeOwner(address)',
         async callAsync(
             owner: string,
             callData: Partial<CallData> = {},
@@ -155,10 +153,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.removeOwner.functionSignature, [owner
+            const encodedData = self._strictEncodeArguments('removeOwner(address)', [owner
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.removeOwner.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('removeOwner(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -172,7 +170,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.revokeConfirmation.functionSignature, [transactionId
+            const encodedData = self._strictEncodeArguments('revokeConfirmation(uint256)', [transactionId
     ]);
             const gasEstimateFunction = self.revokeConfirmation.estimateGasAsync.bind(self, transactionId
     );
@@ -184,7 +182,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.revokeConfirmation.functionSignature, [transactionId
+            const encodedData = self._strictEncodeArguments('revokeConfirmation(uint256)', [transactionId
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -193,11 +191,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             transactionId: BigNumber,
         ): string {
             const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.revokeConfirmation.functionSignature, [transactionId
+            const abiEncodedTransactionData = self._strictEncodeArguments('revokeConfirmation(uint256)', [transactionId
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'revokeConfirmation(uint256)',
         async callAsync(
             transactionId: BigNumber,
             callData: Partial<CallData> = {},
@@ -205,10 +202,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.revokeConfirmation.functionSignature, [transactionId
+            const encodedData = self._strictEncodeArguments('revokeConfirmation(uint256)', [transactionId
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.revokeConfirmation.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('revokeConfirmation(uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -217,7 +214,6 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
     };
     public isOwner = {
-        functionSignature: 'isOwner(address)',
         async callAsync(
             index_0: string,
             callData: Partial<CallData> = {},
@@ -225,10 +221,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.isOwner.functionSignature, [index_0
+            const encodedData = self._strictEncodeArguments('isOwner(address)', [index_0
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.isOwner.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('isOwner(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -237,7 +233,6 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
     };
     public confirmations = {
-        functionSignature: 'confirmations(uint256,address)',
         async callAsync(
             index_0: BigNumber,
             index_1: string,
@@ -246,11 +241,11 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.confirmations.functionSignature, [index_0,
+            const encodedData = self._strictEncodeArguments('confirmations(uint256,address)', [index_0,
         index_1
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.confirmations.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('confirmations(uint256,address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -264,7 +259,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.executeRemoveAuthorizedAddressAtIndex.functionSignature, [transactionId
+            const encodedData = self._strictEncodeArguments('executeRemoveAuthorizedAddressAtIndex(uint256)', [transactionId
     ]);
             const gasEstimateFunction = self.executeRemoveAuthorizedAddressAtIndex.estimateGasAsync.bind(self, transactionId
     );
@@ -276,7 +271,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.executeRemoveAuthorizedAddressAtIndex.functionSignature, [transactionId
+            const encodedData = self._strictEncodeArguments('executeRemoveAuthorizedAddressAtIndex(uint256)', [transactionId
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -285,11 +280,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             transactionId: BigNumber,
         ): string {
             const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.executeRemoveAuthorizedAddressAtIndex.functionSignature, [transactionId
+            const abiEncodedTransactionData = self._strictEncodeArguments('executeRemoveAuthorizedAddressAtIndex(uint256)', [transactionId
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'executeRemoveAuthorizedAddressAtIndex(uint256)',
         async callAsync(
             transactionId: BigNumber,
             callData: Partial<CallData> = {},
@@ -297,10 +291,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.executeRemoveAuthorizedAddressAtIndex.functionSignature, [transactionId
+            const encodedData = self._strictEncodeArguments('executeRemoveAuthorizedAddressAtIndex(uint256)', [transactionId
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.executeRemoveAuthorizedAddressAtIndex.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('executeRemoveAuthorizedAddressAtIndex(uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -309,16 +303,15 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
     };
     public secondsTimeLocked = {
-        functionSignature: 'secondsTimeLocked()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.secondsTimeLocked.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('secondsTimeLocked()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.secondsTimeLocked.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('secondsTimeLocked()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -327,7 +320,6 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
     };
     public getTransactionCount = {
-        functionSignature: 'getTransactionCount(bool,bool)',
         async callAsync(
             pending: boolean,
             executed: boolean,
@@ -336,11 +328,11 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.getTransactionCount.functionSignature, [pending,
+            const encodedData = self._strictEncodeArguments('getTransactionCount(bool,bool)', [pending,
         executed
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.getTransactionCount.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('getTransactionCount(bool,bool)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -355,7 +347,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.registerAssetProxy.functionSignature, [assetProxyContract,
+            const encodedData = self._strictEncodeArguments('registerAssetProxy(address,bool)', [assetProxyContract,
     isRegistered
     ]);
             const gasEstimateFunction = self.registerAssetProxy.estimateGasAsync.bind(self, assetProxyContract,
@@ -370,7 +362,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.registerAssetProxy.functionSignature, [assetProxyContract,
+            const encodedData = self._strictEncodeArguments('registerAssetProxy(address,bool)', [assetProxyContract,
     isRegistered
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
@@ -381,12 +373,11 @@ export class AssetProxyOwnerContract extends BaseContract {
             isRegistered: boolean,
         ): string {
             const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.registerAssetProxy.functionSignature, [assetProxyContract,
+            const abiEncodedTransactionData = self._strictEncodeArguments('registerAssetProxy(address,bool)', [assetProxyContract,
     isRegistered
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'registerAssetProxy(address,bool)',
         async callAsync(
             assetProxyContract: string,
             isRegistered: boolean,
@@ -395,11 +386,11 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.registerAssetProxy.functionSignature, [assetProxyContract,
+            const encodedData = self._strictEncodeArguments('registerAssetProxy(address,bool)', [assetProxyContract,
         isRegistered
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.registerAssetProxy.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('registerAssetProxy(address,bool)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -413,7 +404,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.addOwner.functionSignature, [owner
+            const encodedData = self._strictEncodeArguments('addOwner(address)', [owner
     ]);
             const gasEstimateFunction = self.addOwner.estimateGasAsync.bind(self, owner
     );
@@ -425,7 +416,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.addOwner.functionSignature, [owner
+            const encodedData = self._strictEncodeArguments('addOwner(address)', [owner
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -434,11 +425,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             owner: string,
         ): string {
             const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.addOwner.functionSignature, [owner
+            const abiEncodedTransactionData = self._strictEncodeArguments('addOwner(address)', [owner
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'addOwner(address)',
         async callAsync(
             owner: string,
             callData: Partial<CallData> = {},
@@ -446,10 +436,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.addOwner.functionSignature, [owner
+            const encodedData = self._strictEncodeArguments('addOwner(address)', [owner
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.addOwner.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('addOwner(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -458,7 +448,6 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
     };
     public isConfirmed = {
-        functionSignature: 'isConfirmed(uint256)',
         async callAsync(
             transactionId: BigNumber,
             callData: Partial<CallData> = {},
@@ -466,10 +455,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.isConfirmed.functionSignature, [transactionId
+            const encodedData = self._strictEncodeArguments('isConfirmed(uint256)', [transactionId
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.isConfirmed.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('isConfirmed(uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -483,7 +472,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.changeTimeLock.functionSignature, [_secondsTimeLocked
+            const encodedData = self._strictEncodeArguments('changeTimeLock(uint256)', [_secondsTimeLocked
     ]);
             const gasEstimateFunction = self.changeTimeLock.estimateGasAsync.bind(self, _secondsTimeLocked
     );
@@ -495,7 +484,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.changeTimeLock.functionSignature, [_secondsTimeLocked
+            const encodedData = self._strictEncodeArguments('changeTimeLock(uint256)', [_secondsTimeLocked
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -504,11 +493,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             _secondsTimeLocked: BigNumber,
         ): string {
             const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.changeTimeLock.functionSignature, [_secondsTimeLocked
+            const abiEncodedTransactionData = self._strictEncodeArguments('changeTimeLock(uint256)', [_secondsTimeLocked
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'changeTimeLock(uint256)',
         async callAsync(
             _secondsTimeLocked: BigNumber,
             callData: Partial<CallData> = {},
@@ -516,10 +504,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.changeTimeLock.functionSignature, [_secondsTimeLocked
+            const encodedData = self._strictEncodeArguments('changeTimeLock(uint256)', [_secondsTimeLocked
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.changeTimeLock.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('changeTimeLock(uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -528,7 +516,6 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
     };
     public isAssetProxyRegistered = {
-        functionSignature: 'isAssetProxyRegistered(address)',
         async callAsync(
             index_0: string,
             callData: Partial<CallData> = {},
@@ -536,10 +523,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.isAssetProxyRegistered.functionSignature, [index_0
+            const encodedData = self._strictEncodeArguments('isAssetProxyRegistered(address)', [index_0
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.isAssetProxyRegistered.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('isAssetProxyRegistered(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -548,7 +535,6 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
     };
     public getConfirmationCount = {
-        functionSignature: 'getConfirmationCount(uint256)',
         async callAsync(
             transactionId: BigNumber,
             callData: Partial<CallData> = {},
@@ -556,10 +542,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.getConfirmationCount.functionSignature, [transactionId
+            const encodedData = self._strictEncodeArguments('getConfirmationCount(uint256)', [transactionId
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.getConfirmationCount.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('getConfirmationCount(uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -568,7 +554,6 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
     };
     public transactions = {
-        functionSignature: 'transactions(uint256)',
         async callAsync(
             index_0: BigNumber,
             callData: Partial<CallData> = {},
@@ -576,10 +561,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<[string, BigNumber, string, boolean]
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.transactions.functionSignature, [index_0
+            const encodedData = self._strictEncodeArguments('transactions(uint256)', [index_0
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.transactions.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('transactions(uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<[string, BigNumber, string, boolean]
         >(rawCallResult);
@@ -588,16 +573,15 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
     };
     public getOwners = {
-        functionSignature: 'getOwners()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.getOwners.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('getOwners()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.getOwners.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('getOwners()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string[]
         >(rawCallResult);
@@ -606,7 +590,6 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
     };
     public getTransactionIds = {
-        functionSignature: 'getTransactionIds(uint256,uint256,bool,bool)',
         async callAsync(
             from: BigNumber,
             to: BigNumber,
@@ -617,13 +600,13 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<BigNumber[]
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.getTransactionIds.functionSignature, [from,
+            const encodedData = self._strictEncodeArguments('getTransactionIds(uint256,uint256,bool,bool)', [from,
         to,
         pending,
         executed
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.getTransactionIds.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('getTransactionIds(uint256,uint256,bool,bool)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber[]
         >(rawCallResult);
@@ -632,7 +615,6 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
     };
     public getConfirmations = {
-        functionSignature: 'getConfirmations(uint256)',
         async callAsync(
             transactionId: BigNumber,
             callData: Partial<CallData> = {},
@@ -640,10 +622,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<string[]
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.getConfirmations.functionSignature, [transactionId
+            const encodedData = self._strictEncodeArguments('getConfirmations(uint256)', [transactionId
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.getConfirmations.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('getConfirmations(uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string[]
         >(rawCallResult);
@@ -652,16 +634,15 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
     };
     public transactionCount = {
-        functionSignature: 'transactionCount()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.transactionCount.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('transactionCount()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.transactionCount.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('transactionCount()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -675,7 +656,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.changeRequirement.functionSignature, [_required
+            const encodedData = self._strictEncodeArguments('changeRequirement(uint256)', [_required
     ]);
             const gasEstimateFunction = self.changeRequirement.estimateGasAsync.bind(self, _required
     );
@@ -687,7 +668,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.changeRequirement.functionSignature, [_required
+            const encodedData = self._strictEncodeArguments('changeRequirement(uint256)', [_required
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -696,11 +677,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             _required: BigNumber,
         ): string {
             const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.changeRequirement.functionSignature, [_required
+            const abiEncodedTransactionData = self._strictEncodeArguments('changeRequirement(uint256)', [_required
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'changeRequirement(uint256)',
         async callAsync(
             _required: BigNumber,
             callData: Partial<CallData> = {},
@@ -708,10 +688,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.changeRequirement.functionSignature, [_required
+            const encodedData = self._strictEncodeArguments('changeRequirement(uint256)', [_required
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.changeRequirement.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('changeRequirement(uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -725,7 +705,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.confirmTransaction.functionSignature, [transactionId
+            const encodedData = self._strictEncodeArguments('confirmTransaction(uint256)', [transactionId
     ]);
             const gasEstimateFunction = self.confirmTransaction.estimateGasAsync.bind(self, transactionId
     );
@@ -737,7 +717,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.confirmTransaction.functionSignature, [transactionId
+            const encodedData = self._strictEncodeArguments('confirmTransaction(uint256)', [transactionId
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -746,11 +726,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             transactionId: BigNumber,
         ): string {
             const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.confirmTransaction.functionSignature, [transactionId
+            const abiEncodedTransactionData = self._strictEncodeArguments('confirmTransaction(uint256)', [transactionId
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'confirmTransaction(uint256)',
         async callAsync(
             transactionId: BigNumber,
             callData: Partial<CallData> = {},
@@ -758,10 +737,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.confirmTransaction.functionSignature, [transactionId
+            const encodedData = self._strictEncodeArguments('confirmTransaction(uint256)', [transactionId
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.confirmTransaction.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('confirmTransaction(uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -777,7 +756,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.submitTransaction.functionSignature, [destination,
+            const encodedData = self._strictEncodeArguments('submitTransaction(address,uint256,bytes)', [destination,
     value,
     data
     ]);
@@ -795,7 +774,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.submitTransaction.functionSignature, [destination,
+            const encodedData = self._strictEncodeArguments('submitTransaction(address,uint256,bytes)', [destination,
     value,
     data
     ]);
@@ -808,13 +787,12 @@ export class AssetProxyOwnerContract extends BaseContract {
             data: string,
         ): string {
             const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.submitTransaction.functionSignature, [destination,
+            const abiEncodedTransactionData = self._strictEncodeArguments('submitTransaction(address,uint256,bytes)', [destination,
     value,
     data
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'submitTransaction(address,uint256,bytes)',
         async callAsync(
             destination: string,
             value: BigNumber,
@@ -824,12 +802,12 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.submitTransaction.functionSignature, [destination,
+            const encodedData = self._strictEncodeArguments('submitTransaction(address,uint256,bytes)', [destination,
         value,
         data
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.submitTransaction.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('submitTransaction(address,uint256,bytes)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -838,7 +816,6 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
     };
     public confirmationTimes = {
-        functionSignature: 'confirmationTimes(uint256)',
         async callAsync(
             index_0: BigNumber,
             callData: Partial<CallData> = {},
@@ -846,10 +823,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.confirmationTimes.functionSignature, [index_0
+            const encodedData = self._strictEncodeArguments('confirmationTimes(uint256)', [index_0
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.confirmationTimes.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('confirmationTimes(uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -858,16 +835,15 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
     };
     public MAX_OWNER_COUNT = {
-        functionSignature: 'MAX_OWNER_COUNT()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.MAX_OWNER_COUNT.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('MAX_OWNER_COUNT()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.MAX_OWNER_COUNT.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('MAX_OWNER_COUNT()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -876,16 +852,15 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
     };
     public required = {
-        functionSignature: 'required()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.required.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('required()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.required.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('required()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -900,7 +875,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.replaceOwner.functionSignature, [owner,
+            const encodedData = self._strictEncodeArguments('replaceOwner(address,address)', [owner,
     newOwner
     ]);
             const gasEstimateFunction = self.replaceOwner.estimateGasAsync.bind(self, owner,
@@ -915,7 +890,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.replaceOwner.functionSignature, [owner,
+            const encodedData = self._strictEncodeArguments('replaceOwner(address,address)', [owner,
     newOwner
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
@@ -926,12 +901,11 @@ export class AssetProxyOwnerContract extends BaseContract {
             newOwner: string,
         ): string {
             const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.replaceOwner.functionSignature, [owner,
+            const abiEncodedTransactionData = self._strictEncodeArguments('replaceOwner(address,address)', [owner,
     newOwner
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'replaceOwner(address,address)',
         async callAsync(
             owner: string,
             newOwner: string,
@@ -940,11 +914,11 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.replaceOwner.functionSignature, [owner,
+            const encodedData = self._strictEncodeArguments('replaceOwner(address,address)', [owner,
         newOwner
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.replaceOwner.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('replaceOwner(address,address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -958,7 +932,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.executeTransaction.functionSignature, [transactionId
+            const encodedData = self._strictEncodeArguments('executeTransaction(uint256)', [transactionId
     ]);
             const gasEstimateFunction = self.executeTransaction.estimateGasAsync.bind(self, transactionId
     );
@@ -970,7 +944,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.executeTransaction.functionSignature, [transactionId
+            const encodedData = self._strictEncodeArguments('executeTransaction(uint256)', [transactionId
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -979,11 +953,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             transactionId: BigNumber,
         ): string {
             const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.executeTransaction.functionSignature, [transactionId
+            const abiEncodedTransactionData = self._strictEncodeArguments('executeTransaction(uint256)', [transactionId
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'executeTransaction(uint256)',
         async callAsync(
             transactionId: BigNumber,
             callData: Partial<CallData> = {},
@@ -991,10 +964,10 @@ export class AssetProxyOwnerContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments(self.executeTransaction.functionSignature, [transactionId
+            const encodedData = self._strictEncodeArguments('executeTransaction(uint256)', [transactionId
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.executeTransaction.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('executeTransaction(uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/coordinator.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/coordinator.ts
@@ -6,8 +6,7 @@ import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact,
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
-import * as ethers from 'ethers';
-import * as _ from 'lodash';
+import { isUndefined } from 'lodash';
 // tslint:enable:no-unused-variable
 
 
@@ -16,6 +15,7 @@ import * as _ from 'lodash';
 // tslint:disable-next-line:class-name
 export class CoordinatorContract extends BaseContract {
     public getSignerAddress = {
+        functionSignature: 'getSignerAddress(bytes32,bytes)',
         async callAsync(
             hash: string,
             signature: string,
@@ -24,20 +24,11 @@ export class CoordinatorContract extends BaseContract {
         ): Promise<string
         > {
             const self = this as any as CoordinatorContract;
-            const encodedData = self._strictEncodeArguments('getSignerAddress(bytes32,bytes)', [hash,
+            const encodedData = self._strictEncodeArguments(self.getSignerAddress.functionSignature, [hash,
         signature
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('getSignerAddress(bytes32,bytes)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.getSignerAddress.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -55,29 +46,19 @@ export class CoordinatorContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as CoordinatorContract;
-            const encodedData = self._strictEncodeArguments('executeTransaction((uint256,address,bytes),address,bytes,uint256[],bytes[])', [transaction,
+            const encodedData = self._strictEncodeArguments(self.executeTransaction.functionSignature, [transaction,
     txOrigin,
     transactionSignature,
     approvalExpirationTimeSeconds,
     approvalSignatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.executeTransaction.estimateGasAsync.bind(
-                    self,
-                    transaction,
-                    txOrigin,
-                    transactionSignature,
-                    approvalExpirationTimeSeconds,
-                    approvalSignatures
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.executeTransaction.estimateGasAsync.bind(self, transaction,
+    txOrigin,
+    transactionSignature,
+    approvalExpirationTimeSeconds,
+    approvalSignatures
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -89,21 +70,13 @@ export class CoordinatorContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as CoordinatorContract;
-            const encodedData = self._strictEncodeArguments('executeTransaction((uint256,address,bytes),address,bytes,uint256[],bytes[])', [transaction,
+            const encodedData = self._strictEncodeArguments(self.executeTransaction.functionSignature, [transaction,
     txOrigin,
     transactionSignature,
     approvalExpirationTimeSeconds,
     approvalSignatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -114,7 +87,7 @@ export class CoordinatorContract extends BaseContract {
             approvalSignatures: string[],
         ): string {
             const self = this as any as CoordinatorContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('executeTransaction((uint256,address,bytes),address,bytes,uint256[],bytes[])', [transaction,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.executeTransaction.functionSignature, [transaction,
     txOrigin,
     transactionSignature,
     approvalExpirationTimeSeconds,
@@ -122,6 +95,7 @@ export class CoordinatorContract extends BaseContract {
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'executeTransaction((uint256,address,bytes),address,bytes,uint256[],bytes[])',
         async callAsync(
             transaction: {salt: BigNumber;signerAddress: string;data: string},
             txOrigin: string,
@@ -133,23 +107,14 @@ export class CoordinatorContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as CoordinatorContract;
-            const encodedData = self._strictEncodeArguments('executeTransaction((uint256,address,bytes),address,bytes,uint256[],bytes[])', [transaction,
+            const encodedData = self._strictEncodeArguments(self.executeTransaction.functionSignature, [transaction,
         txOrigin,
         transactionSignature,
         approvalExpirationTimeSeconds,
         approvalSignatures
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('executeTransaction((uint256,address,bytes),address,bytes,uint256[],bytes[])');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.executeTransaction.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -158,6 +123,7 @@ export class CoordinatorContract extends BaseContract {
         },
     };
     public assertValidCoordinatorApprovals = {
+        functionSignature: 'assertValidCoordinatorApprovals((uint256,address,bytes),address,bytes,uint256[],bytes[])',
         async callAsync(
             transaction: {salt: BigNumber;signerAddress: string;data: string},
             txOrigin: string,
@@ -169,23 +135,14 @@ export class CoordinatorContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as CoordinatorContract;
-            const encodedData = self._strictEncodeArguments('assertValidCoordinatorApprovals((uint256,address,bytes),address,bytes,uint256[],bytes[])', [transaction,
+            const encodedData = self._strictEncodeArguments(self.assertValidCoordinatorApprovals.functionSignature, [transaction,
         txOrigin,
         transactionSignature,
         approvalExpirationTimeSeconds,
         approvalSignatures
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('assertValidCoordinatorApprovals((uint256,address,bytes),address,bytes,uint256[],bytes[])');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.assertValidCoordinatorApprovals.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -194,24 +151,16 @@ export class CoordinatorContract extends BaseContract {
         },
     };
     public EIP712_DOMAIN_HASH = {
+        functionSignature: 'EIP712_DOMAIN_HASH()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as CoordinatorContract;
-            const encodedData = self._strictEncodeArguments('EIP712_DOMAIN_HASH()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('EIP712_DOMAIN_HASH()');
+            const encodedData = self._strictEncodeArguments(self.EIP712_DOMAIN_HASH.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.EIP712_DOMAIN_HASH.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -220,6 +169,7 @@ export class CoordinatorContract extends BaseContract {
         },
     };
     public assertValidTransactionOrdersApproval = {
+        functionSignature: 'assertValidTransactionOrdersApproval((uint256,address,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],address,bytes,uint256[],bytes[])',
         async callAsync(
             transaction: {salt: BigNumber;signerAddress: string;data: string},
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -232,24 +182,15 @@ export class CoordinatorContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as CoordinatorContract;
-            const encodedData = self._strictEncodeArguments('assertValidTransactionOrdersApproval((uint256,address,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],address,bytes,uint256[],bytes[])', [transaction,
+            const encodedData = self._strictEncodeArguments(self.assertValidTransactionOrdersApproval.functionSignature, [transaction,
         orders,
         txOrigin,
         transactionSignature,
         approvalExpirationTimeSeconds,
         approvalSignatures
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('assertValidTransactionOrdersApproval((uint256,address,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],address,bytes,uint256[],bytes[])');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.assertValidTransactionOrdersApproval.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -263,7 +204,7 @@ export class CoordinatorContract extends BaseContract {
         txDefaults: Partial<TxData>,
             _exchange: string,
     ): Promise<CoordinatorContract> {
-        if (_.isUndefined(artifact.compilerOutput)) {
+        if (isUndefined(artifact.compilerOutput)) {
             throw new Error('Compiler output not found in the artifact file');
         }
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
@@ -288,24 +229,7 @@ export class CoordinatorContract extends BaseContract {
 ],
             BaseContract._bigNumberToString,
         );
-        const iface = new ethers.utils.Interface(abi);
-        const deployInfo = iface.deployFunction;
-        const txData = deployInfo.encode(bytecode, [_exchange
-]);
-        const web3Wrapper = new Web3Wrapper(provider);
-        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-            {data: txData},
-            txDefaults,
-            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
-        );
-        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-        logUtils.log(`transactionHash: ${txHash}`);
-        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
-        logUtils.log(`Coordinator successfully deployed at ${txReceipt.contractAddress}`);
-        const contractInstance = new CoordinatorContract(abi, txReceipt.contractAddress as string, provider, txDefaults);
-        contractInstance.constructorArgs = [_exchange
-];
-        return contractInstance;
+        return {} as any;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
         super('Coordinator', abi, address, supportedProvider, txDefaults);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/coordinator.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/coordinator.ts
@@ -15,7 +15,6 @@ import { isUndefined } from 'lodash';
 // tslint:disable-next-line:class-name
 export class CoordinatorContract extends BaseContract {
     public getSignerAddress = {
-        functionSignature: 'getSignerAddress(bytes32,bytes)',
         async callAsync(
             hash: string,
             signature: string,
@@ -24,11 +23,11 @@ export class CoordinatorContract extends BaseContract {
         ): Promise<string
         > {
             const self = this as any as CoordinatorContract;
-            const encodedData = self._strictEncodeArguments(self.getSignerAddress.functionSignature, [hash,
+            const encodedData = self._strictEncodeArguments('getSignerAddress(bytes32,bytes)', [hash,
         signature
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.getSignerAddress.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('getSignerAddress(bytes32,bytes)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -46,7 +45,7 @@ export class CoordinatorContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as CoordinatorContract;
-            const encodedData = self._strictEncodeArguments(self.executeTransaction.functionSignature, [transaction,
+            const encodedData = self._strictEncodeArguments('executeTransaction((uint256,address,bytes),address,bytes,uint256[],bytes[])', [transaction,
     txOrigin,
     transactionSignature,
     approvalExpirationTimeSeconds,
@@ -70,7 +69,7 @@ export class CoordinatorContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as CoordinatorContract;
-            const encodedData = self._strictEncodeArguments(self.executeTransaction.functionSignature, [transaction,
+            const encodedData = self._strictEncodeArguments('executeTransaction((uint256,address,bytes),address,bytes,uint256[],bytes[])', [transaction,
     txOrigin,
     transactionSignature,
     approvalExpirationTimeSeconds,
@@ -87,7 +86,7 @@ export class CoordinatorContract extends BaseContract {
             approvalSignatures: string[],
         ): string {
             const self = this as any as CoordinatorContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.executeTransaction.functionSignature, [transaction,
+            const abiEncodedTransactionData = self._strictEncodeArguments('executeTransaction((uint256,address,bytes),address,bytes,uint256[],bytes[])', [transaction,
     txOrigin,
     transactionSignature,
     approvalExpirationTimeSeconds,
@@ -95,7 +94,6 @@ export class CoordinatorContract extends BaseContract {
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'executeTransaction((uint256,address,bytes),address,bytes,uint256[],bytes[])',
         async callAsync(
             transaction: {salt: BigNumber;signerAddress: string;data: string},
             txOrigin: string,
@@ -107,14 +105,14 @@ export class CoordinatorContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as CoordinatorContract;
-            const encodedData = self._strictEncodeArguments(self.executeTransaction.functionSignature, [transaction,
+            const encodedData = self._strictEncodeArguments('executeTransaction((uint256,address,bytes),address,bytes,uint256[],bytes[])', [transaction,
         txOrigin,
         transactionSignature,
         approvalExpirationTimeSeconds,
         approvalSignatures
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.executeTransaction.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('executeTransaction((uint256,address,bytes),address,bytes,uint256[],bytes[])');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -123,7 +121,6 @@ export class CoordinatorContract extends BaseContract {
         },
     };
     public assertValidCoordinatorApprovals = {
-        functionSignature: 'assertValidCoordinatorApprovals((uint256,address,bytes),address,bytes,uint256[],bytes[])',
         async callAsync(
             transaction: {salt: BigNumber;signerAddress: string;data: string},
             txOrigin: string,
@@ -135,14 +132,14 @@ export class CoordinatorContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as CoordinatorContract;
-            const encodedData = self._strictEncodeArguments(self.assertValidCoordinatorApprovals.functionSignature, [transaction,
+            const encodedData = self._strictEncodeArguments('assertValidCoordinatorApprovals((uint256,address,bytes),address,bytes,uint256[],bytes[])', [transaction,
         txOrigin,
         transactionSignature,
         approvalExpirationTimeSeconds,
         approvalSignatures
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.assertValidCoordinatorApprovals.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('assertValidCoordinatorApprovals((uint256,address,bytes),address,bytes,uint256[],bytes[])');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -151,16 +148,15 @@ export class CoordinatorContract extends BaseContract {
         },
     };
     public EIP712_DOMAIN_HASH = {
-        functionSignature: 'EIP712_DOMAIN_HASH()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as CoordinatorContract;
-            const encodedData = self._strictEncodeArguments(self.EIP712_DOMAIN_HASH.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('EIP712_DOMAIN_HASH()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.EIP712_DOMAIN_HASH.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('EIP712_DOMAIN_HASH()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -169,7 +165,6 @@ export class CoordinatorContract extends BaseContract {
         },
     };
     public assertValidTransactionOrdersApproval = {
-        functionSignature: 'assertValidTransactionOrdersApproval((uint256,address,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],address,bytes,uint256[],bytes[])',
         async callAsync(
             transaction: {salt: BigNumber;signerAddress: string;data: string},
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -182,7 +177,7 @@ export class CoordinatorContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as CoordinatorContract;
-            const encodedData = self._strictEncodeArguments(self.assertValidTransactionOrdersApproval.functionSignature, [transaction,
+            const encodedData = self._strictEncodeArguments('assertValidTransactionOrdersApproval((uint256,address,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],address,bytes,uint256[],bytes[])', [transaction,
         orders,
         txOrigin,
         transactionSignature,
@@ -190,7 +185,7 @@ export class CoordinatorContract extends BaseContract {
         approvalSignatures
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.assertValidTransactionOrdersApproval.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('assertValidTransactionOrdersApproval((uint256,address,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],address,bytes,uint256[],bytes[])');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/coordinator.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/coordinator.ts
@@ -3,7 +3,7 @@
 // tslint:disable:no-unbound-method
 import { BaseContract } from '@0x/base-contract';
 import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact, DecodedLogArgs, MethodAbi, TxData, TxDataPayable, SupportedProvider } from 'ethereum-types';
-import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
+import { AbiEncoder, BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 import { isUndefined } from 'lodash';
@@ -229,7 +229,23 @@ export class CoordinatorContract extends BaseContract {
 ],
             BaseContract._bigNumberToString,
         );
-        return {} as any;
+        const encoder = new AbiEncoder.Constructor(constructorAbi);
+        const txData = encoder.encode(bytecode, [_exchange
+]);
+        const web3Wrapper = new Web3Wrapper(provider);
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {data: txData},
+            txDefaults,
+            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
+        );
+        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        logUtils.log(`transactionHash: ${txHash}`);
+        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
+        logUtils.log(`Coordinator successfully deployed at ${txReceipt.contractAddress}`);
+        const contractInstance = new CoordinatorContract(abi, txReceipt.contractAddress as string, provider, txDefaults);
+        contractInstance.constructorArgs = [_exchange
+];
+        return contractInstance;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
         super('Coordinator', abi, address, supportedProvider, txDefaults);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/coordinator_registry.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/coordinator_registry.ts
@@ -3,7 +3,7 @@
 // tslint:disable:no-unbound-method
 import { BaseContract } from '@0x/base-contract';
 import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact, DecodedLogArgs, MethodAbi, TxData, TxDataPayable, SupportedProvider } from 'ethereum-types';
-import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
+import { AbiEncoder, BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 import { isUndefined } from 'lodash';
@@ -122,7 +122,21 @@ export class CoordinatorRegistryContract extends BaseContract {
             [],
             BaseContract._bigNumberToString,
         );
-        return {} as any;
+        const encoder = new AbiEncoder.Constructor(constructorAbi);
+        const txData = encoder.encode(bytecode, []);
+        const web3Wrapper = new Web3Wrapper(provider);
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {data: txData},
+            txDefaults,
+            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
+        );
+        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        logUtils.log(`transactionHash: ${txHash}`);
+        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
+        logUtils.log(`CoordinatorRegistry successfully deployed at ${txReceipt.contractAddress}`);
+        const contractInstance = new CoordinatorRegistryContract(abi, txReceipt.contractAddress as string, provider, txDefaults);
+        contractInstance.constructorArgs = [];
+        return contractInstance;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
         super('CoordinatorRegistry', abi, address, supportedProvider, txDefaults);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/coordinator_registry.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/coordinator_registry.ts
@@ -32,7 +32,7 @@ export class CoordinatorRegistryContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as CoordinatorRegistryContract;
-            const encodedData = self._strictEncodeArguments(self.setCoordinatorEndpoint.functionSignature, [coordinatorEndpoint
+            const encodedData = self._strictEncodeArguments('setCoordinatorEndpoint(string)', [coordinatorEndpoint
     ]);
             const gasEstimateFunction = self.setCoordinatorEndpoint.estimateGasAsync.bind(self, coordinatorEndpoint
     );
@@ -44,7 +44,7 @@ export class CoordinatorRegistryContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as CoordinatorRegistryContract;
-            const encodedData = self._strictEncodeArguments(self.setCoordinatorEndpoint.functionSignature, [coordinatorEndpoint
+            const encodedData = self._strictEncodeArguments('setCoordinatorEndpoint(string)', [coordinatorEndpoint
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -53,11 +53,10 @@ export class CoordinatorRegistryContract extends BaseContract {
             coordinatorEndpoint: string,
         ): string {
             const self = this as any as CoordinatorRegistryContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.setCoordinatorEndpoint.functionSignature, [coordinatorEndpoint
+            const abiEncodedTransactionData = self._strictEncodeArguments('setCoordinatorEndpoint(string)', [coordinatorEndpoint
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'setCoordinatorEndpoint(string)',
         async callAsync(
             coordinatorEndpoint: string,
             callData: Partial<CallData> = {},
@@ -65,10 +64,10 @@ export class CoordinatorRegistryContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as CoordinatorRegistryContract;
-            const encodedData = self._strictEncodeArguments(self.setCoordinatorEndpoint.functionSignature, [coordinatorEndpoint
+            const encodedData = self._strictEncodeArguments('setCoordinatorEndpoint(string)', [coordinatorEndpoint
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.setCoordinatorEndpoint.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('setCoordinatorEndpoint(string)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -77,7 +76,6 @@ export class CoordinatorRegistryContract extends BaseContract {
         },
     };
     public getCoordinatorEndpoint = {
-        functionSignature: 'getCoordinatorEndpoint(address)',
         async callAsync(
             coordinatorOperator: string,
             callData: Partial<CallData> = {},
@@ -85,10 +83,10 @@ export class CoordinatorRegistryContract extends BaseContract {
         ): Promise<string
         > {
             const self = this as any as CoordinatorRegistryContract;
-            const encodedData = self._strictEncodeArguments(self.getCoordinatorEndpoint.functionSignature, [coordinatorOperator
+            const encodedData = self._strictEncodeArguments('getCoordinatorEndpoint(address)', [coordinatorOperator
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.getCoordinatorEndpoint.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('getCoordinatorEndpoint(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc20_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc20_token.ts
@@ -6,8 +6,7 @@ import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact,
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
-import * as ethers from 'ethers';
-import * as _ from 'lodash';
+import { isUndefined } from 'lodash';
 // tslint:enable:no-unused-variable
 
 export type DummyERC20TokenEventArgs =
@@ -37,24 +36,16 @@ export interface DummyERC20TokenApprovalEventArgs extends DecodedLogArgs {
 // tslint:disable-next-line:class-name
 export class DummyERC20TokenContract extends BaseContract {
     public name = {
+        functionSignature: 'name()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('name()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('name()');
+            const encodedData = self._strictEncodeArguments(self.name.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.name.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -69,23 +60,13 @@ export class DummyERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
+            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [_spender,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.approve.estimateGasAsync.bind(
-                    self,
-                    _spender,
-                    _value
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.approve.estimateGasAsync.bind(self, _spender,
+    _value
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -94,18 +75,10 @@ export class DummyERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
+            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [_spender,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -113,11 +86,12 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
         ): string {
             const self = this as any as DummyERC20TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.approve.functionSignature, [_spender,
     _value
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'approve(address,uint256)',
         async callAsync(
             _spender: string,
             _value: BigNumber,
@@ -126,20 +100,11 @@ export class DummyERC20TokenContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
+            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [_spender,
         _value
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('approve(address,uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.approve.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -148,24 +113,16 @@ export class DummyERC20TokenContract extends BaseContract {
         },
     };
     public totalSupply = {
+        functionSignature: 'totalSupply()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('totalSupply()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('totalSupply()');
+            const encodedData = self._strictEncodeArguments(self.totalSupply.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.totalSupply.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -181,25 +138,15 @@ export class DummyERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
     _to,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transferFrom.estimateGasAsync.bind(
-                    self,
-                    _from,
-                    _to,
-                    _value
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.transferFrom.estimateGasAsync.bind(self, _from,
+    _to,
+    _value
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -209,19 +156,11 @@ export class DummyERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
     _to,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -230,12 +169,13 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
         ): string {
             const self = this as any as DummyERC20TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
     _to,
     _value
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'transferFrom(address,address,uint256)',
         async callAsync(
             _from: string,
             _to: string,
@@ -245,21 +185,12 @@ export class DummyERC20TokenContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
         _to,
         _value
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('transferFrom(address,address,uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.transferFrom.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -268,24 +199,16 @@ export class DummyERC20TokenContract extends BaseContract {
         },
     };
     public decimals = {
+        functionSignature: 'decimals()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('decimals()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('decimals()');
+            const encodedData = self._strictEncodeArguments(self.decimals.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.decimals.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -294,6 +217,7 @@ export class DummyERC20TokenContract extends BaseContract {
         },
     };
     public balanceOf = {
+        functionSignature: 'balanceOf(address)',
         async callAsync(
             _owner: string,
             callData: Partial<CallData> = {},
@@ -301,19 +225,10 @@ export class DummyERC20TokenContract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('balanceOf(address)', [_owner
+            const encodedData = self._strictEncodeArguments(self.balanceOf.functionSignature, [_owner
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('balanceOf(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.balanceOf.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -322,24 +237,16 @@ export class DummyERC20TokenContract extends BaseContract {
         },
     };
     public owner = {
+        functionSignature: 'owner()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('owner()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('owner()');
+            const encodedData = self._strictEncodeArguments(self.owner.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.owner.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -348,24 +255,16 @@ export class DummyERC20TokenContract extends BaseContract {
         },
     };
     public symbol = {
+        functionSignature: 'symbol()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('symbol()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('symbol()');
+            const encodedData = self._strictEncodeArguments(self.symbol.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.symbol.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -379,21 +278,11 @@ export class DummyERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('mint(uint256)', [_value
+            const encodedData = self._strictEncodeArguments(self.mint.functionSignature, [_value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.mint.estimateGasAsync.bind(
-                    self,
-                    _value
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.mint.estimateGasAsync.bind(self, _value
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -401,27 +290,20 @@ export class DummyERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('mint(uint256)', [_value
+            const encodedData = self._strictEncodeArguments(self.mint.functionSignature, [_value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             _value: BigNumber,
         ): string {
             const self = this as any as DummyERC20TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('mint(uint256)', [_value
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.mint.functionSignature, [_value
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'mint(uint256)',
         async callAsync(
             _value: BigNumber,
             callData: Partial<CallData> = {},
@@ -429,19 +311,10 @@ export class DummyERC20TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('mint(uint256)', [_value
+            const encodedData = self._strictEncodeArguments(self.mint.functionSignature, [_value
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('mint(uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.mint.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -456,23 +329,13 @@ export class DummyERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
+            const encodedData = self._strictEncodeArguments(self.transfer.functionSignature, [_to,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transfer.estimateGasAsync.bind(
-                    self,
-                    _to,
-                    _value
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.transfer.estimateGasAsync.bind(self, _to,
+    _value
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -481,18 +344,10 @@ export class DummyERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
+            const encodedData = self._strictEncodeArguments(self.transfer.functionSignature, [_to,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -500,11 +355,12 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
         ): string {
             const self = this as any as DummyERC20TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.transfer.functionSignature, [_to,
     _value
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'transfer(address,uint256)',
         async callAsync(
             _to: string,
             _value: BigNumber,
@@ -513,20 +369,11 @@ export class DummyERC20TokenContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
+            const encodedData = self._strictEncodeArguments(self.transfer.functionSignature, [_to,
         _value
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('transfer(address,uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.transfer.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -535,6 +382,7 @@ export class DummyERC20TokenContract extends BaseContract {
         },
     };
     public allowance = {
+        functionSignature: 'allowance(address,address)',
         async callAsync(
             _owner: string,
             _spender: string,
@@ -543,20 +391,11 @@ export class DummyERC20TokenContract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('allowance(address,address)', [_owner,
+            const encodedData = self._strictEncodeArguments(self.allowance.functionSignature, [_owner,
         _spender
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('allowance(address,address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.allowance.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -571,23 +410,13 @@ export class DummyERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('setBalance(address,uint256)', [_target,
+            const encodedData = self._strictEncodeArguments(self.setBalance.functionSignature, [_target,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.setBalance.estimateGasAsync.bind(
-                    self,
-                    _target,
-                    _value
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.setBalance.estimateGasAsync.bind(self, _target,
+    _value
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -596,18 +425,10 @@ export class DummyERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('setBalance(address,uint256)', [_target,
+            const encodedData = self._strictEncodeArguments(self.setBalance.functionSignature, [_target,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -615,11 +436,12 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
         ): string {
             const self = this as any as DummyERC20TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('setBalance(address,uint256)', [_target,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.setBalance.functionSignature, [_target,
     _value
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'setBalance(address,uint256)',
         async callAsync(
             _target: string,
             _value: BigNumber,
@@ -628,20 +450,11 @@ export class DummyERC20TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('setBalance(address,uint256)', [_target,
+            const encodedData = self._strictEncodeArguments(self.setBalance.functionSignature, [_target,
         _value
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('setBalance(address,uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.setBalance.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -655,21 +468,11 @@ export class DummyERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transferOwnership.estimateGasAsync.bind(
-                    self,
-                    newOwner
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.transferOwnership.estimateGasAsync.bind(self, newOwner
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -677,27 +480,20 @@ export class DummyERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             newOwner: string,
         ): string {
             const self = this as any as DummyERC20TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'transferOwnership(address)',
         async callAsync(
             newOwner: string,
             callData: Partial<CallData> = {},
@@ -705,19 +501,10 @@ export class DummyERC20TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('transferOwnership(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.transferOwnership.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -726,24 +513,16 @@ export class DummyERC20TokenContract extends BaseContract {
         },
     };
     public MAX_MINT_AMOUNT = {
+        functionSignature: 'MAX_MINT_AMOUNT()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('MAX_MINT_AMOUNT()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('MAX_MINT_AMOUNT()');
+            const encodedData = self._strictEncodeArguments(self.MAX_MINT_AMOUNT.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.MAX_MINT_AMOUNT.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -760,7 +539,7 @@ export class DummyERC20TokenContract extends BaseContract {
             _decimals: BigNumber,
             _totalSupply: BigNumber,
     ): Promise<DummyERC20TokenContract> {
-        if (_.isUndefined(artifact.compilerOutput)) {
+        if (isUndefined(artifact.compilerOutput)) {
             throw new Error('Compiler output not found in the artifact file');
         }
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
@@ -797,33 +576,10 @@ _totalSupply
 ],
             BaseContract._bigNumberToString,
         );
-        const iface = new ethers.utils.Interface(abi);
-        const deployInfo = iface.deployFunction;
-        const txData = deployInfo.encode(bytecode, [_name,
-_symbol,
-_decimals,
-_totalSupply
-]);
-        const web3Wrapper = new Web3Wrapper(provider);
-        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-            {data: txData},
-            txDefaults,
-            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
-        );
-        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-        logUtils.log(`transactionHash: ${txHash}`);
-        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
-        logUtils.log(`DummyERC20Token successfully deployed at ${txReceipt.contractAddress}`);
-        const contractInstance = new DummyERC20TokenContract(abi, txReceipt.contractAddress as string, provider, txDefaults);
-        contractInstance.constructorArgs = [_name,
-_symbol,
-_decimals,
-_totalSupply
-];
-        return contractInstance;
+        return {} as any;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
-        super('DummyERC20Token', abi, address, providerUtils.standardizeOrThrow(supportedProvider), txDefaults);
+        super('DummyERC20Token', abi, address, supportedProvider, txDefaults);
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count

--- a/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc20_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc20_token.ts
@@ -3,7 +3,7 @@
 // tslint:disable:no-unbound-method
 import { BaseContract } from '@0x/base-contract';
 import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact, DecodedLogArgs, MethodAbi, TxData, TxDataPayable, SupportedProvider } from 'ethereum-types';
-import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
+import { AbiEncoder, BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 import { isUndefined } from 'lodash';
@@ -576,7 +576,29 @@ _totalSupply
 ],
             BaseContract._bigNumberToString,
         );
-        return {} as any;
+        const encoder = new AbiEncoder.Constructor(constructorAbi);
+        const txData = encoder.encode(bytecode, [_name,
+_symbol,
+_decimals,
+_totalSupply
+]);
+        const web3Wrapper = new Web3Wrapper(provider);
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {data: txData},
+            txDefaults,
+            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
+        );
+        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        logUtils.log(`transactionHash: ${txHash}`);
+        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
+        logUtils.log(`DummyERC20Token successfully deployed at ${txReceipt.contractAddress}`);
+        const contractInstance = new DummyERC20TokenContract(abi, txReceipt.contractAddress as string, provider, txDefaults);
+        contractInstance.constructorArgs = [_name,
+_symbol,
+_decimals,
+_totalSupply
+];
+        return contractInstance;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
         super('DummyERC20Token', abi, address, supportedProvider, txDefaults);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc20_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc20_token.ts
@@ -36,16 +36,15 @@ export interface DummyERC20TokenApprovalEventArgs extends DecodedLogArgs {
 // tslint:disable-next-line:class-name
 export class DummyERC20TokenContract extends BaseContract {
     public name = {
-        functionSignature: 'name()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.name.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('name()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.name.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('name()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -60,7 +59,7 @@ export class DummyERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [_spender,
+            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
             const gasEstimateFunction = self.approve.estimateGasAsync.bind(self, _spender,
@@ -75,7 +74,7 @@ export class DummyERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [_spender,
+            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
@@ -86,12 +85,11 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
         ): string {
             const self = this as any as DummyERC20TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.approve.functionSignature, [_spender,
+            const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'approve(address,uint256)',
         async callAsync(
             _spender: string,
             _value: BigNumber,
@@ -100,11 +98,11 @@ export class DummyERC20TokenContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [_spender,
+            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
         _value
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.approve.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('approve(address,uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -113,16 +111,15 @@ export class DummyERC20TokenContract extends BaseContract {
         },
     };
     public totalSupply = {
-        functionSignature: 'totalSupply()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.totalSupply.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('totalSupply()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.totalSupply.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('totalSupply()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -138,7 +135,7 @@ export class DummyERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
+            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
@@ -156,7 +153,7 @@ export class DummyERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
+            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
@@ -169,13 +166,12 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
         ): string {
             const self = this as any as DummyERC20TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
+            const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'transferFrom(address,address,uint256)',
         async callAsync(
             _from: string,
             _to: string,
@@ -185,12 +181,12 @@ export class DummyERC20TokenContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
+            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
         _to,
         _value
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.transferFrom.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('transferFrom(address,address,uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -199,16 +195,15 @@ export class DummyERC20TokenContract extends BaseContract {
         },
     };
     public decimals = {
-        functionSignature: 'decimals()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.decimals.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('decimals()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.decimals.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('decimals()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -217,7 +212,6 @@ export class DummyERC20TokenContract extends BaseContract {
         },
     };
     public balanceOf = {
-        functionSignature: 'balanceOf(address)',
         async callAsync(
             _owner: string,
             callData: Partial<CallData> = {},
@@ -225,10 +219,10 @@ export class DummyERC20TokenContract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.balanceOf.functionSignature, [_owner
+            const encodedData = self._strictEncodeArguments('balanceOf(address)', [_owner
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.balanceOf.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('balanceOf(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -237,16 +231,15 @@ export class DummyERC20TokenContract extends BaseContract {
         },
     };
     public owner = {
-        functionSignature: 'owner()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.owner.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('owner()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.owner.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('owner()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -255,16 +248,15 @@ export class DummyERC20TokenContract extends BaseContract {
         },
     };
     public symbol = {
-        functionSignature: 'symbol()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.symbol.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('symbol()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.symbol.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('symbol()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -278,7 +270,7 @@ export class DummyERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.mint.functionSignature, [_value
+            const encodedData = self._strictEncodeArguments('mint(uint256)', [_value
     ]);
             const gasEstimateFunction = self.mint.estimateGasAsync.bind(self, _value
     );
@@ -290,7 +282,7 @@ export class DummyERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.mint.functionSignature, [_value
+            const encodedData = self._strictEncodeArguments('mint(uint256)', [_value
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -299,11 +291,10 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
         ): string {
             const self = this as any as DummyERC20TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.mint.functionSignature, [_value
+            const abiEncodedTransactionData = self._strictEncodeArguments('mint(uint256)', [_value
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'mint(uint256)',
         async callAsync(
             _value: BigNumber,
             callData: Partial<CallData> = {},
@@ -311,10 +302,10 @@ export class DummyERC20TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.mint.functionSignature, [_value
+            const encodedData = self._strictEncodeArguments('mint(uint256)', [_value
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.mint.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('mint(uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -329,7 +320,7 @@ export class DummyERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.transfer.functionSignature, [_to,
+            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
             const gasEstimateFunction = self.transfer.estimateGasAsync.bind(self, _to,
@@ -344,7 +335,7 @@ export class DummyERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.transfer.functionSignature, [_to,
+            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
@@ -355,12 +346,11 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
         ): string {
             const self = this as any as DummyERC20TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.transfer.functionSignature, [_to,
+            const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'transfer(address,uint256)',
         async callAsync(
             _to: string,
             _value: BigNumber,
@@ -369,11 +359,11 @@ export class DummyERC20TokenContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.transfer.functionSignature, [_to,
+            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
         _value
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.transfer.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('transfer(address,uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -382,7 +372,6 @@ export class DummyERC20TokenContract extends BaseContract {
         },
     };
     public allowance = {
-        functionSignature: 'allowance(address,address)',
         async callAsync(
             _owner: string,
             _spender: string,
@@ -391,11 +380,11 @@ export class DummyERC20TokenContract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.allowance.functionSignature, [_owner,
+            const encodedData = self._strictEncodeArguments('allowance(address,address)', [_owner,
         _spender
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.allowance.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('allowance(address,address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -410,7 +399,7 @@ export class DummyERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.setBalance.functionSignature, [_target,
+            const encodedData = self._strictEncodeArguments('setBalance(address,uint256)', [_target,
     _value
     ]);
             const gasEstimateFunction = self.setBalance.estimateGasAsync.bind(self, _target,
@@ -425,7 +414,7 @@ export class DummyERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.setBalance.functionSignature, [_target,
+            const encodedData = self._strictEncodeArguments('setBalance(address,uint256)', [_target,
     _value
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
@@ -436,12 +425,11 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
         ): string {
             const self = this as any as DummyERC20TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.setBalance.functionSignature, [_target,
+            const abiEncodedTransactionData = self._strictEncodeArguments('setBalance(address,uint256)', [_target,
     _value
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'setBalance(address,uint256)',
         async callAsync(
             _target: string,
             _value: BigNumber,
@@ -450,11 +438,11 @@ export class DummyERC20TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.setBalance.functionSignature, [_target,
+            const encodedData = self._strictEncodeArguments('setBalance(address,uint256)', [_target,
         _value
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.setBalance.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('setBalance(address,uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -468,7 +456,7 @@ export class DummyERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
             const gasEstimateFunction = self.transferOwnership.estimateGasAsync.bind(self, newOwner
     );
@@ -480,7 +468,7 @@ export class DummyERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -489,11 +477,10 @@ export class DummyERC20TokenContract extends BaseContract {
             newOwner: string,
         ): string {
             const self = this as any as DummyERC20TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'transferOwnership(address)',
         async callAsync(
             newOwner: string,
             callData: Partial<CallData> = {},
@@ -501,10 +488,10 @@ export class DummyERC20TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.transferOwnership.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('transferOwnership(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -513,16 +500,15 @@ export class DummyERC20TokenContract extends BaseContract {
         },
     };
     public MAX_MINT_AMOUNT = {
-        functionSignature: 'MAX_MINT_AMOUNT()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
             const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.MAX_MINT_AMOUNT.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('MAX_MINT_AMOUNT()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.MAX_MINT_AMOUNT.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('MAX_MINT_AMOUNT()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc721_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc721_token.ts
@@ -3,7 +3,7 @@
 // tslint:disable:no-unbound-method
 import { BaseContract } from '@0x/base-contract';
 import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact, DecodedLogArgs, MethodAbi, TxData, TxDataPayable, SupportedProvider } from 'ethereum-types';
-import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
+import { AbiEncoder, BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 import { isUndefined } from 'lodash';
@@ -714,7 +714,25 @@ _symbol
 ],
             BaseContract._bigNumberToString,
         );
-        return {} as any;
+        const encoder = new AbiEncoder.Constructor(constructorAbi);
+        const txData = encoder.encode(bytecode, [_name,
+_symbol
+]);
+        const web3Wrapper = new Web3Wrapper(provider);
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {data: txData},
+            txDefaults,
+            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
+        );
+        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        logUtils.log(`transactionHash: ${txHash}`);
+        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
+        logUtils.log(`DummyERC721Token successfully deployed at ${txReceipt.contractAddress}`);
+        const contractInstance = new DummyERC721TokenContract(abi, txReceipt.contractAddress as string, provider, txDefaults);
+        contractInstance.constructorArgs = [_name,
+_symbol
+];
+        return contractInstance;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
         super('DummyERC721Token', abi, address, supportedProvider, txDefaults);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc721_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc721_token.ts
@@ -6,8 +6,7 @@ import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact,
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
-import * as ethers from 'ethers';
-import * as _ from 'lodash';
+import { isUndefined } from 'lodash';
 // tslint:enable:no-unused-variable
 
 export type DummyERC721TokenEventArgs =
@@ -45,24 +44,16 @@ export interface DummyERC721TokenApprovalForAllEventArgs extends DecodedLogArgs 
 // tslint:disable-next-line:class-name
 export class DummyERC721TokenContract extends BaseContract {
     public name = {
+        functionSignature: 'name()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('name()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('name()');
+            const encodedData = self._strictEncodeArguments(self.name.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.name.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -71,6 +62,7 @@ export class DummyERC721TokenContract extends BaseContract {
         },
     };
     public getApproved = {
+        functionSignature: 'getApproved(uint256)',
         async callAsync(
             _tokenId: BigNumber,
             callData: Partial<CallData> = {},
@@ -78,19 +70,10 @@ export class DummyERC721TokenContract extends BaseContract {
         ): Promise<string
         > {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('getApproved(uint256)', [_tokenId
+            const encodedData = self._strictEncodeArguments(self.getApproved.functionSignature, [_tokenId
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('getApproved(uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.getApproved.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -105,23 +88,13 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
+            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [_approved,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.approve.estimateGasAsync.bind(
-                    self,
-                    _approved,
-                    _tokenId
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.approve.estimateGasAsync.bind(self, _approved,
+    _tokenId
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -130,18 +103,10 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
+            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [_approved,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -149,11 +114,12 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         ): string {
             const self = this as any as DummyERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.approve.functionSignature, [_approved,
     _tokenId
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'approve(address,uint256)',
         async callAsync(
             _approved: string,
             _tokenId: BigNumber,
@@ -162,20 +128,11 @@ export class DummyERC721TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
+            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [_approved,
         _tokenId
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('approve(address,uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.approve.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -191,25 +148,15 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
     _to,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transferFrom.estimateGasAsync.bind(
-                    self,
-                    _from,
-                    _to,
-                    _tokenId
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.transferFrom.estimateGasAsync.bind(self, _from,
+    _to,
+    _tokenId
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -219,19 +166,11 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
     _to,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -240,12 +179,13 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         ): string {
             const self = this as any as DummyERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
     _to,
     _tokenId
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'transferFrom(address,address,uint256)',
         async callAsync(
             _from: string,
             _to: string,
@@ -255,21 +195,12 @@ export class DummyERC721TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
         _to,
         _tokenId
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('transferFrom(address,address,uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.transferFrom.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -284,23 +215,13 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('mint(address,uint256)', [_to,
+            const encodedData = self._strictEncodeArguments(self.mint.functionSignature, [_to,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.mint.estimateGasAsync.bind(
-                    self,
-                    _to,
-                    _tokenId
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.mint.estimateGasAsync.bind(self, _to,
+    _tokenId
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -309,18 +230,10 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('mint(address,uint256)', [_to,
+            const encodedData = self._strictEncodeArguments(self.mint.functionSignature, [_to,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -328,11 +241,12 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         ): string {
             const self = this as any as DummyERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('mint(address,uint256)', [_to,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.mint.functionSignature, [_to,
     _tokenId
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'mint(address,uint256)',
         async callAsync(
             _to: string,
             _tokenId: BigNumber,
@@ -341,20 +255,11 @@ export class DummyERC721TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('mint(address,uint256)', [_to,
+            const encodedData = self._strictEncodeArguments(self.mint.functionSignature, [_to,
         _tokenId
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('mint(address,uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.mint.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -370,25 +275,15 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
+            const encodedData = self._strictEncodeArguments(self.safeTransferFrom1.functionSignature, [_from,
     _to,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.safeTransferFrom1.estimateGasAsync.bind(
-                    self,
-                    _from,
-                    _to,
-                    _tokenId
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.safeTransferFrom1.estimateGasAsync.bind(self, _from,
+    _to,
+    _tokenId
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -398,19 +293,11 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
+            const encodedData = self._strictEncodeArguments(self.safeTransferFrom1.functionSignature, [_from,
     _to,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -419,12 +306,13 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         ): string {
             const self = this as any as DummyERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.safeTransferFrom1.functionSignature, [_from,
     _to,
     _tokenId
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'safeTransferFrom(address,address,uint256)',
         async callAsync(
             _from: string,
             _to: string,
@@ -434,21 +322,12 @@ export class DummyERC721TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
+            const encodedData = self._strictEncodeArguments(self.safeTransferFrom1.functionSignature, [_from,
         _to,
         _tokenId
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('safeTransferFrom(address,address,uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.safeTransferFrom1.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -457,6 +336,7 @@ export class DummyERC721TokenContract extends BaseContract {
         },
     };
     public ownerOf = {
+        functionSignature: 'ownerOf(uint256)',
         async callAsync(
             _tokenId: BigNumber,
             callData: Partial<CallData> = {},
@@ -464,19 +344,10 @@ export class DummyERC721TokenContract extends BaseContract {
         ): Promise<string
         > {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('ownerOf(uint256)', [_tokenId
+            const encodedData = self._strictEncodeArguments(self.ownerOf.functionSignature, [_tokenId
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('ownerOf(uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.ownerOf.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -485,6 +356,7 @@ export class DummyERC721TokenContract extends BaseContract {
         },
     };
     public balanceOf = {
+        functionSignature: 'balanceOf(address)',
         async callAsync(
             _owner: string,
             callData: Partial<CallData> = {},
@@ -492,19 +364,10 @@ export class DummyERC721TokenContract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('balanceOf(address)', [_owner
+            const encodedData = self._strictEncodeArguments(self.balanceOf.functionSignature, [_owner
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('balanceOf(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.balanceOf.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -513,24 +376,16 @@ export class DummyERC721TokenContract extends BaseContract {
         },
     };
     public owner = {
+        functionSignature: 'owner()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('owner()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('owner()');
+            const encodedData = self._strictEncodeArguments(self.owner.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.owner.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -539,24 +394,16 @@ export class DummyERC721TokenContract extends BaseContract {
         },
     };
     public symbol = {
+        functionSignature: 'symbol()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('symbol()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('symbol()');
+            const encodedData = self._strictEncodeArguments(self.symbol.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.symbol.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -571,23 +418,13 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('burn(address,uint256)', [_owner,
+            const encodedData = self._strictEncodeArguments(self.burn.functionSignature, [_owner,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.burn.estimateGasAsync.bind(
-                    self,
-                    _owner,
-                    _tokenId
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.burn.estimateGasAsync.bind(self, _owner,
+    _tokenId
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -596,18 +433,10 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('burn(address,uint256)', [_owner,
+            const encodedData = self._strictEncodeArguments(self.burn.functionSignature, [_owner,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -615,11 +444,12 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         ): string {
             const self = this as any as DummyERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('burn(address,uint256)', [_owner,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.burn.functionSignature, [_owner,
     _tokenId
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'burn(address,uint256)',
         async callAsync(
             _owner: string,
             _tokenId: BigNumber,
@@ -628,20 +458,11 @@ export class DummyERC721TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('burn(address,uint256)', [_owner,
+            const encodedData = self._strictEncodeArguments(self.burn.functionSignature, [_owner,
         _tokenId
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('burn(address,uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.burn.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -656,23 +477,13 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
+            const encodedData = self._strictEncodeArguments(self.setApprovalForAll.functionSignature, [_operator,
     _approved
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.setApprovalForAll.estimateGasAsync.bind(
-                    self,
-                    _operator,
-                    _approved
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.setApprovalForAll.estimateGasAsync.bind(self, _operator,
+    _approved
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -681,18 +492,10 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
+            const encodedData = self._strictEncodeArguments(self.setApprovalForAll.functionSignature, [_operator,
     _approved
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -700,11 +503,12 @@ export class DummyERC721TokenContract extends BaseContract {
             _approved: boolean,
         ): string {
             const self = this as any as DummyERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.setApprovalForAll.functionSignature, [_operator,
     _approved
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'setApprovalForAll(address,bool)',
         async callAsync(
             _operator: string,
             _approved: boolean,
@@ -713,20 +517,11 @@ export class DummyERC721TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
+            const encodedData = self._strictEncodeArguments(self.setApprovalForAll.functionSignature, [_operator,
         _approved
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('setApprovalForAll(address,bool)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.setApprovalForAll.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -743,27 +538,17 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
+            const encodedData = self._strictEncodeArguments(self.safeTransferFrom2.functionSignature, [_from,
     _to,
     _tokenId,
     _data
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.safeTransferFrom2.estimateGasAsync.bind(
-                    self,
-                    _from,
-                    _to,
-                    _tokenId,
-                    _data
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.safeTransferFrom2.estimateGasAsync.bind(self, _from,
+    _to,
+    _tokenId,
+    _data
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -774,20 +559,12 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
+            const encodedData = self._strictEncodeArguments(self.safeTransferFrom2.functionSignature, [_from,
     _to,
     _tokenId,
     _data
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -797,13 +574,14 @@ export class DummyERC721TokenContract extends BaseContract {
             _data: string,
         ): string {
             const self = this as any as DummyERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.safeTransferFrom2.functionSignature, [_from,
     _to,
     _tokenId,
     _data
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'safeTransferFrom(address,address,uint256,bytes)',
         async callAsync(
             _from: string,
             _to: string,
@@ -814,22 +592,13 @@ export class DummyERC721TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
+            const encodedData = self._strictEncodeArguments(self.safeTransferFrom2.functionSignature, [_from,
         _to,
         _tokenId,
         _data
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('safeTransferFrom(address,address,uint256,bytes)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.safeTransferFrom2.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -838,6 +607,7 @@ export class DummyERC721TokenContract extends BaseContract {
         },
     };
     public isApprovedForAll = {
+        functionSignature: 'isApprovedForAll(address,address)',
         async callAsync(
             _owner: string,
             _operator: string,
@@ -846,20 +616,11 @@ export class DummyERC721TokenContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('isApprovedForAll(address,address)', [_owner,
+            const encodedData = self._strictEncodeArguments(self.isApprovedForAll.functionSignature, [_owner,
         _operator
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('isApprovedForAll(address,address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.isApprovedForAll.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -873,21 +634,11 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transferOwnership.estimateGasAsync.bind(
-                    self,
-                    newOwner
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.transferOwnership.estimateGasAsync.bind(self, newOwner
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -895,27 +646,20 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             newOwner: string,
         ): string {
             const self = this as any as DummyERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'transferOwnership(address)',
         async callAsync(
             newOwner: string,
             callData: Partial<CallData> = {},
@@ -923,19 +667,10 @@ export class DummyERC721TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('transferOwnership(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.transferOwnership.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -950,7 +685,7 @@ export class DummyERC721TokenContract extends BaseContract {
             _name: string,
             _symbol: string,
     ): Promise<DummyERC721TokenContract> {
-        if (_.isUndefined(artifact.compilerOutput)) {
+        if (isUndefined(artifact.compilerOutput)) {
             throw new Error('Compiler output not found in the artifact file');
         }
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
@@ -979,29 +714,10 @@ _symbol
 ],
             BaseContract._bigNumberToString,
         );
-        const iface = new ethers.utils.Interface(abi);
-        const deployInfo = iface.deployFunction;
-        const txData = deployInfo.encode(bytecode, [_name,
-_symbol
-]);
-        const web3Wrapper = new Web3Wrapper(provider);
-        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-            {data: txData},
-            txDefaults,
-            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
-        );
-        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-        logUtils.log(`transactionHash: ${txHash}`);
-        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
-        logUtils.log(`DummyERC721Token successfully deployed at ${txReceipt.contractAddress}`);
-        const contractInstance = new DummyERC721TokenContract(abi, txReceipt.contractAddress as string, provider, txDefaults);
-        contractInstance.constructorArgs = [_name,
-_symbol
-];
-        return contractInstance;
+        return {} as any;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
-        super('DummyERC721Token', abi, address, providerUtils.standardizeOrThrow(supportedProvider), txDefaults);
+        super('DummyERC721Token', abi, address, supportedProvider, txDefaults);
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count

--- a/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc721_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc721_token.ts
@@ -44,16 +44,15 @@ export interface DummyERC721TokenApprovalForAllEventArgs extends DecodedLogArgs 
 // tslint:disable-next-line:class-name
 export class DummyERC721TokenContract extends BaseContract {
     public name = {
-        functionSignature: 'name()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.name.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('name()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.name.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('name()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -62,7 +61,6 @@ export class DummyERC721TokenContract extends BaseContract {
         },
     };
     public getApproved = {
-        functionSignature: 'getApproved(uint256)',
         async callAsync(
             _tokenId: BigNumber,
             callData: Partial<CallData> = {},
@@ -70,10 +68,10 @@ export class DummyERC721TokenContract extends BaseContract {
         ): Promise<string
         > {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.getApproved.functionSignature, [_tokenId
+            const encodedData = self._strictEncodeArguments('getApproved(uint256)', [_tokenId
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.getApproved.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('getApproved(uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -88,7 +86,7 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [_approved,
+            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
     ]);
             const gasEstimateFunction = self.approve.estimateGasAsync.bind(self, _approved,
@@ -103,7 +101,7 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [_approved,
+            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
@@ -114,12 +112,11 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         ): string {
             const self = this as any as DummyERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.approve.functionSignature, [_approved,
+            const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'approve(address,uint256)',
         async callAsync(
             _approved: string,
             _tokenId: BigNumber,
@@ -128,11 +125,11 @@ export class DummyERC721TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [_approved,
+            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
         _tokenId
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.approve.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('approve(address,uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -148,7 +145,7 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
+            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
@@ -166,7 +163,7 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
+            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
@@ -179,13 +176,12 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         ): string {
             const self = this as any as DummyERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
+            const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'transferFrom(address,address,uint256)',
         async callAsync(
             _from: string,
             _to: string,
@@ -195,12 +191,12 @@ export class DummyERC721TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
+            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
         _to,
         _tokenId
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.transferFrom.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('transferFrom(address,address,uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -215,7 +211,7 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.mint.functionSignature, [_to,
+            const encodedData = self._strictEncodeArguments('mint(address,uint256)', [_to,
     _tokenId
     ]);
             const gasEstimateFunction = self.mint.estimateGasAsync.bind(self, _to,
@@ -230,7 +226,7 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.mint.functionSignature, [_to,
+            const encodedData = self._strictEncodeArguments('mint(address,uint256)', [_to,
     _tokenId
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
@@ -241,12 +237,11 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         ): string {
             const self = this as any as DummyERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.mint.functionSignature, [_to,
+            const abiEncodedTransactionData = self._strictEncodeArguments('mint(address,uint256)', [_to,
     _tokenId
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'mint(address,uint256)',
         async callAsync(
             _to: string,
             _tokenId: BigNumber,
@@ -255,11 +250,11 @@ export class DummyERC721TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.mint.functionSignature, [_to,
+            const encodedData = self._strictEncodeArguments('mint(address,uint256)', [_to,
         _tokenId
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.mint.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('mint(address,uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -275,7 +270,7 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.safeTransferFrom1.functionSignature, [_from,
+            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
@@ -293,7 +288,7 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.safeTransferFrom1.functionSignature, [_from,
+            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
@@ -306,13 +301,12 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         ): string {
             const self = this as any as DummyERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.safeTransferFrom1.functionSignature, [_from,
+            const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'safeTransferFrom(address,address,uint256)',
         async callAsync(
             _from: string,
             _to: string,
@@ -322,12 +316,12 @@ export class DummyERC721TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.safeTransferFrom1.functionSignature, [_from,
+            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
         _to,
         _tokenId
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.safeTransferFrom1.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('safeTransferFrom(address,address,uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -336,7 +330,6 @@ export class DummyERC721TokenContract extends BaseContract {
         },
     };
     public ownerOf = {
-        functionSignature: 'ownerOf(uint256)',
         async callAsync(
             _tokenId: BigNumber,
             callData: Partial<CallData> = {},
@@ -344,10 +337,10 @@ export class DummyERC721TokenContract extends BaseContract {
         ): Promise<string
         > {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.ownerOf.functionSignature, [_tokenId
+            const encodedData = self._strictEncodeArguments('ownerOf(uint256)', [_tokenId
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.ownerOf.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('ownerOf(uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -356,7 +349,6 @@ export class DummyERC721TokenContract extends BaseContract {
         },
     };
     public balanceOf = {
-        functionSignature: 'balanceOf(address)',
         async callAsync(
             _owner: string,
             callData: Partial<CallData> = {},
@@ -364,10 +356,10 @@ export class DummyERC721TokenContract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.balanceOf.functionSignature, [_owner
+            const encodedData = self._strictEncodeArguments('balanceOf(address)', [_owner
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.balanceOf.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('balanceOf(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -376,16 +368,15 @@ export class DummyERC721TokenContract extends BaseContract {
         },
     };
     public owner = {
-        functionSignature: 'owner()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.owner.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('owner()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.owner.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('owner()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -394,16 +385,15 @@ export class DummyERC721TokenContract extends BaseContract {
         },
     };
     public symbol = {
-        functionSignature: 'symbol()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.symbol.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('symbol()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.symbol.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('symbol()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -418,7 +408,7 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.burn.functionSignature, [_owner,
+            const encodedData = self._strictEncodeArguments('burn(address,uint256)', [_owner,
     _tokenId
     ]);
             const gasEstimateFunction = self.burn.estimateGasAsync.bind(self, _owner,
@@ -433,7 +423,7 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.burn.functionSignature, [_owner,
+            const encodedData = self._strictEncodeArguments('burn(address,uint256)', [_owner,
     _tokenId
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
@@ -444,12 +434,11 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         ): string {
             const self = this as any as DummyERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.burn.functionSignature, [_owner,
+            const abiEncodedTransactionData = self._strictEncodeArguments('burn(address,uint256)', [_owner,
     _tokenId
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'burn(address,uint256)',
         async callAsync(
             _owner: string,
             _tokenId: BigNumber,
@@ -458,11 +447,11 @@ export class DummyERC721TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.burn.functionSignature, [_owner,
+            const encodedData = self._strictEncodeArguments('burn(address,uint256)', [_owner,
         _tokenId
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.burn.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('burn(address,uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -477,7 +466,7 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.setApprovalForAll.functionSignature, [_operator,
+            const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
     ]);
             const gasEstimateFunction = self.setApprovalForAll.estimateGasAsync.bind(self, _operator,
@@ -492,7 +481,7 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.setApprovalForAll.functionSignature, [_operator,
+            const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
@@ -503,12 +492,11 @@ export class DummyERC721TokenContract extends BaseContract {
             _approved: boolean,
         ): string {
             const self = this as any as DummyERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.setApprovalForAll.functionSignature, [_operator,
+            const abiEncodedTransactionData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'setApprovalForAll(address,bool)',
         async callAsync(
             _operator: string,
             _approved: boolean,
@@ -517,11 +505,11 @@ export class DummyERC721TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.setApprovalForAll.functionSignature, [_operator,
+            const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
         _approved
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.setApprovalForAll.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('setApprovalForAll(address,bool)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -538,7 +526,7 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.safeTransferFrom2.functionSignature, [_from,
+            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
     _tokenId,
     _data
@@ -559,7 +547,7 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.safeTransferFrom2.functionSignature, [_from,
+            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
     _tokenId,
     _data
@@ -574,14 +562,13 @@ export class DummyERC721TokenContract extends BaseContract {
             _data: string,
         ): string {
             const self = this as any as DummyERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.safeTransferFrom2.functionSignature, [_from,
+            const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
     _tokenId,
     _data
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'safeTransferFrom(address,address,uint256,bytes)',
         async callAsync(
             _from: string,
             _to: string,
@@ -592,13 +579,13 @@ export class DummyERC721TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.safeTransferFrom2.functionSignature, [_from,
+            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
         _to,
         _tokenId,
         _data
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.safeTransferFrom2.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('safeTransferFrom(address,address,uint256,bytes)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -607,7 +594,6 @@ export class DummyERC721TokenContract extends BaseContract {
         },
     };
     public isApprovedForAll = {
-        functionSignature: 'isApprovedForAll(address,address)',
         async callAsync(
             _owner: string,
             _operator: string,
@@ -616,11 +602,11 @@ export class DummyERC721TokenContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.isApprovedForAll.functionSignature, [_owner,
+            const encodedData = self._strictEncodeArguments('isApprovedForAll(address,address)', [_owner,
         _operator
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.isApprovedForAll.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('isApprovedForAll(address,address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -634,7 +620,7 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
             const gasEstimateFunction = self.transferOwnership.estimateGasAsync.bind(self, newOwner
     );
@@ -646,7 +632,7 @@ export class DummyERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -655,11 +641,10 @@ export class DummyERC721TokenContract extends BaseContract {
             newOwner: string,
         ): string {
             const self = this as any as DummyERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'transferOwnership(address)',
         async callAsync(
             newOwner: string,
             callData: Partial<CallData> = {},
@@ -667,10 +652,10 @@ export class DummyERC721TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.transferOwnership.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('transferOwnership(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/dutch_auction.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/dutch_auction.ts
@@ -20,7 +20,7 @@ export class DutchAuctionContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DutchAuctionContract;
-            const encodedData = self._strictEncodeArguments(self.getAuctionDetails.functionSignature, [order
+            const encodedData = self._strictEncodeArguments('getAuctionDetails((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
     ]);
             const gasEstimateFunction = self.getAuctionDetails.estimateGasAsync.bind(self, order
     );
@@ -32,7 +32,7 @@ export class DutchAuctionContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DutchAuctionContract;
-            const encodedData = self._strictEncodeArguments(self.getAuctionDetails.functionSignature, [order
+            const encodedData = self._strictEncodeArguments('getAuctionDetails((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -41,11 +41,10 @@ export class DutchAuctionContract extends BaseContract {
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
         ): string {
             const self = this as any as DutchAuctionContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.getAuctionDetails.functionSignature, [order
+            const abiEncodedTransactionData = self._strictEncodeArguments('getAuctionDetails((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'getAuctionDetails((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))',
         async callAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             callData: Partial<CallData> = {},
@@ -53,10 +52,10 @@ export class DutchAuctionContract extends BaseContract {
         ): Promise<{beginTimeSeconds: BigNumber;endTimeSeconds: BigNumber;beginAmount: BigNumber;endAmount: BigNumber;currentAmount: BigNumber;currentTimeSeconds: BigNumber}
         > {
             const self = this as any as DutchAuctionContract;
-            const encodedData = self._strictEncodeArguments(self.getAuctionDetails.functionSignature, [order
+            const encodedData = self._strictEncodeArguments('getAuctionDetails((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.getAuctionDetails.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('getAuctionDetails((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<{beginTimeSeconds: BigNumber;endTimeSeconds: BigNumber;beginAmount: BigNumber;endAmount: BigNumber;currentAmount: BigNumber;currentTimeSeconds: BigNumber}
         >(rawCallResult);
@@ -73,7 +72,7 @@ export class DutchAuctionContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DutchAuctionContract;
-            const encodedData = self._strictEncodeArguments(self.matchOrders.functionSignature, [buyOrder,
+            const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [buyOrder,
     sellOrder,
     buySignature,
     sellSignature
@@ -94,7 +93,7 @@ export class DutchAuctionContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DutchAuctionContract;
-            const encodedData = self._strictEncodeArguments(self.matchOrders.functionSignature, [buyOrder,
+            const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [buyOrder,
     sellOrder,
     buySignature,
     sellSignature
@@ -109,14 +108,13 @@ export class DutchAuctionContract extends BaseContract {
             sellSignature: string,
         ): string {
             const self = this as any as DutchAuctionContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.matchOrders.functionSignature, [buyOrder,
+            const abiEncodedTransactionData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [buyOrder,
     sellOrder,
     buySignature,
     sellSignature
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)',
         async callAsync(
             buyOrder: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             sellOrder: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
@@ -127,13 +125,13 @@ export class DutchAuctionContract extends BaseContract {
         ): Promise<{left: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};right: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};leftMakerAssetSpreadAmount: BigNumber}
         > {
             const self = this as any as DutchAuctionContract;
-            const encodedData = self._strictEncodeArguments(self.matchOrders.functionSignature, [buyOrder,
+            const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [buyOrder,
         sellOrder,
         buySignature,
         sellSignature
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.matchOrders.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<{left: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};right: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};leftMakerAssetSpreadAmount: BigNumber}
         >(rawCallResult);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/dutch_auction.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/dutch_auction.ts
@@ -6,8 +6,7 @@ import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact,
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
-import * as ethers from 'ethers';
-import * as _ from 'lodash';
+import { isUndefined } from 'lodash';
 // tslint:enable:no-unused-variable
 
 
@@ -21,21 +20,11 @@ export class DutchAuctionContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DutchAuctionContract;
-            const encodedData = self._strictEncodeArguments('getAuctionDetails((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
+            const encodedData = self._strictEncodeArguments(self.getAuctionDetails.functionSignature, [order
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.getAuctionDetails.estimateGasAsync.bind(
-                    self,
-                    order
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.getAuctionDetails.estimateGasAsync.bind(self, order
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -43,27 +32,20 @@ export class DutchAuctionContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DutchAuctionContract;
-            const encodedData = self._strictEncodeArguments('getAuctionDetails((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
+            const encodedData = self._strictEncodeArguments(self.getAuctionDetails.functionSignature, [order
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
         ): string {
             const self = this as any as DutchAuctionContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('getAuctionDetails((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.getAuctionDetails.functionSignature, [order
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'getAuctionDetails((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))',
         async callAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             callData: Partial<CallData> = {},
@@ -71,19 +53,10 @@ export class DutchAuctionContract extends BaseContract {
         ): Promise<{beginTimeSeconds: BigNumber;endTimeSeconds: BigNumber;beginAmount: BigNumber;endAmount: BigNumber;currentAmount: BigNumber;currentTimeSeconds: BigNumber}
         > {
             const self = this as any as DutchAuctionContract;
-            const encodedData = self._strictEncodeArguments('getAuctionDetails((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
+            const encodedData = self._strictEncodeArguments(self.getAuctionDetails.functionSignature, [order
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('getAuctionDetails((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.getAuctionDetails.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<{beginTimeSeconds: BigNumber;endTimeSeconds: BigNumber;beginAmount: BigNumber;endAmount: BigNumber;currentAmount: BigNumber;currentTimeSeconds: BigNumber}
         >(rawCallResult);
@@ -100,27 +73,17 @@ export class DutchAuctionContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as DutchAuctionContract;
-            const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [buyOrder,
+            const encodedData = self._strictEncodeArguments(self.matchOrders.functionSignature, [buyOrder,
     sellOrder,
     buySignature,
     sellSignature
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.matchOrders.estimateGasAsync.bind(
-                    self,
-                    buyOrder,
-                    sellOrder,
-                    buySignature,
-                    sellSignature
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.matchOrders.estimateGasAsync.bind(self, buyOrder,
+    sellOrder,
+    buySignature,
+    sellSignature
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -131,20 +94,12 @@ export class DutchAuctionContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as DutchAuctionContract;
-            const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [buyOrder,
+            const encodedData = self._strictEncodeArguments(self.matchOrders.functionSignature, [buyOrder,
     sellOrder,
     buySignature,
     sellSignature
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -154,13 +109,14 @@ export class DutchAuctionContract extends BaseContract {
             sellSignature: string,
         ): string {
             const self = this as any as DutchAuctionContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [buyOrder,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.matchOrders.functionSignature, [buyOrder,
     sellOrder,
     buySignature,
     sellSignature
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)',
         async callAsync(
             buyOrder: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             sellOrder: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
@@ -171,22 +127,13 @@ export class DutchAuctionContract extends BaseContract {
         ): Promise<{left: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};right: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};leftMakerAssetSpreadAmount: BigNumber}
         > {
             const self = this as any as DutchAuctionContract;
-            const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [buyOrder,
+            const encodedData = self._strictEncodeArguments(self.matchOrders.functionSignature, [buyOrder,
         sellOrder,
         buySignature,
         sellSignature
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.matchOrders.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<{left: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};right: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};leftMakerAssetSpreadAmount: BigNumber}
         >(rawCallResult);
@@ -200,7 +147,7 @@ export class DutchAuctionContract extends BaseContract {
         txDefaults: Partial<TxData>,
             _exchange: string,
     ): Promise<DutchAuctionContract> {
-        if (_.isUndefined(artifact.compilerOutput)) {
+        if (isUndefined(artifact.compilerOutput)) {
             throw new Error('Compiler output not found in the artifact file');
         }
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
@@ -225,27 +172,10 @@ export class DutchAuctionContract extends BaseContract {
 ],
             BaseContract._bigNumberToString,
         );
-        const iface = new ethers.utils.Interface(abi);
-        const deployInfo = iface.deployFunction;
-        const txData = deployInfo.encode(bytecode, [_exchange
-]);
-        const web3Wrapper = new Web3Wrapper(provider);
-        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-            {data: txData},
-            txDefaults,
-            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
-        );
-        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-        logUtils.log(`transactionHash: ${txHash}`);
-        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
-        logUtils.log(`DutchAuction successfully deployed at ${txReceipt.contractAddress}`);
-        const contractInstance = new DutchAuctionContract(abi, txReceipt.contractAddress as string, provider, txDefaults);
-        contractInstance.constructorArgs = [_exchange
-];
-        return contractInstance;
+        return {} as any;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
-        super('DutchAuction', abi, address, providerUtils.standardizeOrThrow(supportedProvider), txDefaults);
+        super('DutchAuction', abi, address, supportedProvider, txDefaults);
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count

--- a/packages/abi-gen-wrappers/src/generated-wrappers/dutch_auction.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/dutch_auction.ts
@@ -3,7 +3,7 @@
 // tslint:disable:no-unbound-method
 import { BaseContract } from '@0x/base-contract';
 import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact, DecodedLogArgs, MethodAbi, TxData, TxDataPayable, SupportedProvider } from 'ethereum-types';
-import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
+import { AbiEncoder, BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 import { isUndefined } from 'lodash';
@@ -172,7 +172,23 @@ export class DutchAuctionContract extends BaseContract {
 ],
             BaseContract._bigNumberToString,
         );
-        return {} as any;
+        const encoder = new AbiEncoder.Constructor(constructorAbi);
+        const txData = encoder.encode(bytecode, [_exchange
+]);
+        const web3Wrapper = new Web3Wrapper(provider);
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {data: txData},
+            txDefaults,
+            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
+        );
+        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        logUtils.log(`transactionHash: ${txHash}`);
+        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
+        logUtils.log(`DutchAuction successfully deployed at ${txReceipt.contractAddress}`);
+        const contractInstance = new DutchAuctionContract(abi, txReceipt.contractAddress as string, provider, txDefaults);
+        contractInstance.constructorArgs = [_exchange
+];
+        return contractInstance;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
         super('DutchAuction', abi, address, supportedProvider, txDefaults);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc20_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc20_proxy.ts
@@ -6,8 +6,7 @@ import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact,
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
-import * as ethers from 'ethers';
-import * as _ from 'lodash';
+import { isUndefined } from 'lodash';
 // tslint:enable:no-unused-variable
 
 export type ERC20ProxyEventArgs =
@@ -40,21 +39,11 @@ export class ERC20ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
+            const encodedData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.addAuthorizedAddress.estimateGasAsync.bind(
-                    self,
-                    target
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.addAuthorizedAddress.estimateGasAsync.bind(self, target
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -62,27 +51,20 @@ export class ERC20ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
+            const encodedData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             target: string,
         ): string {
             const self = this as any as ERC20ProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'addAuthorizedAddress(address)',
         async callAsync(
             target: string,
             callData: Partial<CallData> = {},
@@ -90,19 +72,10 @@ export class ERC20ProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
+            const encodedData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('addAuthorizedAddress(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.addAuthorizedAddress.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -111,6 +84,7 @@ export class ERC20ProxyContract extends BaseContract {
         },
     };
     public authorities = {
+        functionSignature: 'authorities(uint256)',
         async callAsync(
             index_0: BigNumber,
             callData: Partial<CallData> = {},
@@ -118,19 +92,10 @@ export class ERC20ProxyContract extends BaseContract {
         ): Promise<string
         > {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments('authorities(uint256)', [index_0
+            const encodedData = self._strictEncodeArguments(self.authorities.functionSignature, [index_0
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('authorities(uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.authorities.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -144,21 +109,11 @@ export class ERC20ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
+            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.removeAuthorizedAddress.estimateGasAsync.bind(
-                    self,
-                    target
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.removeAuthorizedAddress.estimateGasAsync.bind(self, target
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -166,27 +121,20 @@ export class ERC20ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
+            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             target: string,
         ): string {
             const self = this as any as ERC20ProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'removeAuthorizedAddress(address)',
         async callAsync(
             target: string,
             callData: Partial<CallData> = {},
@@ -194,19 +142,10 @@ export class ERC20ProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
+            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('removeAuthorizedAddress(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.removeAuthorizedAddress.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -215,24 +154,16 @@ export class ERC20ProxyContract extends BaseContract {
         },
     };
     public owner = {
+        functionSignature: 'owner()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments('owner()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('owner()');
+            const encodedData = self._strictEncodeArguments(self.owner.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.owner.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -247,23 +178,13 @@ export class ERC20ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
+            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
     index
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.removeAuthorizedAddressAtIndex.estimateGasAsync.bind(
-                    self,
-                    target,
-                    index
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.removeAuthorizedAddressAtIndex.estimateGasAsync.bind(self, target,
+    index
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -272,18 +193,10 @@ export class ERC20ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
+            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
     index
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -291,11 +204,12 @@ export class ERC20ProxyContract extends BaseContract {
             index: BigNumber,
         ): string {
             const self = this as any as ERC20ProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
     index
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'removeAuthorizedAddressAtIndex(address,uint256)',
         async callAsync(
             target: string,
             index: BigNumber,
@@ -304,20 +218,11 @@ export class ERC20ProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
+            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
         index
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('removeAuthorizedAddressAtIndex(address,uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.removeAuthorizedAddressAtIndex.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -326,24 +231,16 @@ export class ERC20ProxyContract extends BaseContract {
         },
     };
     public getProxyId = {
+        functionSignature: 'getProxyId()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments('getProxyId()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('getProxyId()');
+            const encodedData = self._strictEncodeArguments(self.getProxyId.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.getProxyId.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -352,6 +249,7 @@ export class ERC20ProxyContract extends BaseContract {
         },
     };
     public authorized = {
+        functionSignature: 'authorized(address)',
         async callAsync(
             index_0: string,
             callData: Partial<CallData> = {},
@@ -359,19 +257,10 @@ export class ERC20ProxyContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments('authorized(address)', [index_0
+            const encodedData = self._strictEncodeArguments(self.authorized.functionSignature, [index_0
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('authorized(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.authorized.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -380,24 +269,16 @@ export class ERC20ProxyContract extends BaseContract {
         },
     };
     public getAuthorizedAddresses = {
+        functionSignature: 'getAuthorizedAddresses()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments('getAuthorizedAddresses()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('getAuthorizedAddresses()');
+            const encodedData = self._strictEncodeArguments(self.getAuthorizedAddresses.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.getAuthorizedAddresses.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string[]
         >(rawCallResult);
@@ -411,21 +292,11 @@ export class ERC20ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transferOwnership.estimateGasAsync.bind(
-                    self,
-                    newOwner
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.transferOwnership.estimateGasAsync.bind(self, newOwner
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -433,27 +304,20 @@ export class ERC20ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             newOwner: string,
         ): string {
             const self = this as any as ERC20ProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'transferOwnership(address)',
         async callAsync(
             newOwner: string,
             callData: Partial<CallData> = {},
@@ -461,19 +325,10 @@ export class ERC20ProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('transferOwnership(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.transferOwnership.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -486,7 +341,7 @@ export class ERC20ProxyContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<ERC20ProxyContract> {
-        if (_.isUndefined(artifact.compilerOutput)) {
+        if (isUndefined(artifact.compilerOutput)) {
             throw new Error('Compiler output not found in the artifact file');
         }
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
@@ -507,25 +362,10 @@ export class ERC20ProxyContract extends BaseContract {
             [],
             BaseContract._bigNumberToString,
         );
-        const iface = new ethers.utils.Interface(abi);
-        const deployInfo = iface.deployFunction;
-        const txData = deployInfo.encode(bytecode, []);
-        const web3Wrapper = new Web3Wrapper(provider);
-        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-            {data: txData},
-            txDefaults,
-            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
-        );
-        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-        logUtils.log(`transactionHash: ${txHash}`);
-        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
-        logUtils.log(`ERC20Proxy successfully deployed at ${txReceipt.contractAddress}`);
-        const contractInstance = new ERC20ProxyContract(abi, txReceipt.contractAddress as string, provider, txDefaults);
-        contractInstance.constructorArgs = [];
-        return contractInstance;
+        return {} as any;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
-        super('ERC20Proxy', abi, address, providerUtils.standardizeOrThrow(supportedProvider), txDefaults);
+        super('ERC20Proxy', abi, address, supportedProvider, txDefaults);
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc20_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc20_proxy.ts
@@ -39,7 +39,7 @@ export class ERC20ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
+            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
             const gasEstimateFunction = self.addAuthorizedAddress.estimateGasAsync.bind(self, target
     );
@@ -51,7 +51,7 @@ export class ERC20ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
+            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -60,11 +60,10 @@ export class ERC20ProxyContract extends BaseContract {
             target: string,
         ): string {
             const self = this as any as ERC20ProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
+            const abiEncodedTransactionData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'addAuthorizedAddress(address)',
         async callAsync(
             target: string,
             callData: Partial<CallData> = {},
@@ -72,10 +71,10 @@ export class ERC20ProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
+            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.addAuthorizedAddress.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('addAuthorizedAddress(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -84,7 +83,6 @@ export class ERC20ProxyContract extends BaseContract {
         },
     };
     public authorities = {
-        functionSignature: 'authorities(uint256)',
         async callAsync(
             index_0: BigNumber,
             callData: Partial<CallData> = {},
@@ -92,10 +90,10 @@ export class ERC20ProxyContract extends BaseContract {
         ): Promise<string
         > {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.authorities.functionSignature, [index_0
+            const encodedData = self._strictEncodeArguments('authorities(uint256)', [index_0
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.authorities.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('authorities(uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -109,7 +107,7 @@ export class ERC20ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
+            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
             const gasEstimateFunction = self.removeAuthorizedAddress.estimateGasAsync.bind(self, target
     );
@@ -121,7 +119,7 @@ export class ERC20ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
+            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -130,11 +128,10 @@ export class ERC20ProxyContract extends BaseContract {
             target: string,
         ): string {
             const self = this as any as ERC20ProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
+            const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'removeAuthorizedAddress(address)',
         async callAsync(
             target: string,
             callData: Partial<CallData> = {},
@@ -142,10 +139,10 @@ export class ERC20ProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
+            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.removeAuthorizedAddress.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('removeAuthorizedAddress(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -154,16 +151,15 @@ export class ERC20ProxyContract extends BaseContract {
         },
     };
     public owner = {
-        functionSignature: 'owner()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.owner.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('owner()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.owner.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('owner()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -178,7 +174,7 @@ export class ERC20ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
+            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
             const gasEstimateFunction = self.removeAuthorizedAddressAtIndex.estimateGasAsync.bind(self, target,
@@ -193,7 +189,7 @@ export class ERC20ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
+            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
@@ -204,12 +200,11 @@ export class ERC20ProxyContract extends BaseContract {
             index: BigNumber,
         ): string {
             const self = this as any as ERC20ProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
+            const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'removeAuthorizedAddressAtIndex(address,uint256)',
         async callAsync(
             target: string,
             index: BigNumber,
@@ -218,11 +213,11 @@ export class ERC20ProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
+            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
         index
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.removeAuthorizedAddressAtIndex.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('removeAuthorizedAddressAtIndex(address,uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -231,16 +226,15 @@ export class ERC20ProxyContract extends BaseContract {
         },
     };
     public getProxyId = {
-        functionSignature: 'getProxyId()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.getProxyId.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('getProxyId()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.getProxyId.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('getProxyId()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -249,7 +243,6 @@ export class ERC20ProxyContract extends BaseContract {
         },
     };
     public authorized = {
-        functionSignature: 'authorized(address)',
         async callAsync(
             index_0: string,
             callData: Partial<CallData> = {},
@@ -257,10 +250,10 @@ export class ERC20ProxyContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.authorized.functionSignature, [index_0
+            const encodedData = self._strictEncodeArguments('authorized(address)', [index_0
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.authorized.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('authorized(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -269,16 +262,15 @@ export class ERC20ProxyContract extends BaseContract {
         },
     };
     public getAuthorizedAddresses = {
-        functionSignature: 'getAuthorizedAddresses()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.getAuthorizedAddresses.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('getAuthorizedAddresses()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.getAuthorizedAddresses.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('getAuthorizedAddresses()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string[]
         >(rawCallResult);
@@ -292,7 +284,7 @@ export class ERC20ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
             const gasEstimateFunction = self.transferOwnership.estimateGasAsync.bind(self, newOwner
     );
@@ -304,7 +296,7 @@ export class ERC20ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -313,11 +305,10 @@ export class ERC20ProxyContract extends BaseContract {
             newOwner: string,
         ): string {
             const self = this as any as ERC20ProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'transferOwnership(address)',
         async callAsync(
             newOwner: string,
             callData: Partial<CallData> = {},
@@ -325,10 +316,10 @@ export class ERC20ProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.transferOwnership.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('transferOwnership(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc20_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc20_token.ts
@@ -6,8 +6,7 @@ import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact,
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
-import * as ethers from 'ethers';
-import * as _ from 'lodash';
+import { isUndefined } from 'lodash';
 // tslint:enable:no-unused-variable
 
 export type ERC20TokenEventArgs =
@@ -43,23 +42,13 @@ export class ERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
+            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [_spender,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.approve.estimateGasAsync.bind(
-                    self,
-                    _spender,
-                    _value
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.approve.estimateGasAsync.bind(self, _spender,
+    _value
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -68,18 +57,10 @@ export class ERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
+            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [_spender,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -87,11 +68,12 @@ export class ERC20TokenContract extends BaseContract {
             _value: BigNumber,
         ): string {
             const self = this as any as ERC20TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.approve.functionSignature, [_spender,
     _value
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'approve(address,uint256)',
         async callAsync(
             _spender: string,
             _value: BigNumber,
@@ -100,20 +82,11 @@ export class ERC20TokenContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as ERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
+            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [_spender,
         _value
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('approve(address,uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.approve.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -122,24 +95,16 @@ export class ERC20TokenContract extends BaseContract {
         },
     };
     public totalSupply = {
+        functionSignature: 'totalSupply()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
             const self = this as any as ERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('totalSupply()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('totalSupply()');
+            const encodedData = self._strictEncodeArguments(self.totalSupply.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.totalSupply.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -155,25 +120,15 @@ export class ERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
     _to,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transferFrom.estimateGasAsync.bind(
-                    self,
-                    _from,
-                    _to,
-                    _value
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.transferFrom.estimateGasAsync.bind(self, _from,
+    _to,
+    _value
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -183,19 +138,11 @@ export class ERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
     _to,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -204,12 +151,13 @@ export class ERC20TokenContract extends BaseContract {
             _value: BigNumber,
         ): string {
             const self = this as any as ERC20TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
     _to,
     _value
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'transferFrom(address,address,uint256)',
         async callAsync(
             _from: string,
             _to: string,
@@ -219,21 +167,12 @@ export class ERC20TokenContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as ERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
         _to,
         _value
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('transferFrom(address,address,uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.transferFrom.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -242,6 +181,7 @@ export class ERC20TokenContract extends BaseContract {
         },
     };
     public balanceOf = {
+        functionSignature: 'balanceOf(address)',
         async callAsync(
             _owner: string,
             callData: Partial<CallData> = {},
@@ -249,19 +189,10 @@ export class ERC20TokenContract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as ERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('balanceOf(address)', [_owner
+            const encodedData = self._strictEncodeArguments(self.balanceOf.functionSignature, [_owner
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('balanceOf(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.balanceOf.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -276,23 +207,13 @@ export class ERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
+            const encodedData = self._strictEncodeArguments(self.transfer.functionSignature, [_to,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transfer.estimateGasAsync.bind(
-                    self,
-                    _to,
-                    _value
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.transfer.estimateGasAsync.bind(self, _to,
+    _value
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -301,18 +222,10 @@ export class ERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
+            const encodedData = self._strictEncodeArguments(self.transfer.functionSignature, [_to,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -320,11 +233,12 @@ export class ERC20TokenContract extends BaseContract {
             _value: BigNumber,
         ): string {
             const self = this as any as ERC20TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.transfer.functionSignature, [_to,
     _value
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'transfer(address,uint256)',
         async callAsync(
             _to: string,
             _value: BigNumber,
@@ -333,20 +247,11 @@ export class ERC20TokenContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as ERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
+            const encodedData = self._strictEncodeArguments(self.transfer.functionSignature, [_to,
         _value
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('transfer(address,uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.transfer.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -355,6 +260,7 @@ export class ERC20TokenContract extends BaseContract {
         },
     };
     public allowance = {
+        functionSignature: 'allowance(address,address)',
         async callAsync(
             _owner: string,
             _spender: string,
@@ -363,20 +269,11 @@ export class ERC20TokenContract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as ERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('allowance(address,address)', [_owner,
+            const encodedData = self._strictEncodeArguments(self.allowance.functionSignature, [_owner,
         _spender
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('allowance(address,address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.allowance.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -389,7 +286,7 @@ export class ERC20TokenContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<ERC20TokenContract> {
-        if (_.isUndefined(artifact.compilerOutput)) {
+        if (isUndefined(artifact.compilerOutput)) {
             throw new Error('Compiler output not found in the artifact file');
         }
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
@@ -410,25 +307,10 @@ export class ERC20TokenContract extends BaseContract {
             [],
             BaseContract._bigNumberToString,
         );
-        const iface = new ethers.utils.Interface(abi);
-        const deployInfo = iface.deployFunction;
-        const txData = deployInfo.encode(bytecode, []);
-        const web3Wrapper = new Web3Wrapper(provider);
-        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-            {data: txData},
-            txDefaults,
-            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
-        );
-        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-        logUtils.log(`transactionHash: ${txHash}`);
-        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
-        logUtils.log(`ERC20Token successfully deployed at ${txReceipt.contractAddress}`);
-        const contractInstance = new ERC20TokenContract(abi, txReceipt.contractAddress as string, provider, txDefaults);
-        contractInstance.constructorArgs = [];
-        return contractInstance;
+        return {} as any;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
-        super('ERC20Token', abi, address, providerUtils.standardizeOrThrow(supportedProvider), txDefaults);
+        super('ERC20Token', abi, address, supportedProvider, txDefaults);
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc20_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc20_token.ts
@@ -42,7 +42,7 @@ export class ERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [_spender,
+            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
             const gasEstimateFunction = self.approve.estimateGasAsync.bind(self, _spender,
@@ -57,7 +57,7 @@ export class ERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [_spender,
+            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
@@ -68,12 +68,11 @@ export class ERC20TokenContract extends BaseContract {
             _value: BigNumber,
         ): string {
             const self = this as any as ERC20TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.approve.functionSignature, [_spender,
+            const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'approve(address,uint256)',
         async callAsync(
             _spender: string,
             _value: BigNumber,
@@ -82,11 +81,11 @@ export class ERC20TokenContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as ERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [_spender,
+            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
         _value
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.approve.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('approve(address,uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -95,16 +94,15 @@ export class ERC20TokenContract extends BaseContract {
         },
     };
     public totalSupply = {
-        functionSignature: 'totalSupply()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
             const self = this as any as ERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.totalSupply.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('totalSupply()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.totalSupply.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('totalSupply()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -120,7 +118,7 @@ export class ERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
+            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
@@ -138,7 +136,7 @@ export class ERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
+            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
@@ -151,13 +149,12 @@ export class ERC20TokenContract extends BaseContract {
             _value: BigNumber,
         ): string {
             const self = this as any as ERC20TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
+            const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'transferFrom(address,address,uint256)',
         async callAsync(
             _from: string,
             _to: string,
@@ -167,12 +164,12 @@ export class ERC20TokenContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as ERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
+            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
         _to,
         _value
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.transferFrom.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('transferFrom(address,address,uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -181,7 +178,6 @@ export class ERC20TokenContract extends BaseContract {
         },
     };
     public balanceOf = {
-        functionSignature: 'balanceOf(address)',
         async callAsync(
             _owner: string,
             callData: Partial<CallData> = {},
@@ -189,10 +185,10 @@ export class ERC20TokenContract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as ERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.balanceOf.functionSignature, [_owner
+            const encodedData = self._strictEncodeArguments('balanceOf(address)', [_owner
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.balanceOf.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('balanceOf(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -207,7 +203,7 @@ export class ERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.transfer.functionSignature, [_to,
+            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
             const gasEstimateFunction = self.transfer.estimateGasAsync.bind(self, _to,
@@ -222,7 +218,7 @@ export class ERC20TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.transfer.functionSignature, [_to,
+            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
@@ -233,12 +229,11 @@ export class ERC20TokenContract extends BaseContract {
             _value: BigNumber,
         ): string {
             const self = this as any as ERC20TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.transfer.functionSignature, [_to,
+            const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'transfer(address,uint256)',
         async callAsync(
             _to: string,
             _value: BigNumber,
@@ -247,11 +242,11 @@ export class ERC20TokenContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as ERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.transfer.functionSignature, [_to,
+            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
         _value
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.transfer.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('transfer(address,uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -260,7 +255,6 @@ export class ERC20TokenContract extends BaseContract {
         },
     };
     public allowance = {
-        functionSignature: 'allowance(address,address)',
         async callAsync(
             _owner: string,
             _spender: string,
@@ -269,11 +263,11 @@ export class ERC20TokenContract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as ERC20TokenContract;
-            const encodedData = self._strictEncodeArguments(self.allowance.functionSignature, [_owner,
+            const encodedData = self._strictEncodeArguments('allowance(address,address)', [_owner,
         _spender
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.allowance.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('allowance(address,address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc20_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc20_token.ts
@@ -3,7 +3,7 @@
 // tslint:disable:no-unbound-method
 import { BaseContract } from '@0x/base-contract';
 import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact, DecodedLogArgs, MethodAbi, TxData, TxDataPayable, SupportedProvider } from 'ethereum-types';
-import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
+import { AbiEncoder, BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 import { isUndefined } from 'lodash';
@@ -307,7 +307,21 @@ export class ERC20TokenContract extends BaseContract {
             [],
             BaseContract._bigNumberToString,
         );
-        return {} as any;
+        const encoder = new AbiEncoder.Constructor(constructorAbi);
+        const txData = encoder.encode(bytecode, []);
+        const web3Wrapper = new Web3Wrapper(provider);
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {data: txData},
+            txDefaults,
+            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
+        );
+        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        logUtils.log(`transactionHash: ${txHash}`);
+        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
+        logUtils.log(`ERC20Token successfully deployed at ${txReceipt.contractAddress}`);
+        const contractInstance = new ERC20TokenContract(abi, txReceipt.contractAddress as string, provider, txDefaults);
+        contractInstance.constructorArgs = [];
+        return contractInstance;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
         super('ERC20Token', abi, address, supportedProvider, txDefaults);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc721_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc721_proxy.ts
@@ -39,7 +39,7 @@ export class ERC721ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
+            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
             const gasEstimateFunction = self.addAuthorizedAddress.estimateGasAsync.bind(self, target
     );
@@ -51,7 +51,7 @@ export class ERC721ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
+            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -60,11 +60,10 @@ export class ERC721ProxyContract extends BaseContract {
             target: string,
         ): string {
             const self = this as any as ERC721ProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
+            const abiEncodedTransactionData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'addAuthorizedAddress(address)',
         async callAsync(
             target: string,
             callData: Partial<CallData> = {},
@@ -72,10 +71,10 @@ export class ERC721ProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
+            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.addAuthorizedAddress.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('addAuthorizedAddress(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -84,7 +83,6 @@ export class ERC721ProxyContract extends BaseContract {
         },
     };
     public authorities = {
-        functionSignature: 'authorities(uint256)',
         async callAsync(
             index_0: BigNumber,
             callData: Partial<CallData> = {},
@@ -92,10 +90,10 @@ export class ERC721ProxyContract extends BaseContract {
         ): Promise<string
         > {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.authorities.functionSignature, [index_0
+            const encodedData = self._strictEncodeArguments('authorities(uint256)', [index_0
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.authorities.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('authorities(uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -109,7 +107,7 @@ export class ERC721ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
+            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
             const gasEstimateFunction = self.removeAuthorizedAddress.estimateGasAsync.bind(self, target
     );
@@ -121,7 +119,7 @@ export class ERC721ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
+            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -130,11 +128,10 @@ export class ERC721ProxyContract extends BaseContract {
             target: string,
         ): string {
             const self = this as any as ERC721ProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
+            const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'removeAuthorizedAddress(address)',
         async callAsync(
             target: string,
             callData: Partial<CallData> = {},
@@ -142,10 +139,10 @@ export class ERC721ProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
+            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.removeAuthorizedAddress.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('removeAuthorizedAddress(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -154,16 +151,15 @@ export class ERC721ProxyContract extends BaseContract {
         },
     };
     public owner = {
-        functionSignature: 'owner()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.owner.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('owner()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.owner.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('owner()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -178,7 +174,7 @@ export class ERC721ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
+            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
             const gasEstimateFunction = self.removeAuthorizedAddressAtIndex.estimateGasAsync.bind(self, target,
@@ -193,7 +189,7 @@ export class ERC721ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
+            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
@@ -204,12 +200,11 @@ export class ERC721ProxyContract extends BaseContract {
             index: BigNumber,
         ): string {
             const self = this as any as ERC721ProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
+            const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'removeAuthorizedAddressAtIndex(address,uint256)',
         async callAsync(
             target: string,
             index: BigNumber,
@@ -218,11 +213,11 @@ export class ERC721ProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
+            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
         index
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.removeAuthorizedAddressAtIndex.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('removeAuthorizedAddressAtIndex(address,uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -231,16 +226,15 @@ export class ERC721ProxyContract extends BaseContract {
         },
     };
     public getProxyId = {
-        functionSignature: 'getProxyId()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.getProxyId.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('getProxyId()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.getProxyId.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('getProxyId()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -249,7 +243,6 @@ export class ERC721ProxyContract extends BaseContract {
         },
     };
     public authorized = {
-        functionSignature: 'authorized(address)',
         async callAsync(
             index_0: string,
             callData: Partial<CallData> = {},
@@ -257,10 +250,10 @@ export class ERC721ProxyContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.authorized.functionSignature, [index_0
+            const encodedData = self._strictEncodeArguments('authorized(address)', [index_0
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.authorized.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('authorized(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -269,16 +262,15 @@ export class ERC721ProxyContract extends BaseContract {
         },
     };
     public getAuthorizedAddresses = {
-        functionSignature: 'getAuthorizedAddresses()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.getAuthorizedAddresses.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('getAuthorizedAddresses()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.getAuthorizedAddresses.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('getAuthorizedAddresses()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string[]
         >(rawCallResult);
@@ -292,7 +284,7 @@ export class ERC721ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
             const gasEstimateFunction = self.transferOwnership.estimateGasAsync.bind(self, newOwner
     );
@@ -304,7 +296,7 @@ export class ERC721ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -313,11 +305,10 @@ export class ERC721ProxyContract extends BaseContract {
             newOwner: string,
         ): string {
             const self = this as any as ERC721ProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'transferOwnership(address)',
         async callAsync(
             newOwner: string,
             callData: Partial<CallData> = {},
@@ -325,10 +316,10 @@ export class ERC721ProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.transferOwnership.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('transferOwnership(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc721_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc721_proxy.ts
@@ -6,8 +6,7 @@ import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact,
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
-import * as ethers from 'ethers';
-import * as _ from 'lodash';
+import { isUndefined } from 'lodash';
 // tslint:enable:no-unused-variable
 
 export type ERC721ProxyEventArgs =
@@ -40,21 +39,11 @@ export class ERC721ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
+            const encodedData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.addAuthorizedAddress.estimateGasAsync.bind(
-                    self,
-                    target
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.addAuthorizedAddress.estimateGasAsync.bind(self, target
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -62,27 +51,20 @@ export class ERC721ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
+            const encodedData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             target: string,
         ): string {
             const self = this as any as ERC721ProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'addAuthorizedAddress(address)',
         async callAsync(
             target: string,
             callData: Partial<CallData> = {},
@@ -90,19 +72,10 @@ export class ERC721ProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
+            const encodedData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('addAuthorizedAddress(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.addAuthorizedAddress.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -111,6 +84,7 @@ export class ERC721ProxyContract extends BaseContract {
         },
     };
     public authorities = {
+        functionSignature: 'authorities(uint256)',
         async callAsync(
             index_0: BigNumber,
             callData: Partial<CallData> = {},
@@ -118,19 +92,10 @@ export class ERC721ProxyContract extends BaseContract {
         ): Promise<string
         > {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments('authorities(uint256)', [index_0
+            const encodedData = self._strictEncodeArguments(self.authorities.functionSignature, [index_0
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('authorities(uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.authorities.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -144,21 +109,11 @@ export class ERC721ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
+            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.removeAuthorizedAddress.estimateGasAsync.bind(
-                    self,
-                    target
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.removeAuthorizedAddress.estimateGasAsync.bind(self, target
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -166,27 +121,20 @@ export class ERC721ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
+            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             target: string,
         ): string {
             const self = this as any as ERC721ProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'removeAuthorizedAddress(address)',
         async callAsync(
             target: string,
             callData: Partial<CallData> = {},
@@ -194,19 +142,10 @@ export class ERC721ProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
+            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('removeAuthorizedAddress(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.removeAuthorizedAddress.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -215,24 +154,16 @@ export class ERC721ProxyContract extends BaseContract {
         },
     };
     public owner = {
+        functionSignature: 'owner()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments('owner()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('owner()');
+            const encodedData = self._strictEncodeArguments(self.owner.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.owner.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -247,23 +178,13 @@ export class ERC721ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
+            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
     index
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.removeAuthorizedAddressAtIndex.estimateGasAsync.bind(
-                    self,
-                    target,
-                    index
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.removeAuthorizedAddressAtIndex.estimateGasAsync.bind(self, target,
+    index
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -272,18 +193,10 @@ export class ERC721ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
+            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
     index
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -291,11 +204,12 @@ export class ERC721ProxyContract extends BaseContract {
             index: BigNumber,
         ): string {
             const self = this as any as ERC721ProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
     index
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'removeAuthorizedAddressAtIndex(address,uint256)',
         async callAsync(
             target: string,
             index: BigNumber,
@@ -304,20 +218,11 @@ export class ERC721ProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
+            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
         index
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('removeAuthorizedAddressAtIndex(address,uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.removeAuthorizedAddressAtIndex.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -326,24 +231,16 @@ export class ERC721ProxyContract extends BaseContract {
         },
     };
     public getProxyId = {
+        functionSignature: 'getProxyId()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments('getProxyId()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('getProxyId()');
+            const encodedData = self._strictEncodeArguments(self.getProxyId.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.getProxyId.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -352,6 +249,7 @@ export class ERC721ProxyContract extends BaseContract {
         },
     };
     public authorized = {
+        functionSignature: 'authorized(address)',
         async callAsync(
             index_0: string,
             callData: Partial<CallData> = {},
@@ -359,19 +257,10 @@ export class ERC721ProxyContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments('authorized(address)', [index_0
+            const encodedData = self._strictEncodeArguments(self.authorized.functionSignature, [index_0
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('authorized(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.authorized.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -380,24 +269,16 @@ export class ERC721ProxyContract extends BaseContract {
         },
     };
     public getAuthorizedAddresses = {
+        functionSignature: 'getAuthorizedAddresses()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments('getAuthorizedAddresses()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('getAuthorizedAddresses()');
+            const encodedData = self._strictEncodeArguments(self.getAuthorizedAddresses.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.getAuthorizedAddresses.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string[]
         >(rawCallResult);
@@ -411,21 +292,11 @@ export class ERC721ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transferOwnership.estimateGasAsync.bind(
-                    self,
-                    newOwner
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.transferOwnership.estimateGasAsync.bind(self, newOwner
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -433,27 +304,20 @@ export class ERC721ProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             newOwner: string,
         ): string {
             const self = this as any as ERC721ProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'transferOwnership(address)',
         async callAsync(
             newOwner: string,
             callData: Partial<CallData> = {},
@@ -461,19 +325,10 @@ export class ERC721ProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('transferOwnership(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.transferOwnership.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -486,7 +341,7 @@ export class ERC721ProxyContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<ERC721ProxyContract> {
-        if (_.isUndefined(artifact.compilerOutput)) {
+        if (isUndefined(artifact.compilerOutput)) {
             throw new Error('Compiler output not found in the artifact file');
         }
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
@@ -507,25 +362,10 @@ export class ERC721ProxyContract extends BaseContract {
             [],
             BaseContract._bigNumberToString,
         );
-        const iface = new ethers.utils.Interface(abi);
-        const deployInfo = iface.deployFunction;
-        const txData = deployInfo.encode(bytecode, []);
-        const web3Wrapper = new Web3Wrapper(provider);
-        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-            {data: txData},
-            txDefaults,
-            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
-        );
-        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-        logUtils.log(`transactionHash: ${txHash}`);
-        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
-        logUtils.log(`ERC721Proxy successfully deployed at ${txReceipt.contractAddress}`);
-        const contractInstance = new ERC721ProxyContract(abi, txReceipt.contractAddress as string, provider, txDefaults);
-        contractInstance.constructorArgs = [];
-        return contractInstance;
+        return {} as any;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
-        super('ERC721Proxy', abi, address, providerUtils.standardizeOrThrow(supportedProvider), txDefaults);
+        super('ERC721Proxy', abi, address, supportedProvider, txDefaults);
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc721_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc721_proxy.ts
@@ -3,7 +3,7 @@
 // tslint:disable:no-unbound-method
 import { BaseContract } from '@0x/base-contract';
 import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact, DecodedLogArgs, MethodAbi, TxData, TxDataPayable, SupportedProvider } from 'ethereum-types';
-import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
+import { AbiEncoder, BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 import { isUndefined } from 'lodash';
@@ -362,7 +362,21 @@ export class ERC721ProxyContract extends BaseContract {
             [],
             BaseContract._bigNumberToString,
         );
-        return {} as any;
+        const encoder = new AbiEncoder.Constructor(constructorAbi);
+        const txData = encoder.encode(bytecode, []);
+        const web3Wrapper = new Web3Wrapper(provider);
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {data: txData},
+            txDefaults,
+            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
+        );
+        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        logUtils.log(`transactionHash: ${txHash}`);
+        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
+        logUtils.log(`ERC721Proxy successfully deployed at ${txReceipt.contractAddress}`);
+        const contractInstance = new ERC721ProxyContract(abi, txReceipt.contractAddress as string, provider, txDefaults);
+        contractInstance.constructorArgs = [];
+        return contractInstance;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
         super('ERC721Proxy', abi, address, supportedProvider, txDefaults);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc721_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc721_token.ts
@@ -3,7 +3,7 @@
 // tslint:disable:no-unbound-method
 import { BaseContract } from '@0x/base-contract';
 import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact, DecodedLogArgs, MethodAbi, TxData, TxDataPayable, SupportedProvider } from 'ethereum-types';
-import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
+import { AbiEncoder, BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 import { isUndefined } from 'lodash';
@@ -482,7 +482,21 @@ export class ERC721TokenContract extends BaseContract {
             [],
             BaseContract._bigNumberToString,
         );
-        return {} as any;
+        const encoder = new AbiEncoder.Constructor(constructorAbi);
+        const txData = encoder.encode(bytecode, []);
+        const web3Wrapper = new Web3Wrapper(provider);
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {data: txData},
+            txDefaults,
+            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
+        );
+        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        logUtils.log(`transactionHash: ${txHash}`);
+        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
+        logUtils.log(`ERC721Token successfully deployed at ${txReceipt.contractAddress}`);
+        const contractInstance = new ERC721TokenContract(abi, txReceipt.contractAddress as string, provider, txDefaults);
+        contractInstance.constructorArgs = [];
+        return contractInstance;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
         super('ERC721Token', abi, address, supportedProvider, txDefaults);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc721_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc721_token.ts
@@ -6,8 +6,7 @@ import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact,
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
-import * as ethers from 'ethers';
-import * as _ from 'lodash';
+import { isUndefined } from 'lodash';
 // tslint:enable:no-unused-variable
 
 export type ERC721TokenEventArgs =
@@ -45,6 +44,7 @@ export interface ERC721TokenApprovalForAllEventArgs extends DecodedLogArgs {
 // tslint:disable-next-line:class-name
 export class ERC721TokenContract extends BaseContract {
     public getApproved = {
+        functionSignature: 'getApproved(uint256)',
         async callAsync(
             _tokenId: BigNumber,
             callData: Partial<CallData> = {},
@@ -52,19 +52,10 @@ export class ERC721TokenContract extends BaseContract {
         ): Promise<string
         > {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('getApproved(uint256)', [_tokenId
+            const encodedData = self._strictEncodeArguments(self.getApproved.functionSignature, [_tokenId
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('getApproved(uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.getApproved.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -79,23 +70,13 @@ export class ERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
+            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [_approved,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.approve.estimateGasAsync.bind(
-                    self,
-                    _approved,
-                    _tokenId
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.approve.estimateGasAsync.bind(self, _approved,
+    _tokenId
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -104,18 +85,10 @@ export class ERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
+            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [_approved,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -123,11 +96,12 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         ): string {
             const self = this as any as ERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.approve.functionSignature, [_approved,
     _tokenId
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'approve(address,uint256)',
         async callAsync(
             _approved: string,
             _tokenId: BigNumber,
@@ -136,20 +110,11 @@ export class ERC721TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
+            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [_approved,
         _tokenId
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('approve(address,uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.approve.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -165,25 +130,15 @@ export class ERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
     _to,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transferFrom.estimateGasAsync.bind(
-                    self,
-                    _from,
-                    _to,
-                    _tokenId
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.transferFrom.estimateGasAsync.bind(self, _from,
+    _to,
+    _tokenId
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -193,19 +148,11 @@ export class ERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
     _to,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -214,12 +161,13 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         ): string {
             const self = this as any as ERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
     _to,
     _tokenId
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'transferFrom(address,address,uint256)',
         async callAsync(
             _from: string,
             _to: string,
@@ -229,21 +177,12 @@ export class ERC721TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
         _to,
         _tokenId
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('transferFrom(address,address,uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.transferFrom.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -259,25 +198,15 @@ export class ERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
+            const encodedData = self._strictEncodeArguments(self.safeTransferFrom1.functionSignature, [_from,
     _to,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.safeTransferFrom1.estimateGasAsync.bind(
-                    self,
-                    _from,
-                    _to,
-                    _tokenId
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.safeTransferFrom1.estimateGasAsync.bind(self, _from,
+    _to,
+    _tokenId
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -287,19 +216,11 @@ export class ERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
+            const encodedData = self._strictEncodeArguments(self.safeTransferFrom1.functionSignature, [_from,
     _to,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -308,12 +229,13 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         ): string {
             const self = this as any as ERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.safeTransferFrom1.functionSignature, [_from,
     _to,
     _tokenId
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'safeTransferFrom(address,address,uint256)',
         async callAsync(
             _from: string,
             _to: string,
@@ -323,21 +245,12 @@ export class ERC721TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
+            const encodedData = self._strictEncodeArguments(self.safeTransferFrom1.functionSignature, [_from,
         _to,
         _tokenId
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('safeTransferFrom(address,address,uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.safeTransferFrom1.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -346,6 +259,7 @@ export class ERC721TokenContract extends BaseContract {
         },
     };
     public ownerOf = {
+        functionSignature: 'ownerOf(uint256)',
         async callAsync(
             _tokenId: BigNumber,
             callData: Partial<CallData> = {},
@@ -353,19 +267,10 @@ export class ERC721TokenContract extends BaseContract {
         ): Promise<string
         > {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('ownerOf(uint256)', [_tokenId
+            const encodedData = self._strictEncodeArguments(self.ownerOf.functionSignature, [_tokenId
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('ownerOf(uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.ownerOf.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -374,6 +279,7 @@ export class ERC721TokenContract extends BaseContract {
         },
     };
     public balanceOf = {
+        functionSignature: 'balanceOf(address)',
         async callAsync(
             _owner: string,
             callData: Partial<CallData> = {},
@@ -381,19 +287,10 @@ export class ERC721TokenContract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('balanceOf(address)', [_owner
+            const encodedData = self._strictEncodeArguments(self.balanceOf.functionSignature, [_owner
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('balanceOf(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.balanceOf.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -408,23 +305,13 @@ export class ERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
+            const encodedData = self._strictEncodeArguments(self.setApprovalForAll.functionSignature, [_operator,
     _approved
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.setApprovalForAll.estimateGasAsync.bind(
-                    self,
-                    _operator,
-                    _approved
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.setApprovalForAll.estimateGasAsync.bind(self, _operator,
+    _approved
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -433,18 +320,10 @@ export class ERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
+            const encodedData = self._strictEncodeArguments(self.setApprovalForAll.functionSignature, [_operator,
     _approved
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -452,11 +331,12 @@ export class ERC721TokenContract extends BaseContract {
             _approved: boolean,
         ): string {
             const self = this as any as ERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.setApprovalForAll.functionSignature, [_operator,
     _approved
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'setApprovalForAll(address,bool)',
         async callAsync(
             _operator: string,
             _approved: boolean,
@@ -465,20 +345,11 @@ export class ERC721TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
+            const encodedData = self._strictEncodeArguments(self.setApprovalForAll.functionSignature, [_operator,
         _approved
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('setApprovalForAll(address,bool)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.setApprovalForAll.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -495,27 +366,17 @@ export class ERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
+            const encodedData = self._strictEncodeArguments(self.safeTransferFrom2.functionSignature, [_from,
     _to,
     _tokenId,
     _data
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.safeTransferFrom2.estimateGasAsync.bind(
-                    self,
-                    _from,
-                    _to,
-                    _tokenId,
-                    _data
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.safeTransferFrom2.estimateGasAsync.bind(self, _from,
+    _to,
+    _tokenId,
+    _data
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -526,20 +387,12 @@ export class ERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
+            const encodedData = self._strictEncodeArguments(self.safeTransferFrom2.functionSignature, [_from,
     _to,
     _tokenId,
     _data
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -549,13 +402,14 @@ export class ERC721TokenContract extends BaseContract {
             _data: string,
         ): string {
             const self = this as any as ERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.safeTransferFrom2.functionSignature, [_from,
     _to,
     _tokenId,
     _data
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'safeTransferFrom(address,address,uint256,bytes)',
         async callAsync(
             _from: string,
             _to: string,
@@ -566,22 +420,13 @@ export class ERC721TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
+            const encodedData = self._strictEncodeArguments(self.safeTransferFrom2.functionSignature, [_from,
         _to,
         _tokenId,
         _data
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('safeTransferFrom(address,address,uint256,bytes)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.safeTransferFrom2.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -590,6 +435,7 @@ export class ERC721TokenContract extends BaseContract {
         },
     };
     public isApprovedForAll = {
+        functionSignature: 'isApprovedForAll(address,address)',
         async callAsync(
             _owner: string,
             _operator: string,
@@ -598,20 +444,11 @@ export class ERC721TokenContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('isApprovedForAll(address,address)', [_owner,
+            const encodedData = self._strictEncodeArguments(self.isApprovedForAll.functionSignature, [_owner,
         _operator
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('isApprovedForAll(address,address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.isApprovedForAll.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -624,7 +461,7 @@ export class ERC721TokenContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<ERC721TokenContract> {
-        if (_.isUndefined(artifact.compilerOutput)) {
+        if (isUndefined(artifact.compilerOutput)) {
             throw new Error('Compiler output not found in the artifact file');
         }
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
@@ -645,25 +482,10 @@ export class ERC721TokenContract extends BaseContract {
             [],
             BaseContract._bigNumberToString,
         );
-        const iface = new ethers.utils.Interface(abi);
-        const deployInfo = iface.deployFunction;
-        const txData = deployInfo.encode(bytecode, []);
-        const web3Wrapper = new Web3Wrapper(provider);
-        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-            {data: txData},
-            txDefaults,
-            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
-        );
-        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-        logUtils.log(`transactionHash: ${txHash}`);
-        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
-        logUtils.log(`ERC721Token successfully deployed at ${txReceipt.contractAddress}`);
-        const contractInstance = new ERC721TokenContract(abi, txReceipt.contractAddress as string, provider, txDefaults);
-        contractInstance.constructorArgs = [];
-        return contractInstance;
+        return {} as any;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
-        super('ERC721Token', abi, address, providerUtils.standardizeOrThrow(supportedProvider), txDefaults);
+        super('ERC721Token', abi, address, supportedProvider, txDefaults);
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc721_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc721_token.ts
@@ -44,7 +44,6 @@ export interface ERC721TokenApprovalForAllEventArgs extends DecodedLogArgs {
 // tslint:disable-next-line:class-name
 export class ERC721TokenContract extends BaseContract {
     public getApproved = {
-        functionSignature: 'getApproved(uint256)',
         async callAsync(
             _tokenId: BigNumber,
             callData: Partial<CallData> = {},
@@ -52,10 +51,10 @@ export class ERC721TokenContract extends BaseContract {
         ): Promise<string
         > {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.getApproved.functionSignature, [_tokenId
+            const encodedData = self._strictEncodeArguments('getApproved(uint256)', [_tokenId
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.getApproved.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('getApproved(uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -70,7 +69,7 @@ export class ERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [_approved,
+            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
     ]);
             const gasEstimateFunction = self.approve.estimateGasAsync.bind(self, _approved,
@@ -85,7 +84,7 @@ export class ERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [_approved,
+            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
@@ -96,12 +95,11 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         ): string {
             const self = this as any as ERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.approve.functionSignature, [_approved,
+            const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'approve(address,uint256)',
         async callAsync(
             _approved: string,
             _tokenId: BigNumber,
@@ -110,11 +108,11 @@ export class ERC721TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [_approved,
+            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
         _tokenId
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.approve.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('approve(address,uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -130,7 +128,7 @@ export class ERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
+            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
@@ -148,7 +146,7 @@ export class ERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
+            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
@@ -161,13 +159,12 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         ): string {
             const self = this as any as ERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
+            const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'transferFrom(address,address,uint256)',
         async callAsync(
             _from: string,
             _to: string,
@@ -177,12 +174,12 @@ export class ERC721TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
+            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
         _to,
         _tokenId
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.transferFrom.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('transferFrom(address,address,uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -198,7 +195,7 @@ export class ERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.safeTransferFrom1.functionSignature, [_from,
+            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
@@ -216,7 +213,7 @@ export class ERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.safeTransferFrom1.functionSignature, [_from,
+            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
@@ -229,13 +226,12 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         ): string {
             const self = this as any as ERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.safeTransferFrom1.functionSignature, [_from,
+            const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'safeTransferFrom(address,address,uint256)',
         async callAsync(
             _from: string,
             _to: string,
@@ -245,12 +241,12 @@ export class ERC721TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.safeTransferFrom1.functionSignature, [_from,
+            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
         _to,
         _tokenId
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.safeTransferFrom1.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('safeTransferFrom(address,address,uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -259,7 +255,6 @@ export class ERC721TokenContract extends BaseContract {
         },
     };
     public ownerOf = {
-        functionSignature: 'ownerOf(uint256)',
         async callAsync(
             _tokenId: BigNumber,
             callData: Partial<CallData> = {},
@@ -267,10 +262,10 @@ export class ERC721TokenContract extends BaseContract {
         ): Promise<string
         > {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.ownerOf.functionSignature, [_tokenId
+            const encodedData = self._strictEncodeArguments('ownerOf(uint256)', [_tokenId
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.ownerOf.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('ownerOf(uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -279,7 +274,6 @@ export class ERC721TokenContract extends BaseContract {
         },
     };
     public balanceOf = {
-        functionSignature: 'balanceOf(address)',
         async callAsync(
             _owner: string,
             callData: Partial<CallData> = {},
@@ -287,10 +281,10 @@ export class ERC721TokenContract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.balanceOf.functionSignature, [_owner
+            const encodedData = self._strictEncodeArguments('balanceOf(address)', [_owner
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.balanceOf.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('balanceOf(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -305,7 +299,7 @@ export class ERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.setApprovalForAll.functionSignature, [_operator,
+            const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
     ]);
             const gasEstimateFunction = self.setApprovalForAll.estimateGasAsync.bind(self, _operator,
@@ -320,7 +314,7 @@ export class ERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.setApprovalForAll.functionSignature, [_operator,
+            const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
@@ -331,12 +325,11 @@ export class ERC721TokenContract extends BaseContract {
             _approved: boolean,
         ): string {
             const self = this as any as ERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.setApprovalForAll.functionSignature, [_operator,
+            const abiEncodedTransactionData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'setApprovalForAll(address,bool)',
         async callAsync(
             _operator: string,
             _approved: boolean,
@@ -345,11 +338,11 @@ export class ERC721TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.setApprovalForAll.functionSignature, [_operator,
+            const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
         _approved
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.setApprovalForAll.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('setApprovalForAll(address,bool)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -366,7 +359,7 @@ export class ERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.safeTransferFrom2.functionSignature, [_from,
+            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
     _tokenId,
     _data
@@ -387,7 +380,7 @@ export class ERC721TokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.safeTransferFrom2.functionSignature, [_from,
+            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
     _tokenId,
     _data
@@ -402,14 +395,13 @@ export class ERC721TokenContract extends BaseContract {
             _data: string,
         ): string {
             const self = this as any as ERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.safeTransferFrom2.functionSignature, [_from,
+            const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
     _tokenId,
     _data
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'safeTransferFrom(address,address,uint256,bytes)',
         async callAsync(
             _from: string,
             _to: string,
@@ -420,13 +412,13 @@ export class ERC721TokenContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.safeTransferFrom2.functionSignature, [_from,
+            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
         _to,
         _tokenId,
         _data
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.safeTransferFrom2.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('safeTransferFrom(address,address,uint256,bytes)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -435,7 +427,6 @@ export class ERC721TokenContract extends BaseContract {
         },
     };
     public isApprovedForAll = {
-        functionSignature: 'isApprovedForAll(address,address)',
         async callAsync(
             _owner: string,
             _operator: string,
@@ -444,11 +435,11 @@ export class ERC721TokenContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments(self.isApprovedForAll.functionSignature, [_owner,
+            const encodedData = self._strictEncodeArguments('isApprovedForAll(address,address)', [_owner,
         _operator
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.isApprovedForAll.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('isApprovedForAll(address,address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/exchange.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/exchange.ts
@@ -6,8 +6,7 @@ import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact,
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
-import * as ethers from 'ethers';
-import * as _ from 'lodash';
+import { isUndefined } from 'lodash';
 // tslint:enable:no-unused-variable
 
 export type ExchangeEventArgs =
@@ -71,6 +70,7 @@ export interface ExchangeAssetProxyRegisteredEventArgs extends DecodedLogArgs {
 // tslint:disable-next-line:class-name
 export class ExchangeContract extends BaseContract {
     public filled = {
+        functionSignature: 'filled(bytes32)',
         async callAsync(
             index_0: string,
             callData: Partial<CallData> = {},
@@ -78,19 +78,10 @@ export class ExchangeContract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('filled(bytes32)', [index_0
+            const encodedData = self._strictEncodeArguments(self.filled.functionSignature, [index_0
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('filled(bytes32)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.filled.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -106,25 +97,15 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
+            const encodedData = self._strictEncodeArguments(self.batchFillOrders.functionSignature, [orders,
     takerAssetFillAmounts,
     signatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.batchFillOrders.estimateGasAsync.bind(
-                    self,
-                    orders,
-                    takerAssetFillAmounts,
-                    signatures
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.batchFillOrders.estimateGasAsync.bind(self, orders,
+    takerAssetFillAmounts,
+    signatures
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -134,19 +115,11 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
+            const encodedData = self._strictEncodeArguments(self.batchFillOrders.functionSignature, [orders,
     takerAssetFillAmounts,
     signatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -155,12 +128,13 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.batchFillOrders.functionSignature, [orders,
     takerAssetFillAmounts,
     signatures
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])',
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAssetFillAmounts: BigNumber[],
@@ -170,21 +144,12 @@ export class ExchangeContract extends BaseContract {
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
+            const encodedData = self._strictEncodeArguments(self.batchFillOrders.functionSignature, [orders,
         takerAssetFillAmounts,
         signatures
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.batchFillOrders.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         >(rawCallResult);
@@ -193,6 +158,7 @@ export class ExchangeContract extends BaseContract {
         },
     };
     public cancelled = {
+        functionSignature: 'cancelled(bytes32)',
         async callAsync(
             index_0: string,
             callData: Partial<CallData> = {},
@@ -200,19 +166,10 @@ export class ExchangeContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('cancelled(bytes32)', [index_0
+            const encodedData = self._strictEncodeArguments(self.cancelled.functionSignature, [index_0
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('cancelled(bytes32)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.cancelled.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -228,25 +185,15 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('preSign(bytes32,address,bytes)', [hash,
+            const encodedData = self._strictEncodeArguments(self.preSign.functionSignature, [hash,
     signerAddress,
     signature
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.preSign.estimateGasAsync.bind(
-                    self,
-                    hash,
-                    signerAddress,
-                    signature
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.preSign.estimateGasAsync.bind(self, hash,
+    signerAddress,
+    signature
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -256,19 +203,11 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('preSign(bytes32,address,bytes)', [hash,
+            const encodedData = self._strictEncodeArguments(self.preSign.functionSignature, [hash,
     signerAddress,
     signature
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -277,12 +216,13 @@ export class ExchangeContract extends BaseContract {
             signature: string,
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('preSign(bytes32,address,bytes)', [hash,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.preSign.functionSignature, [hash,
     signerAddress,
     signature
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'preSign(bytes32,address,bytes)',
         async callAsync(
             hash: string,
             signerAddress: string,
@@ -292,21 +232,12 @@ export class ExchangeContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('preSign(bytes32,address,bytes)', [hash,
+            const encodedData = self._strictEncodeArguments(self.preSign.functionSignature, [hash,
         signerAddress,
         signature
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('preSign(bytes32,address,bytes)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.preSign.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -323,27 +254,17 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [leftOrder,
+            const encodedData = self._strictEncodeArguments(self.matchOrders.functionSignature, [leftOrder,
     rightOrder,
     leftSignature,
     rightSignature
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.matchOrders.estimateGasAsync.bind(
-                    self,
-                    leftOrder,
-                    rightOrder,
-                    leftSignature,
-                    rightSignature
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.matchOrders.estimateGasAsync.bind(self, leftOrder,
+    rightOrder,
+    leftSignature,
+    rightSignature
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -354,20 +275,12 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [leftOrder,
+            const encodedData = self._strictEncodeArguments(self.matchOrders.functionSignature, [leftOrder,
     rightOrder,
     leftSignature,
     rightSignature
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -377,13 +290,14 @@ export class ExchangeContract extends BaseContract {
             rightSignature: string,
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [leftOrder,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.matchOrders.functionSignature, [leftOrder,
     rightOrder,
     leftSignature,
     rightSignature
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)',
         async callAsync(
             leftOrder: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             rightOrder: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
@@ -394,22 +308,13 @@ export class ExchangeContract extends BaseContract {
         ): Promise<{left: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};right: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};leftMakerAssetSpreadAmount: BigNumber}
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [leftOrder,
+            const encodedData = self._strictEncodeArguments(self.matchOrders.functionSignature, [leftOrder,
         rightOrder,
         leftSignature,
         rightSignature
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.matchOrders.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<{left: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};right: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};leftMakerAssetSpreadAmount: BigNumber}
         >(rawCallResult);
@@ -425,25 +330,15 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
+            const encodedData = self._strictEncodeArguments(self.fillOrderNoThrow.functionSignature, [order,
     takerAssetFillAmount,
     signature
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.fillOrderNoThrow.estimateGasAsync.bind(
-                    self,
-                    order,
-                    takerAssetFillAmount,
-                    signature
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.fillOrderNoThrow.estimateGasAsync.bind(self, order,
+    takerAssetFillAmount,
+    signature
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -453,19 +348,11 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
+            const encodedData = self._strictEncodeArguments(self.fillOrderNoThrow.functionSignature, [order,
     takerAssetFillAmount,
     signature
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -474,12 +361,13 @@ export class ExchangeContract extends BaseContract {
             signature: string,
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.fillOrderNoThrow.functionSignature, [order,
     takerAssetFillAmount,
     signature
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)',
         async callAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             takerAssetFillAmount: BigNumber,
@@ -489,21 +377,12 @@ export class ExchangeContract extends BaseContract {
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
+            const encodedData = self._strictEncodeArguments(self.fillOrderNoThrow.functionSignature, [order,
         takerAssetFillAmount,
         signature
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.fillOrderNoThrow.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         >(rawCallResult);
@@ -512,6 +391,7 @@ export class ExchangeContract extends BaseContract {
         },
     };
     public assetProxies = {
+        functionSignature: 'assetProxies(bytes4)',
         async callAsync(
             index_0: string,
             callData: Partial<CallData> = {},
@@ -519,19 +399,10 @@ export class ExchangeContract extends BaseContract {
         ): Promise<string
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('assetProxies(bytes4)', [index_0
+            const encodedData = self._strictEncodeArguments(self.assetProxies.functionSignature, [index_0
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('assetProxies(bytes4)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.assetProxies.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -545,21 +416,11 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('batchCancelOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])', [orders
+            const encodedData = self._strictEncodeArguments(self.batchCancelOrders.functionSignature, [orders
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.batchCancelOrders.estimateGasAsync.bind(
-                    self,
-                    orders
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.batchCancelOrders.estimateGasAsync.bind(self, orders
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -567,27 +428,20 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('batchCancelOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])', [orders
+            const encodedData = self._strictEncodeArguments(self.batchCancelOrders.functionSignature, [orders
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('batchCancelOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])', [orders
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.batchCancelOrders.functionSignature, [orders
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'batchCancelOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])',
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             callData: Partial<CallData> = {},
@@ -595,19 +449,10 @@ export class ExchangeContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('batchCancelOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])', [orders
+            const encodedData = self._strictEncodeArguments(self.batchCancelOrders.functionSignature, [orders
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('batchCancelOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.batchCancelOrders.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -623,25 +468,15 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
+            const encodedData = self._strictEncodeArguments(self.batchFillOrKillOrders.functionSignature, [orders,
     takerAssetFillAmounts,
     signatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.batchFillOrKillOrders.estimateGasAsync.bind(
-                    self,
-                    orders,
-                    takerAssetFillAmounts,
-                    signatures
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.batchFillOrKillOrders.estimateGasAsync.bind(self, orders,
+    takerAssetFillAmounts,
+    signatures
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -651,19 +486,11 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
+            const encodedData = self._strictEncodeArguments(self.batchFillOrKillOrders.functionSignature, [orders,
     takerAssetFillAmounts,
     signatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -672,12 +499,13 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.batchFillOrKillOrders.functionSignature, [orders,
     takerAssetFillAmounts,
     signatures
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])',
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAssetFillAmounts: BigNumber[],
@@ -687,21 +515,12 @@ export class ExchangeContract extends BaseContract {
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
+            const encodedData = self._strictEncodeArguments(self.batchFillOrKillOrders.functionSignature, [orders,
         takerAssetFillAmounts,
         signatures
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.batchFillOrKillOrders.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         >(rawCallResult);
@@ -715,21 +534,11 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('cancelOrdersUpTo(uint256)', [targetOrderEpoch
+            const encodedData = self._strictEncodeArguments(self.cancelOrdersUpTo.functionSignature, [targetOrderEpoch
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.cancelOrdersUpTo.estimateGasAsync.bind(
-                    self,
-                    targetOrderEpoch
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.cancelOrdersUpTo.estimateGasAsync.bind(self, targetOrderEpoch
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -737,27 +546,20 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('cancelOrdersUpTo(uint256)', [targetOrderEpoch
+            const encodedData = self._strictEncodeArguments(self.cancelOrdersUpTo.functionSignature, [targetOrderEpoch
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             targetOrderEpoch: BigNumber,
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('cancelOrdersUpTo(uint256)', [targetOrderEpoch
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.cancelOrdersUpTo.functionSignature, [targetOrderEpoch
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'cancelOrdersUpTo(uint256)',
         async callAsync(
             targetOrderEpoch: BigNumber,
             callData: Partial<CallData> = {},
@@ -765,19 +567,10 @@ export class ExchangeContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('cancelOrdersUpTo(uint256)', [targetOrderEpoch
+            const encodedData = self._strictEncodeArguments(self.cancelOrdersUpTo.functionSignature, [targetOrderEpoch
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('cancelOrdersUpTo(uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.cancelOrdersUpTo.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -793,25 +586,15 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
+            const encodedData = self._strictEncodeArguments(self.batchFillOrdersNoThrow.functionSignature, [orders,
     takerAssetFillAmounts,
     signatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.batchFillOrdersNoThrow.estimateGasAsync.bind(
-                    self,
-                    orders,
-                    takerAssetFillAmounts,
-                    signatures
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.batchFillOrdersNoThrow.estimateGasAsync.bind(self, orders,
+    takerAssetFillAmounts,
+    signatures
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -821,19 +604,11 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
+            const encodedData = self._strictEncodeArguments(self.batchFillOrdersNoThrow.functionSignature, [orders,
     takerAssetFillAmounts,
     signatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -842,12 +617,13 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.batchFillOrdersNoThrow.functionSignature, [orders,
     takerAssetFillAmounts,
     signatures
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])',
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAssetFillAmounts: BigNumber[],
@@ -857,21 +633,12 @@ export class ExchangeContract extends BaseContract {
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
+            const encodedData = self._strictEncodeArguments(self.batchFillOrdersNoThrow.functionSignature, [orders,
         takerAssetFillAmounts,
         signatures
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.batchFillOrdersNoThrow.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         >(rawCallResult);
@@ -880,6 +647,7 @@ export class ExchangeContract extends BaseContract {
         },
     };
     public getAssetProxy = {
+        functionSignature: 'getAssetProxy(bytes4)',
         async callAsync(
             assetProxyId: string,
             callData: Partial<CallData> = {},
@@ -887,19 +655,10 @@ export class ExchangeContract extends BaseContract {
         ): Promise<string
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('getAssetProxy(bytes4)', [assetProxyId
+            const encodedData = self._strictEncodeArguments(self.getAssetProxy.functionSignature, [assetProxyId
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('getAssetProxy(bytes4)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.getAssetProxy.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -908,6 +667,7 @@ export class ExchangeContract extends BaseContract {
         },
     };
     public transactions = {
+        functionSignature: 'transactions(bytes32)',
         async callAsync(
             index_0: string,
             callData: Partial<CallData> = {},
@@ -915,19 +675,10 @@ export class ExchangeContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('transactions(bytes32)', [index_0
+            const encodedData = self._strictEncodeArguments(self.transactions.functionSignature, [index_0
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('transactions(bytes32)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.transactions.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -943,25 +694,15 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
+            const encodedData = self._strictEncodeArguments(self.fillOrKillOrder.functionSignature, [order,
     takerAssetFillAmount,
     signature
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.fillOrKillOrder.estimateGasAsync.bind(
-                    self,
-                    order,
-                    takerAssetFillAmount,
-                    signature
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.fillOrKillOrder.estimateGasAsync.bind(self, order,
+    takerAssetFillAmount,
+    signature
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -971,19 +712,11 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
+            const encodedData = self._strictEncodeArguments(self.fillOrKillOrder.functionSignature, [order,
     takerAssetFillAmount,
     signature
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -992,12 +725,13 @@ export class ExchangeContract extends BaseContract {
             signature: string,
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.fillOrKillOrder.functionSignature, [order,
     takerAssetFillAmount,
     signature
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)',
         async callAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             takerAssetFillAmount: BigNumber,
@@ -1007,21 +741,12 @@ export class ExchangeContract extends BaseContract {
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
+            const encodedData = self._strictEncodeArguments(self.fillOrKillOrder.functionSignature, [order,
         takerAssetFillAmount,
         signature
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.fillOrKillOrder.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         >(rawCallResult);
@@ -1036,23 +761,13 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('setSignatureValidatorApproval(address,bool)', [validatorAddress,
+            const encodedData = self._strictEncodeArguments(self.setSignatureValidatorApproval.functionSignature, [validatorAddress,
     approval
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.setSignatureValidatorApproval.estimateGasAsync.bind(
-                    self,
-                    validatorAddress,
-                    approval
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.setSignatureValidatorApproval.estimateGasAsync.bind(self, validatorAddress,
+    approval
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -1061,18 +776,10 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('setSignatureValidatorApproval(address,bool)', [validatorAddress,
+            const encodedData = self._strictEncodeArguments(self.setSignatureValidatorApproval.functionSignature, [validatorAddress,
     approval
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -1080,11 +787,12 @@ export class ExchangeContract extends BaseContract {
             approval: boolean,
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('setSignatureValidatorApproval(address,bool)', [validatorAddress,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.setSignatureValidatorApproval.functionSignature, [validatorAddress,
     approval
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'setSignatureValidatorApproval(address,bool)',
         async callAsync(
             validatorAddress: string,
             approval: boolean,
@@ -1093,20 +801,11 @@ export class ExchangeContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('setSignatureValidatorApproval(address,bool)', [validatorAddress,
+            const encodedData = self._strictEncodeArguments(self.setSignatureValidatorApproval.functionSignature, [validatorAddress,
         approval
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('setSignatureValidatorApproval(address,bool)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.setSignatureValidatorApproval.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -1115,6 +814,7 @@ export class ExchangeContract extends BaseContract {
         },
     };
     public allowedValidators = {
+        functionSignature: 'allowedValidators(address,address)',
         async callAsync(
             index_0: string,
             index_1: string,
@@ -1123,20 +823,11 @@ export class ExchangeContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('allowedValidators(address,address)', [index_0,
+            const encodedData = self._strictEncodeArguments(self.allowedValidators.functionSignature, [index_0,
         index_1
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('allowedValidators(address,address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.allowedValidators.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -1152,25 +843,15 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
+            const encodedData = self._strictEncodeArguments(self.marketSellOrders.functionSignature, [orders,
     takerAssetFillAmount,
     signatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.marketSellOrders.estimateGasAsync.bind(
-                    self,
-                    orders,
-                    takerAssetFillAmount,
-                    signatures
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.marketSellOrders.estimateGasAsync.bind(self, orders,
+    takerAssetFillAmount,
+    signatures
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -1180,19 +861,11 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
+            const encodedData = self._strictEncodeArguments(self.marketSellOrders.functionSignature, [orders,
     takerAssetFillAmount,
     signatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -1201,12 +874,13 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.marketSellOrders.functionSignature, [orders,
     takerAssetFillAmount,
     signatures
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])',
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAssetFillAmount: BigNumber,
@@ -1216,21 +890,12 @@ export class ExchangeContract extends BaseContract {
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
+            const encodedData = self._strictEncodeArguments(self.marketSellOrders.functionSignature, [orders,
         takerAssetFillAmount,
         signatures
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.marketSellOrders.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         >(rawCallResult);
@@ -1239,6 +904,7 @@ export class ExchangeContract extends BaseContract {
         },
     };
     public getOrdersInfo = {
+        functionSignature: 'getOrdersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])',
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             callData: Partial<CallData> = {},
@@ -1246,19 +912,10 @@ export class ExchangeContract extends BaseContract {
         ): Promise<Array<{orderStatus: number;orderHash: string;orderTakerAssetFilledAmount: BigNumber}>
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('getOrdersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])', [orders
+            const encodedData = self._strictEncodeArguments(self.getOrdersInfo.functionSignature, [orders
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('getOrdersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.getOrdersInfo.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<Array<{orderStatus: number;orderHash: string;orderTakerAssetFilledAmount: BigNumber}>
         >(rawCallResult);
@@ -1267,6 +924,7 @@ export class ExchangeContract extends BaseContract {
         },
     };
     public preSigned = {
+        functionSignature: 'preSigned(bytes32,address)',
         async callAsync(
             index_0: string,
             index_1: string,
@@ -1275,20 +933,11 @@ export class ExchangeContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('preSigned(bytes32,address)', [index_0,
+            const encodedData = self._strictEncodeArguments(self.preSigned.functionSignature, [index_0,
         index_1
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('preSigned(bytes32,address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.preSigned.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -1297,24 +946,16 @@ export class ExchangeContract extends BaseContract {
         },
     };
     public owner = {
+        functionSignature: 'owner()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('owner()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('owner()');
+            const encodedData = self._strictEncodeArguments(self.owner.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.owner.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -1323,6 +964,7 @@ export class ExchangeContract extends BaseContract {
         },
     };
     public isValidSignature = {
+        functionSignature: 'isValidSignature(bytes32,address,bytes)',
         async callAsync(
             hash: string,
             signerAddress: string,
@@ -1332,21 +974,12 @@ export class ExchangeContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('isValidSignature(bytes32,address,bytes)', [hash,
+            const encodedData = self._strictEncodeArguments(self.isValidSignature.functionSignature, [hash,
         signerAddress,
         signature
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('isValidSignature(bytes32,address,bytes)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.isValidSignature.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -1362,25 +995,15 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
+            const encodedData = self._strictEncodeArguments(self.marketBuyOrdersNoThrow.functionSignature, [orders,
     makerAssetFillAmount,
     signatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.marketBuyOrdersNoThrow.estimateGasAsync.bind(
-                    self,
-                    orders,
-                    makerAssetFillAmount,
-                    signatures
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.marketBuyOrdersNoThrow.estimateGasAsync.bind(self, orders,
+    makerAssetFillAmount,
+    signatures
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -1390,19 +1013,11 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
+            const encodedData = self._strictEncodeArguments(self.marketBuyOrdersNoThrow.functionSignature, [orders,
     makerAssetFillAmount,
     signatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -1411,12 +1026,13 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.marketBuyOrdersNoThrow.functionSignature, [orders,
     makerAssetFillAmount,
     signatures
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])',
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             makerAssetFillAmount: BigNumber,
@@ -1426,21 +1042,12 @@ export class ExchangeContract extends BaseContract {
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
+            const encodedData = self._strictEncodeArguments(self.marketBuyOrdersNoThrow.functionSignature, [orders,
         makerAssetFillAmount,
         signatures
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.marketBuyOrdersNoThrow.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         >(rawCallResult);
@@ -1456,25 +1063,15 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
+            const encodedData = self._strictEncodeArguments(self.fillOrder.functionSignature, [order,
     takerAssetFillAmount,
     signature
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.fillOrder.estimateGasAsync.bind(
-                    self,
-                    order,
-                    takerAssetFillAmount,
-                    signature
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.fillOrder.estimateGasAsync.bind(self, order,
+    takerAssetFillAmount,
+    signature
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -1484,19 +1081,11 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
+            const encodedData = self._strictEncodeArguments(self.fillOrder.functionSignature, [order,
     takerAssetFillAmount,
     signature
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -1505,12 +1094,13 @@ export class ExchangeContract extends BaseContract {
             signature: string,
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.fillOrder.functionSignature, [order,
     takerAssetFillAmount,
     signature
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)',
         async callAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             takerAssetFillAmount: BigNumber,
@@ -1520,21 +1110,12 @@ export class ExchangeContract extends BaseContract {
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
+            const encodedData = self._strictEncodeArguments(self.fillOrder.functionSignature, [order,
         takerAssetFillAmount,
         signature
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.fillOrder.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         >(rawCallResult);
@@ -1551,27 +1132,17 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('executeTransaction(uint256,address,bytes,bytes)', [salt,
+            const encodedData = self._strictEncodeArguments(self.executeTransaction.functionSignature, [salt,
     signerAddress,
     data,
     signature
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.executeTransaction.estimateGasAsync.bind(
-                    self,
-                    salt,
-                    signerAddress,
-                    data,
-                    signature
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.executeTransaction.estimateGasAsync.bind(self, salt,
+    signerAddress,
+    data,
+    signature
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -1582,20 +1153,12 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('executeTransaction(uint256,address,bytes,bytes)', [salt,
+            const encodedData = self._strictEncodeArguments(self.executeTransaction.functionSignature, [salt,
     signerAddress,
     data,
     signature
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -1605,13 +1168,14 @@ export class ExchangeContract extends BaseContract {
             signature: string,
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('executeTransaction(uint256,address,bytes,bytes)', [salt,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.executeTransaction.functionSignature, [salt,
     signerAddress,
     data,
     signature
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'executeTransaction(uint256,address,bytes,bytes)',
         async callAsync(
             salt: BigNumber,
             signerAddress: string,
@@ -1622,22 +1186,13 @@ export class ExchangeContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('executeTransaction(uint256,address,bytes,bytes)', [salt,
+            const encodedData = self._strictEncodeArguments(self.executeTransaction.functionSignature, [salt,
         signerAddress,
         data,
         signature
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('executeTransaction(uint256,address,bytes,bytes)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.executeTransaction.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -1651,21 +1206,11 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
+            const encodedData = self._strictEncodeArguments(self.registerAssetProxy.functionSignature, [assetProxy
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.registerAssetProxy.estimateGasAsync.bind(
-                    self,
-                    assetProxy
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.registerAssetProxy.estimateGasAsync.bind(self, assetProxy
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -1673,27 +1218,20 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
+            const encodedData = self._strictEncodeArguments(self.registerAssetProxy.functionSignature, [assetProxy
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             assetProxy: string,
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.registerAssetProxy.functionSignature, [assetProxy
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'registerAssetProxy(address)',
         async callAsync(
             assetProxy: string,
             callData: Partial<CallData> = {},
@@ -1701,19 +1239,10 @@ export class ExchangeContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
+            const encodedData = self._strictEncodeArguments(self.registerAssetProxy.functionSignature, [assetProxy
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('registerAssetProxy(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.registerAssetProxy.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -1722,6 +1251,7 @@ export class ExchangeContract extends BaseContract {
         },
     };
     public getOrderInfo = {
+        functionSignature: 'getOrderInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))',
         async callAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             callData: Partial<CallData> = {},
@@ -1729,19 +1259,10 @@ export class ExchangeContract extends BaseContract {
         ): Promise<{orderStatus: number;orderHash: string;orderTakerAssetFilledAmount: BigNumber}
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('getOrderInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
+            const encodedData = self._strictEncodeArguments(self.getOrderInfo.functionSignature, [order
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('getOrderInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.getOrderInfo.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<{orderStatus: number;orderHash: string;orderTakerAssetFilledAmount: BigNumber}
         >(rawCallResult);
@@ -1755,21 +1276,11 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('cancelOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
+            const encodedData = self._strictEncodeArguments(self.cancelOrder.functionSignature, [order
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.cancelOrder.estimateGasAsync.bind(
-                    self,
-                    order
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.cancelOrder.estimateGasAsync.bind(self, order
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -1777,27 +1288,20 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('cancelOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
+            const encodedData = self._strictEncodeArguments(self.cancelOrder.functionSignature, [order
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('cancelOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.cancelOrder.functionSignature, [order
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'cancelOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))',
         async callAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             callData: Partial<CallData> = {},
@@ -1805,19 +1309,10 @@ export class ExchangeContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('cancelOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
+            const encodedData = self._strictEncodeArguments(self.cancelOrder.functionSignature, [order
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('cancelOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.cancelOrder.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -1826,6 +1321,7 @@ export class ExchangeContract extends BaseContract {
         },
     };
     public orderEpoch = {
+        functionSignature: 'orderEpoch(address,address)',
         async callAsync(
             index_0: string,
             index_1: string,
@@ -1834,20 +1330,11 @@ export class ExchangeContract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('orderEpoch(address,address)', [index_0,
+            const encodedData = self._strictEncodeArguments(self.orderEpoch.functionSignature, [index_0,
         index_1
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('orderEpoch(address,address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.orderEpoch.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -1856,24 +1343,16 @@ export class ExchangeContract extends BaseContract {
         },
     };
     public ZRX_ASSET_DATA = {
+        functionSignature: 'ZRX_ASSET_DATA()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('ZRX_ASSET_DATA()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('ZRX_ASSET_DATA()');
+            const encodedData = self._strictEncodeArguments(self.ZRX_ASSET_DATA.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.ZRX_ASSET_DATA.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -1889,25 +1368,15 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
+            const encodedData = self._strictEncodeArguments(self.marketSellOrdersNoThrow.functionSignature, [orders,
     takerAssetFillAmount,
     signatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.marketSellOrdersNoThrow.estimateGasAsync.bind(
-                    self,
-                    orders,
-                    takerAssetFillAmount,
-                    signatures
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.marketSellOrdersNoThrow.estimateGasAsync.bind(self, orders,
+    takerAssetFillAmount,
+    signatures
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -1917,19 +1386,11 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
+            const encodedData = self._strictEncodeArguments(self.marketSellOrdersNoThrow.functionSignature, [orders,
     takerAssetFillAmount,
     signatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -1938,12 +1399,13 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.marketSellOrdersNoThrow.functionSignature, [orders,
     takerAssetFillAmount,
     signatures
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])',
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAssetFillAmount: BigNumber,
@@ -1953,21 +1415,12 @@ export class ExchangeContract extends BaseContract {
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
+            const encodedData = self._strictEncodeArguments(self.marketSellOrdersNoThrow.functionSignature, [orders,
         takerAssetFillAmount,
         signatures
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.marketSellOrdersNoThrow.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         >(rawCallResult);
@@ -1976,24 +1429,16 @@ export class ExchangeContract extends BaseContract {
         },
     };
     public EIP712_DOMAIN_HASH = {
+        functionSignature: 'EIP712_DOMAIN_HASH()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('EIP712_DOMAIN_HASH()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('EIP712_DOMAIN_HASH()');
+            const encodedData = self._strictEncodeArguments(self.EIP712_DOMAIN_HASH.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.EIP712_DOMAIN_HASH.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -2009,25 +1454,15 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
+            const encodedData = self._strictEncodeArguments(self.marketBuyOrders.functionSignature, [orders,
     makerAssetFillAmount,
     signatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.marketBuyOrders.estimateGasAsync.bind(
-                    self,
-                    orders,
-                    makerAssetFillAmount,
-                    signatures
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.marketBuyOrders.estimateGasAsync.bind(self, orders,
+    makerAssetFillAmount,
+    signatures
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -2037,19 +1472,11 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
+            const encodedData = self._strictEncodeArguments(self.marketBuyOrders.functionSignature, [orders,
     makerAssetFillAmount,
     signatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -2058,12 +1485,13 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.marketBuyOrders.functionSignature, [orders,
     makerAssetFillAmount,
     signatures
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])',
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             makerAssetFillAmount: BigNumber,
@@ -2073,21 +1501,12 @@ export class ExchangeContract extends BaseContract {
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
+            const encodedData = self._strictEncodeArguments(self.marketBuyOrders.functionSignature, [orders,
         makerAssetFillAmount,
         signatures
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.marketBuyOrders.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         >(rawCallResult);
@@ -2096,24 +1515,16 @@ export class ExchangeContract extends BaseContract {
         },
     };
     public currentContextAddress = {
+        functionSignature: 'currentContextAddress()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('currentContextAddress()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('currentContextAddress()');
+            const encodedData = self._strictEncodeArguments(self.currentContextAddress.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.currentContextAddress.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -2127,21 +1538,11 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transferOwnership.estimateGasAsync.bind(
-                    self,
-                    newOwner
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.transferOwnership.estimateGasAsync.bind(self, newOwner
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -2149,27 +1550,20 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             newOwner: string,
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'transferOwnership(address)',
         async callAsync(
             newOwner: string,
             callData: Partial<CallData> = {},
@@ -2177,19 +1571,10 @@ export class ExchangeContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('transferOwnership(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.transferOwnership.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -2198,24 +1583,16 @@ export class ExchangeContract extends BaseContract {
         },
     };
     public VERSION = {
+        functionSignature: 'VERSION()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('VERSION()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('VERSION()');
+            const encodedData = self._strictEncodeArguments(self.VERSION.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.VERSION.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -2229,7 +1606,7 @@ export class ExchangeContract extends BaseContract {
         txDefaults: Partial<TxData>,
             _zrxAssetData: string,
     ): Promise<ExchangeContract> {
-        if (_.isUndefined(artifact.compilerOutput)) {
+        if (isUndefined(artifact.compilerOutput)) {
             throw new Error('Compiler output not found in the artifact file');
         }
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
@@ -2254,27 +1631,10 @@ export class ExchangeContract extends BaseContract {
 ],
             BaseContract._bigNumberToString,
         );
-        const iface = new ethers.utils.Interface(abi);
-        const deployInfo = iface.deployFunction;
-        const txData = deployInfo.encode(bytecode, [_zrxAssetData
-]);
-        const web3Wrapper = new Web3Wrapper(provider);
-        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-            {data: txData},
-            txDefaults,
-            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
-        );
-        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-        logUtils.log(`transactionHash: ${txHash}`);
-        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
-        logUtils.log(`Exchange successfully deployed at ${txReceipt.contractAddress}`);
-        const contractInstance = new ExchangeContract(abi, txReceipt.contractAddress as string, provider, txDefaults);
-        contractInstance.constructorArgs = [_zrxAssetData
-];
-        return contractInstance;
+        return {} as any;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
-        super('Exchange', abi, address, providerUtils.standardizeOrThrow(supportedProvider), txDefaults);
+        super('Exchange', abi, address, supportedProvider, txDefaults);
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count

--- a/packages/abi-gen-wrappers/src/generated-wrappers/exchange.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/exchange.ts
@@ -3,7 +3,7 @@
 // tslint:disable:no-unbound-method
 import { BaseContract } from '@0x/base-contract';
 import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact, DecodedLogArgs, MethodAbi, TxData, TxDataPayable, SupportedProvider } from 'ethereum-types';
-import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
+import { AbiEncoder, BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 import { isUndefined } from 'lodash';
@@ -1631,7 +1631,23 @@ export class ExchangeContract extends BaseContract {
 ],
             BaseContract._bigNumberToString,
         );
-        return {} as any;
+        const encoder = new AbiEncoder.Constructor(constructorAbi);
+        const txData = encoder.encode(bytecode, [_zrxAssetData
+]);
+        const web3Wrapper = new Web3Wrapper(provider);
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {data: txData},
+            txDefaults,
+            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
+        );
+        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        logUtils.log(`transactionHash: ${txHash}`);
+        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
+        logUtils.log(`Exchange successfully deployed at ${txReceipt.contractAddress}`);
+        const contractInstance = new ExchangeContract(abi, txReceipt.contractAddress as string, provider, txDefaults);
+        contractInstance.constructorArgs = [_zrxAssetData
+];
+        return contractInstance;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
         super('Exchange', abi, address, supportedProvider, txDefaults);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/exchange.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/exchange.ts
@@ -70,7 +70,6 @@ export interface ExchangeAssetProxyRegisteredEventArgs extends DecodedLogArgs {
 // tslint:disable-next-line:class-name
 export class ExchangeContract extends BaseContract {
     public filled = {
-        functionSignature: 'filled(bytes32)',
         async callAsync(
             index_0: string,
             callData: Partial<CallData> = {},
@@ -78,10 +77,10 @@ export class ExchangeContract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.filled.functionSignature, [index_0
+            const encodedData = self._strictEncodeArguments('filled(bytes32)', [index_0
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.filled.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('filled(bytes32)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -97,7 +96,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.batchFillOrders.functionSignature, [orders,
+            const encodedData = self._strictEncodeArguments('batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
@@ -115,7 +114,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.batchFillOrders.functionSignature, [orders,
+            const encodedData = self._strictEncodeArguments('batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
@@ -128,13 +127,12 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.batchFillOrders.functionSignature, [orders,
+            const abiEncodedTransactionData = self._strictEncodeArguments('batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])',
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAssetFillAmounts: BigNumber[],
@@ -144,12 +142,12 @@ export class ExchangeContract extends BaseContract {
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.batchFillOrders.functionSignature, [orders,
+            const encodedData = self._strictEncodeArguments('batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
         takerAssetFillAmounts,
         signatures
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.batchFillOrders.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         >(rawCallResult);
@@ -158,7 +156,6 @@ export class ExchangeContract extends BaseContract {
         },
     };
     public cancelled = {
-        functionSignature: 'cancelled(bytes32)',
         async callAsync(
             index_0: string,
             callData: Partial<CallData> = {},
@@ -166,10 +163,10 @@ export class ExchangeContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.cancelled.functionSignature, [index_0
+            const encodedData = self._strictEncodeArguments('cancelled(bytes32)', [index_0
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.cancelled.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('cancelled(bytes32)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -185,7 +182,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.preSign.functionSignature, [hash,
+            const encodedData = self._strictEncodeArguments('preSign(bytes32,address,bytes)', [hash,
     signerAddress,
     signature
     ]);
@@ -203,7 +200,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.preSign.functionSignature, [hash,
+            const encodedData = self._strictEncodeArguments('preSign(bytes32,address,bytes)', [hash,
     signerAddress,
     signature
     ]);
@@ -216,13 +213,12 @@ export class ExchangeContract extends BaseContract {
             signature: string,
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.preSign.functionSignature, [hash,
+            const abiEncodedTransactionData = self._strictEncodeArguments('preSign(bytes32,address,bytes)', [hash,
     signerAddress,
     signature
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'preSign(bytes32,address,bytes)',
         async callAsync(
             hash: string,
             signerAddress: string,
@@ -232,12 +228,12 @@ export class ExchangeContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.preSign.functionSignature, [hash,
+            const encodedData = self._strictEncodeArguments('preSign(bytes32,address,bytes)', [hash,
         signerAddress,
         signature
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.preSign.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('preSign(bytes32,address,bytes)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -254,7 +250,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.matchOrders.functionSignature, [leftOrder,
+            const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [leftOrder,
     rightOrder,
     leftSignature,
     rightSignature
@@ -275,7 +271,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.matchOrders.functionSignature, [leftOrder,
+            const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [leftOrder,
     rightOrder,
     leftSignature,
     rightSignature
@@ -290,14 +286,13 @@ export class ExchangeContract extends BaseContract {
             rightSignature: string,
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.matchOrders.functionSignature, [leftOrder,
+            const abiEncodedTransactionData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [leftOrder,
     rightOrder,
     leftSignature,
     rightSignature
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)',
         async callAsync(
             leftOrder: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             rightOrder: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
@@ -308,13 +303,13 @@ export class ExchangeContract extends BaseContract {
         ): Promise<{left: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};right: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};leftMakerAssetSpreadAmount: BigNumber}
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.matchOrders.functionSignature, [leftOrder,
+            const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [leftOrder,
         rightOrder,
         leftSignature,
         rightSignature
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.matchOrders.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<{left: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};right: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};leftMakerAssetSpreadAmount: BigNumber}
         >(rawCallResult);
@@ -330,7 +325,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.fillOrderNoThrow.functionSignature, [order,
+            const encodedData = self._strictEncodeArguments('fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
@@ -348,7 +343,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.fillOrderNoThrow.functionSignature, [order,
+            const encodedData = self._strictEncodeArguments('fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
@@ -361,13 +356,12 @@ export class ExchangeContract extends BaseContract {
             signature: string,
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.fillOrderNoThrow.functionSignature, [order,
+            const abiEncodedTransactionData = self._strictEncodeArguments('fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)',
         async callAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             takerAssetFillAmount: BigNumber,
@@ -377,12 +371,12 @@ export class ExchangeContract extends BaseContract {
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.fillOrderNoThrow.functionSignature, [order,
+            const encodedData = self._strictEncodeArguments('fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
         takerAssetFillAmount,
         signature
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.fillOrderNoThrow.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         >(rawCallResult);
@@ -391,7 +385,6 @@ export class ExchangeContract extends BaseContract {
         },
     };
     public assetProxies = {
-        functionSignature: 'assetProxies(bytes4)',
         async callAsync(
             index_0: string,
             callData: Partial<CallData> = {},
@@ -399,10 +392,10 @@ export class ExchangeContract extends BaseContract {
         ): Promise<string
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.assetProxies.functionSignature, [index_0
+            const encodedData = self._strictEncodeArguments('assetProxies(bytes4)', [index_0
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.assetProxies.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('assetProxies(bytes4)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -416,7 +409,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.batchCancelOrders.functionSignature, [orders
+            const encodedData = self._strictEncodeArguments('batchCancelOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])', [orders
     ]);
             const gasEstimateFunction = self.batchCancelOrders.estimateGasAsync.bind(self, orders
     );
@@ -428,7 +421,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.batchCancelOrders.functionSignature, [orders
+            const encodedData = self._strictEncodeArguments('batchCancelOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])', [orders
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -437,11 +430,10 @@ export class ExchangeContract extends BaseContract {
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.batchCancelOrders.functionSignature, [orders
+            const abiEncodedTransactionData = self._strictEncodeArguments('batchCancelOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])', [orders
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'batchCancelOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])',
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             callData: Partial<CallData> = {},
@@ -449,10 +441,10 @@ export class ExchangeContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.batchCancelOrders.functionSignature, [orders
+            const encodedData = self._strictEncodeArguments('batchCancelOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])', [orders
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.batchCancelOrders.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('batchCancelOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -468,7 +460,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.batchFillOrKillOrders.functionSignature, [orders,
+            const encodedData = self._strictEncodeArguments('batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
@@ -486,7 +478,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.batchFillOrKillOrders.functionSignature, [orders,
+            const encodedData = self._strictEncodeArguments('batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
@@ -499,13 +491,12 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.batchFillOrKillOrders.functionSignature, [orders,
+            const abiEncodedTransactionData = self._strictEncodeArguments('batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])',
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAssetFillAmounts: BigNumber[],
@@ -515,12 +506,12 @@ export class ExchangeContract extends BaseContract {
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.batchFillOrKillOrders.functionSignature, [orders,
+            const encodedData = self._strictEncodeArguments('batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
         takerAssetFillAmounts,
         signatures
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.batchFillOrKillOrders.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         >(rawCallResult);
@@ -534,7 +525,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.cancelOrdersUpTo.functionSignature, [targetOrderEpoch
+            const encodedData = self._strictEncodeArguments('cancelOrdersUpTo(uint256)', [targetOrderEpoch
     ]);
             const gasEstimateFunction = self.cancelOrdersUpTo.estimateGasAsync.bind(self, targetOrderEpoch
     );
@@ -546,7 +537,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.cancelOrdersUpTo.functionSignature, [targetOrderEpoch
+            const encodedData = self._strictEncodeArguments('cancelOrdersUpTo(uint256)', [targetOrderEpoch
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -555,11 +546,10 @@ export class ExchangeContract extends BaseContract {
             targetOrderEpoch: BigNumber,
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.cancelOrdersUpTo.functionSignature, [targetOrderEpoch
+            const abiEncodedTransactionData = self._strictEncodeArguments('cancelOrdersUpTo(uint256)', [targetOrderEpoch
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'cancelOrdersUpTo(uint256)',
         async callAsync(
             targetOrderEpoch: BigNumber,
             callData: Partial<CallData> = {},
@@ -567,10 +557,10 @@ export class ExchangeContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.cancelOrdersUpTo.functionSignature, [targetOrderEpoch
+            const encodedData = self._strictEncodeArguments('cancelOrdersUpTo(uint256)', [targetOrderEpoch
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.cancelOrdersUpTo.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('cancelOrdersUpTo(uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -586,7 +576,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.batchFillOrdersNoThrow.functionSignature, [orders,
+            const encodedData = self._strictEncodeArguments('batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
@@ -604,7 +594,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.batchFillOrdersNoThrow.functionSignature, [orders,
+            const encodedData = self._strictEncodeArguments('batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
@@ -617,13 +607,12 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.batchFillOrdersNoThrow.functionSignature, [orders,
+            const abiEncodedTransactionData = self._strictEncodeArguments('batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])',
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAssetFillAmounts: BigNumber[],
@@ -633,12 +622,12 @@ export class ExchangeContract extends BaseContract {
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.batchFillOrdersNoThrow.functionSignature, [orders,
+            const encodedData = self._strictEncodeArguments('batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
         takerAssetFillAmounts,
         signatures
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.batchFillOrdersNoThrow.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         >(rawCallResult);
@@ -647,7 +636,6 @@ export class ExchangeContract extends BaseContract {
         },
     };
     public getAssetProxy = {
-        functionSignature: 'getAssetProxy(bytes4)',
         async callAsync(
             assetProxyId: string,
             callData: Partial<CallData> = {},
@@ -655,10 +643,10 @@ export class ExchangeContract extends BaseContract {
         ): Promise<string
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.getAssetProxy.functionSignature, [assetProxyId
+            const encodedData = self._strictEncodeArguments('getAssetProxy(bytes4)', [assetProxyId
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.getAssetProxy.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('getAssetProxy(bytes4)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -667,7 +655,6 @@ export class ExchangeContract extends BaseContract {
         },
     };
     public transactions = {
-        functionSignature: 'transactions(bytes32)',
         async callAsync(
             index_0: string,
             callData: Partial<CallData> = {},
@@ -675,10 +662,10 @@ export class ExchangeContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.transactions.functionSignature, [index_0
+            const encodedData = self._strictEncodeArguments('transactions(bytes32)', [index_0
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.transactions.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('transactions(bytes32)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -694,7 +681,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.fillOrKillOrder.functionSignature, [order,
+            const encodedData = self._strictEncodeArguments('fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
@@ -712,7 +699,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.fillOrKillOrder.functionSignature, [order,
+            const encodedData = self._strictEncodeArguments('fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
@@ -725,13 +712,12 @@ export class ExchangeContract extends BaseContract {
             signature: string,
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.fillOrKillOrder.functionSignature, [order,
+            const abiEncodedTransactionData = self._strictEncodeArguments('fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)',
         async callAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             takerAssetFillAmount: BigNumber,
@@ -741,12 +727,12 @@ export class ExchangeContract extends BaseContract {
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.fillOrKillOrder.functionSignature, [order,
+            const encodedData = self._strictEncodeArguments('fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
         takerAssetFillAmount,
         signature
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.fillOrKillOrder.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         >(rawCallResult);
@@ -761,7 +747,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.setSignatureValidatorApproval.functionSignature, [validatorAddress,
+            const encodedData = self._strictEncodeArguments('setSignatureValidatorApproval(address,bool)', [validatorAddress,
     approval
     ]);
             const gasEstimateFunction = self.setSignatureValidatorApproval.estimateGasAsync.bind(self, validatorAddress,
@@ -776,7 +762,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.setSignatureValidatorApproval.functionSignature, [validatorAddress,
+            const encodedData = self._strictEncodeArguments('setSignatureValidatorApproval(address,bool)', [validatorAddress,
     approval
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
@@ -787,12 +773,11 @@ export class ExchangeContract extends BaseContract {
             approval: boolean,
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.setSignatureValidatorApproval.functionSignature, [validatorAddress,
+            const abiEncodedTransactionData = self._strictEncodeArguments('setSignatureValidatorApproval(address,bool)', [validatorAddress,
     approval
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'setSignatureValidatorApproval(address,bool)',
         async callAsync(
             validatorAddress: string,
             approval: boolean,
@@ -801,11 +786,11 @@ export class ExchangeContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.setSignatureValidatorApproval.functionSignature, [validatorAddress,
+            const encodedData = self._strictEncodeArguments('setSignatureValidatorApproval(address,bool)', [validatorAddress,
         approval
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.setSignatureValidatorApproval.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('setSignatureValidatorApproval(address,bool)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -814,7 +799,6 @@ export class ExchangeContract extends BaseContract {
         },
     };
     public allowedValidators = {
-        functionSignature: 'allowedValidators(address,address)',
         async callAsync(
             index_0: string,
             index_1: string,
@@ -823,11 +807,11 @@ export class ExchangeContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.allowedValidators.functionSignature, [index_0,
+            const encodedData = self._strictEncodeArguments('allowedValidators(address,address)', [index_0,
         index_1
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.allowedValidators.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('allowedValidators(address,address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -843,7 +827,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.marketSellOrders.functionSignature, [orders,
+            const encodedData = self._strictEncodeArguments('marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
     signatures
     ]);
@@ -861,7 +845,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.marketSellOrders.functionSignature, [orders,
+            const encodedData = self._strictEncodeArguments('marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
     signatures
     ]);
@@ -874,13 +858,12 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.marketSellOrders.functionSignature, [orders,
+            const abiEncodedTransactionData = self._strictEncodeArguments('marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
     signatures
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])',
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAssetFillAmount: BigNumber,
@@ -890,12 +873,12 @@ export class ExchangeContract extends BaseContract {
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.marketSellOrders.functionSignature, [orders,
+            const encodedData = self._strictEncodeArguments('marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
         takerAssetFillAmount,
         signatures
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.marketSellOrders.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         >(rawCallResult);
@@ -904,7 +887,6 @@ export class ExchangeContract extends BaseContract {
         },
     };
     public getOrdersInfo = {
-        functionSignature: 'getOrdersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])',
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             callData: Partial<CallData> = {},
@@ -912,10 +894,10 @@ export class ExchangeContract extends BaseContract {
         ): Promise<Array<{orderStatus: number;orderHash: string;orderTakerAssetFilledAmount: BigNumber}>
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.getOrdersInfo.functionSignature, [orders
+            const encodedData = self._strictEncodeArguments('getOrdersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])', [orders
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.getOrdersInfo.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('getOrdersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<Array<{orderStatus: number;orderHash: string;orderTakerAssetFilledAmount: BigNumber}>
         >(rawCallResult);
@@ -924,7 +906,6 @@ export class ExchangeContract extends BaseContract {
         },
     };
     public preSigned = {
-        functionSignature: 'preSigned(bytes32,address)',
         async callAsync(
             index_0: string,
             index_1: string,
@@ -933,11 +914,11 @@ export class ExchangeContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.preSigned.functionSignature, [index_0,
+            const encodedData = self._strictEncodeArguments('preSigned(bytes32,address)', [index_0,
         index_1
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.preSigned.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('preSigned(bytes32,address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -946,16 +927,15 @@ export class ExchangeContract extends BaseContract {
         },
     };
     public owner = {
-        functionSignature: 'owner()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.owner.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('owner()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.owner.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('owner()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -964,7 +944,6 @@ export class ExchangeContract extends BaseContract {
         },
     };
     public isValidSignature = {
-        functionSignature: 'isValidSignature(bytes32,address,bytes)',
         async callAsync(
             hash: string,
             signerAddress: string,
@@ -974,12 +953,12 @@ export class ExchangeContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.isValidSignature.functionSignature, [hash,
+            const encodedData = self._strictEncodeArguments('isValidSignature(bytes32,address,bytes)', [hash,
         signerAddress,
         signature
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.isValidSignature.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('isValidSignature(bytes32,address,bytes)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -995,7 +974,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.marketBuyOrdersNoThrow.functionSignature, [orders,
+            const encodedData = self._strictEncodeArguments('marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
     signatures
     ]);
@@ -1013,7 +992,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.marketBuyOrdersNoThrow.functionSignature, [orders,
+            const encodedData = self._strictEncodeArguments('marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
     signatures
     ]);
@@ -1026,13 +1005,12 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.marketBuyOrdersNoThrow.functionSignature, [orders,
+            const abiEncodedTransactionData = self._strictEncodeArguments('marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
     signatures
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])',
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             makerAssetFillAmount: BigNumber,
@@ -1042,12 +1020,12 @@ export class ExchangeContract extends BaseContract {
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.marketBuyOrdersNoThrow.functionSignature, [orders,
+            const encodedData = self._strictEncodeArguments('marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
         makerAssetFillAmount,
         signatures
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.marketBuyOrdersNoThrow.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         >(rawCallResult);
@@ -1063,7 +1041,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.fillOrder.functionSignature, [order,
+            const encodedData = self._strictEncodeArguments('fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
@@ -1081,7 +1059,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.fillOrder.functionSignature, [order,
+            const encodedData = self._strictEncodeArguments('fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
@@ -1094,13 +1072,12 @@ export class ExchangeContract extends BaseContract {
             signature: string,
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.fillOrder.functionSignature, [order,
+            const abiEncodedTransactionData = self._strictEncodeArguments('fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)',
         async callAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             takerAssetFillAmount: BigNumber,
@@ -1110,12 +1087,12 @@ export class ExchangeContract extends BaseContract {
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.fillOrder.functionSignature, [order,
+            const encodedData = self._strictEncodeArguments('fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
         takerAssetFillAmount,
         signature
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.fillOrder.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         >(rawCallResult);
@@ -1132,7 +1109,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.executeTransaction.functionSignature, [salt,
+            const encodedData = self._strictEncodeArguments('executeTransaction(uint256,address,bytes,bytes)', [salt,
     signerAddress,
     data,
     signature
@@ -1153,7 +1130,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.executeTransaction.functionSignature, [salt,
+            const encodedData = self._strictEncodeArguments('executeTransaction(uint256,address,bytes,bytes)', [salt,
     signerAddress,
     data,
     signature
@@ -1168,14 +1145,13 @@ export class ExchangeContract extends BaseContract {
             signature: string,
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.executeTransaction.functionSignature, [salt,
+            const abiEncodedTransactionData = self._strictEncodeArguments('executeTransaction(uint256,address,bytes,bytes)', [salt,
     signerAddress,
     data,
     signature
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'executeTransaction(uint256,address,bytes,bytes)',
         async callAsync(
             salt: BigNumber,
             signerAddress: string,
@@ -1186,13 +1162,13 @@ export class ExchangeContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.executeTransaction.functionSignature, [salt,
+            const encodedData = self._strictEncodeArguments('executeTransaction(uint256,address,bytes,bytes)', [salt,
         signerAddress,
         data,
         signature
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.executeTransaction.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('executeTransaction(uint256,address,bytes,bytes)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -1206,7 +1182,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.registerAssetProxy.functionSignature, [assetProxy
+            const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
     ]);
             const gasEstimateFunction = self.registerAssetProxy.estimateGasAsync.bind(self, assetProxy
     );
@@ -1218,7 +1194,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.registerAssetProxy.functionSignature, [assetProxy
+            const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -1227,11 +1203,10 @@ export class ExchangeContract extends BaseContract {
             assetProxy: string,
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.registerAssetProxy.functionSignature, [assetProxy
+            const abiEncodedTransactionData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'registerAssetProxy(address)',
         async callAsync(
             assetProxy: string,
             callData: Partial<CallData> = {},
@@ -1239,10 +1214,10 @@ export class ExchangeContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.registerAssetProxy.functionSignature, [assetProxy
+            const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.registerAssetProxy.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('registerAssetProxy(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -1251,7 +1226,6 @@ export class ExchangeContract extends BaseContract {
         },
     };
     public getOrderInfo = {
-        functionSignature: 'getOrderInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))',
         async callAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             callData: Partial<CallData> = {},
@@ -1259,10 +1233,10 @@ export class ExchangeContract extends BaseContract {
         ): Promise<{orderStatus: number;orderHash: string;orderTakerAssetFilledAmount: BigNumber}
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.getOrderInfo.functionSignature, [order
+            const encodedData = self._strictEncodeArguments('getOrderInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.getOrderInfo.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('getOrderInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<{orderStatus: number;orderHash: string;orderTakerAssetFilledAmount: BigNumber}
         >(rawCallResult);
@@ -1276,7 +1250,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.cancelOrder.functionSignature, [order
+            const encodedData = self._strictEncodeArguments('cancelOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
     ]);
             const gasEstimateFunction = self.cancelOrder.estimateGasAsync.bind(self, order
     );
@@ -1288,7 +1262,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.cancelOrder.functionSignature, [order
+            const encodedData = self._strictEncodeArguments('cancelOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -1297,11 +1271,10 @@ export class ExchangeContract extends BaseContract {
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.cancelOrder.functionSignature, [order
+            const abiEncodedTransactionData = self._strictEncodeArguments('cancelOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'cancelOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))',
         async callAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             callData: Partial<CallData> = {},
@@ -1309,10 +1282,10 @@ export class ExchangeContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.cancelOrder.functionSignature, [order
+            const encodedData = self._strictEncodeArguments('cancelOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.cancelOrder.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('cancelOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -1321,7 +1294,6 @@ export class ExchangeContract extends BaseContract {
         },
     };
     public orderEpoch = {
-        functionSignature: 'orderEpoch(address,address)',
         async callAsync(
             index_0: string,
             index_1: string,
@@ -1330,11 +1302,11 @@ export class ExchangeContract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.orderEpoch.functionSignature, [index_0,
+            const encodedData = self._strictEncodeArguments('orderEpoch(address,address)', [index_0,
         index_1
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.orderEpoch.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('orderEpoch(address,address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -1343,16 +1315,15 @@ export class ExchangeContract extends BaseContract {
         },
     };
     public ZRX_ASSET_DATA = {
-        functionSignature: 'ZRX_ASSET_DATA()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.ZRX_ASSET_DATA.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('ZRX_ASSET_DATA()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.ZRX_ASSET_DATA.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('ZRX_ASSET_DATA()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -1368,7 +1339,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.marketSellOrdersNoThrow.functionSignature, [orders,
+            const encodedData = self._strictEncodeArguments('marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
     signatures
     ]);
@@ -1386,7 +1357,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.marketSellOrdersNoThrow.functionSignature, [orders,
+            const encodedData = self._strictEncodeArguments('marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
     signatures
     ]);
@@ -1399,13 +1370,12 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.marketSellOrdersNoThrow.functionSignature, [orders,
+            const abiEncodedTransactionData = self._strictEncodeArguments('marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
     signatures
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])',
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAssetFillAmount: BigNumber,
@@ -1415,12 +1385,12 @@ export class ExchangeContract extends BaseContract {
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.marketSellOrdersNoThrow.functionSignature, [orders,
+            const encodedData = self._strictEncodeArguments('marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
         takerAssetFillAmount,
         signatures
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.marketSellOrdersNoThrow.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         >(rawCallResult);
@@ -1429,16 +1399,15 @@ export class ExchangeContract extends BaseContract {
         },
     };
     public EIP712_DOMAIN_HASH = {
-        functionSignature: 'EIP712_DOMAIN_HASH()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.EIP712_DOMAIN_HASH.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('EIP712_DOMAIN_HASH()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.EIP712_DOMAIN_HASH.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('EIP712_DOMAIN_HASH()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -1454,7 +1423,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.marketBuyOrders.functionSignature, [orders,
+            const encodedData = self._strictEncodeArguments('marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
     signatures
     ]);
@@ -1472,7 +1441,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.marketBuyOrders.functionSignature, [orders,
+            const encodedData = self._strictEncodeArguments('marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
     signatures
     ]);
@@ -1485,13 +1454,12 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.marketBuyOrders.functionSignature, [orders,
+            const abiEncodedTransactionData = self._strictEncodeArguments('marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
     signatures
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])',
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             makerAssetFillAmount: BigNumber,
@@ -1501,12 +1469,12 @@ export class ExchangeContract extends BaseContract {
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.marketBuyOrders.functionSignature, [orders,
+            const encodedData = self._strictEncodeArguments('marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
         makerAssetFillAmount,
         signatures
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.marketBuyOrders.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         >(rawCallResult);
@@ -1515,16 +1483,15 @@ export class ExchangeContract extends BaseContract {
         },
     };
     public currentContextAddress = {
-        functionSignature: 'currentContextAddress()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.currentContextAddress.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('currentContextAddress()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.currentContextAddress.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('currentContextAddress()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -1538,7 +1505,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
             const gasEstimateFunction = self.transferOwnership.estimateGasAsync.bind(self, newOwner
     );
@@ -1550,7 +1517,7 @@ export class ExchangeContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -1559,11 +1526,10 @@ export class ExchangeContract extends BaseContract {
             newOwner: string,
         ): string {
             const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'transferOwnership(address)',
         async callAsync(
             newOwner: string,
             callData: Partial<CallData> = {},
@@ -1571,10 +1537,10 @@ export class ExchangeContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.transferOwnership.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('transferOwnership(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -1583,16 +1549,15 @@ export class ExchangeContract extends BaseContract {
         },
     };
     public VERSION = {
-        functionSignature: 'VERSION()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments(self.VERSION.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('VERSION()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.VERSION.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('VERSION()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/forwarder.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/forwarder.ts
@@ -3,7 +3,7 @@
 // tslint:disable:no-unbound-method
 import { BaseContract } from '@0x/base-contract';
 import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact, DecodedLogArgs, MethodAbi, TxData, TxDataPayable, SupportedProvider } from 'ethereum-types';
-import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
+import { AbiEncoder, BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 import { isUndefined } from 'lodash';
@@ -381,7 +381,27 @@ _wethAssetData
 ],
             BaseContract._bigNumberToString,
         );
-        return {} as any;
+        const encoder = new AbiEncoder.Constructor(constructorAbi);
+        const txData = encoder.encode(bytecode, [_exchange,
+_zrxAssetData,
+_wethAssetData
+]);
+        const web3Wrapper = new Web3Wrapper(provider);
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {data: txData},
+            txDefaults,
+            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
+        );
+        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        logUtils.log(`transactionHash: ${txHash}`);
+        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
+        logUtils.log(`Forwarder successfully deployed at ${txReceipt.contractAddress}`);
+        const contractInstance = new ForwarderContract(abi, txReceipt.contractAddress as string, provider, txDefaults);
+        contractInstance.constructorArgs = [_exchange,
+_zrxAssetData,
+_wethAssetData
+];
+        return contractInstance;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
         super('Forwarder', abi, address, supportedProvider, txDefaults);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/forwarder.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/forwarder.ts
@@ -6,8 +6,7 @@ import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact,
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
-import * as ethers from 'ethers';
-import * as _ from 'lodash';
+import { isUndefined } from 'lodash';
 // tslint:enable:no-unused-variable
 
 
@@ -27,7 +26,7 @@ export class ForwarderContract extends BaseContract {
             txData: Partial<TxDataPayable> = {},
         ): Promise<string> {
             const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments('marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
+            const encodedData = self._strictEncodeArguments(self.marketBuyOrdersWithEth.functionSignature, [orders,
     makerAssetFillAmount,
     signatures,
     feeOrders,
@@ -35,25 +34,15 @@ export class ForwarderContract extends BaseContract {
     feePercentage,
     feeRecipient
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.marketBuyOrdersWithEth.estimateGasAsync.bind(
-                    self,
-                    orders,
-                    makerAssetFillAmount,
-                    signatures,
-                    feeOrders,
-                    feeSignatures,
-                    feePercentage,
-                    feeRecipient
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.marketBuyOrdersWithEth.estimateGasAsync.bind(self, orders,
+    makerAssetFillAmount,
+    signatures,
+    feeOrders,
+    feeSignatures,
+    feePercentage,
+    feeRecipient
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -67,7 +56,7 @@ export class ForwarderContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments('marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
+            const encodedData = self._strictEncodeArguments(self.marketBuyOrdersWithEth.functionSignature, [orders,
     makerAssetFillAmount,
     signatures,
     feeOrders,
@@ -75,15 +64,7 @@ export class ForwarderContract extends BaseContract {
     feePercentage,
     feeRecipient
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -96,7 +77,7 @@ export class ForwarderContract extends BaseContract {
             feeRecipient: string,
         ): string {
             const self = this as any as ForwarderContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.marketBuyOrdersWithEth.functionSignature, [orders,
     makerAssetFillAmount,
     signatures,
     feeOrders,
@@ -106,6 +87,7 @@ export class ForwarderContract extends BaseContract {
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)',
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             makerAssetFillAmount: BigNumber,
@@ -119,7 +101,7 @@ export class ForwarderContract extends BaseContract {
         ): Promise<[{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}, {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}]
         > {
             const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments('marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
+            const encodedData = self._strictEncodeArguments(self.marketBuyOrdersWithEth.functionSignature, [orders,
         makerAssetFillAmount,
         signatures,
         feeOrders,
@@ -127,17 +109,8 @@ export class ForwarderContract extends BaseContract {
         feePercentage,
         feeRecipient
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.marketBuyOrdersWithEth.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<[{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}, {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}]
         >(rawCallResult);
@@ -152,23 +125,13 @@ export class ForwarderContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments('withdrawAsset(bytes,uint256)', [assetData,
+            const encodedData = self._strictEncodeArguments(self.withdrawAsset.functionSignature, [assetData,
     amount
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.withdrawAsset.estimateGasAsync.bind(
-                    self,
-                    assetData,
-                    amount
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.withdrawAsset.estimateGasAsync.bind(self, assetData,
+    amount
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -177,18 +140,10 @@ export class ForwarderContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments('withdrawAsset(bytes,uint256)', [assetData,
+            const encodedData = self._strictEncodeArguments(self.withdrawAsset.functionSignature, [assetData,
     amount
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -196,11 +151,12 @@ export class ForwarderContract extends BaseContract {
             amount: BigNumber,
         ): string {
             const self = this as any as ForwarderContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('withdrawAsset(bytes,uint256)', [assetData,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.withdrawAsset.functionSignature, [assetData,
     amount
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'withdrawAsset(bytes,uint256)',
         async callAsync(
             assetData: string,
             amount: BigNumber,
@@ -209,20 +165,11 @@ export class ForwarderContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments('withdrawAsset(bytes,uint256)', [assetData,
+            const encodedData = self._strictEncodeArguments(self.withdrawAsset.functionSignature, [assetData,
         amount
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('withdrawAsset(bytes,uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.withdrawAsset.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -231,24 +178,16 @@ export class ForwarderContract extends BaseContract {
         },
     };
     public owner = {
+        functionSignature: 'owner()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments('owner()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('owner()');
+            const encodedData = self._strictEncodeArguments(self.owner.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.owner.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -267,31 +206,21 @@ export class ForwarderContract extends BaseContract {
             txData: Partial<TxDataPayable> = {},
         ): Promise<string> {
             const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments('marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
+            const encodedData = self._strictEncodeArguments(self.marketSellOrdersWithEth.functionSignature, [orders,
     signatures,
     feeOrders,
     feeSignatures,
     feePercentage,
     feeRecipient
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.marketSellOrdersWithEth.estimateGasAsync.bind(
-                    self,
-                    orders,
-                    signatures,
-                    feeOrders,
-                    feeSignatures,
-                    feePercentage,
-                    feeRecipient
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.marketSellOrdersWithEth.estimateGasAsync.bind(self, orders,
+    signatures,
+    feeOrders,
+    feeSignatures,
+    feePercentage,
+    feeRecipient
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -304,22 +233,14 @@ export class ForwarderContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments('marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
+            const encodedData = self._strictEncodeArguments(self.marketSellOrdersWithEth.functionSignature, [orders,
     signatures,
     feeOrders,
     feeSignatures,
     feePercentage,
     feeRecipient
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -331,7 +252,7 @@ export class ForwarderContract extends BaseContract {
             feeRecipient: string,
         ): string {
             const self = this as any as ForwarderContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.marketSellOrdersWithEth.functionSignature, [orders,
     signatures,
     feeOrders,
     feeSignatures,
@@ -340,6 +261,7 @@ export class ForwarderContract extends BaseContract {
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)',
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             signatures: string[],
@@ -352,24 +274,15 @@ export class ForwarderContract extends BaseContract {
         ): Promise<[{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}, {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}]
         > {
             const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments('marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
+            const encodedData = self._strictEncodeArguments(self.marketSellOrdersWithEth.functionSignature, [orders,
         signatures,
         feeOrders,
         feeSignatures,
         feePercentage,
         feeRecipient
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.marketSellOrdersWithEth.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<[{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}, {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}]
         >(rawCallResult);
@@ -383,21 +296,11 @@ export class ForwarderContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transferOwnership.estimateGasAsync.bind(
-                    self,
-                    newOwner
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.transferOwnership.estimateGasAsync.bind(self, newOwner
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -405,27 +308,20 @@ export class ForwarderContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             newOwner: string,
         ): string {
             const self = this as any as ForwarderContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'transferOwnership(address)',
         async callAsync(
             newOwner: string,
             callData: Partial<CallData> = {},
@@ -433,19 +329,10 @@ export class ForwarderContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('transferOwnership(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.transferOwnership.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -461,7 +348,7 @@ export class ForwarderContract extends BaseContract {
             _zrxAssetData: string,
             _wethAssetData: string,
     ): Promise<ForwarderContract> {
-        if (_.isUndefined(artifact.compilerOutput)) {
+        if (isUndefined(artifact.compilerOutput)) {
             throw new Error('Compiler output not found in the artifact file');
         }
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
@@ -494,31 +381,10 @@ _wethAssetData
 ],
             BaseContract._bigNumberToString,
         );
-        const iface = new ethers.utils.Interface(abi);
-        const deployInfo = iface.deployFunction;
-        const txData = deployInfo.encode(bytecode, [_exchange,
-_zrxAssetData,
-_wethAssetData
-]);
-        const web3Wrapper = new Web3Wrapper(provider);
-        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-            {data: txData},
-            txDefaults,
-            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
-        );
-        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-        logUtils.log(`transactionHash: ${txHash}`);
-        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
-        logUtils.log(`Forwarder successfully deployed at ${txReceipt.contractAddress}`);
-        const contractInstance = new ForwarderContract(abi, txReceipt.contractAddress as string, provider, txDefaults);
-        contractInstance.constructorArgs = [_exchange,
-_zrxAssetData,
-_wethAssetData
-];
-        return contractInstance;
+        return {} as any;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
-        super('Forwarder', abi, address, providerUtils.standardizeOrThrow(supportedProvider), txDefaults);
+        super('Forwarder', abi, address, supportedProvider, txDefaults);
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count

--- a/packages/abi-gen-wrappers/src/generated-wrappers/forwarder.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/forwarder.ts
@@ -26,7 +26,7 @@ export class ForwarderContract extends BaseContract {
             txData: Partial<TxDataPayable> = {},
         ): Promise<string> {
             const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments(self.marketBuyOrdersWithEth.functionSignature, [orders,
+            const encodedData = self._strictEncodeArguments('marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     makerAssetFillAmount,
     signatures,
     feeOrders,
@@ -56,7 +56,7 @@ export class ForwarderContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments(self.marketBuyOrdersWithEth.functionSignature, [orders,
+            const encodedData = self._strictEncodeArguments('marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     makerAssetFillAmount,
     signatures,
     feeOrders,
@@ -77,7 +77,7 @@ export class ForwarderContract extends BaseContract {
             feeRecipient: string,
         ): string {
             const self = this as any as ForwarderContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.marketBuyOrdersWithEth.functionSignature, [orders,
+            const abiEncodedTransactionData = self._strictEncodeArguments('marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     makerAssetFillAmount,
     signatures,
     feeOrders,
@@ -87,7 +87,6 @@ export class ForwarderContract extends BaseContract {
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)',
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             makerAssetFillAmount: BigNumber,
@@ -101,7 +100,7 @@ export class ForwarderContract extends BaseContract {
         ): Promise<[{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}, {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}]
         > {
             const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments(self.marketBuyOrdersWithEth.functionSignature, [orders,
+            const encodedData = self._strictEncodeArguments('marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
         makerAssetFillAmount,
         signatures,
         feeOrders,
@@ -110,7 +109,7 @@ export class ForwarderContract extends BaseContract {
         feeRecipient
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.marketBuyOrdersWithEth.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<[{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}, {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}]
         >(rawCallResult);
@@ -125,7 +124,7 @@ export class ForwarderContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments(self.withdrawAsset.functionSignature, [assetData,
+            const encodedData = self._strictEncodeArguments('withdrawAsset(bytes,uint256)', [assetData,
     amount
     ]);
             const gasEstimateFunction = self.withdrawAsset.estimateGasAsync.bind(self, assetData,
@@ -140,7 +139,7 @@ export class ForwarderContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments(self.withdrawAsset.functionSignature, [assetData,
+            const encodedData = self._strictEncodeArguments('withdrawAsset(bytes,uint256)', [assetData,
     amount
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
@@ -151,12 +150,11 @@ export class ForwarderContract extends BaseContract {
             amount: BigNumber,
         ): string {
             const self = this as any as ForwarderContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.withdrawAsset.functionSignature, [assetData,
+            const abiEncodedTransactionData = self._strictEncodeArguments('withdrawAsset(bytes,uint256)', [assetData,
     amount
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'withdrawAsset(bytes,uint256)',
         async callAsync(
             assetData: string,
             amount: BigNumber,
@@ -165,11 +163,11 @@ export class ForwarderContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments(self.withdrawAsset.functionSignature, [assetData,
+            const encodedData = self._strictEncodeArguments('withdrawAsset(bytes,uint256)', [assetData,
         amount
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.withdrawAsset.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('withdrawAsset(bytes,uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -178,16 +176,15 @@ export class ForwarderContract extends BaseContract {
         },
     };
     public owner = {
-        functionSignature: 'owner()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments(self.owner.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('owner()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.owner.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('owner()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -206,7 +203,7 @@ export class ForwarderContract extends BaseContract {
             txData: Partial<TxDataPayable> = {},
         ): Promise<string> {
             const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments(self.marketSellOrdersWithEth.functionSignature, [orders,
+            const encodedData = self._strictEncodeArguments('marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     signatures,
     feeOrders,
     feeSignatures,
@@ -233,7 +230,7 @@ export class ForwarderContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments(self.marketSellOrdersWithEth.functionSignature, [orders,
+            const encodedData = self._strictEncodeArguments('marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     signatures,
     feeOrders,
     feeSignatures,
@@ -252,7 +249,7 @@ export class ForwarderContract extends BaseContract {
             feeRecipient: string,
         ): string {
             const self = this as any as ForwarderContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.marketSellOrdersWithEth.functionSignature, [orders,
+            const abiEncodedTransactionData = self._strictEncodeArguments('marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     signatures,
     feeOrders,
     feeSignatures,
@@ -261,7 +258,6 @@ export class ForwarderContract extends BaseContract {
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)',
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             signatures: string[],
@@ -274,7 +270,7 @@ export class ForwarderContract extends BaseContract {
         ): Promise<[{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}, {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}]
         > {
             const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments(self.marketSellOrdersWithEth.functionSignature, [orders,
+            const encodedData = self._strictEncodeArguments('marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
         signatures,
         feeOrders,
         feeSignatures,
@@ -282,7 +278,7 @@ export class ForwarderContract extends BaseContract {
         feeRecipient
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.marketSellOrdersWithEth.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<[{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}, {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}]
         >(rawCallResult);
@@ -296,7 +292,7 @@ export class ForwarderContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
             const gasEstimateFunction = self.transferOwnership.estimateGasAsync.bind(self, newOwner
     );
@@ -308,7 +304,7 @@ export class ForwarderContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -317,11 +313,10 @@ export class ForwarderContract extends BaseContract {
             newOwner: string,
         ): string {
             const self = this as any as ForwarderContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'transferOwnership(address)',
         async callAsync(
             newOwner: string,
             callData: Partial<CallData> = {},
@@ -329,10 +324,10 @@ export class ForwarderContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.transferOwnership.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('transferOwnership(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/i_asset_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/i_asset_proxy.ts
@@ -6,8 +6,7 @@ import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact,
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
-import * as ethers from 'ethers';
-import * as _ from 'lodash';
+import { isUndefined } from 'lodash';
 // tslint:enable:no-unused-variable
 
 
@@ -21,21 +20,11 @@ export class IAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
+            const encodedData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.addAuthorizedAddress.estimateGasAsync.bind(
-                    self,
-                    target
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.addAuthorizedAddress.estimateGasAsync.bind(self, target
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -43,27 +32,20 @@ export class IAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
+            const encodedData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             target: string,
         ): string {
             const self = this as any as IAssetProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'addAuthorizedAddress(address)',
         async callAsync(
             target: string,
             callData: Partial<CallData> = {},
@@ -71,19 +53,10 @@ export class IAssetProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
+            const encodedData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('addAuthorizedAddress(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.addAuthorizedAddress.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -97,21 +70,11 @@ export class IAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
+            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.removeAuthorizedAddress.estimateGasAsync.bind(
-                    self,
-                    target
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.removeAuthorizedAddress.estimateGasAsync.bind(self, target
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -119,27 +82,20 @@ export class IAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
+            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             target: string,
         ): string {
             const self = this as any as IAssetProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'removeAuthorizedAddress(address)',
         async callAsync(
             target: string,
             callData: Partial<CallData> = {},
@@ -147,19 +103,10 @@ export class IAssetProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
+            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('removeAuthorizedAddress(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.removeAuthorizedAddress.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -174,23 +121,13 @@ export class IAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
+            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
     index
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.removeAuthorizedAddressAtIndex.estimateGasAsync.bind(
-                    self,
-                    target,
-                    index
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.removeAuthorizedAddressAtIndex.estimateGasAsync.bind(self, target,
+    index
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -199,18 +136,10 @@ export class IAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
+            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
     index
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -218,11 +147,12 @@ export class IAssetProxyContract extends BaseContract {
             index: BigNumber,
         ): string {
             const self = this as any as IAssetProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
     index
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'removeAuthorizedAddressAtIndex(address,uint256)',
         async callAsync(
             target: string,
             index: BigNumber,
@@ -231,20 +161,11 @@ export class IAssetProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
+            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
         index
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('removeAuthorizedAddressAtIndex(address,uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.removeAuthorizedAddressAtIndex.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -261,27 +182,17 @@ export class IAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('transferFrom(bytes,address,address,uint256)', [assetData,
+            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [assetData,
     from,
     to,
     amount
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transferFrom.estimateGasAsync.bind(
-                    self,
-                    assetData,
-                    from,
-                    to,
-                    amount
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.transferFrom.estimateGasAsync.bind(self, assetData,
+    from,
+    to,
+    amount
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -292,20 +203,12 @@ export class IAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('transferFrom(bytes,address,address,uint256)', [assetData,
+            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [assetData,
     from,
     to,
     amount
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -315,13 +218,14 @@ export class IAssetProxyContract extends BaseContract {
             amount: BigNumber,
         ): string {
             const self = this as any as IAssetProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(bytes,address,address,uint256)', [assetData,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.transferFrom.functionSignature, [assetData,
     from,
     to,
     amount
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'transferFrom(bytes,address,address,uint256)',
         async callAsync(
             assetData: string,
             from: string,
@@ -332,22 +236,13 @@ export class IAssetProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('transferFrom(bytes,address,address,uint256)', [assetData,
+            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [assetData,
         from,
         to,
         amount
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('transferFrom(bytes,address,address,uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.transferFrom.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -356,24 +251,16 @@ export class IAssetProxyContract extends BaseContract {
         },
     };
     public getProxyId = {
+        functionSignature: 'getProxyId()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('getProxyId()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('getProxyId()');
+            const encodedData = self._strictEncodeArguments(self.getProxyId.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.getProxyId.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -382,24 +269,16 @@ export class IAssetProxyContract extends BaseContract {
         },
     };
     public getAuthorizedAddresses = {
+        functionSignature: 'getAuthorizedAddresses()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('getAuthorizedAddresses()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('getAuthorizedAddresses()');
+            const encodedData = self._strictEncodeArguments(self.getAuthorizedAddresses.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.getAuthorizedAddresses.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string[]
         >(rawCallResult);
@@ -413,21 +292,11 @@ export class IAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transferOwnership.estimateGasAsync.bind(
-                    self,
-                    newOwner
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.transferOwnership.estimateGasAsync.bind(self, newOwner
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -435,27 +304,20 @@ export class IAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             newOwner: string,
         ): string {
             const self = this as any as IAssetProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'transferOwnership(address)',
         async callAsync(
             newOwner: string,
             callData: Partial<CallData> = {},
@@ -463,19 +325,10 @@ export class IAssetProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('transferOwnership(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.transferOwnership.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -488,7 +341,7 @@ export class IAssetProxyContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<IAssetProxyContract> {
-        if (_.isUndefined(artifact.compilerOutput)) {
+        if (isUndefined(artifact.compilerOutput)) {
             throw new Error('Compiler output not found in the artifact file');
         }
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
@@ -509,22 +362,7 @@ export class IAssetProxyContract extends BaseContract {
             [],
             BaseContract._bigNumberToString,
         );
-        const iface = new ethers.utils.Interface(abi);
-        const deployInfo = iface.deployFunction;
-        const txData = deployInfo.encode(bytecode, []);
-        const web3Wrapper = new Web3Wrapper(provider);
-        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-            {data: txData},
-            txDefaults,
-            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
-        );
-        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-        logUtils.log(`transactionHash: ${txHash}`);
-        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
-        logUtils.log(`IAssetProxy successfully deployed at ${txReceipt.contractAddress}`);
-        const contractInstance = new IAssetProxyContract(abi, txReceipt.contractAddress as string, provider, txDefaults);
-        contractInstance.constructorArgs = [];
-        return contractInstance;
+        return {} as any;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
         super('IAssetProxy', abi, address, supportedProvider, txDefaults);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/i_asset_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/i_asset_proxy.ts
@@ -3,7 +3,7 @@
 // tslint:disable:no-unbound-method
 import { BaseContract } from '@0x/base-contract';
 import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact, DecodedLogArgs, MethodAbi, TxData, TxDataPayable, SupportedProvider } from 'ethereum-types';
-import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
+import { AbiEncoder, BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 import { isUndefined } from 'lodash';
@@ -362,7 +362,21 @@ export class IAssetProxyContract extends BaseContract {
             [],
             BaseContract._bigNumberToString,
         );
-        return {} as any;
+        const encoder = new AbiEncoder.Constructor(constructorAbi);
+        const txData = encoder.encode(bytecode, []);
+        const web3Wrapper = new Web3Wrapper(provider);
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {data: txData},
+            txDefaults,
+            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
+        );
+        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        logUtils.log(`transactionHash: ${txHash}`);
+        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
+        logUtils.log(`IAssetProxy successfully deployed at ${txReceipt.contractAddress}`);
+        const contractInstance = new IAssetProxyContract(abi, txReceipt.contractAddress as string, provider, txDefaults);
+        contractInstance.constructorArgs = [];
+        return contractInstance;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
         super('IAssetProxy', abi, address, supportedProvider, txDefaults);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/i_asset_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/i_asset_proxy.ts
@@ -20,7 +20,7 @@ export class IAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
+            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
             const gasEstimateFunction = self.addAuthorizedAddress.estimateGasAsync.bind(self, target
     );
@@ -32,7 +32,7 @@ export class IAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
+            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -41,11 +41,10 @@ export class IAssetProxyContract extends BaseContract {
             target: string,
         ): string {
             const self = this as any as IAssetProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
+            const abiEncodedTransactionData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'addAuthorizedAddress(address)',
         async callAsync(
             target: string,
             callData: Partial<CallData> = {},
@@ -53,10 +52,10 @@ export class IAssetProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
+            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.addAuthorizedAddress.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('addAuthorizedAddress(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -70,7 +69,7 @@ export class IAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
+            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
             const gasEstimateFunction = self.removeAuthorizedAddress.estimateGasAsync.bind(self, target
     );
@@ -82,7 +81,7 @@ export class IAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
+            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -91,11 +90,10 @@ export class IAssetProxyContract extends BaseContract {
             target: string,
         ): string {
             const self = this as any as IAssetProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
+            const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'removeAuthorizedAddress(address)',
         async callAsync(
             target: string,
             callData: Partial<CallData> = {},
@@ -103,10 +101,10 @@ export class IAssetProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
+            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.removeAuthorizedAddress.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('removeAuthorizedAddress(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -121,7 +119,7 @@ export class IAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
+            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
             const gasEstimateFunction = self.removeAuthorizedAddressAtIndex.estimateGasAsync.bind(self, target,
@@ -136,7 +134,7 @@ export class IAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
+            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
@@ -147,12 +145,11 @@ export class IAssetProxyContract extends BaseContract {
             index: BigNumber,
         ): string {
             const self = this as any as IAssetProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
+            const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'removeAuthorizedAddressAtIndex(address,uint256)',
         async callAsync(
             target: string,
             index: BigNumber,
@@ -161,11 +158,11 @@ export class IAssetProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
+            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
         index
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.removeAuthorizedAddressAtIndex.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('removeAuthorizedAddressAtIndex(address,uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -182,7 +179,7 @@ export class IAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [assetData,
+            const encodedData = self._strictEncodeArguments('transferFrom(bytes,address,address,uint256)', [assetData,
     from,
     to,
     amount
@@ -203,7 +200,7 @@ export class IAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [assetData,
+            const encodedData = self._strictEncodeArguments('transferFrom(bytes,address,address,uint256)', [assetData,
     from,
     to,
     amount
@@ -218,14 +215,13 @@ export class IAssetProxyContract extends BaseContract {
             amount: BigNumber,
         ): string {
             const self = this as any as IAssetProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.transferFrom.functionSignature, [assetData,
+            const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(bytes,address,address,uint256)', [assetData,
     from,
     to,
     amount
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'transferFrom(bytes,address,address,uint256)',
         async callAsync(
             assetData: string,
             from: string,
@@ -236,13 +232,13 @@ export class IAssetProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [assetData,
+            const encodedData = self._strictEncodeArguments('transferFrom(bytes,address,address,uint256)', [assetData,
         from,
         to,
         amount
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.transferFrom.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('transferFrom(bytes,address,address,uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -251,16 +247,15 @@ export class IAssetProxyContract extends BaseContract {
         },
     };
     public getProxyId = {
-        functionSignature: 'getProxyId()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.getProxyId.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('getProxyId()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.getProxyId.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('getProxyId()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -269,16 +264,15 @@ export class IAssetProxyContract extends BaseContract {
         },
     };
     public getAuthorizedAddresses = {
-        functionSignature: 'getAuthorizedAddresses()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.getAuthorizedAddresses.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('getAuthorizedAddresses()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.getAuthorizedAddresses.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('getAuthorizedAddresses()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string[]
         >(rawCallResult);
@@ -292,7 +286,7 @@ export class IAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
             const gasEstimateFunction = self.transferOwnership.estimateGasAsync.bind(self, newOwner
     );
@@ -304,7 +298,7 @@ export class IAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -313,11 +307,10 @@ export class IAssetProxyContract extends BaseContract {
             newOwner: string,
         ): string {
             const self = this as any as IAssetProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'transferOwnership(address)',
         async callAsync(
             newOwner: string,
             callData: Partial<CallData> = {},
@@ -325,10 +318,10 @@ export class IAssetProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.transferOwnership.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('transferOwnership(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/i_validator.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/i_validator.ts
@@ -15,7 +15,6 @@ import { isUndefined } from 'lodash';
 // tslint:disable-next-line:class-name
 export class IValidatorContract extends BaseContract {
     public isValidSignature = {
-        functionSignature: 'isValidSignature(bytes32,address,bytes)',
         async callAsync(
             hash: string,
             signerAddress: string,
@@ -25,12 +24,12 @@ export class IValidatorContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as IValidatorContract;
-            const encodedData = self._strictEncodeArguments(self.isValidSignature.functionSignature, [hash,
+            const encodedData = self._strictEncodeArguments('isValidSignature(bytes32,address,bytes)', [hash,
         signerAddress,
         signature
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.isValidSignature.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('isValidSignature(bytes32,address,bytes)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/i_wallet.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/i_wallet.ts
@@ -15,7 +15,6 @@ import { isUndefined } from 'lodash';
 // tslint:disable-next-line:class-name
 export class IWalletContract extends BaseContract {
     public isValidSignature = {
-        functionSignature: 'isValidSignature(bytes32,bytes)',
         async callAsync(
             hash: string,
             signature: string,
@@ -24,11 +23,11 @@ export class IWalletContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as IWalletContract;
-            const encodedData = self._strictEncodeArguments(self.isValidSignature.functionSignature, [hash,
+            const encodedData = self._strictEncodeArguments('isValidSignature(bytes32,bytes)', [hash,
         signature
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.isValidSignature.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('isValidSignature(bytes32,bytes)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/i_wallet.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/i_wallet.ts
@@ -3,7 +3,7 @@
 // tslint:disable:no-unbound-method
 import { BaseContract } from '@0x/base-contract';
 import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact, DecodedLogArgs, MethodAbi, TxData, TxDataPayable, SupportedProvider } from 'ethereum-types';
-import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
+import { AbiEncoder, BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 import { isUndefined } from 'lodash';
@@ -62,7 +62,21 @@ export class IWalletContract extends BaseContract {
             [],
             BaseContract._bigNumberToString,
         );
-        return {} as any;
+        const encoder = new AbiEncoder.Constructor(constructorAbi);
+        const txData = encoder.encode(bytecode, []);
+        const web3Wrapper = new Web3Wrapper(provider);
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {data: txData},
+            txDefaults,
+            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
+        );
+        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        logUtils.log(`transactionHash: ${txHash}`);
+        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
+        logUtils.log(`IWallet successfully deployed at ${txReceipt.contractAddress}`);
+        const contractInstance = new IWalletContract(abi, txReceipt.contractAddress as string, provider, txDefaults);
+        contractInstance.constructorArgs = [];
+        return contractInstance;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
         super('IWallet', abi, address, supportedProvider, txDefaults);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/multi_asset_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/multi_asset_proxy.ts
@@ -3,7 +3,7 @@
 // tslint:disable:no-unbound-method
 import { BaseContract } from '@0x/base-contract';
 import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact, DecodedLogArgs, MethodAbi, TxData, TxDataPayable, SupportedProvider } from 'ethereum-types';
-import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
+import { AbiEncoder, BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 import { isUndefined } from 'lodash';
@@ -459,7 +459,21 @@ export class MultiAssetProxyContract extends BaseContract {
             [],
             BaseContract._bigNumberToString,
         );
-        return {} as any;
+        const encoder = new AbiEncoder.Constructor(constructorAbi);
+        const txData = encoder.encode(bytecode, []);
+        const web3Wrapper = new Web3Wrapper(provider);
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {data: txData},
+            txDefaults,
+            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
+        );
+        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        logUtils.log(`transactionHash: ${txHash}`);
+        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
+        logUtils.log(`MultiAssetProxy successfully deployed at ${txReceipt.contractAddress}`);
+        const contractInstance = new MultiAssetProxyContract(abi, txReceipt.contractAddress as string, provider, txDefaults);
+        contractInstance.constructorArgs = [];
+        return contractInstance;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
         super('MultiAssetProxy', abi, address, supportedProvider, txDefaults);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/multi_asset_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/multi_asset_proxy.ts
@@ -41,7 +41,6 @@ export interface MultiAssetProxyAssetProxyRegisteredEventArgs extends DecodedLog
 // tslint:disable-next-line:class-name
 export class MultiAssetProxyContract extends BaseContract {
     public assetProxies = {
-        functionSignature: 'assetProxies(bytes4)',
         async callAsync(
             index_0: string,
             callData: Partial<CallData> = {},
@@ -49,10 +48,10 @@ export class MultiAssetProxyContract extends BaseContract {
         ): Promise<string
         > {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.assetProxies.functionSignature, [index_0
+            const encodedData = self._strictEncodeArguments('assetProxies(bytes4)', [index_0
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.assetProxies.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('assetProxies(bytes4)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -66,7 +65,7 @@ export class MultiAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
+            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
             const gasEstimateFunction = self.addAuthorizedAddress.estimateGasAsync.bind(self, target
     );
@@ -78,7 +77,7 @@ export class MultiAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
+            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -87,11 +86,10 @@ export class MultiAssetProxyContract extends BaseContract {
             target: string,
         ): string {
             const self = this as any as MultiAssetProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
+            const abiEncodedTransactionData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'addAuthorizedAddress(address)',
         async callAsync(
             target: string,
             callData: Partial<CallData> = {},
@@ -99,10 +97,10 @@ export class MultiAssetProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
+            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.addAuthorizedAddress.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('addAuthorizedAddress(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -111,7 +109,6 @@ export class MultiAssetProxyContract extends BaseContract {
         },
     };
     public authorities = {
-        functionSignature: 'authorities(uint256)',
         async callAsync(
             index_0: BigNumber,
             callData: Partial<CallData> = {},
@@ -119,10 +116,10 @@ export class MultiAssetProxyContract extends BaseContract {
         ): Promise<string
         > {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.authorities.functionSignature, [index_0
+            const encodedData = self._strictEncodeArguments('authorities(uint256)', [index_0
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.authorities.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('authorities(uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -131,7 +128,6 @@ export class MultiAssetProxyContract extends BaseContract {
         },
     };
     public getAssetProxy = {
-        functionSignature: 'getAssetProxy(bytes4)',
         async callAsync(
             assetProxyId: string,
             callData: Partial<CallData> = {},
@@ -139,10 +135,10 @@ export class MultiAssetProxyContract extends BaseContract {
         ): Promise<string
         > {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.getAssetProxy.functionSignature, [assetProxyId
+            const encodedData = self._strictEncodeArguments('getAssetProxy(bytes4)', [assetProxyId
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.getAssetProxy.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('getAssetProxy(bytes4)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -156,7 +152,7 @@ export class MultiAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
+            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
             const gasEstimateFunction = self.removeAuthorizedAddress.estimateGasAsync.bind(self, target
     );
@@ -168,7 +164,7 @@ export class MultiAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
+            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -177,11 +173,10 @@ export class MultiAssetProxyContract extends BaseContract {
             target: string,
         ): string {
             const self = this as any as MultiAssetProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
+            const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'removeAuthorizedAddress(address)',
         async callAsync(
             target: string,
             callData: Partial<CallData> = {},
@@ -189,10 +184,10 @@ export class MultiAssetProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
+            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.removeAuthorizedAddress.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('removeAuthorizedAddress(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -201,16 +196,15 @@ export class MultiAssetProxyContract extends BaseContract {
         },
     };
     public owner = {
-        functionSignature: 'owner()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.owner.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('owner()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.owner.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('owner()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -225,7 +219,7 @@ export class MultiAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
+            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
             const gasEstimateFunction = self.removeAuthorizedAddressAtIndex.estimateGasAsync.bind(self, target,
@@ -240,7 +234,7 @@ export class MultiAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
+            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
@@ -251,12 +245,11 @@ export class MultiAssetProxyContract extends BaseContract {
             index: BigNumber,
         ): string {
             const self = this as any as MultiAssetProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
+            const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'removeAuthorizedAddressAtIndex(address,uint256)',
         async callAsync(
             target: string,
             index: BigNumber,
@@ -265,11 +258,11 @@ export class MultiAssetProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
+            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
         index
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.removeAuthorizedAddressAtIndex.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('removeAuthorizedAddressAtIndex(address,uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -278,16 +271,15 @@ export class MultiAssetProxyContract extends BaseContract {
         },
     };
     public getProxyId = {
-        functionSignature: 'getProxyId()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.getProxyId.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('getProxyId()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.getProxyId.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('getProxyId()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -296,7 +288,6 @@ export class MultiAssetProxyContract extends BaseContract {
         },
     };
     public authorized = {
-        functionSignature: 'authorized(address)',
         async callAsync(
             index_0: string,
             callData: Partial<CallData> = {},
@@ -304,10 +295,10 @@ export class MultiAssetProxyContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.authorized.functionSignature, [index_0
+            const encodedData = self._strictEncodeArguments('authorized(address)', [index_0
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.authorized.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('authorized(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -321,7 +312,7 @@ export class MultiAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.registerAssetProxy.functionSignature, [assetProxy
+            const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
     ]);
             const gasEstimateFunction = self.registerAssetProxy.estimateGasAsync.bind(self, assetProxy
     );
@@ -333,7 +324,7 @@ export class MultiAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.registerAssetProxy.functionSignature, [assetProxy
+            const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -342,11 +333,10 @@ export class MultiAssetProxyContract extends BaseContract {
             assetProxy: string,
         ): string {
             const self = this as any as MultiAssetProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.registerAssetProxy.functionSignature, [assetProxy
+            const abiEncodedTransactionData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'registerAssetProxy(address)',
         async callAsync(
             assetProxy: string,
             callData: Partial<CallData> = {},
@@ -354,10 +344,10 @@ export class MultiAssetProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.registerAssetProxy.functionSignature, [assetProxy
+            const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.registerAssetProxy.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('registerAssetProxy(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -366,16 +356,15 @@ export class MultiAssetProxyContract extends BaseContract {
         },
     };
     public getAuthorizedAddresses = {
-        functionSignature: 'getAuthorizedAddresses()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.getAuthorizedAddresses.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('getAuthorizedAddresses()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.getAuthorizedAddresses.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('getAuthorizedAddresses()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string[]
         >(rawCallResult);
@@ -389,7 +378,7 @@ export class MultiAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
             const gasEstimateFunction = self.transferOwnership.estimateGasAsync.bind(self, newOwner
     );
@@ -401,7 +390,7 @@ export class MultiAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -410,11 +399,10 @@ export class MultiAssetProxyContract extends BaseContract {
             newOwner: string,
         ): string {
             const self = this as any as MultiAssetProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'transferOwnership(address)',
         async callAsync(
             newOwner: string,
             callData: Partial<CallData> = {},
@@ -422,10 +410,10 @@ export class MultiAssetProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
+            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.transferOwnership.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('transferOwnership(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/multi_asset_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/multi_asset_proxy.ts
@@ -6,8 +6,7 @@ import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact,
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
-import * as ethers from 'ethers';
-import * as _ from 'lodash';
+import { isUndefined } from 'lodash';
 // tslint:enable:no-unused-variable
 
 export type MultiAssetProxyEventArgs =
@@ -42,6 +41,7 @@ export interface MultiAssetProxyAssetProxyRegisteredEventArgs extends DecodedLog
 // tslint:disable-next-line:class-name
 export class MultiAssetProxyContract extends BaseContract {
     public assetProxies = {
+        functionSignature: 'assetProxies(bytes4)',
         async callAsync(
             index_0: string,
             callData: Partial<CallData> = {},
@@ -49,19 +49,10 @@ export class MultiAssetProxyContract extends BaseContract {
         ): Promise<string
         > {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('assetProxies(bytes4)', [index_0
+            const encodedData = self._strictEncodeArguments(self.assetProxies.functionSignature, [index_0
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('assetProxies(bytes4)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.assetProxies.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -75,21 +66,11 @@ export class MultiAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
+            const encodedData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.addAuthorizedAddress.estimateGasAsync.bind(
-                    self,
-                    target
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.addAuthorizedAddress.estimateGasAsync.bind(self, target
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -97,27 +78,20 @@ export class MultiAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
+            const encodedData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             target: string,
         ): string {
             const self = this as any as MultiAssetProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'addAuthorizedAddress(address)',
         async callAsync(
             target: string,
             callData: Partial<CallData> = {},
@@ -125,19 +99,10 @@ export class MultiAssetProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
+            const encodedData = self._strictEncodeArguments(self.addAuthorizedAddress.functionSignature, [target
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('addAuthorizedAddress(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.addAuthorizedAddress.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -146,6 +111,7 @@ export class MultiAssetProxyContract extends BaseContract {
         },
     };
     public authorities = {
+        functionSignature: 'authorities(uint256)',
         async callAsync(
             index_0: BigNumber,
             callData: Partial<CallData> = {},
@@ -153,19 +119,10 @@ export class MultiAssetProxyContract extends BaseContract {
         ): Promise<string
         > {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('authorities(uint256)', [index_0
+            const encodedData = self._strictEncodeArguments(self.authorities.functionSignature, [index_0
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('authorities(uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.authorities.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -174,6 +131,7 @@ export class MultiAssetProxyContract extends BaseContract {
         },
     };
     public getAssetProxy = {
+        functionSignature: 'getAssetProxy(bytes4)',
         async callAsync(
             assetProxyId: string,
             callData: Partial<CallData> = {},
@@ -181,19 +139,10 @@ export class MultiAssetProxyContract extends BaseContract {
         ): Promise<string
         > {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('getAssetProxy(bytes4)', [assetProxyId
+            const encodedData = self._strictEncodeArguments(self.getAssetProxy.functionSignature, [assetProxyId
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('getAssetProxy(bytes4)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.getAssetProxy.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -207,21 +156,11 @@ export class MultiAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
+            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.removeAuthorizedAddress.estimateGasAsync.bind(
-                    self,
-                    target
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.removeAuthorizedAddress.estimateGasAsync.bind(self, target
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -229,27 +168,20 @@ export class MultiAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
+            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             target: string,
         ): string {
             const self = this as any as MultiAssetProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'removeAuthorizedAddress(address)',
         async callAsync(
             target: string,
             callData: Partial<CallData> = {},
@@ -257,19 +189,10 @@ export class MultiAssetProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
+            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddress.functionSignature, [target
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('removeAuthorizedAddress(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.removeAuthorizedAddress.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -278,24 +201,16 @@ export class MultiAssetProxyContract extends BaseContract {
         },
     };
     public owner = {
+        functionSignature: 'owner()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('owner()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('owner()');
+            const encodedData = self._strictEncodeArguments(self.owner.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.owner.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -310,23 +225,13 @@ export class MultiAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
+            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
     index
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.removeAuthorizedAddressAtIndex.estimateGasAsync.bind(
-                    self,
-                    target,
-                    index
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.removeAuthorizedAddressAtIndex.estimateGasAsync.bind(self, target,
+    index
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -335,18 +240,10 @@ export class MultiAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
+            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
     index
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -354,11 +251,12 @@ export class MultiAssetProxyContract extends BaseContract {
             index: BigNumber,
         ): string {
             const self = this as any as MultiAssetProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
     index
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'removeAuthorizedAddressAtIndex(address,uint256)',
         async callAsync(
             target: string,
             index: BigNumber,
@@ -367,20 +265,11 @@ export class MultiAssetProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
+            const encodedData = self._strictEncodeArguments(self.removeAuthorizedAddressAtIndex.functionSignature, [target,
         index
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('removeAuthorizedAddressAtIndex(address,uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.removeAuthorizedAddressAtIndex.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -389,24 +278,16 @@ export class MultiAssetProxyContract extends BaseContract {
         },
     };
     public getProxyId = {
+        functionSignature: 'getProxyId()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('getProxyId()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('getProxyId()');
+            const encodedData = self._strictEncodeArguments(self.getProxyId.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.getProxyId.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -415,6 +296,7 @@ export class MultiAssetProxyContract extends BaseContract {
         },
     };
     public authorized = {
+        functionSignature: 'authorized(address)',
         async callAsync(
             index_0: string,
             callData: Partial<CallData> = {},
@@ -422,19 +304,10 @@ export class MultiAssetProxyContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('authorized(address)', [index_0
+            const encodedData = self._strictEncodeArguments(self.authorized.functionSignature, [index_0
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('authorized(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.authorized.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -448,21 +321,11 @@ export class MultiAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
+            const encodedData = self._strictEncodeArguments(self.registerAssetProxy.functionSignature, [assetProxy
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.registerAssetProxy.estimateGasAsync.bind(
-                    self,
-                    assetProxy
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.registerAssetProxy.estimateGasAsync.bind(self, assetProxy
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -470,27 +333,20 @@ export class MultiAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
+            const encodedData = self._strictEncodeArguments(self.registerAssetProxy.functionSignature, [assetProxy
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             assetProxy: string,
         ): string {
             const self = this as any as MultiAssetProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.registerAssetProxy.functionSignature, [assetProxy
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'registerAssetProxy(address)',
         async callAsync(
             assetProxy: string,
             callData: Partial<CallData> = {},
@@ -498,19 +354,10 @@ export class MultiAssetProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
+            const encodedData = self._strictEncodeArguments(self.registerAssetProxy.functionSignature, [assetProxy
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('registerAssetProxy(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.registerAssetProxy.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -519,24 +366,16 @@ export class MultiAssetProxyContract extends BaseContract {
         },
     };
     public getAuthorizedAddresses = {
+        functionSignature: 'getAuthorizedAddresses()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('getAuthorizedAddresses()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('getAuthorizedAddresses()');
+            const encodedData = self._strictEncodeArguments(self.getAuthorizedAddresses.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.getAuthorizedAddresses.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string[]
         >(rawCallResult);
@@ -550,21 +389,11 @@ export class MultiAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transferOwnership.estimateGasAsync.bind(
-                    self,
-                    newOwner
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.transferOwnership.estimateGasAsync.bind(self, newOwner
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -572,27 +401,20 @@ export class MultiAssetProxyContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             newOwner: string,
         ): string {
             const self = this as any as MultiAssetProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'transferOwnership(address)',
         async callAsync(
             newOwner: string,
             callData: Partial<CallData> = {},
@@ -600,19 +422,10 @@ export class MultiAssetProxyContract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+            const encodedData = self._strictEncodeArguments(self.transferOwnership.functionSignature, [newOwner
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('transferOwnership(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.transferOwnership.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -625,7 +438,7 @@ export class MultiAssetProxyContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<MultiAssetProxyContract> {
-        if (_.isUndefined(artifact.compilerOutput)) {
+        if (isUndefined(artifact.compilerOutput)) {
             throw new Error('Compiler output not found in the artifact file');
         }
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
@@ -646,25 +459,10 @@ export class MultiAssetProxyContract extends BaseContract {
             [],
             BaseContract._bigNumberToString,
         );
-        const iface = new ethers.utils.Interface(abi);
-        const deployInfo = iface.deployFunction;
-        const txData = deployInfo.encode(bytecode, []);
-        const web3Wrapper = new Web3Wrapper(provider);
-        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-            {data: txData},
-            txDefaults,
-            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
-        );
-        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-        logUtils.log(`transactionHash: ${txHash}`);
-        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
-        logUtils.log(`MultiAssetProxy successfully deployed at ${txReceipt.contractAddress}`);
-        const contractInstance = new MultiAssetProxyContract(abi, txReceipt.contractAddress as string, provider, txDefaults);
-        contractInstance.constructorArgs = [];
-        return contractInstance;
+        return {} as any;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
-        super('MultiAssetProxy', abi, address, providerUtils.standardizeOrThrow(supportedProvider), txDefaults);
+        super('MultiAssetProxy', abi, address, supportedProvider, txDefaults);
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count

--- a/packages/abi-gen-wrappers/src/generated-wrappers/order_validator.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/order_validator.ts
@@ -6,8 +6,7 @@ import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact,
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
-import * as ethers from 'ethers';
-import * as _ from 'lodash';
+import { isUndefined } from 'lodash';
 // tslint:enable:no-unused-variable
 
 
@@ -16,6 +15,7 @@ import * as _ from 'lodash';
 // tslint:disable-next-line:class-name
 export class OrderValidatorContract extends BaseContract {
     public getOrderAndTraderInfo = {
+        functionSignature: 'getOrderAndTraderInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),address)',
         async callAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             takerAddress: string,
@@ -24,20 +24,11 @@ export class OrderValidatorContract extends BaseContract {
         ): Promise<[{orderStatus: number;orderHash: string;orderTakerAssetFilledAmount: BigNumber}, {makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}]
         > {
             const self = this as any as OrderValidatorContract;
-            const encodedData = self._strictEncodeArguments('getOrderAndTraderInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),address)', [order,
+            const encodedData = self._strictEncodeArguments(self.getOrderAndTraderInfo.functionSignature, [order,
         takerAddress
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('getOrderAndTraderInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.getOrderAndTraderInfo.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<[{orderStatus: number;orderHash: string;orderTakerAssetFilledAmount: BigNumber}, {makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}]
         >(rawCallResult);
@@ -46,6 +37,7 @@ export class OrderValidatorContract extends BaseContract {
         },
     };
     public getBalanceAndAllowance = {
+        functionSignature: 'getBalanceAndAllowance(address,bytes)',
         async callAsync(
             target: string,
             assetData: string,
@@ -54,20 +46,11 @@ export class OrderValidatorContract extends BaseContract {
         ): Promise<[BigNumber, BigNumber]
         > {
             const self = this as any as OrderValidatorContract;
-            const encodedData = self._strictEncodeArguments('getBalanceAndAllowance(address,bytes)', [target,
+            const encodedData = self._strictEncodeArguments(self.getBalanceAndAllowance.functionSignature, [target,
         assetData
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('getBalanceAndAllowance(address,bytes)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.getBalanceAndAllowance.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<[BigNumber, BigNumber]
         >(rawCallResult);
@@ -76,6 +59,7 @@ export class OrderValidatorContract extends BaseContract {
         },
     };
     public getOrdersAndTradersInfo = {
+        functionSignature: 'getOrdersAndTradersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],address[])',
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAddresses: string[],
@@ -84,20 +68,11 @@ export class OrderValidatorContract extends BaseContract {
         ): Promise<[Array<{orderStatus: number;orderHash: string;orderTakerAssetFilledAmount: BigNumber}>, Array<{makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}>]
         > {
             const self = this as any as OrderValidatorContract;
-            const encodedData = self._strictEncodeArguments('getOrdersAndTradersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],address[])', [orders,
+            const encodedData = self._strictEncodeArguments(self.getOrdersAndTradersInfo.functionSignature, [orders,
         takerAddresses
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('getOrdersAndTradersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],address[])');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.getOrdersAndTradersInfo.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<[Array<{orderStatus: number;orderHash: string;orderTakerAssetFilledAmount: BigNumber}>, Array<{makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}>]
         >(rawCallResult);
@@ -106,6 +81,7 @@ export class OrderValidatorContract extends BaseContract {
         },
     };
     public getTradersInfo = {
+        functionSignature: 'getTradersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],address[])',
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAddresses: string[],
@@ -114,20 +90,11 @@ export class OrderValidatorContract extends BaseContract {
         ): Promise<Array<{makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}>
         > {
             const self = this as any as OrderValidatorContract;
-            const encodedData = self._strictEncodeArguments('getTradersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],address[])', [orders,
+            const encodedData = self._strictEncodeArguments(self.getTradersInfo.functionSignature, [orders,
         takerAddresses
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('getTradersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],address[])');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.getTradersInfo.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<Array<{makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}>
         >(rawCallResult);
@@ -136,6 +103,7 @@ export class OrderValidatorContract extends BaseContract {
         },
     };
     public getERC721TokenOwner = {
+        functionSignature: 'getERC721TokenOwner(address,uint256)',
         async callAsync(
             token: string,
             tokenId: BigNumber,
@@ -144,20 +112,11 @@ export class OrderValidatorContract extends BaseContract {
         ): Promise<string
         > {
             const self = this as any as OrderValidatorContract;
-            const encodedData = self._strictEncodeArguments('getERC721TokenOwner(address,uint256)', [token,
+            const encodedData = self._strictEncodeArguments(self.getERC721TokenOwner.functionSignature, [token,
         tokenId
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('getERC721TokenOwner(address,uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.getERC721TokenOwner.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -166,6 +125,7 @@ export class OrderValidatorContract extends BaseContract {
         },
     };
     public getBalancesAndAllowances = {
+        functionSignature: 'getBalancesAndAllowances(address,bytes[])',
         async callAsync(
             target: string,
             assetData: string[],
@@ -174,20 +134,11 @@ export class OrderValidatorContract extends BaseContract {
         ): Promise<[BigNumber[], BigNumber[]]
         > {
             const self = this as any as OrderValidatorContract;
-            const encodedData = self._strictEncodeArguments('getBalancesAndAllowances(address,bytes[])', [target,
+            const encodedData = self._strictEncodeArguments(self.getBalancesAndAllowances.functionSignature, [target,
         assetData
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('getBalancesAndAllowances(address,bytes[])');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.getBalancesAndAllowances.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<[BigNumber[], BigNumber[]]
         >(rawCallResult);
@@ -196,6 +147,7 @@ export class OrderValidatorContract extends BaseContract {
         },
     };
     public getTraderInfo = {
+        functionSignature: 'getTraderInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),address)',
         async callAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             takerAddress: string,
@@ -204,20 +156,11 @@ export class OrderValidatorContract extends BaseContract {
         ): Promise<{makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}
         > {
             const self = this as any as OrderValidatorContract;
-            const encodedData = self._strictEncodeArguments('getTraderInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),address)', [order,
+            const encodedData = self._strictEncodeArguments(self.getTraderInfo.functionSignature, [order,
         takerAddress
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('getTraderInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.getTraderInfo.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<{makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}
         >(rawCallResult);
@@ -232,7 +175,7 @@ export class OrderValidatorContract extends BaseContract {
             _exchange: string,
             _zrxAssetData: string,
     ): Promise<OrderValidatorContract> {
-        if (_.isUndefined(artifact.compilerOutput)) {
+        if (isUndefined(artifact.compilerOutput)) {
             throw new Error('Compiler output not found in the artifact file');
         }
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
@@ -261,29 +204,10 @@ _zrxAssetData
 ],
             BaseContract._bigNumberToString,
         );
-        const iface = new ethers.utils.Interface(abi);
-        const deployInfo = iface.deployFunction;
-        const txData = deployInfo.encode(bytecode, [_exchange,
-_zrxAssetData
-]);
-        const web3Wrapper = new Web3Wrapper(provider);
-        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-            {data: txData},
-            txDefaults,
-            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
-        );
-        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-        logUtils.log(`transactionHash: ${txHash}`);
-        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
-        logUtils.log(`OrderValidator successfully deployed at ${txReceipt.contractAddress}`);
-        const contractInstance = new OrderValidatorContract(abi, txReceipt.contractAddress as string, provider, txDefaults);
-        contractInstance.constructorArgs = [_exchange,
-_zrxAssetData
-];
-        return contractInstance;
+        return {} as any;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
-        super('OrderValidator', abi, address, providerUtils.standardizeOrThrow(supportedProvider), txDefaults);
+        super('OrderValidator', abi, address, supportedProvider, txDefaults);
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count

--- a/packages/abi-gen-wrappers/src/generated-wrappers/order_validator.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/order_validator.ts
@@ -15,7 +15,6 @@ import { isUndefined } from 'lodash';
 // tslint:disable-next-line:class-name
 export class OrderValidatorContract extends BaseContract {
     public getOrderAndTraderInfo = {
-        functionSignature: 'getOrderAndTraderInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),address)',
         async callAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             takerAddress: string,
@@ -24,11 +23,11 @@ export class OrderValidatorContract extends BaseContract {
         ): Promise<[{orderStatus: number;orderHash: string;orderTakerAssetFilledAmount: BigNumber}, {makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}]
         > {
             const self = this as any as OrderValidatorContract;
-            const encodedData = self._strictEncodeArguments(self.getOrderAndTraderInfo.functionSignature, [order,
+            const encodedData = self._strictEncodeArguments('getOrderAndTraderInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),address)', [order,
         takerAddress
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.getOrderAndTraderInfo.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('getOrderAndTraderInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<[{orderStatus: number;orderHash: string;orderTakerAssetFilledAmount: BigNumber}, {makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}]
         >(rawCallResult);
@@ -37,7 +36,6 @@ export class OrderValidatorContract extends BaseContract {
         },
     };
     public getBalanceAndAllowance = {
-        functionSignature: 'getBalanceAndAllowance(address,bytes)',
         async callAsync(
             target: string,
             assetData: string,
@@ -46,11 +44,11 @@ export class OrderValidatorContract extends BaseContract {
         ): Promise<[BigNumber, BigNumber]
         > {
             const self = this as any as OrderValidatorContract;
-            const encodedData = self._strictEncodeArguments(self.getBalanceAndAllowance.functionSignature, [target,
+            const encodedData = self._strictEncodeArguments('getBalanceAndAllowance(address,bytes)', [target,
         assetData
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.getBalanceAndAllowance.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('getBalanceAndAllowance(address,bytes)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<[BigNumber, BigNumber]
         >(rawCallResult);
@@ -59,7 +57,6 @@ export class OrderValidatorContract extends BaseContract {
         },
     };
     public getOrdersAndTradersInfo = {
-        functionSignature: 'getOrdersAndTradersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],address[])',
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAddresses: string[],
@@ -68,11 +65,11 @@ export class OrderValidatorContract extends BaseContract {
         ): Promise<[Array<{orderStatus: number;orderHash: string;orderTakerAssetFilledAmount: BigNumber}>, Array<{makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}>]
         > {
             const self = this as any as OrderValidatorContract;
-            const encodedData = self._strictEncodeArguments(self.getOrdersAndTradersInfo.functionSignature, [orders,
+            const encodedData = self._strictEncodeArguments('getOrdersAndTradersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],address[])', [orders,
         takerAddresses
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.getOrdersAndTradersInfo.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('getOrdersAndTradersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],address[])');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<[Array<{orderStatus: number;orderHash: string;orderTakerAssetFilledAmount: BigNumber}>, Array<{makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}>]
         >(rawCallResult);
@@ -81,7 +78,6 @@ export class OrderValidatorContract extends BaseContract {
         },
     };
     public getTradersInfo = {
-        functionSignature: 'getTradersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],address[])',
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAddresses: string[],
@@ -90,11 +86,11 @@ export class OrderValidatorContract extends BaseContract {
         ): Promise<Array<{makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}>
         > {
             const self = this as any as OrderValidatorContract;
-            const encodedData = self._strictEncodeArguments(self.getTradersInfo.functionSignature, [orders,
+            const encodedData = self._strictEncodeArguments('getTradersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],address[])', [orders,
         takerAddresses
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.getTradersInfo.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('getTradersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],address[])');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<Array<{makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}>
         >(rawCallResult);
@@ -103,7 +99,6 @@ export class OrderValidatorContract extends BaseContract {
         },
     };
     public getERC721TokenOwner = {
-        functionSignature: 'getERC721TokenOwner(address,uint256)',
         async callAsync(
             token: string,
             tokenId: BigNumber,
@@ -112,11 +107,11 @@ export class OrderValidatorContract extends BaseContract {
         ): Promise<string
         > {
             const self = this as any as OrderValidatorContract;
-            const encodedData = self._strictEncodeArguments(self.getERC721TokenOwner.functionSignature, [token,
+            const encodedData = self._strictEncodeArguments('getERC721TokenOwner(address,uint256)', [token,
         tokenId
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.getERC721TokenOwner.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('getERC721TokenOwner(address,uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -125,7 +120,6 @@ export class OrderValidatorContract extends BaseContract {
         },
     };
     public getBalancesAndAllowances = {
-        functionSignature: 'getBalancesAndAllowances(address,bytes[])',
         async callAsync(
             target: string,
             assetData: string[],
@@ -134,11 +128,11 @@ export class OrderValidatorContract extends BaseContract {
         ): Promise<[BigNumber[], BigNumber[]]
         > {
             const self = this as any as OrderValidatorContract;
-            const encodedData = self._strictEncodeArguments(self.getBalancesAndAllowances.functionSignature, [target,
+            const encodedData = self._strictEncodeArguments('getBalancesAndAllowances(address,bytes[])', [target,
         assetData
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.getBalancesAndAllowances.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('getBalancesAndAllowances(address,bytes[])');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<[BigNumber[], BigNumber[]]
         >(rawCallResult);
@@ -147,7 +141,6 @@ export class OrderValidatorContract extends BaseContract {
         },
     };
     public getTraderInfo = {
-        functionSignature: 'getTraderInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),address)',
         async callAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             takerAddress: string,
@@ -156,11 +149,11 @@ export class OrderValidatorContract extends BaseContract {
         ): Promise<{makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}
         > {
             const self = this as any as OrderValidatorContract;
-            const encodedData = self._strictEncodeArguments(self.getTraderInfo.functionSignature, [order,
+            const encodedData = self._strictEncodeArguments('getTraderInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),address)', [order,
         takerAddress
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.getTraderInfo.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('getTraderInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<{makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}
         >(rawCallResult);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/order_validator.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/order_validator.ts
@@ -3,7 +3,7 @@
 // tslint:disable:no-unbound-method
 import { BaseContract } from '@0x/base-contract';
 import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact, DecodedLogArgs, MethodAbi, TxData, TxDataPayable, SupportedProvider } from 'ethereum-types';
-import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
+import { AbiEncoder, BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 import { isUndefined } from 'lodash';
@@ -204,7 +204,25 @@ _zrxAssetData
 ],
             BaseContract._bigNumberToString,
         );
-        return {} as any;
+        const encoder = new AbiEncoder.Constructor(constructorAbi);
+        const txData = encoder.encode(bytecode, [_exchange,
+_zrxAssetData
+]);
+        const web3Wrapper = new Web3Wrapper(provider);
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {data: txData},
+            txDefaults,
+            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
+        );
+        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        logUtils.log(`transactionHash: ${txHash}`);
+        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
+        logUtils.log(`OrderValidator successfully deployed at ${txReceipt.contractAddress}`);
+        const contractInstance = new OrderValidatorContract(abi, txReceipt.contractAddress as string, provider, txDefaults);
+        contractInstance.constructorArgs = [_exchange,
+_zrxAssetData
+];
+        return contractInstance;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
         super('OrderValidator', abi, address, supportedProvider, txDefaults);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/weth9.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/weth9.ts
@@ -50,16 +50,15 @@ export interface WETH9WithdrawalEventArgs extends DecodedLogArgs {
 // tslint:disable-next-line:class-name
 export class WETH9Contract extends BaseContract {
     public name = {
-        functionSignature: 'name()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments(self.name.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('name()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.name.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('name()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -74,7 +73,7 @@ export class WETH9Contract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [guy,
+            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [guy,
     wad
     ]);
             const gasEstimateFunction = self.approve.estimateGasAsync.bind(self, guy,
@@ -89,7 +88,7 @@ export class WETH9Contract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [guy,
+            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [guy,
     wad
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
@@ -100,12 +99,11 @@ export class WETH9Contract extends BaseContract {
             wad: BigNumber,
         ): string {
             const self = this as any as WETH9Contract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.approve.functionSignature, [guy,
+            const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [guy,
     wad
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'approve(address,uint256)',
         async callAsync(
             guy: string,
             wad: BigNumber,
@@ -114,11 +112,11 @@ export class WETH9Contract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [guy,
+            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [guy,
         wad
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.approve.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('approve(address,uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -127,16 +125,15 @@ export class WETH9Contract extends BaseContract {
         },
     };
     public totalSupply = {
-        functionSignature: 'totalSupply()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments(self.totalSupply.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('totalSupply()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.totalSupply.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('totalSupply()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -152,7 +149,7 @@ export class WETH9Contract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [src,
+            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [src,
     dst,
     wad
     ]);
@@ -170,7 +167,7 @@ export class WETH9Contract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [src,
+            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [src,
     dst,
     wad
     ]);
@@ -183,13 +180,12 @@ export class WETH9Contract extends BaseContract {
             wad: BigNumber,
         ): string {
             const self = this as any as WETH9Contract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.transferFrom.functionSignature, [src,
+            const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [src,
     dst,
     wad
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'transferFrom(address,address,uint256)',
         async callAsync(
             src: string,
             dst: string,
@@ -199,12 +195,12 @@ export class WETH9Contract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [src,
+            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [src,
         dst,
         wad
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.transferFrom.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('transferFrom(address,address,uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -218,7 +214,7 @@ export class WETH9Contract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments(self.withdraw.functionSignature, [wad
+            const encodedData = self._strictEncodeArguments('withdraw(uint256)', [wad
     ]);
             const gasEstimateFunction = self.withdraw.estimateGasAsync.bind(self, wad
     );
@@ -230,7 +226,7 @@ export class WETH9Contract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments(self.withdraw.functionSignature, [wad
+            const encodedData = self._strictEncodeArguments('withdraw(uint256)', [wad
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
@@ -239,11 +235,10 @@ export class WETH9Contract extends BaseContract {
             wad: BigNumber,
         ): string {
             const self = this as any as WETH9Contract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.withdraw.functionSignature, [wad
+            const abiEncodedTransactionData = self._strictEncodeArguments('withdraw(uint256)', [wad
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'withdraw(uint256)',
         async callAsync(
             wad: BigNumber,
             callData: Partial<CallData> = {},
@@ -251,10 +246,10 @@ export class WETH9Contract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments(self.withdraw.functionSignature, [wad
+            const encodedData = self._strictEncodeArguments('withdraw(uint256)', [wad
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.withdraw.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('withdraw(uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -263,16 +258,15 @@ export class WETH9Contract extends BaseContract {
         },
     };
     public decimals = {
-        functionSignature: 'decimals()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<number
         > {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments(self.decimals.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('decimals()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.decimals.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('decimals()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<number
         >(rawCallResult);
@@ -281,7 +275,6 @@ export class WETH9Contract extends BaseContract {
         },
     };
     public balanceOf = {
-        functionSignature: 'balanceOf(address)',
         async callAsync(
             index_0: string,
             callData: Partial<CallData> = {},
@@ -289,10 +282,10 @@ export class WETH9Contract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments(self.balanceOf.functionSignature, [index_0
+            const encodedData = self._strictEncodeArguments('balanceOf(address)', [index_0
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.balanceOf.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('balanceOf(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -301,16 +294,15 @@ export class WETH9Contract extends BaseContract {
         },
     };
     public symbol = {
-        functionSignature: 'symbol()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments(self.symbol.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('symbol()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.symbol.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('symbol()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -325,7 +317,7 @@ export class WETH9Contract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments(self.transfer.functionSignature, [dst,
+            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [dst,
     wad
     ]);
             const gasEstimateFunction = self.transfer.estimateGasAsync.bind(self, dst,
@@ -340,7 +332,7 @@ export class WETH9Contract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments(self.transfer.functionSignature, [dst,
+            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [dst,
     wad
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
@@ -351,12 +343,11 @@ export class WETH9Contract extends BaseContract {
             wad: BigNumber,
         ): string {
             const self = this as any as WETH9Contract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.transfer.functionSignature, [dst,
+            const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [dst,
     wad
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'transfer(address,uint256)',
         async callAsync(
             dst: string,
             wad: BigNumber,
@@ -365,11 +356,11 @@ export class WETH9Contract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments(self.transfer.functionSignature, [dst,
+            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [dst,
         wad
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.transfer.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('transfer(address,uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -382,7 +373,7 @@ export class WETH9Contract extends BaseContract {
             txData: Partial<TxDataPayable> = {},
         ): Promise<string> {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments(self.deposit.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('deposit()', []);
             const gasEstimateFunction = self.deposit.estimateGasAsync.bind(self, );
             const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
@@ -391,26 +382,25 @@ export class WETH9Contract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments(self.deposit.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('deposit()', []);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
         ): string {
             const self = this as any as WETH9Contract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.deposit.functionSignature, []);
+            const abiEncodedTransactionData = self._strictEncodeArguments('deposit()', []);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'deposit()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments(self.deposit.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('deposit()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.deposit.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('deposit()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -419,7 +409,6 @@ export class WETH9Contract extends BaseContract {
         },
     };
     public allowance = {
-        functionSignature: 'allowance(address,address)',
         async callAsync(
             index_0: string,
             index_1: string,
@@ -428,11 +417,11 @@ export class WETH9Contract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments(self.allowance.functionSignature, [index_0,
+            const encodedData = self._strictEncodeArguments('allowance(address,address)', [index_0,
         index_1
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.allowance.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('allowance(address,address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/weth9.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/weth9.ts
@@ -6,8 +6,7 @@ import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact,
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
-import * as ethers from 'ethers';
-import * as _ from 'lodash';
+import { isUndefined } from 'lodash';
 // tslint:enable:no-unused-variable
 
 export type WETH9EventArgs =
@@ -51,24 +50,16 @@ export interface WETH9WithdrawalEventArgs extends DecodedLogArgs {
 // tslint:disable-next-line:class-name
 export class WETH9Contract extends BaseContract {
     public name = {
+        functionSignature: 'name()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('name()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('name()');
+            const encodedData = self._strictEncodeArguments(self.name.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.name.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -83,23 +74,13 @@ export class WETH9Contract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [guy,
+            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [guy,
     wad
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.approve.estimateGasAsync.bind(
-                    self,
-                    guy,
-                    wad
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.approve.estimateGasAsync.bind(self, guy,
+    wad
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -108,18 +89,10 @@ export class WETH9Contract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [guy,
+            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [guy,
     wad
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -127,11 +100,12 @@ export class WETH9Contract extends BaseContract {
             wad: BigNumber,
         ): string {
             const self = this as any as WETH9Contract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [guy,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.approve.functionSignature, [guy,
     wad
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'approve(address,uint256)',
         async callAsync(
             guy: string,
             wad: BigNumber,
@@ -140,20 +114,11 @@ export class WETH9Contract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [guy,
+            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [guy,
         wad
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('approve(address,uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.approve.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -162,24 +127,16 @@ export class WETH9Contract extends BaseContract {
         },
     };
     public totalSupply = {
+        functionSignature: 'totalSupply()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('totalSupply()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('totalSupply()');
+            const encodedData = self._strictEncodeArguments(self.totalSupply.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.totalSupply.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -195,25 +152,15 @@ export class WETH9Contract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [src,
+            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [src,
     dst,
     wad
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transferFrom.estimateGasAsync.bind(
-                    self,
-                    src,
-                    dst,
-                    wad
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.transferFrom.estimateGasAsync.bind(self, src,
+    dst,
+    wad
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -223,19 +170,11 @@ export class WETH9Contract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [src,
+            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [src,
     dst,
     wad
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -244,12 +183,13 @@ export class WETH9Contract extends BaseContract {
             wad: BigNumber,
         ): string {
             const self = this as any as WETH9Contract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [src,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.transferFrom.functionSignature, [src,
     dst,
     wad
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'transferFrom(address,address,uint256)',
         async callAsync(
             src: string,
             dst: string,
@@ -259,21 +199,12 @@ export class WETH9Contract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [src,
+            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [src,
         dst,
         wad
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('transferFrom(address,address,uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.transferFrom.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -287,21 +218,11 @@ export class WETH9Contract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('withdraw(uint256)', [wad
+            const encodedData = self._strictEncodeArguments(self.withdraw.functionSignature, [wad
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.withdraw.estimateGasAsync.bind(
-                    self,
-                    wad
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.withdraw.estimateGasAsync.bind(self, wad
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -309,27 +230,20 @@ export class WETH9Contract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('withdraw(uint256)', [wad
+            const encodedData = self._strictEncodeArguments(self.withdraw.functionSignature, [wad
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
             wad: BigNumber,
         ): string {
             const self = this as any as WETH9Contract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('withdraw(uint256)', [wad
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.withdraw.functionSignature, [wad
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'withdraw(uint256)',
         async callAsync(
             wad: BigNumber,
             callData: Partial<CallData> = {},
@@ -337,19 +251,10 @@ export class WETH9Contract extends BaseContract {
         ): Promise<void
         > {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('withdraw(uint256)', [wad
+            const encodedData = self._strictEncodeArguments(self.withdraw.functionSignature, [wad
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('withdraw(uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.withdraw.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -358,24 +263,16 @@ export class WETH9Contract extends BaseContract {
         },
     };
     public decimals = {
+        functionSignature: 'decimals()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<number
         > {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('decimals()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('decimals()');
+            const encodedData = self._strictEncodeArguments(self.decimals.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.decimals.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<number
         >(rawCallResult);
@@ -384,6 +281,7 @@ export class WETH9Contract extends BaseContract {
         },
     };
     public balanceOf = {
+        functionSignature: 'balanceOf(address)',
         async callAsync(
             index_0: string,
             callData: Partial<CallData> = {},
@@ -391,19 +289,10 @@ export class WETH9Contract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('balanceOf(address)', [index_0
+            const encodedData = self._strictEncodeArguments(self.balanceOf.functionSignature, [index_0
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('balanceOf(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.balanceOf.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -412,24 +301,16 @@ export class WETH9Contract extends BaseContract {
         },
     };
     public symbol = {
+        functionSignature: 'symbol()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('symbol()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('symbol()');
+            const encodedData = self._strictEncodeArguments(self.symbol.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.symbol.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -444,23 +325,13 @@ export class WETH9Contract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [dst,
+            const encodedData = self._strictEncodeArguments(self.transfer.functionSignature, [dst,
     wad
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transfer.estimateGasAsync.bind(
-                    self,
-                    dst,
-                    wad
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.transfer.estimateGasAsync.bind(self, dst,
+    wad
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -469,18 +340,10 @@ export class WETH9Contract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [dst,
+            const encodedData = self._strictEncodeArguments(self.transfer.functionSignature, [dst,
     wad
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -488,11 +351,12 @@ export class WETH9Contract extends BaseContract {
             wad: BigNumber,
         ): string {
             const self = this as any as WETH9Contract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [dst,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.transfer.functionSignature, [dst,
     wad
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'transfer(address,uint256)',
         async callAsync(
             dst: string,
             wad: BigNumber,
@@ -501,20 +365,11 @@ export class WETH9Contract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [dst,
+            const encodedData = self._strictEncodeArguments(self.transfer.functionSignature, [dst,
         wad
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('transfer(address,uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.transfer.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -527,61 +382,35 @@ export class WETH9Contract extends BaseContract {
             txData: Partial<TxDataPayable> = {},
         ): Promise<string> {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('deposit()', []);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.deposit.estimateGasAsync.bind(
-                    self,
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const encodedData = self._strictEncodeArguments(self.deposit.functionSignature, []);
+            const gasEstimateFunction = self.deposit.estimateGasAsync.bind(self, );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('deposit()', []);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const encodedData = self._strictEncodeArguments(self.deposit.functionSignature, []);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
         ): string {
             const self = this as any as WETH9Contract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('deposit()', []);
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.deposit.functionSignature, []);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'deposit()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('deposit()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('deposit()');
+            const encodedData = self._strictEncodeArguments(self.deposit.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.deposit.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<void
         >(rawCallResult);
@@ -590,6 +419,7 @@ export class WETH9Contract extends BaseContract {
         },
     };
     public allowance = {
+        functionSignature: 'allowance(address,address)',
         async callAsync(
             index_0: string,
             index_1: string,
@@ -598,20 +428,11 @@ export class WETH9Contract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('allowance(address,address)', [index_0,
+            const encodedData = self._strictEncodeArguments(self.allowance.functionSignature, [index_0,
         index_1
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('allowance(address,address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.allowance.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -624,7 +445,7 @@ export class WETH9Contract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<WETH9Contract> {
-        if (_.isUndefined(artifact.compilerOutput)) {
+        if (isUndefined(artifact.compilerOutput)) {
             throw new Error('Compiler output not found in the artifact file');
         }
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
@@ -645,25 +466,10 @@ export class WETH9Contract extends BaseContract {
             [],
             BaseContract._bigNumberToString,
         );
-        const iface = new ethers.utils.Interface(abi);
-        const deployInfo = iface.deployFunction;
-        const txData = deployInfo.encode(bytecode, []);
-        const web3Wrapper = new Web3Wrapper(provider);
-        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-            {data: txData},
-            txDefaults,
-            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
-        );
-        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-        logUtils.log(`transactionHash: ${txHash}`);
-        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
-        logUtils.log(`WETH9 successfully deployed at ${txReceipt.contractAddress}`);
-        const contractInstance = new WETH9Contract(abi, txReceipt.contractAddress as string, provider, txDefaults);
-        contractInstance.constructorArgs = [];
-        return contractInstance;
+        return {} as any;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
-        super('WETH9', abi, address, providerUtils.standardizeOrThrow(supportedProvider), txDefaults);
+        super('WETH9', abi, address, supportedProvider, txDefaults);
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count

--- a/packages/abi-gen-wrappers/src/generated-wrappers/weth9.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/weth9.ts
@@ -3,7 +3,7 @@
 // tslint:disable:no-unbound-method
 import { BaseContract } from '@0x/base-contract';
 import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact, DecodedLogArgs, MethodAbi, TxData, TxDataPayable, SupportedProvider } from 'ethereum-types';
-import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
+import { AbiEncoder, BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 import { isUndefined } from 'lodash';
@@ -466,7 +466,21 @@ export class WETH9Contract extends BaseContract {
             [],
             BaseContract._bigNumberToString,
         );
-        return {} as any;
+        const encoder = new AbiEncoder.Constructor(constructorAbi);
+        const txData = encoder.encode(bytecode, []);
+        const web3Wrapper = new Web3Wrapper(provider);
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {data: txData},
+            txDefaults,
+            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
+        );
+        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        logUtils.log(`transactionHash: ${txHash}`);
+        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
+        logUtils.log(`WETH9 successfully deployed at ${txReceipt.contractAddress}`);
+        const contractInstance = new WETH9Contract(abi, txReceipt.contractAddress as string, provider, txDefaults);
+        contractInstance.constructorArgs = [];
+        return contractInstance;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
         super('WETH9', abi, address, supportedProvider, txDefaults);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/zrx_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/zrx_token.ts
@@ -3,7 +3,7 @@
 // tslint:disable:no-unbound-method
 import { BaseContract } from '@0x/base-contract';
 import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact, DecodedLogArgs, MethodAbi, TxData, TxDataPayable, SupportedProvider } from 'ethereum-types';
-import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
+import { AbiEncoder, BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 import { isUndefined } from 'lodash';
@@ -361,7 +361,21 @@ export class ZRXTokenContract extends BaseContract {
             [],
             BaseContract._bigNumberToString,
         );
-        return {} as any;
+        const encoder = new AbiEncoder.Constructor(constructorAbi);
+        const txData = encoder.encode(bytecode, []);
+        const web3Wrapper = new Web3Wrapper(provider);
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {data: txData},
+            txDefaults,
+            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
+        );
+        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        logUtils.log(`transactionHash: ${txHash}`);
+        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
+        logUtils.log(`ZRXToken successfully deployed at ${txReceipt.contractAddress}`);
+        const contractInstance = new ZRXTokenContract(abi, txReceipt.contractAddress as string, provider, txDefaults);
+        contractInstance.constructorArgs = [];
+        return contractInstance;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
         super('ZRXToken', abi, address, supportedProvider, txDefaults);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/zrx_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/zrx_token.ts
@@ -36,16 +36,15 @@ export interface ZRXTokenApprovalEventArgs extends DecodedLogArgs {
 // tslint:disable-next-line:class-name
 export class ZRXTokenContract extends BaseContract {
     public name = {
-        functionSignature: 'name()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments(self.name.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('name()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.name.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('name()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -60,7 +59,7 @@ export class ZRXTokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [_spender,
+            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
             const gasEstimateFunction = self.approve.estimateGasAsync.bind(self, _spender,
@@ -75,7 +74,7 @@ export class ZRXTokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [_spender,
+            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
@@ -86,12 +85,11 @@ export class ZRXTokenContract extends BaseContract {
             _value: BigNumber,
         ): string {
             const self = this as any as ZRXTokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.approve.functionSignature, [_spender,
+            const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'approve(address,uint256)',
         async callAsync(
             _spender: string,
             _value: BigNumber,
@@ -100,11 +98,11 @@ export class ZRXTokenContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [_spender,
+            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
         _value
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.approve.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('approve(address,uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -113,16 +111,15 @@ export class ZRXTokenContract extends BaseContract {
         },
     };
     public totalSupply = {
-        functionSignature: 'totalSupply()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
             const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments(self.totalSupply.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('totalSupply()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.totalSupply.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('totalSupply()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -138,7 +135,7 @@ export class ZRXTokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
+            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
@@ -156,7 +153,7 @@ export class ZRXTokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
+            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
@@ -169,13 +166,12 @@ export class ZRXTokenContract extends BaseContract {
             _value: BigNumber,
         ): string {
             const self = this as any as ZRXTokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
+            const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'transferFrom(address,address,uint256)',
         async callAsync(
             _from: string,
             _to: string,
@@ -185,12 +181,12 @@ export class ZRXTokenContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
+            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
         _to,
         _value
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.transferFrom.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('transferFrom(address,address,uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -199,16 +195,15 @@ export class ZRXTokenContract extends BaseContract {
         },
     };
     public decimals = {
-        functionSignature: 'decimals()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<number
         > {
             const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments(self.decimals.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('decimals()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.decimals.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('decimals()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<number
         >(rawCallResult);
@@ -217,7 +212,6 @@ export class ZRXTokenContract extends BaseContract {
         },
     };
     public balanceOf = {
-        functionSignature: 'balanceOf(address)',
         async callAsync(
             _owner: string,
             callData: Partial<CallData> = {},
@@ -225,10 +219,10 @@ export class ZRXTokenContract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments(self.balanceOf.functionSignature, [_owner
+            const encodedData = self._strictEncodeArguments('balanceOf(address)', [_owner
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.balanceOf.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('balanceOf(address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -237,16 +231,15 @@ export class ZRXTokenContract extends BaseContract {
         },
     };
     public symbol = {
-        functionSignature: 'symbol()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments(self.symbol.functionSignature, []);
+            const encodedData = self._strictEncodeArguments('symbol()', []);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.symbol.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('symbol()');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -261,7 +254,7 @@ export class ZRXTokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments(self.transfer.functionSignature, [_to,
+            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
             const gasEstimateFunction = self.transfer.estimateGasAsync.bind(self, _to,
@@ -276,7 +269,7 @@ export class ZRXTokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments(self.transfer.functionSignature, [_to,
+            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
             const gas = await self._estimateGasAsync(self.address, encodedData, txData);
@@ -287,12 +280,11 @@ export class ZRXTokenContract extends BaseContract {
             _value: BigNumber,
         ): string {
             const self = this as any as ZRXTokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments(self.transfer.functionSignature, [_to,
+            const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
             return abiEncodedTransactionData;
         },
-        functionSignature: 'transfer(address,uint256)',
         async callAsync(
             _to: string,
             _value: BigNumber,
@@ -301,11 +293,11 @@ export class ZRXTokenContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments(self.transfer.functionSignature, [_to,
+            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
         _value
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.transfer.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('transfer(address,uint256)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -314,7 +306,6 @@ export class ZRXTokenContract extends BaseContract {
         },
     };
     public allowance = {
-        functionSignature: 'allowance(address,address)',
         async callAsync(
             _owner: string,
             _spender: string,
@@ -323,11 +314,11 @@ export class ZRXTokenContract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments(self.allowance.functionSignature, [_owner,
+            const encodedData = self._strictEncodeArguments('allowance(address,address)', [_owner,
         _spender
         ]);
             const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
-            const abiEncoder = self._lookupAbiEncoder(self.allowance.functionSignature);
+            const abiEncoder = self._lookupAbiEncoder('allowance(address,address)');
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);

--- a/packages/abi-gen-wrappers/src/generated-wrappers/zrx_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/zrx_token.ts
@@ -6,8 +6,7 @@ import { BlockParam, BlockParamLiteral, CallData, ContractAbi, ContractArtifact,
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
-import * as ethers from 'ethers';
-import * as _ from 'lodash';
+import { isUndefined } from 'lodash';
 // tslint:enable:no-unused-variable
 
 export type ZRXTokenEventArgs =
@@ -37,24 +36,16 @@ export interface ZRXTokenApprovalEventArgs extends DecodedLogArgs {
 // tslint:disable-next-line:class-name
 export class ZRXTokenContract extends BaseContract {
     public name = {
+        functionSignature: 'name()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments('name()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('name()');
+            const encodedData = self._strictEncodeArguments(self.name.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.name.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -69,23 +60,13 @@ export class ZRXTokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
+            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [_spender,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.approve.estimateGasAsync.bind(
-                    self,
-                    _spender,
-                    _value
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.approve.estimateGasAsync.bind(self, _spender,
+    _value
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -94,18 +75,10 @@ export class ZRXTokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
+            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [_spender,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -113,11 +86,12 @@ export class ZRXTokenContract extends BaseContract {
             _value: BigNumber,
         ): string {
             const self = this as any as ZRXTokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.approve.functionSignature, [_spender,
     _value
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'approve(address,uint256)',
         async callAsync(
             _spender: string,
             _value: BigNumber,
@@ -126,20 +100,11 @@ export class ZRXTokenContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
+            const encodedData = self._strictEncodeArguments(self.approve.functionSignature, [_spender,
         _value
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('approve(address,uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.approve.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -148,24 +113,16 @@ export class ZRXTokenContract extends BaseContract {
         },
     };
     public totalSupply = {
+        functionSignature: 'totalSupply()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
             const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments('totalSupply()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('totalSupply()');
+            const encodedData = self._strictEncodeArguments(self.totalSupply.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.totalSupply.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -181,25 +138,15 @@ export class ZRXTokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
     _to,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transferFrom.estimateGasAsync.bind(
-                    self,
-                    _from,
-                    _to,
-                    _value
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.transferFrom.estimateGasAsync.bind(self, _from,
+    _to,
+    _value
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -209,19 +156,11 @@ export class ZRXTokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
     _to,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -230,12 +169,13 @@ export class ZRXTokenContract extends BaseContract {
             _value: BigNumber,
         ): string {
             const self = this as any as ZRXTokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
     _to,
     _value
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'transferFrom(address,address,uint256)',
         async callAsync(
             _from: string,
             _to: string,
@@ -245,21 +185,12 @@ export class ZRXTokenContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+            const encodedData = self._strictEncodeArguments(self.transferFrom.functionSignature, [_from,
         _to,
         _value
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('transferFrom(address,address,uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.transferFrom.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -268,24 +199,16 @@ export class ZRXTokenContract extends BaseContract {
         },
     };
     public decimals = {
+        functionSignature: 'decimals()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<number
         > {
             const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments('decimals()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('decimals()');
+            const encodedData = self._strictEncodeArguments(self.decimals.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.decimals.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<number
         >(rawCallResult);
@@ -294,6 +217,7 @@ export class ZRXTokenContract extends BaseContract {
         },
     };
     public balanceOf = {
+        functionSignature: 'balanceOf(address)',
         async callAsync(
             _owner: string,
             callData: Partial<CallData> = {},
@@ -301,19 +225,10 @@ export class ZRXTokenContract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments('balanceOf(address)', [_owner
+            const encodedData = self._strictEncodeArguments(self.balanceOf.functionSignature, [_owner
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('balanceOf(address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.balanceOf.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -322,24 +237,16 @@ export class ZRXTokenContract extends BaseContract {
         },
     };
     public symbol = {
+        functionSignature: 'symbol()',
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
             const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments('symbol()', []);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('symbol()');
+            const encodedData = self._strictEncodeArguments(self.symbol.functionSignature, []);
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.symbol.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<string
         >(rawCallResult);
@@ -354,23 +261,13 @@ export class ZRXTokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<string> {
             const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
+            const encodedData = self._strictEncodeArguments(self.transfer.functionSignature, [_to,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transfer.estimateGasAsync.bind(
-                    self,
-                    _to,
-                    _value
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+            const gasEstimateFunction = self.transfer.estimateGasAsync.bind(self, _to,
+    _value
+    );
+            const txHash = await self._sendTransactionAsync(self.address, encodedData, txData, gasEstimateFunction);
             return txHash;
         },
         async estimateGasAsync(
@@ -379,18 +276,10 @@ export class ZRXTokenContract extends BaseContract {
             txData: Partial<TxData> = {},
         ): Promise<number> {
             const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
+            const encodedData = self._strictEncodeArguments(self.transfer.functionSignature, [_to,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+            const gas = await self._estimateGasAsync(self.address, encodedData, txData);
             return gas;
         },
         getABIEncodedTransactionData(
@@ -398,11 +287,12 @@ export class ZRXTokenContract extends BaseContract {
             _value: BigNumber,
         ): string {
             const self = this as any as ZRXTokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
+            const abiEncodedTransactionData = self._strictEncodeArguments(self.transfer.functionSignature, [_to,
     _value
     ]);
             return abiEncodedTransactionData;
         },
+        functionSignature: 'transfer(address,uint256)',
         async callAsync(
             _to: string,
             _value: BigNumber,
@@ -411,20 +301,11 @@ export class ZRXTokenContract extends BaseContract {
         ): Promise<boolean
         > {
             const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
+            const encodedData = self._strictEncodeArguments(self.transfer.functionSignature, [_to,
         _value
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('transfer(address,uint256)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.transfer.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<boolean
         >(rawCallResult);
@@ -433,6 +314,7 @@ export class ZRXTokenContract extends BaseContract {
         },
     };
     public allowance = {
+        functionSignature: 'allowance(address,address)',
         async callAsync(
             _owner: string,
             _spender: string,
@@ -441,20 +323,11 @@ export class ZRXTokenContract extends BaseContract {
         ): Promise<BigNumber
         > {
             const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments('allowance(address,address)', [_owner,
+            const encodedData = self._strictEncodeArguments(self.allowance.functionSignature, [_owner,
         _spender
         ]);
-            const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...callData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const rawCallResult = await self._web3Wrapper.callAsync(callDataWithDefaults, defaultBlock);
-            BaseContract._throwIfRevertWithReasonCallResult(rawCallResult);
-            const abiEncoder = self._lookupAbiEncoder('allowance(address,address)');
+            const rawCallResult = await self._callAsync(self.address, encodedData, callData, defaultBlock);
+            const abiEncoder = self._lookupAbiEncoder(self.allowance.functionSignature);
             // tslint:disable boolean-naming
             const result = abiEncoder.strictDecodeReturnValue<BigNumber
         >(rawCallResult);
@@ -467,7 +340,7 @@ export class ZRXTokenContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<ZRXTokenContract> {
-        if (_.isUndefined(artifact.compilerOutput)) {
+        if (isUndefined(artifact.compilerOutput)) {
             throw new Error('Compiler output not found in the artifact file');
         }
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
@@ -488,25 +361,10 @@ export class ZRXTokenContract extends BaseContract {
             [],
             BaseContract._bigNumberToString,
         );
-        const iface = new ethers.utils.Interface(abi);
-        const deployInfo = iface.deployFunction;
-        const txData = deployInfo.encode(bytecode, []);
-        const web3Wrapper = new Web3Wrapper(provider);
-        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-            {data: txData},
-            txDefaults,
-            web3Wrapper.estimateGasAsync.bind(web3Wrapper),
-        );
-        const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-        logUtils.log(`transactionHash: ${txHash}`);
-        const txReceipt = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
-        logUtils.log(`ZRXToken successfully deployed at ${txReceipt.contractAddress}`);
-        const contractInstance = new ZRXTokenContract(abi, txReceipt.contractAddress as string, provider, txDefaults);
-        contractInstance.constructorArgs = [];
-        return contractInstance;
+        return {} as any;
     }
     constructor(abi: ContractAbi, address: string, supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
-        super('ZRXToken', abi, address, providerUtils.standardizeOrThrow(supportedProvider), txDefaults);
+        super('ZRXToken', abi, address, supportedProvider, txDefaults);
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count

--- a/packages/base-contract/package.json
+++ b/packages/base-contract/package.json
@@ -44,7 +44,6 @@
         "@0x/utils": "^4.3.0",
         "@0x/web3-wrapper": "^6.0.4",
         "ethereum-types": "^2.1.1",
-        "ethers": "~4.0.4",
         "lodash": "^4.17.11"
     },
     "publishConfig": {

--- a/packages/sol-tracing-utils/src/trace_collection_subprovider.ts
+++ b/packages/sol-tracing-utils/src/trace_collection_subprovider.ts
@@ -101,6 +101,7 @@ export abstract class TraceCollectionSubprovider extends Subprovider {
                     if (!this._config.shouldCollectTransactionTraces) {
                         next();
                     } else {
+                        // TODO(FFF): Replace with ethereumjs-utils parse transaction
                         const txData = utils.parseTransaction(payload.params[0]);
                         if (txData.to === null) {
                             txData.to = constants.NEW_CONTRACT;

--- a/packages/utils/src/abi_decoder.ts
+++ b/packages/utils/src/abi_decoder.ts
@@ -179,6 +179,7 @@ export class AbiDecoder {
         });
     }
     private _addEventABI(eventAbi: EventAbi, ethersInterface: ethers.utils.Interface): void {
+        // TODO(FFF): Replace with events decoder
         const topic = ethersInterface.events[eventAbi.name].topic;
         const numIndexedArgs = _.reduce(eventAbi.inputs, (sum, input) => (input.indexed ? sum + 1 : sum), 0);
         this._eventIds[topic] = {

--- a/packages/utils/src/abi_decoder.ts
+++ b/packages/utils/src/abi_decoder.ts
@@ -8,7 +8,6 @@ import {
     MethodAbi,
     RawLog,
 } from 'ethereum-types';
-import * as ethers from 'ethers';
 import * as _ from 'lodash';
 
 import { AbiEncoder } from '.';
@@ -116,12 +115,11 @@ export class AbiDecoder {
         if (_.isUndefined(abiArray)) {
             return;
         }
-        const ethersInterface = new ethers.utils.Interface(abiArray);
         _.map(abiArray, (abi: AbiDefinition) => {
             switch (abi.type) {
                 case AbiType.Event:
                     // tslint:disable-next-line:no-unnecessary-type-assertion
-                    this._addEventABI(abi as EventAbi, ethersInterface);
+                    this._addEventABI(abi as EventAbi);
                     break;
 
                 case AbiType.Function:
@@ -135,9 +133,10 @@ export class AbiDecoder {
             }
         });
     }
-    private _addEventABI(eventAbi: EventAbi, ethersInterface: ethers.utils.Interface): void {
+    private _addEventABI(eventAbi: EventAbi): void {
         // TODO(FFF): Replace with events decoder
-        const topic = ethersInterface.events[eventAbi.name].topic;
+        const encoder = new AbiEncoder.Event(eventAbi);
+        const topic = encoder.getSelector();
         const numIndexedArgs = _.reduce(eventAbi.inputs, (sum, input) => (input.indexed ? sum + 1 : sum), 0);
         this._eventIds[topic] = {
             ...this._eventIds[topic],

--- a/packages/utils/src/abi_encoder/evm_data_type_factory.ts
+++ b/packages/utils/src/abi_encoder/evm_data_type_factory.ts
@@ -1,5 +1,5 @@
 /* tslint:disable max-classes-per-file */
-import { ConstructorAbi, DataItem, MethodAbi } from 'ethereum-types';
+import { ConstructorAbi, DataItem, EventAbi, MethodAbi } from 'ethereum-types';
 import * as _ from 'lodash';
 
 import { generateDataItemFromSignature } from './utils/signature_parser';
@@ -11,6 +11,7 @@ import { ArrayDataType } from './evm_data_types/array';
 import { BoolDataType } from './evm_data_types/bool';
 import { ConstructorDataType } from './evm_data_types/constructor';
 import { DynamicBytesDataType } from './evm_data_types/dynamic_bytes';
+import { EventDataType } from './evm_data_types/event';
 import { IntDataType } from './evm_data_types/int';
 import { MethodDataType } from './evm_data_types/method';
 import { PointerDataType } from './evm_data_types/pointer';
@@ -87,6 +88,12 @@ export class Method extends MethodDataType {
 
 export class Constructor extends ConstructorDataType {
     public constructor(abi: ConstructorAbi) {
+        super(abi, EvmDataTypeFactory.getInstance());
+    }
+}
+
+export class Event extends EventDataType {
+    public constructor(abi: EventAbi) {
         super(abi, EvmDataTypeFactory.getInstance());
     }
 }

--- a/packages/utils/src/abi_encoder/evm_data_type_factory.ts
+++ b/packages/utils/src/abi_encoder/evm_data_type_factory.ts
@@ -1,5 +1,5 @@
 /* tslint:disable max-classes-per-file */
-import { DataItem, MethodAbi } from 'ethereum-types';
+import { ConstructorAbi, DataItem, MethodAbi } from 'ethereum-types';
 import * as _ from 'lodash';
 
 import { generateDataItemFromSignature } from './utils/signature_parser';
@@ -9,6 +9,7 @@ import { DataTypeFactory } from './abstract_data_types/interfaces';
 import { AddressDataType } from './evm_data_types/address';
 import { ArrayDataType } from './evm_data_types/array';
 import { BoolDataType } from './evm_data_types/bool';
+import { ConstructorDataType } from './evm_data_types/constructor';
 import { DynamicBytesDataType } from './evm_data_types/dynamic_bytes';
 import { IntDataType } from './evm_data_types/int';
 import { MethodDataType } from './evm_data_types/method';
@@ -80,6 +81,12 @@ export class Array extends ArrayDataType {
 
 export class Method extends MethodDataType {
     public constructor(abi: MethodAbi) {
+        super(abi, EvmDataTypeFactory.getInstance());
+    }
+}
+
+export class Constructor extends ConstructorDataType {
+    public constructor(abi: ConstructorAbi) {
         super(abi, EvmDataTypeFactory.getInstance());
     }
 }

--- a/packages/utils/src/abi_encoder/evm_data_types/constructor.ts
+++ b/packages/utils/src/abi_encoder/evm_data_types/constructor.ts
@@ -1,4 +1,4 @@
-import { ConstructorAbi, DataItem, MethodAbi } from 'ethereum-types';
+import { ConstructorAbi, DataItem } from 'ethereum-types';
 
 import { DataType } from '../abstract_data_types/data_type';
 import { DataTypeFactory } from '../abstract_data_types/interfaces';

--- a/packages/utils/src/abi_encoder/evm_data_types/constructor.ts
+++ b/packages/utils/src/abi_encoder/evm_data_types/constructor.ts
@@ -1,0 +1,27 @@
+import { ConstructorAbi, DataItem, MethodAbi } from 'ethereum-types';
+
+import { DataType } from '../abstract_data_types/data_type';
+import { DataTypeFactory } from '../abstract_data_types/interfaces';
+import { DecodingRules, EncodingRules } from '../utils/rules';
+
+import { TupleDataType } from './tuple';
+
+export class ConstructorDataType {
+    private readonly _returnDataType: DataType;
+    public constructor(abi: ConstructorAbi, dataTypeFactory: DataTypeFactory) {
+        const returnDataItem: DataItem = { type: 'tuple', name: 'constructor', components: abi.inputs };
+        this._returnDataType = new TupleDataType(returnDataItem, dataTypeFactory);
+    }
+    public encode(bytecode: string, value: any, rules?: EncodingRules): string {
+        const encodedArgs = this._returnDataType.encode(value, rules);
+        const returnData = `${bytecode}${encodedArgs.slice(2)}`;
+        return returnData;
+    }
+
+    // tslint:disable-next-line:prefer-function-over-method
+    public decode(calldata: string, rules?: DecodingRules): any[] | object {
+        // const value = super.decode(calldata, rules, this.getSelector());
+        // return value;
+        return {};
+    }
+}

--- a/packages/utils/src/abi_encoder/evm_data_types/event.ts
+++ b/packages/utils/src/abi_encoder/evm_data_types/event.ts
@@ -1,5 +1,5 @@
 import {
-    DataItem,
+    AbiType,
     DecodedLogArgs,
     EventAbi,
     EventParameter,
@@ -8,6 +8,7 @@ import {
     RawLog,
     SolidityTypes,
 } from 'ethereum-types';
+import * as ethUtil from 'ethereumjs-util';
 import * as _ from 'lodash';
 
 import { addressUtils, BigNumber } from '../..';
@@ -15,17 +16,54 @@ import { DataType } from '../abstract_data_types/data_type';
 import { DataTypeFactory } from '../abstract_data_types/interfaces';
 import { DecodingRules, EncodingRules } from '../utils/rules';
 
+import { AddressDataType } from './address';
+import { IntDataType } from './int';
 import { TupleDataType } from './tuple';
+import { UIntDataType } from './uint';
 
 export class EventDataType {
     private readonly _abi: EventAbi;
     private readonly _nonIndexedDataType: DataType;
+    private readonly _signature: string;
+    private readonly _selector: string;
+    public static matchType(type: string): boolean {
+        return type === AbiType.Event;
+    }
+    private static _normalizeValue(type: string, value: BigNumber | string | number): BigNumber | string | number {
+        let normalizedValue = value;
+        if (AddressDataType.matchType(type)) {
+            const baseHex = 16;
+            normalizedValue = addressUtils.padZeros(new BigNumber((value as string).toLowerCase()).toString(baseHex));
+        } else if (type === SolidityTypes.Uint8) {
+            normalizedValue = new BigNumber(value).toNumber();
+        } else if (IntDataType.matchType(type) || UIntDataType.matchType(type)) {
+            normalizedValue = new BigNumber(value);
+        }
+        return normalizedValue;
+    }
     public constructor(abi: EventAbi, dataTypeFactory: DataTypeFactory) {
         this._abi = abi;
+        if (!EventDataType.matchType(abi.type)) {
+            throw new Error(`Invalid event ABI type ${abi.type}`);
+        }
+        const eventDataItem = { type: 'tuple', name: 'function', components: abi.inputs };
+        this._signature = new TupleDataType(eventDataItem, dataTypeFactory).getSignature();
         const nonIndexedParams = _.filter(this._abi.inputs, i => i.indexed === false);
-        const nonIndexDataItem = { type: 'tuple', name: 'constructor', components: nonIndexedParams };
-        this._nonIndexedDataType = new TupleDataType(nonIndexDataItem, dataTypeFactory);
+        this._nonIndexedDataType = new TupleDataType(
+            { ...eventDataItem, components: nonIndexedParams },
+            dataTypeFactory,
+        );
+        this._selector = ethUtil.bufferToHex(ethUtil.toBuffer(ethUtil.sha3(`${this._abi.name}${this._signature}`)));
     }
+
+    public getSignatureType(): string {
+        return this._signature;
+    }
+
+    public getSelector(): string {
+        return this._selector;
+    }
+
     // tslint:disable-next-line:prefer-function-over-method
     public encode(bytecode: string, value: any, rules?: EncodingRules): string {
         throw new Error('Unimplemented');
@@ -35,34 +73,22 @@ export class EventDataType {
         logEvent: LogEntry,
         rules?: DecodingRules,
     ): LogWithDecodedArgs<ArgsType> | RawLog {
-        let decodedData: any[];
-        decodedData = this._nonIndexedDataType.decode(logEvent.data);
-        let didFailToDecode = false;
+        if (logEvent.topics[0] !== this.getSelector()) {
+            throw new Error(`Invalid log for event ABI, expected ${this.getSelector()}`);
+        }
+        const decodedData = this._nonIndexedDataType.decode(logEvent.data, rules);
+        const decodedDataValues = _.values(decodedData);
         let topicsIndex = 1;
         let decodedDataIndex = 0;
         const decodedParams: DecodedLogArgs = {};
-        _.forEach(this._abi.inputs, (param: EventParameter, i: number) => {
+        _.forEach(this._abi.inputs, (param: EventParameter) => {
             // Indexed parameters are stored in topics. Non-indexed ones in decodedData
-            let value: BigNumber | string | number = param.indexed
-                ? logEvent.topics[topicsIndex++]
-                : _.values(decodedData)[decodedDataIndex++];
+            const value = param.indexed ? logEvent.topics[topicsIndex++] : decodedDataValues[decodedDataIndex++];
             if (_.isUndefined(value)) {
-                didFailToDecode = true;
-                return;
+                throw new Error(`Failed to decode ${param.name}`);
             }
-            if (param.type === SolidityTypes.Address) {
-                const baseHex = 16;
-                value = addressUtils.padZeros(new BigNumber((value as string).toLowerCase()).toString(baseHex));
-            } else if (param.type === SolidityTypes.Uint256 || param.type === SolidityTypes.Uint) {
-                value = new BigNumber(value);
-            } else if (param.type === SolidityTypes.Uint8) {
-                value = new BigNumber(value).toNumber();
-            }
-            decodedParams[param.name] = value;
+            decodedParams[param.name] = EventDataType._normalizeValue(param.type, value);
         });
-        if (didFailToDecode) {
-            return logEvent;
-        }
         return {
             ...logEvent,
             event: this._abi.name,

--- a/packages/utils/src/abi_encoder/evm_data_types/event.ts
+++ b/packages/utils/src/abi_encoder/evm_data_types/event.ts
@@ -1,0 +1,72 @@
+import {
+    DataItem,
+    DecodedLogArgs,
+    EventAbi,
+    EventParameter,
+    LogEntry,
+    LogWithDecodedArgs,
+    RawLog,
+    SolidityTypes,
+} from 'ethereum-types';
+import * as _ from 'lodash';
+
+import { addressUtils, BigNumber } from '../..';
+import { DataType } from '../abstract_data_types/data_type';
+import { DataTypeFactory } from '../abstract_data_types/interfaces';
+import { DecodingRules, EncodingRules } from '../utils/rules';
+
+import { TupleDataType } from './tuple';
+
+export class EventDataType {
+    private readonly _abi: EventAbi;
+    private readonly _nonIndexedDataType: DataType;
+    public constructor(abi: EventAbi, dataTypeFactory: DataTypeFactory) {
+        this._abi = abi;
+        const nonIndexedParams = _.filter(this._abi.inputs, i => i.indexed === false);
+        const nonIndexDataItem = { type: 'tuple', name: 'constructor', components: nonIndexedParams };
+        this._nonIndexedDataType = new TupleDataType(nonIndexDataItem, dataTypeFactory);
+    }
+    // tslint:disable-next-line:prefer-function-over-method
+    public encode(bytecode: string, value: any, rules?: EncodingRules): string {
+        throw new Error('Unimplemented');
+    }
+
+    public decode<ArgsType extends DecodedLogArgs>(
+        logEvent: LogEntry,
+        rules?: DecodingRules,
+    ): LogWithDecodedArgs<ArgsType> | RawLog {
+        let decodedData: any[];
+        decodedData = this._nonIndexedDataType.decode(logEvent.data);
+        let didFailToDecode = false;
+        let topicsIndex = 1;
+        let decodedDataIndex = 0;
+        const decodedParams: DecodedLogArgs = {};
+        _.forEach(this._abi.inputs, (param: EventParameter, i: number) => {
+            // Indexed parameters are stored in topics. Non-indexed ones in decodedData
+            let value: BigNumber | string | number = param.indexed
+                ? logEvent.topics[topicsIndex++]
+                : _.values(decodedData)[decodedDataIndex++];
+            if (_.isUndefined(value)) {
+                didFailToDecode = true;
+                return;
+            }
+            if (param.type === SolidityTypes.Address) {
+                const baseHex = 16;
+                value = addressUtils.padZeros(new BigNumber((value as string).toLowerCase()).toString(baseHex));
+            } else if (param.type === SolidityTypes.Uint256 || param.type === SolidityTypes.Uint) {
+                value = new BigNumber(value);
+            } else if (param.type === SolidityTypes.Uint8) {
+                value = new BigNumber(value).toNumber();
+            }
+            decodedParams[param.name] = value;
+        });
+        if (didFailToDecode) {
+            return logEvent;
+        }
+        return {
+            ...logEvent,
+            event: this._abi.name,
+            args: decodedParams,
+        };
+    }
+}

--- a/packages/utils/src/abi_encoder/index.ts
+++ b/packages/utils/src/abi_encoder/index.ts
@@ -3,6 +3,7 @@ export {
     Address,
     Array,
     Bool,
+    Constructor,
     DynamicBytes,
     Int,
     Method,

--- a/packages/utils/src/abi_encoder/index.ts
+++ b/packages/utils/src/abi_encoder/index.ts
@@ -5,6 +5,7 @@ export {
     Bool,
     Constructor,
     DynamicBytes,
+    Event,
     Int,
     Method,
     Pointer,

--- a/packages/utils/src/sign_typed_data_utils.ts
+++ b/packages/utils/src/sign_typed_data_utils.ts
@@ -68,6 +68,7 @@ export const signTypedDataUtils = {
                 encodedValues.push(normalizedValue);
             }
         }
+        // TODO(FFF): Replace with return data encoding
         return ethers.utils.defaultAbiCoder.encode(encodedTypes, encodedValues);
     },
     _normalizeValue(type: string, value: any): EIP712ObjectValue {

--- a/packages/utils/src/sign_typed_data_utils.ts
+++ b/packages/utils/src/sign_typed_data_utils.ts
@@ -1,8 +1,8 @@
 import { EIP712Object, EIP712ObjectValue, EIP712TypedData, EIP712Types } from '@0x/types';
 import * as ethUtil from 'ethereumjs-util';
-import * as ethers from 'ethers';
 import * as _ from 'lodash';
 
+import { AbiEncoder } from '.';
 import { BigNumber } from './configured_bignumber';
 
 export const signTypedDataUtils = {
@@ -69,7 +69,12 @@ export const signTypedDataUtils = {
             }
         }
         // TODO(FFF): Replace with return data encoding
-        return ethers.utils.defaultAbiCoder.encode(encodedTypes, encodedValues);
+        const dataItem = {
+            type: 'tuple',
+            name: '',
+            components: _.map(encodedTypes, t => ({ type: t, name: '' })),
+        };
+        return AbiEncoder.create(dataItem).encode(encodedValues);
     },
     _normalizeValue(type: string, value: any): EIP712ObjectValue {
         const normalizedValue = type === 'uint256' && BigNumber.isBigNumber(value) ? value.toString() : value;

--- a/packages/utils/test/abi_encoder/abi_samples/constructor_abis.ts
+++ b/packages/utils/test/abi_encoder/abi_samples/constructor_abis.ts
@@ -1,0 +1,24 @@
+import { ConstructorAbi } from 'ethereum-types';
+
+export const simpleAbi: ConstructorAbi = {
+    inputs: [
+        {
+            name: 'greg',
+            type: 'uint256',
+        },
+        {
+            name: 'gregStr',
+            type: 'string',
+        },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'constructor',
+};
+
+export const noArgumentConstructor: ConstructorAbi = {
+    inputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'constructor',
+};

--- a/packages/utils/test/abi_encoder/abi_samples/event_abis.ts
+++ b/packages/utils/test/abi_encoder/abi_samples/event_abis.ts
@@ -23,7 +23,7 @@ export const erc721TransferEvent: EventAbi = {
     type: 'event',
 };
 
-export const erc721TransferNoIndexOnTokenIdEvent: EventAbi = {
+export const erc721ApprovalNoIndexOnTokenIdEvent: EventAbi = {
     anonymous: false,
     inputs: [
         {
@@ -42,6 +42,6 @@ export const erc721TransferNoIndexOnTokenIdEvent: EventAbi = {
             type: 'uint256',
         },
     ],
-    name: 'Transfer',
+    name: 'Approval',
     type: 'event',
 };

--- a/packages/utils/test/abi_encoder/abi_samples/event_abis.ts
+++ b/packages/utils/test/abi_encoder/abi_samples/event_abis.ts
@@ -1,0 +1,47 @@
+import { EventAbi } from 'ethereum-types';
+
+export const erc721TransferEvent: EventAbi = {
+    anonymous: false,
+    inputs: [
+        {
+            indexed: true,
+            name: '_from',
+            type: 'address',
+        },
+        {
+            indexed: true,
+            name: '_to',
+            type: 'address',
+        },
+        {
+            indexed: true,
+            name: '_tokenId',
+            type: 'uint256',
+        },
+    ],
+    name: 'Transfer',
+    type: 'event',
+};
+
+export const erc721TransferNoIndexOnTokenIdEvent: EventAbi = {
+    anonymous: false,
+    inputs: [
+        {
+            indexed: true,
+            name: '_from',
+            type: 'address',
+        },
+        {
+            indexed: true,
+            name: '_to',
+            type: 'address',
+        },
+        {
+            indexed: false,
+            name: '_tokenId',
+            type: 'uint256',
+        },
+    ],
+    name: 'Transfer',
+    type: 'event',
+};

--- a/packages/utils/test/abi_encoder/constructor_test.ts
+++ b/packages/utils/test/abi_encoder/constructor_test.ts
@@ -1,0 +1,29 @@
+import * as chai from 'chai';
+import 'mocha';
+
+import { AbiEncoder, BigNumber } from '../../src/';
+import { chaiSetup } from '../utils/chai_setup';
+
+import * as AbiSamples from './abi_samples/constructor_abis';
+
+chaiSetup.configure();
+const expect = chai.expect;
+
+describe.only('ABI Encoder: Constructor Encoding', () => {
+    const encodingRules: AbiEncoder.EncodingRules = { shouldOptimize: false }; // optimizer is tested separately.
+    it('Encodes the constructor arguments with the bytecode', async () => {
+        const method = new AbiEncoder.Constructor(AbiSamples.simpleAbi);
+        const args = [new BigNumber(1), 'abcd'];
+        const bytecode = '0x0';
+        const calldata = method.encode(bytecode, args, encodingRules);
+        const expectedCallData =
+            '0x00000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000046162636400000000000000000000000000000000000000000000000000000000';
+        expect(calldata).to.eql(expectedCallData);
+    });
+    it('Encodes the constructor arguments with the bytecode', async () => {
+        const method = new AbiEncoder.Constructor(AbiSamples.noArgumentConstructor);
+        const bytecode = '0x1234';
+        const calldata = method.encode(bytecode, [], encodingRules);
+        expect(calldata).to.eql(bytecode);
+    });
+});

--- a/packages/utils/test/abi_encoder/constructor_test.ts
+++ b/packages/utils/test/abi_encoder/constructor_test.ts
@@ -9,7 +9,7 @@ import * as AbiSamples from './abi_samples/constructor_abis';
 chaiSetup.configure();
 const expect = chai.expect;
 
-describe.only('ABI Encoder: Constructor Encoding', () => {
+describe('ABI Encoder: Constructor Encoding', () => {
     const encodingRules: AbiEncoder.EncodingRules = { shouldOptimize: false }; // optimizer is tested separately.
     it('Encodes the constructor arguments with the bytecode', async () => {
         const method = new AbiEncoder.Constructor(AbiSamples.simpleAbi);
@@ -20,7 +20,7 @@ describe.only('ABI Encoder: Constructor Encoding', () => {
             '0x00000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000046162636400000000000000000000000000000000000000000000000000000000';
         expect(calldata).to.eql(expectedCallData);
     });
-    it('Encodes the constructor arguments with the bytecode', async () => {
+    it('Encodes the bytecode with no constructor arguments', async () => {
         const method = new AbiEncoder.Constructor(AbiSamples.noArgumentConstructor);
         const bytecode = '0x1234';
         const calldata = method.encode(bytecode, [], encodingRules);

--- a/packages/utils/test/abi_encoder/event_test.ts
+++ b/packages/utils/test/abi_encoder/event_test.ts
@@ -10,9 +10,9 @@ import * as AbiSamples from './abi_samples/event_abis';
 chaiSetup.configure();
 const expect = chai.expect;
 
-describe.only('ABI Encoder: Event Decoding', () => {
+describe('ABI Encoder: Event Decoding', () => {
     const encodingRules: AbiEncoder.EncodingRules = { shouldOptimize: false }; // optimizer is tested separately.
-    it('Encodes the constructor arguments with the bytecode', async () => {
+    it('encodes the constructor arguments with the bytecode', async () => {
         const logEvent = {
             address: '0xf5b0a3efb8e8e4c201e2a935f110eaaf3ffecb8d',
             topics: [
@@ -21,14 +21,13 @@ describe.only('ABI Encoder: Event Decoding', () => {
                 '0x0000000000000000000000000000000000000000000000000000000000000000',
             ],
             data: '0x000000000000000000000000000000000000000000000000000000000000a986',
-            blockNumber: parseInt('0x726650', 16),
+            blockNumber: 1,
             transactionHash: '0x8bf55be2fddbe9a941fd376e571cc0d6270f7b7bb87cb3c7c4476d8ed6e51bb0',
-            transactionIndex: parseInt('0x43', 16),
+            transactionIndex: 1,
             blockHash: '0x2c14bdc4f78019146ca5fa7aeac6211c055059a00468867c2ccde1b66120e1dc',
-            logIndex: parseInt('0x19', 16),
-            removed: false,
+            logIndex: 1,
         };
-        const event = AbiSamples.erc721TransferNoIndexOnTokenIdEvent;
+        const event = AbiSamples.erc721ApprovalNoIndexOnTokenIdEvent;
         const encoder = new AbiEncoder.Event(event);
         const decodedLog = encoder.decode(logEvent) as LogWithDecodedArgs<any>;
         expect(decodedLog.args._tokenId).to.eql(
@@ -36,5 +35,21 @@ describe.only('ABI Encoder: Event Decoding', () => {
         );
         expect(decodedLog.args._to).to.eql('0x0000000000000000000000000000000000000000');
         expect(decodedLog.args._from).to.eql('0xf4985070ce32b6b1994329df787d1acc9a2dd9e2');
+        expect(decodedLog.event).to.eql('Approval');
+    });
+    it('throws when decoding fails', async () => {
+        const logEvent = {
+            address: '0xf5b0a3efb8e8e4c201e2a935f110eaaf3ffecb8d',
+            topics: ['0x1111111111111111111111111111111111111111111111111111111111111111'],
+            data: '0x000000000000000000000000000000000000000000000000000000000000a986',
+            blockNumber: 1,
+            transactionHash: '0x8bf55be2fddbe9a941fd376e571cc0d6270f7b7bb87cb3c7c4476d8ed6e51bb0',
+            transactionIndex: 1,
+            blockHash: '0x2c14bdc4f78019146ca5fa7aeac6211c055059a00468867c2ccde1b66120e1dc',
+            logIndex: 1,
+        };
+        const event = AbiSamples.erc721ApprovalNoIndexOnTokenIdEvent;
+        const encoder = new AbiEncoder.Event(event);
+        expect(() => encoder.decode(logEvent)).to.throw();
     });
 });

--- a/packages/utils/test/abi_encoder/event_test.ts
+++ b/packages/utils/test/abi_encoder/event_test.ts
@@ -1,0 +1,40 @@
+import * as chai from 'chai';
+import { LogWithDecodedArgs } from 'ethereum-types';
+import 'mocha';
+
+import { AbiEncoder, BigNumber } from '../../src/';
+import { chaiSetup } from '../utils/chai_setup';
+
+import * as AbiSamples from './abi_samples/event_abis';
+
+chaiSetup.configure();
+const expect = chai.expect;
+
+describe.only('ABI Encoder: Event Decoding', () => {
+    const encodingRules: AbiEncoder.EncodingRules = { shouldOptimize: false }; // optimizer is tested separately.
+    it('Encodes the constructor arguments with the bytecode', async () => {
+        const logEvent = {
+            address: '0xf5b0a3efb8e8e4c201e2a935f110eaaf3ffecb8d',
+            topics: [
+                '0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925',
+                '0x000000000000000000000000f4985070ce32b6b1994329df787d1acc9a2dd9e2',
+                '0x0000000000000000000000000000000000000000000000000000000000000000',
+            ],
+            data: '0x000000000000000000000000000000000000000000000000000000000000a986',
+            blockNumber: parseInt('0x726650', 16),
+            transactionHash: '0x8bf55be2fddbe9a941fd376e571cc0d6270f7b7bb87cb3c7c4476d8ed6e51bb0',
+            transactionIndex: parseInt('0x43', 16),
+            blockHash: '0x2c14bdc4f78019146ca5fa7aeac6211c055059a00468867c2ccde1b66120e1dc',
+            logIndex: parseInt('0x19', 16),
+            removed: false,
+        };
+        const event = AbiSamples.erc721TransferNoIndexOnTokenIdEvent;
+        const encoder = new AbiEncoder.Event(event);
+        const decodedLog = encoder.decode(logEvent) as LogWithDecodedArgs<any>;
+        expect(decodedLog.args._tokenId).to.eql(
+            new BigNumber(parseInt('0x000000000000000000000000000000000000000000000000000000000000a986', 16)),
+        );
+        expect(decodedLog.args._to).to.eql('0x0000000000000000000000000000000000000000');
+        expect(decodedLog.args._from).to.eql('0xf4985070ce32b6b1994329df787d1acc9a2dd9e2');
+    });
+});


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
### Optimised ABI gen templates
* Moved shared behaviour to base functions in the base-contract.
* Moved the function signature to a property. Now accessible by other utilities

```
# Before
115K  exchange.ts
 60K  asset_proxy_owner.ts
 39K  dummy_erc721_token.ts
 32K  dummy_erc20_token.ts
 28K  multi_asset_proxy.ts
 27K  forwarder.ts

# After
 87K  exchange.ts
 45K  asset_proxy_owner.ts
 29K  dummy_erc721_token.ts
 24K  dummy_erc20_token.ts
 22K  forwarder.ts
```

### Profiling
#### Webpack bundle analyzer
**Before**
<img width="1386" alt="Screen Shot 2019-04-05 at 11 37 58 am" src="https://user-images.githubusercontent.com/27389/55622248-93a12300-5797-11e9-9575-8cff595eaa24.png">

**After**
<img width="1385" alt="Screen Shot 2019-04-05 at 11 38 11 am" src="https://user-images.githubusercontent.com/27389/55622267-9e5bb800-5797-11e9-8a1c-19b83f92d905.png">

#### File size
index.js
**Before**: 2.55MB
**After**: 1.8MB

instant.js
**Before**: 2.9MB
**After**: 2.3MB


## TODO
- [ ] Support event decoding in AbiEncoder @hysz 
- [ ] Support constructor transaction encoding in AbiEncoder @dekz 

## Thoughts
- [ ] Sideloading of JSON artifacts. Exchange duplicates tuples 16 times, whilst gzip compression optimises this it's still a chunky artifact. If we sideloaded tuples (that is define them once and reference) we could save one filesize
- [ ] Bytecode doesn't need to exist for most use cases. Migrations need this for deployment but not required at runtime. These are difficult to compress as well. Consider creating a `contract-artifacts-lite` or `contract-artifacts-dev`?
- [ ] 0x.js index.js and index.min.js are the same file size

## Sizes

### @0x/order-utils
7.1.1 ![Minified](https://badgen.net/bundlephobia/min/@0x/order-utils@7.1.1)
7.2.0 ![Minified](https://badgen.net/bundlephobia/min/@0x/order-utils@7.2.0)

### 0x.js
6.0.5 ![Minified](https://badgen.net/bundlephobia/min/0x.js@6.0.5)
6.0.6 ![Minified](https://badgen.net/bundlephobia/min/0x.js@6.0.6)

### @0x/contract-artifacts
1.4.0 ![Minified](https://badgen.net/bundlephobia/min/@0x/contract-artifacts@1.4.0)
1.5.0 ![Minified](https://badgen.net/bundlephobia/min/@0x/contract-artifacts@1.5.0)

### @0x/abi-gen-wrappers
4.1.0 ![Minified](https://badgen.net/bundlephobia/min/@0x/abi-gen-wrappers@4.1.0)
4.2.0 ![Minified](https://badgen.net/bundlephobia/min/@0x/abi-gen-wrappers@4.2.0)

### @0x/web3-wrapper
6.0.4 ![Minified](https://badgen.net/bundlephobia/min/@0x/web3-wrapper@6.0.4)
6.0.5 ![Minified](https://badgen.net/bundlephobia/min/@0x/web3-wrapper@6.0.5)

### @0x/order-watcher
4.0.5 ![Minified](https://badgen.net/bundlephobia/min/@0x/order-watcher@4.0.5) 
4.0.6 ![Minified](https://badgen.net/bundlephobia/min/@0x/order-watcher@4.0.6) 
