### PR TITLE
FIX: added `as any` to get around typeguard (pipeline)

### DIFF
--- a/packages/pipeline/src/scripts/pull_exchange_events.ts
+++ b/packages/pipeline/src/scripts/pull_exchange_events.ts
@@ -96,7 +96,7 @@ async function saveEventsAsync<T extends ExchangeEvent>(
         // Split data into numChunks pieces of maximum size BATCH_SAVE_SIZE
         // each.
         for (const eventsBatch of R.splitEvery(BATCH_SAVE_SIZE, events)) {
-            await repository.insert(eventsBatch);
+            await repository.insert(eventsBatch as any); // hack to get around bug in typescript. alternative is to downgrade tsc version. see https://github.com/typeorm/typeorm/issues/1544
         }
     } else {
         // If we possibly have some overlap where we need to update some
@@ -118,7 +118,7 @@ async function saveIndividuallyWithFallbackAsync<T extends ExchangeEvent>(
     for (const event of events) {
         try {
             // First try an insert.
-            await repository.insert(event);
+            await repository.insert(event as any); // hack to get around typescript bug. https://github.com/typeorm/typeorm/issues/1544
         } catch (err) {
             if (err.message.includes('duplicate key value violates unique constraint')) {
                 logUtils.log("Ignore the preceeding INSERT failure; it's not unexpected");


### PR DESCRIPTION
## Description

Build is failing both locally and on CircleCI. Based on https://github.com/typeorm/typeorm/issues/1544 and linked threads it sounds like we can use `as any` or try downgrading typescript. 

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

 * Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Prefix PR title with `[WIP]` if necessary.
-   [x] Add tests to cover changes as needed.
-   [x] Update documentation as needed.
-   [x] Add new entries to the relevant CHANGELOG.jsons.
