### PR TITLE
[WIP] Add SignatureType.OrderValidator support to Exchange

### DIFF
--- a/contracts/exchange/CHANGELOG.json
+++ b/contracts/exchange/CHANGELOG.json
@@ -17,6 +17,10 @@
             {
                 "note": "Refactor example contracts that use `executeTransaction`",
                 "pr": 1753
+            },
+            {
+                "note": "Add support for `SignatureType.OrderValidator` for orders",
+                "pr": 0
             }
         ]
     },

--- a/contracts/exchange/contracts/examples/Validator.sol
+++ b/contracts/exchange/contracts/examples/Validator.sol
@@ -17,15 +17,17 @@
 */
 
 pragma solidity ^0.5.5;
+pragma experimental ABIEncoderV2;
 
+import "@0x/contracts-exchange-libs/contracts/src/LibOrder.sol";
 import "../src/interfaces/IValidator.sol";
 
 
-contract Validator is 
+contract Validator is
     IValidator
 {
 
-    // The single valid signer for this wallet.
+    // The single valid signer for this validator.
     // solhint-disable-next-line var-name-mixedcase
     address internal VALID_SIGNER;
 
@@ -35,14 +37,33 @@ contract Validator is
         VALID_SIGNER = validSigner;
     }
 
+    // solhint-disable no-unused-vars
     /// @dev Verifies that a signature is valid. `signer` must match `VALID_SIGNER`.
     /// @param hash Message hash that is signed.
     /// @param signerAddress Address that should have signed the given hash.
     /// @param signature Proof of signing.
     /// @return Validity of signature.
-    // solhint-disable no-unused-vars
     function isValidSignature(
         bytes32 hash,
+        address signerAddress,
+        bytes calldata signature
+    )
+        external
+        view
+        returns (bool isValid)
+    {
+        return (signerAddress == VALID_SIGNER);
+    }
+    // solhint-enable no-unused-vars
+
+    // solhint-disable no-unused-vars
+    /// @dev Verifies that a signature is valid. `signer` must match `VALID_SIGNER`.
+    /// @param order The order.
+    /// @param signerAddress Address that should have signed the given hash.
+    /// @param signature Proof of signing.
+    /// @return Validity of signature.
+    function isValidOrder(
+        LibOrder.Order calldata order,
         address signerAddress,
         bytes calldata signature
     )

--- a/contracts/exchange/contracts/src/MixinTransactions.sol
+++ b/contracts/exchange/contracts/src/MixinTransactions.sol
@@ -65,7 +65,7 @@ contract MixinTransactions is
         if (signerAddress != msg.sender) {
             // Validate signature
             require(
-                isValidSignature(
+                isValidHashSignature(
                     transactionHash,
                     signerAddress,
                     signature

--- a/contracts/exchange/contracts/src/interfaces/ISignatureValidator.sol
+++ b/contracts/exchange/contracts/src/interfaces/ISignatureValidator.sol
@@ -17,6 +17,9 @@
 */
 
 pragma solidity ^0.5.5;
+pragma experimental ABIEncoderV2;
+
+import "@0x/contracts-exchange-libs/contracts/src/LibOrder.sol";
 
 
 contract ISignatureValidator {
@@ -31,7 +34,7 @@ contract ISignatureValidator {
         bytes calldata signature
     )
         external;
-    
+
     /// @dev Approves/unnapproves a Validator contract to verify signatures on signer's behalf.
     /// @param validatorAddress Address of Validator contract.
     /// @param approval Approval or disapproval of  Validator contract.
@@ -41,13 +44,27 @@ contract ISignatureValidator {
     )
         external;
 
-    /// @dev Verifies that a signature is valid.
+    /// @dev Verifies that a signature for a hash is valid.
     /// @param hash Message hash that is signed.
     /// @param signerAddress Address of signer.
     /// @param signature Proof of signing.
     /// @return Validity of order signature.
-    function isValidSignature(
+    function isValidHashSignature(
         bytes32 hash,
+        address signerAddress,
+        bytes memory signature
+    )
+        public
+        view
+        returns (bool isValid);
+
+    /// @dev Verifies that a signature for an order is valid.
+    /// @param order The order.
+    /// @param signerAddress Address of signer.
+    /// @param signature Proof of signing.
+    /// @return Validity of order signature.
+    function isValidOrderSignature(
+        LibOrder.Order memory order,
         address signerAddress,
         bytes memory signature
     )

--- a/contracts/exchange/contracts/src/interfaces/IValidator.sol
+++ b/contracts/exchange/contracts/src/interfaces/IValidator.sol
@@ -17,6 +17,9 @@
 */
 
 pragma solidity ^0.5.5;
+pragma experimental ABIEncoderV2;
+
+import "@0x/contracts-exchange-libs/contracts/src/LibOrder.sol";
 
 
 contract IValidator {
@@ -28,6 +31,32 @@ contract IValidator {
     /// @return Validity of order signature.
     function isValidSignature(
         bytes32 hash,
+        address signerAddress,
+        bytes calldata signature
+    )
+        external
+        view
+        returns (bool isValid);
+
+    /// @param order The order.
+    /// @param signerAddress Address that should have signed the given order.
+    /// @param signature Proof of signing.
+    /// @return Validity of order signature.
+    function isValidOrderSignature(
+        LibOrder.Order calldata order,
+        address signerAddress,
+        bytes calldata signature
+    )
+        external
+        view
+        returns (bool isValid);
+
+    /// @param order The order.
+    /// @param signerAddress Address that should have signed the given order.
+    /// @param signature Proof of signing.
+    /// @return Validity of order.
+    function isValidOrder(
+        LibOrder.Order calldata order,
         address signerAddress,
         bytes calldata signature
     )

--- a/contracts/exchange/contracts/src/mixins/MSignatureValidator.sol
+++ b/contracts/exchange/contracts/src/mixins/MSignatureValidator.sol
@@ -19,6 +19,7 @@
 pragma solidity ^0.5.5;
 pragma experimental ABIEncoderV2;
 
+import "@0x/contracts-exchange-libs/contracts/src/LibOrder.sol";
 import "../interfaces/ISignatureValidator.sol";
 
 
@@ -40,15 +41,33 @@ contract MSignatureValidator is
         Wallet,          // 0x04
         Validator,       // 0x05
         PreSigned,       // 0x06
-        NSignatureTypes  // 0x07, number of signature types. Always leave at end.
+        OrderValidator,  // 0x07
+        NSignatureTypes  // 0x08, number of signature types. Always leave at end.
     }
+
+    /// @dev Verifies that an order, with provided order hash, has been signed
+    ///      by the given signer.
+    /// @param order The order.
+    /// @param orderHash The hash of the order.
+    /// @param signerAddress Address that should have signed the.Signat given hash.
+    /// @param signature Proof that the hash has been signed by signer.
+    /// @return True if the signature is valid for the given hash and signer.
+    function isValidOrderWithHashSignature(
+        LibOrder.Order memory order,
+        bytes32 orderHash,
+        address signerAddress,
+        bytes memory signature
+    )
+        internal
+        view
+        returns (bool isValid);
 
     /// @dev Verifies signature using logic defined by Wallet contract.
     /// @param hash Any 32 byte hash.
     /// @param walletAddress Address that should have signed the given hash
     ///                      and defines its own signature verification method.
     /// @param signature Proof that the hash has been signed by signer.
-    /// @return True if the address recovered from the provided signature matches the input signer address.
+    /// @return True if the validator approves the signature.
     function isValidWalletSignature(
         bytes32 hash,
         address walletAddress,
@@ -63,10 +82,26 @@ contract MSignatureValidator is
     /// @param hash Any 32 byte hash.
     /// @param signerAddress Address that should have signed the given hash.
     /// @param signature Proof that the hash has been signed by signer.
-    /// @return True if the address recovered from the provided signature matches the input signer address.
+    /// @return True if the validator approves the signature.
     function isValidValidatorSignature(
         address validatorAddress,
         bytes32 hash,
+        address signerAddress,
+        bytes memory signature
+    )
+        internal
+        view
+        returns (bool isValid);
+
+    /// @dev Verifies order AND signature using logic defined by Validator contract.
+    /// @param validatorAddress Address of validator contract.
+    /// @param order The order.
+    /// @param signerAddress Address that should have signed the given order.
+    /// @param signature Proof that the order has been signed by signer.
+    /// @return True if the validator approves the order signature.
+    function isValidOrderValidatorSignature(
+        address validatorAddress,
+        LibOrder.Order memory order,
         address signerAddress,
         bytes memory signature
     )

--- a/contracts/exchange/contracts/test/TestSignatureValidator.sol
+++ b/contracts/exchange/contracts/test/TestSignatureValidator.sol
@@ -35,21 +35,4 @@ contract TestSignatureValidator is
         public
         LibEIP712ExchangeDomain(chainId, address(0))
     {}
-
-    function publicIsValidSignature(
-        bytes32 hash,
-        address signer,
-        bytes memory signature
-    )
-        public
-        view
-        returns (bool isValid)
-    {
-        isValid = isValidSignature(
-            hash,
-            signer,
-            signature
-        );
-        return isValid;
-    }
 }

--- a/contracts/exchange/contracts/test/TestStaticCallReceiver.sol
+++ b/contracts/exchange/contracts/test/TestStaticCallReceiver.sol
@@ -17,7 +17,9 @@
 */
 
 pragma solidity ^0.5.5;
+pragma experimental ABIEncoderV2;
 
+import "@0x/contracts-exchange-libs/contracts/src/LibOrder.sol";
 import "@0x/contracts-erc20/contracts/src/interfaces/IERC20Token.sol";
 
 
@@ -33,6 +35,23 @@ contract TestStaticCallReceiver {
     /// @return Validity of order signature.
     function isValidSignature(
         bytes32 hash,
+        address signerAddress,
+        bytes calldata signature
+    )
+        external
+        returns (bool isValid)
+    {
+        updateState();
+        return true;
+    }
+
+    /// @dev Updates state and returns true. Intended to be used with `OrderValidator` signature type.
+    /// @param order The order.
+    /// @param signerAddress Address that should have signed the given hash.
+    /// @param signature Proof of signing.
+    /// @return Validity of order signature.
+    function isValidOrder(
+        LibOrder.Order calldata order,
         address signerAddress,
         bytes calldata signature
     )

--- a/contracts/exchange/src/artifacts.ts
+++ b/contracts/exchange/src/artifacts.ts
@@ -39,9 +39,9 @@ export const artifacts = {
     IValidator: IValidator as ContractArtifact,
     IWallet: IWallet as ContractArtifact,
     IWrapperFunctions: IWrapperFunctions as ContractArtifact,
+    ReentrantERC20Token: ReentrantERC20Token as ContractArtifact,
     TestAssetProxyDispatcher: TestAssetProxyDispatcher as ContractArtifact,
     TestExchangeInternals: TestExchangeInternals as ContractArtifact,
     TestSignatureValidator: TestSignatureValidator as ContractArtifact,
     TestStaticCallReceiver: TestStaticCallReceiver as ContractArtifact,
-    ReentrantERC20Token: ReentrantERC20Token as ContractArtifact,
 };

--- a/contracts/exchange/test/signature_validator.ts
+++ b/contracts/exchange/test/signature_validator.ts
@@ -31,7 +31,7 @@ const expect = chai.expect;
 
 const blockchainLifecycle = new BlockchainLifecycle(web3Wrapper);
 // tslint:disable:no-unnecessary-type-assertion
-describe.only('MixinSignatureValidator', () => {
+describe('MixinSignatureValidator', () => {
     let chainId: number;
     let signedOrder: SignedOrder;
     let orderFactory: OrderFactory;
@@ -152,11 +152,7 @@ describe.only('MixinSignatureValidator', () => {
 
         it('should return false when SignatureType=Invalid and signature has a length of zero', async () => {
             const signatureHex = `0x${Buffer.from([SignatureType.Invalid]).toString('hex')}`;
-            const isValidSignature = await validateCallAsync(
-                signedOrder,
-                signedOrder.makerAddress,
-                signatureHex,
-            );
+            const isValidSignature = await validateCallAsync(signedOrder, signedOrder.makerAddress, signatureHex);
             expect(isValidSignature).to.be.false();
         });
 
@@ -185,11 +181,7 @@ describe.only('MixinSignatureValidator', () => {
             ]);
             const signatureHex = ethUtil.bufferToHex(signature);
             // Validate signature
-            const isValidSignature = await validateCallAsync(
-                signedOrder,
-                signerAddress,
-                signatureHex,
-            );
+            const isValidSignature = await validateCallAsync(signedOrder, signerAddress, signatureHex);
             expect(isValidSignature).to.be.true();
         });
 
@@ -208,11 +200,7 @@ describe.only('MixinSignatureValidator', () => {
             const signatureHex = ethUtil.bufferToHex(signature);
             // Validate signature.
             // This will fail because `signerAddress` signed the message, but we're passing in `notSignerAddress`
-            const isValidSignature = await validateCallAsync(
-                signedOrder,
-                notSignerAddress,
-                signatureHex,
-            );
+            const isValidSignature = await validateCallAsync(signedOrder, notSignerAddress, signatureHex);
             expect(isValidSignature).to.be.false();
         });
 
@@ -231,11 +219,7 @@ describe.only('MixinSignatureValidator', () => {
             ]);
             const signatureHex = ethUtil.bufferToHex(signature);
             // Validate signature
-            const isValidSignature = await validateCallAsync(
-                signedOrder,
-                signerAddress,
-                signatureHex,
-            );
+            const isValidSignature = await validateCallAsync(signedOrder, signerAddress, signatureHex);
             expect(isValidSignature).to.be.true();
         });
 
@@ -255,11 +239,7 @@ describe.only('MixinSignatureValidator', () => {
             const signatureHex = ethUtil.bufferToHex(signature);
             // Validate signature.
             // This will fail because `signerAddress` signed the message, but we're passing in `notSignerAddress`
-            const isValidSignature = await validateCallAsync(
-                signedOrder,
-                notSignerAddress,
-                signatureHex,
-            );
+            const isValidSignature = await validateCallAsync(signedOrder, notSignerAddress, signatureHex);
             expect(isValidSignature).to.be.false();
         });
 
@@ -277,11 +257,7 @@ describe.only('MixinSignatureValidator', () => {
             ]);
             const signatureHex = ethUtil.bufferToHex(signature);
             // Validate signature
-            const isValidSignature = await validateCallAsync(
-                signedOrder,
-                testWallet.address,
-                signatureHex,
-            );
+            const isValidSignature = await validateCallAsync(signedOrder, testWallet.address, signatureHex);
             expect(isValidSignature).to.be.true();
         });
 
@@ -300,11 +276,7 @@ describe.only('MixinSignatureValidator', () => {
             ]);
             const signatureHex = ethUtil.bufferToHex(signature);
             // Validate signature
-            const isValidSignature = await validateCallAsync(
-                signedOrder,
-                testWallet.address,
-                signatureHex,
-            );
+            const isValidSignature = await validateCallAsync(signedOrder, testWallet.address, signatureHex);
             expect(isValidSignature).to.be.false();
         });
 
@@ -322,11 +294,7 @@ describe.only('MixinSignatureValidator', () => {
             ]);
             const signatureHex = ethUtil.bufferToHex(signature);
             await expectContractCallFailedAsync(
-                validateCallAsync(
-                    signedOrder,
-                    maliciousWallet.address,
-                    signatureHex,
-                ),
+                validateCallAsync(signedOrder, maliciousWallet.address, signatureHex),
                 RevertReason.WalletError,
             );
         });
@@ -336,11 +304,7 @@ describe.only('MixinSignatureValidator', () => {
             const signatureType = ethUtil.toBuffer(`0x${SignatureType.Validator}`);
             const signature = Buffer.concat([validatorAddress, signatureType]);
             const signatureHex = ethUtil.bufferToHex(signature);
-            const isValidSignature = await validateCallAsync(
-                signedOrder,
-                signerAddress,
-                signatureHex,
-            );
+            const isValidSignature = await validateCallAsync(signedOrder, signerAddress, signatureHex);
             expect(isValidSignature).to.be.true();
         });
 
@@ -351,11 +315,7 @@ describe.only('MixinSignatureValidator', () => {
             const signatureHex = ethUtil.bufferToHex(signature);
             // This will return false because we signed the message with `signerAddress`, but
             // are validating against `notSignerAddress`
-            const isValidSignature = await validateCallAsync(
-                signedOrder,
-                notSignerAddress,
-                signatureHex,
-            );
+            const isValidSignature = await validateCallAsync(signedOrder, notSignerAddress, signatureHex);
             expect(isValidSignature).to.be.false();
         });
 
@@ -385,11 +345,7 @@ describe.only('MixinSignatureValidator', () => {
             const signatureType = ethUtil.toBuffer(`0x${SignatureType.Validator}`);
             const signature = Buffer.concat([validatorAddress, signatureType]);
             const signatureHex = ethUtil.bufferToHex(signature);
-            const isValidSignature = await validateCallAsync(
-                signedOrder,
-                signerAddress,
-                signatureHex,
-            );
+            const isValidSignature = await validateCallAsync(signedOrder, signerAddress, signatureHex);
             expect(isValidSignature).to.be.false();
         });
 
@@ -407,29 +363,20 @@ describe.only('MixinSignatureValidator', () => {
             // Validate presigned signature
             const signature = ethUtil.toBuffer(`0x${SignatureType.PreSigned}`);
             const signatureHex = ethUtil.bufferToHex(signature);
-            const isValidSignature = await validateCallAsync(
-                signedOrder,
-                signedOrder.makerAddress,
-                signatureHex,
-            );
+            const isValidSignature = await validateCallAsync(signedOrder, signedOrder.makerAddress, signatureHex);
             expect(isValidSignature).to.be.true();
         });
 
         it('should return false when SignatureType=Presigned and signer has not presigned hash', async () => {
             const signature = ethUtil.toBuffer(`0x${SignatureType.PreSigned}`);
             const signatureHex = ethUtil.bufferToHex(signature);
-            const isValidSignature = await validateCallAsync(
-                signedOrder,
-                signedOrder.makerAddress,
-                signatureHex,
-            );
+            const isValidSignature = await validateCallAsync(signedOrder, signedOrder.makerAddress, signatureHex);
             expect(isValidSignature).to.be.false();
         });
     };
 
     describe('isValidHashSignature', () => {
-
-        const validateCallAsync = (order: SignedOrder, signer: string, signatureHex: string) => {
+        const validateCallAsync = async (order: SignedOrder, signer: string, signatureHex: string) => {
             const orderHashHex = orderHashUtils.getOrderHashHex(order);
             return signatureValidator.isValidHashSignature.callAsync(orderHashHex, signer, signatureHex);
         };
@@ -486,8 +433,7 @@ describe.only('MixinSignatureValidator', () => {
     });
 
     describe('isValidOrderSignature', () => {
-
-        const validateCallAsync = (order: SignedOrder, signer: string, signatureHex: string) => {
+        const validateCallAsync = async (order: SignedOrder, signer: string, signatureHex: string) => {
             return signatureValidator.isValidOrderSignature.callAsync(order, signer, signatureHex);
         };
 
@@ -500,11 +446,7 @@ describe.only('MixinSignatureValidator', () => {
             const signatureType = ethUtil.toBuffer(`0x${SignatureType.OrderValidator}`);
             const signature = Buffer.concat([validatorAddress, signatureType]);
             const signatureHex = ethUtil.bufferToHex(signature);
-            const isValidSignature = await validateCallAsync(
-                signedOrder,
-                signerAddress,
-                signatureHex,
-            );
+            const isValidSignature = await validateCallAsync(signedOrder, signerAddress, signatureHex);
             expect(isValidSignature).to.be.true();
         });
 
@@ -515,11 +457,7 @@ describe.only('MixinSignatureValidator', () => {
             const signatureHex = ethUtil.bufferToHex(signature);
             // This will return false because we signed the message with `signerAddress`, but
             // are validating against `notSignerAddress`
-            const isValidSignature = await validateCallAsync(
-                signedOrder,
-                notSignerAddress,
-                signatureHex,
-            );
+            const isValidSignature = await validateCallAsync(signedOrder, notSignerAddress, signatureHex);
             expect(isValidSignature).to.be.false();
         });
 
@@ -549,11 +487,7 @@ describe.only('MixinSignatureValidator', () => {
             const signatureType = ethUtil.toBuffer(`0x${SignatureType.OrderValidator}`);
             const signature = Buffer.concat([validatorAddress, signatureType]);
             const signatureHex = ethUtil.bufferToHex(signature);
-            const isValidSignature = await validateCallAsync(
-                signedOrder,
-                signerAddress,
-                signatureHex,
-            );
+            const isValidSignature = await validateCallAsync(signedOrder, signerAddress, signatureHex);
             expect(isValidSignature).to.be.false();
         });
 

--- a/packages/types/CHANGELOG.json
+++ b/packages/types/CHANGELOG.json
@@ -13,6 +13,10 @@
             {
                 "note": "Add `chainId` field to `EIP712DomainWithDefaultSchema`",
                 "pr": 1742
+            },
+            {
+                "note": "Add `SignatureType.OrderValidator`, `RevertReason.InappropriateSignatureType`",
+                "pr": 0
             }
         ]
     },

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -156,6 +156,7 @@ export enum SignatureType {
     Wallet,
     Validator,
     PreSigned,
+    OrderValidator,
     NSignatureTypes,
 }
 
@@ -229,6 +230,7 @@ export enum RevertReason {
     SignatureIllegal = 'SIGNATURE_ILLEGAL',
     SignatureInvalid = 'SIGNATURE_INVALID',
     SignatureUnsupported = 'SIGNATURE_UNSUPPORTED',
+    InappropriateSignatureType = 'INAPPROPRIATE_SIGNATURE_TYPE',
     TakerOverpay = 'TAKER_OVERPAY',
     OrderOverfill = 'ORDER_OVERFILL',
     InvalidFillPrice = 'INVALID_FILL_PRICE',


### PR DESCRIPTION
## Description
This adds support for a new order signature scheme to the Exchange: `SignatureType.OrderValidator`.

This new signature is similar to the existing `SignatureType.Validator`, but instead of passing an `bytes32 orderHash`to the validator's `isValidOrderSignature()`, we pass an `Order order` struct to the validator's `isValidOrder()`.

Here is a sample validator contract for use with this signature type:

```solidity
pragma solidity ^0.5.5;
pragma experimental ABIEncoderV2;

contract OrderValidator {
    
    // 0x transaction structure
    struct Order {
        address makerAddress;
        address takerAddress;
        address feeRecipientAddress;
        address senderAddress;
        uint256 makerAssetAmount;
        uint256 takerAssetAmount;
        uint256 makerFee;
        uint256 takerFee;
        uint256 expirationTimeSeconds;
        uint256 salt;
        bytes makerAssetData;
        bytes takerAssetData;
    }

    /// @dev Validate an order AND signature.
    /// @param order The full order.
    /// @param signer The signer (maker) of the order.
    /// @param signature Signature data for the order.
    /// @return `true` if valid.
    function isValidOrder(
        Order calldata order, 
        address signer, 
        bytes calldata signature
    )
        external 
        view
        returns (bool isValid)
    {
        // Validate the order
        // ...
        return true;
    }
}
```

#### Other notes:

- Just like `SignatureType.Validator`, the validator contract is called via `staticall()` and will fail if the validator contract attempts to update state.
- Validators must be registered for a maker ahead of time via `setSignatureValidatorApproval()`.
- Once registered, a validator may use *both* `SignatureType.OrderValidator` and `SignatureType.Validator` schemes.
- The public function `isValidSignature()` has been supplanted by [`isValidHashSignature()`](../blob/feature/3.0/exchange/order-validator-signature/contracts/src/interfaces/ISignatureValidator.sol#L52) and
  [`isValidOrderSignature()`](../blob/feature/3.0/exchange/order-validator-signature/contracts/src/interfaces/ISignatureValidator.sol#L66).
- Transactions use `isValidHashSignature()`, so they do not support `SignatureType.OrderValidator` (which wouldn't make sense anyway).

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

* Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
