### PR TITLE
Disable `useDockerisedSolc` for all contracts `compiler.json`s until latest solc docker images are published

### DIFF
--- a/contracts/asset-proxy/compiler.json
+++ b/contracts/asset-proxy/compiler.json
@@ -1,7 +1,7 @@
 {
     "artifactsDir": "./generated-artifacts",
     "contractsDir": "./contracts",
-    "useDockerisedSolc": true,
+    "useDockerisedSolc": false,
     "isOfflineMode": false,
     "compilerSettings": {
         "evmVersion": "constantinople",

--- a/contracts/erc1155/compiler.json
+++ b/contracts/erc1155/compiler.json
@@ -1,7 +1,7 @@
 {
     "artifactsDir": "generated-artifacts",
     "contractsDir": "contracts",
-    "useDockerisedSolc": true,
+    "useDockerisedSolc": false,
     "compilerSettings": {
         "evmVersion": "constantinople",
         "optimizer": { "enabled": true, "runs": 1000000 },

--- a/contracts/erc721/compiler.json
+++ b/contracts/erc721/compiler.json
@@ -1,7 +1,7 @@
 {
     "artifactsDir": "./generated-artifacts",
     "contractsDir": "./contracts",
-    "useDockerisedSolc": true,
+    "useDockerisedSolc": false,
     "isOfflineMode": false,
     "compilerSettings": {
         "evmVersion": "constantinople",

--- a/contracts/exchange-libs/compiler.json
+++ b/contracts/exchange-libs/compiler.json
@@ -1,7 +1,7 @@
 {
     "artifactsDir": "./generated-artifacts",
     "contractsDir": "./contracts",
-    "useDockerisedSolc": true,
+    "useDockerisedSolc": false,
     "isOfflineMode": false,
     "compilerSettings": {
         "evmVersion": "constantinople",

--- a/contracts/exchange/compiler.json
+++ b/contracts/exchange/compiler.json
@@ -1,7 +1,7 @@
 {
     "artifactsDir": "./generated-artifacts",
     "contractsDir": "./contracts",
-    "useDockerisedSolc": true,
+    "useDockerisedSolc": false,
     "isOfflineMode": false,
     "compilerSettings": {
         "evmVersion": "constantinople",

--- a/contracts/utils/compiler.json
+++ b/contracts/utils/compiler.json
@@ -1,7 +1,7 @@
 {
     "artifactsDir": "./generated-artifacts",
     "contractsDir": "./contracts",
-    "useDockerisedSolc": true,
+    "useDockerisedSolc": false,
     "isOfflineMode": false,
     "compilerSettings": {
         "evmVersion": "constantinople",


### PR DESCRIPTION
## Description

The latest `solc` versions are `0.4.26` and `0.5.8` but there are no docker images for these versions yet. Builds are failing due to this. This PR disables dockerized `solc` until the images are published.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
