### PR TITLE
Update contracts/exchange-forwarder to 0.5.5

### DIFF
--- a/contracts/exchange-forwarder/CHANGELOG.json
+++ b/contracts/exchange-forwarder/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "3.0.0",
+        "changes": [
+            {
+                "note": "Update contracts to solidity ^0.5.5 and unpin dependencies",
+                "pr": TODO
+            }
+        ]
+    },
+    {
         "version": "2.1.1",
         "changes": [
             {

--- a/contracts/exchange-forwarder/CHANGELOG.json
+++ b/contracts/exchange-forwarder/CHANGELOG.json
@@ -4,7 +4,7 @@
         "changes": [
             {
                 "note": "Update contracts to solidity ^0.5.5 and unpin dependencies",
-                "pr": TODO
+                "pr": 1796
             }
         ]
     },

--- a/contracts/exchange-forwarder/contracts/src/Forwarder.sol
+++ b/contracts/exchange-forwarder/contracts/src/Forwarder.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.5.5;
 pragma experimental ABIEncoderV2;
 
 import "./MixinWeth.sol";
@@ -40,6 +40,7 @@ contract Forwarder is
         bytes memory _wethAssetData
     )
         public
+        Ownable()
         LibConstants(
             _exchange,
             _zrxAssetData,

--- a/contracts/exchange-forwarder/contracts/src/MixinAssets.sol
+++ b/contracts/exchange-forwarder/contracts/src/MixinAssets.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.5;
 
 import "@0x/contracts-utils/contracts/src/LibBytes.sol";
 import "@0x/contracts-utils/contracts/src/Ownable.sol";
@@ -35,13 +35,13 @@ contract MixinAssets is
 
     bytes4 constant internal ERC20_TRANSFER_SELECTOR = bytes4(keccak256("transfer(address,uint256)"));
 
-    /// @dev Withdraws assets from this contract. The contract requires a ZRX balance in order to 
+    /// @dev Withdraws assets from this contract. The contract requires a ZRX balance in order to
     ///      function optimally, and this function allows the ZRX to be withdrawn by owner. It may also be
     ///      used to withdraw assets that were accidentally sent to this contract.
     /// @param assetData Byte array encoded for the respective asset proxy.
     /// @param amount Amount of ERC20 token to withdraw.
     function withdrawAsset(
-        bytes assetData,
+        bytes calldata assetData,
         uint256 amount
     )
         external
@@ -84,7 +84,7 @@ contract MixinAssets is
         // Transfer tokens.
         // We do a raw call so we can check the success separate
         // from the return data.
-        bool success = token.call(abi.encodeWithSelector(
+        (bool success,) = token.call(abi.encodeWithSelector(
             ERC20_TRANSFER_SELECTOR,
             msg.sender,
             amount
@@ -93,7 +93,7 @@ contract MixinAssets is
             success,
             "TRANSFER_FAILED"
         );
-        
+
         // Check return data.
         // If there is no return data, we assume the token incorrectly
         // does not return a bool. In this case we expect it to revert

--- a/contracts/exchange-forwarder/contracts/src/MixinExchangeWrapper.sol
+++ b/contracts/exchange-forwarder/contracts/src/MixinExchangeWrapper.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.5;
 pragma experimental ABIEncoderV2;
 
 import "./libs/LibConstants.sol";
@@ -144,6 +144,7 @@ contract MixinExchangeWrapper is
         bytes memory wethAssetData = WETH_ASSET_DATA;
 
         uint256 ordersLength = orders.length;
+        uint256 makerAssetFilledAmount = 0;
         for (uint256 i = 0; i != ordersLength; i++) {
 
             // We assume that asset being bought by taker is the same for each order.
@@ -175,7 +176,7 @@ contract MixinExchangeWrapper is
             addFillResults(totalFillResults, singleFillResults);
 
             // Stop execution if the entire amount of makerAsset has been bought
-            uint256 makerAssetFilledAmount = totalFillResults.makerAssetFilledAmount;
+            makerAssetFilledAmount = totalFillResults.makerAssetFilledAmount;
             if (makerAssetFilledAmount >= makerAssetFillAmount) {
                 break;
             }
@@ -192,7 +193,7 @@ contract MixinExchangeWrapper is
     ///      that at least zrxBuyAmount of ZRX is purchased (sometimes slightly over due to rounding issues).
     ///      It is possible that a request to buy 200 ZRX will require purchasing 202 ZRX
     ///      as 2 ZRX is required to purchase the 200 ZRX fee tokens. This guarantees at least 200 ZRX for future purchases.
-    ///      The asset being sold by taker must always be WETH. 
+    ///      The asset being sold by taker must always be WETH.
     /// @param orders Array of order specifications containing ZRX as makerAsset and WETH as takerAsset.
     /// @param zrxBuyAmount Desired amount of ZRX to buy.
     /// @param signatures Proofs that orders have been created by makers.
@@ -230,7 +231,7 @@ contract MixinExchangeWrapper is
             // of the Maker. In this case we want to overestimate the amount of takerAsset.
             uint256 remainingWethSellAmount = getPartialAmountCeil(
                 orders[i].takerAssetAmount,
-                safeSub(orders[i].makerAssetAmount, orders[i].takerFee),  // our exchange rate after fees 
+                safeSub(orders[i].makerAssetAmount, orders[i].takerFee),  // our exchange rate after fees
                 remainingZrxBuyAmount
             );
 

--- a/contracts/exchange-forwarder/contracts/src/MixinForwarderCore.sol
+++ b/contracts/exchange-forwarder/contracts/src/MixinForwarderCore.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.5;
 pragma experimental ABIEncoderV2;
 
 import "./libs/LibConstants.sol";
@@ -58,7 +58,7 @@ contract MixinForwarderCore is
     ///      Any ZRX required to pay fees for primary orders will automatically be purchased by this contract.
     ///      5% of ETH value is reserved for paying fees to order feeRecipients (in ZRX) and forwarding contract feeRecipient (in ETH).
     ///      Any ETH not spent will be refunded to sender.
-    /// @param orders Array of order specifications used containing desired makerAsset and WETH as takerAsset. 
+    /// @param orders Array of order specifications used containing desired makerAsset and WETH as takerAsset.
     /// @param signatures Proofs that orders have been created by makers.
     /// @param feeOrders Array of order specifications containing ZRX as makerAsset and WETH as takerAsset. Used to purchase ZRX for primary order fees.
     /// @param feeSignatures Proofs that feeOrders have been created by makers.
@@ -70,8 +70,8 @@ contract MixinForwarderCore is
         bytes[] memory signatures,
         LibOrder.Order[] memory feeOrders,
         bytes[] memory feeSignatures,
-        uint256  feePercentage,
-        address feeRecipient
+        uint256 feePercentage,
+        address payable feeRecipient
     )
         public
         payable
@@ -142,7 +142,7 @@ contract MixinForwarderCore is
     /// @dev Attempt to purchase makerAssetFillAmount of makerAsset by selling ETH provided with transaction.
     ///      Any ZRX required to pay fees for primary orders will automatically be purchased by this contract.
     ///      Any ETH not spent will be refunded to sender.
-    /// @param orders Array of order specifications used containing desired makerAsset and WETH as takerAsset. 
+    /// @param orders Array of order specifications used containing desired makerAsset and WETH as takerAsset.
     /// @param makerAssetFillAmount Desired amount of makerAsset to purchase.
     /// @param signatures Proofs that orders have been created by makers.
     /// @param feeOrders Array of order specifications containing ZRX as makerAsset and WETH as takerAsset. Used to purchase ZRX for primary order fees.
@@ -156,8 +156,8 @@ contract MixinForwarderCore is
         bytes[] memory signatures,
         LibOrder.Order[] memory feeOrders,
         bytes[] memory feeSignatures,
-        uint256  feePercentage,
-        address feeRecipient
+        uint256 feePercentage,
+        address payable feeRecipient
     )
         public
         payable

--- a/contracts/exchange-forwarder/contracts/src/MixinWeth.sol
+++ b/contracts/exchange-forwarder/contracts/src/MixinWeth.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.5;
 
 import "@0x/contracts-exchange-libs/contracts/src/LibMath.sol";
 import "./libs/LibConstants.sol";
@@ -30,7 +30,7 @@ contract MixinWeth is
 {
     /// @dev Default payabale function, this allows us to withdraw WETH
     function ()
-        public
+        external
         payable
     {
         require(
@@ -60,7 +60,7 @@ contract MixinWeth is
         uint256 wethSoldExcludingFeeOrders,
         uint256 wethSoldForZrx,
         uint256 feePercentage,
-        address feeRecipient
+        address payable feeRecipient
     )
         internal
     {
@@ -92,7 +92,7 @@ contract MixinWeth is
             ethFee <= wethRemaining,
             "INSUFFICIENT_ETH_REMAINING"
         );
-    
+
         // Do nothing if no WETH remaining
         if (wethRemaining > 0) {
             // Convert remaining WETH to ETH

--- a/contracts/exchange-forwarder/contracts/src/interfaces/IAssets.sol
+++ b/contracts/exchange-forwarder/contracts/src/interfaces/IAssets.sol
@@ -16,18 +16,18 @@
 
 */
 
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.5;
 
 
 contract IAssets {
 
-    /// @dev Withdraws assets from this contract. The contract requires a ZRX balance in order to 
+    /// @dev Withdraws assets from this contract. The contract requires a ZRX balance in order to
     ///      function optimally, and this function allows the ZRX to be withdrawn by owner. It may also be
     ///      used to withdraw assets that were accidentally sent to this contract.
     /// @param assetData Byte array encoded for the respective asset proxy.
     /// @param amount Amount of ERC20 token to withdraw.
     function withdrawAsset(
-        bytes assetData,
+        bytes calldata assetData,
         uint256 amount
     )
         external;

--- a/contracts/exchange-forwarder/contracts/src/interfaces/IForwarder.sol
+++ b/contracts/exchange-forwarder/contracts/src/interfaces/IForwarder.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.5;
 pragma experimental ABIEncoderV2;
 
 import "./IForwarderCore.sol";

--- a/contracts/exchange-forwarder/contracts/src/interfaces/IForwarderCore.sol
+++ b/contracts/exchange-forwarder/contracts/src/interfaces/IForwarderCore.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.5;
 pragma experimental ABIEncoderV2;
 
 import "@0x/contracts-exchange-libs/contracts/src/LibOrder.sol";
@@ -29,7 +29,7 @@ contract IForwarderCore {
     ///      Any ZRX required to pay fees for primary orders will automatically be purchased by this contract.
     ///      5% of ETH value is reserved for paying fees to order feeRecipients (in ZRX) and forwarding contract feeRecipient (in ETH).
     ///      Any ETH not spent will be refunded to sender.
-    /// @param orders Array of order specifications used containing desired makerAsset and WETH as takerAsset. 
+    /// @param orders Array of order specifications used containing desired makerAsset and WETH as takerAsset.
     /// @param signatures Proofs that orders have been created by makers.
     /// @param feeOrders Array of order specifications containing ZRX as makerAsset and WETH as takerAsset. Used to purchase ZRX for primary order fees.
     /// @param feeSignatures Proofs that feeOrders have been created by makers.
@@ -41,8 +41,8 @@ contract IForwarderCore {
         bytes[] memory signatures,
         LibOrder.Order[] memory feeOrders,
         bytes[] memory feeSignatures,
-        uint256  feePercentage,
-        address feeRecipient
+        uint256 feePercentage,
+        address payable feeRecipient
     )
         public
         payable
@@ -54,7 +54,7 @@ contract IForwarderCore {
     /// @dev Attempt to purchase makerAssetFillAmount of makerAsset by selling ETH provided with transaction.
     ///      Any ZRX required to pay fees for primary orders will automatically be purchased by this contract.
     ///      Any ETH not spent will be refunded to sender.
-    /// @param orders Array of order specifications used containing desired makerAsset and WETH as takerAsset. 
+    /// @param orders Array of order specifications used containing desired makerAsset and WETH as takerAsset.
     /// @param makerAssetFillAmount Desired amount of makerAsset to purchase.
     /// @param signatures Proofs that orders have been created by makers.
     /// @param feeOrders Array of order specifications containing ZRX as makerAsset and WETH as takerAsset. Used to purchase ZRX for primary order fees.
@@ -68,8 +68,8 @@ contract IForwarderCore {
         bytes[] memory signatures,
         LibOrder.Order[] memory feeOrders,
         bytes[] memory feeSignatures,
-        uint256  feePercentage,
-        address feeRecipient
+        uint256 feePercentage,
+        address payable feeRecipient
     )
         public
         payable

--- a/contracts/exchange-forwarder/contracts/src/libs/LibConstants.sol
+++ b/contracts/exchange-forwarder/contracts/src/libs/LibConstants.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.5;
 
 import "@0x/contracts-utils/contracts/src/LibBytes.sol";
 import "@0x/contracts-exchange/contracts/src/interfaces/IExchange.sol";
@@ -31,10 +31,10 @@ contract LibConstants {
     bytes4 constant internal ERC20_DATA_ID = bytes4(keccak256("ERC20Token(address)"));
     bytes4 constant internal ERC721_DATA_ID = bytes4(keccak256("ERC721Token(address,uint256)"));
     uint256 constant internal MAX_UINT = 2**256 - 1;
-    uint256 constant internal PERCENTAGE_DENOMINATOR = 10**18; 
+    uint256 constant internal PERCENTAGE_DENOMINATOR = 10**18;
     uint256 constant internal MAX_FEE_PERCENTAGE = 5 * PERCENTAGE_DENOMINATOR / 100;         // 5%
     uint256 constant internal MAX_WETH_FILL_PERCENTAGE = 95 * PERCENTAGE_DENOMINATOR / 100;  // 95%
- 
+
      // solhint-disable var-name-mixedcase
     IExchange internal EXCHANGE;
     IEtherToken internal ETHER_TOKEN;

--- a/contracts/exchange-forwarder/contracts/src/libs/LibForwarderErrors.sol
+++ b/contracts/exchange-forwarder/contracts/src/libs/LibForwarderErrors.sol
@@ -17,7 +17,7 @@
 */
 
 // solhint-disable
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.5;
 
 
 /// This contract is intended to serve as a reference, but is not actually used for efficiency reasons.

--- a/contracts/exchange-forwarder/contracts/src/mixins/MAssets.sol
+++ b/contracts/exchange-forwarder/contracts/src/mixins/MAssets.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.5;
 
 import "../interfaces/IAssets.sol";
 

--- a/contracts/exchange-forwarder/contracts/src/mixins/MExchangeWrapper.sol
+++ b/contracts/exchange-forwarder/contracts/src/mixins/MExchangeWrapper.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.5;
 pragma experimental ABIEncoderV2;
 
 import "@0x/contracts-exchange-libs/contracts/src/LibOrder.sol";
@@ -72,7 +72,7 @@ contract MExchangeWrapper {
     ///      that at least zrxBuyAmount of ZRX is purchased (sometimes slightly over due to rounding issues).
     ///      It is possible that a request to buy 200 ZRX will require purchasing 202 ZRX
     ///      as 2 ZRX is required to purchase the 200 ZRX fee tokens. This guarantees at least 200 ZRX for future purchases.
-    ///      The asset being sold by taker must always be WETH. 
+    ///      The asset being sold by taker must always be WETH.
     /// @param orders Array of order specifications containing ZRX as makerAsset and WETH as takerAsset.
     /// @param zrxBuyAmount Desired amount of ZRX to buy.
     /// @param signatures Proofs that orders have been created by makers.

--- a/contracts/exchange-forwarder/contracts/src/mixins/MWeth.sol
+++ b/contracts/exchange-forwarder/contracts/src/mixins/MWeth.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.5;
 
 
 contract MWeth {
@@ -35,7 +35,7 @@ contract MWeth {
         uint256 wethSoldExcludingFeeOrders,
         uint256 wethSoldForZrx,
         uint256 feePercentage,
-        address feeRecipient
+        address payable feeRecipient
     )
         internal;
 }

--- a/contracts/exchange-forwarder/package.json
+++ b/contracts/exchange-forwarder/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@0x/contracts-exchange-forwarder",
-    "version": "2.1.1",
+    "version": "2.1.0",
     "engines": {
         "node": ">=6.12"
     },
@@ -24,7 +24,6 @@
         "clean": "shx rm -rf lib generated-artifacts generated-wrappers",
         "generate_contract_wrappers": "abi-gen --abis  ${npm_package_config_abis} --template ../../node_modules/@0x/abi-gen-templates/contract.handlebars --partials '../../node_modules/@0x/abi-gen-templates/partials/**/*.handlebars' --output generated-wrappers --backend ethers",
         "lint": "tslint --format stylish --project . --exclude ./generated-wrappers/**/* --exclude ./generated-artifacts/**/* --exclude **/lib/**/* && yarn lint-contracts",
-        "fix": "tslint --fix --format stylish --project . --exclude ./generated-wrappers/**/* --exclude ./generated-artifacts/**/* --exclude **/lib/**/* && yarn lint-contracts",
         "coverage:report:text": "istanbul report text",
         "coverage:report:html": "istanbul report html && open coverage/index.html",
         "profiler:report:html": "istanbul report html && open coverage/index.html",
@@ -71,14 +70,14 @@
     "dependencies": {
         "@0x/base-contract": "^5.0.5",
         "@0x/contracts-asset-proxy": "^2.1.1",
-        "@0x/contracts-erc20": "1.0.8",
-        "@0x/contracts-erc721": "1.0.8",
-        "@0x/contracts-exchange": "1.0.2",
-        "@0x/contracts-exchange-libs": "1.0.2",
-        "@0x/contracts-utils": "2.0.1",
+        "@0x/contracts-erc20": "^2.2.0",
+        "@0x/contracts-erc721": "^2.1.0",
+        "@0x/contracts-exchange": "^2.1.1",
+        "@0x/contracts-exchange-libs": "^2.1.1",
+        "@0x/contracts-utils": "^3.1.1",
         "@0x/order-utils": "^7.2.0",
         "@0x/types": "^2.2.2",
-        "@0x/typescript-typings": "^4.2.2",
+        "@0x/typescript-typings": "^4.2.1",
         "@0x/utils": "^4.3.1",
         "@0x/web3-wrapper": "^6.0.5",
         "ethereum-types": "^2.1.2",


### PR DESCRIPTION
## Description

This backports the `0.5.5` update to the `exchange-forwarder` from the `3.0` branch onto `development`. This is just a compiler update. There are no meaningful changes to the functionality of the contracts. The PR for that branch is #1732.

### Rationale
`exchange-forwarder` relies on older, pinned dependencies. These pinned dependencies break the build when changes to pervasive packages like `base-contract` are introduced due to the way dependencies of dependencies are linked in the monorepo. Updating the smart contracts to soldity `0.5.5` removes the requirement for pinned dependencies.  
 
## Testing instructions

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

New feature (non-breaking change which adds functionality)

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
