### PR TITLE
0x/instant add Rinkeby and Ropsten to Network enum

### DIFF
--- a/packages/instant/src/constants.ts
+++ b/packages/instant/src/constants.ts
@@ -55,6 +55,8 @@ export const META_MASK_OPERA_STORE_URL = 'https://addons.opera.com/en/extensions
 export const META_MASK_SITE_URL = 'https://metamask.io/';
 export const ETHEREUM_NODE_URL_BY_NETWORK = {
     [Network.Mainnet]: `https://mainnet.infura.io/v3/${process.env.INSTANT_INFURA_PROJECT_ID}`,
+    [Network.Ropsten]: `https://ropsten.infura.io/v3/${process.env.INSTANT_INFURA_PROJECT_ID}`,
+    [Network.Rinkeby]: `https://rinkeby.infura.io/v3/${process.env.INSTANT_INFURA_PROJECT_ID}`,
     [Network.Kovan]: `https://kovan.infura.io/v3/${process.env.INSTANT_INFURA_PROJECT_ID}`,
 };
 export const ZERO_EX_SITE_URL = 'https://www.0xproject.com/';

--- a/packages/instant/src/data/asset_data_network_mapping.ts
+++ b/packages/instant/src/data/asset_data_network_mapping.ts
@@ -4,6 +4,8 @@ import { Network } from '../types';
 
 interface AssetDataByNetwork {
     [Network.Kovan]?: string;
+    [Network.Ropsten]?: string;
+    [Network.Rinkeby]?: string;
     [Network.Mainnet]?: string;
 }
 

--- a/packages/instant/src/types.ts
+++ b/packages/instant/src/types.ts
@@ -90,6 +90,8 @@ export interface Asset {
 
 export enum Network {
     Kovan = 42,
+    Rinkeby = 4,
+    Ropsten = 3,
     Mainnet = 1,
 }
 


### PR DESCRIPTION
## Description

0x/instant added Ropsten and Rinkeby to...
- Network enum
- AssetDataByNetwork interface
- ETHEREUM_NODE_URL_BY_NETWORK infura URLs

## Testing instructions

Render zeroExInstant with `networkId: 3` in config, and with MetaMask network set to mainnet, error message should show "Wrong network detected. Try switching to Ropsten."

## Types of changes

* Bug fix (non-breaking change which fixes an issue)

## Checklist:

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.

I'm not sure which of the above are needed, since it is such a small fix.