### PR TITLE
Support for ABI Encoding multibyte strings (Fixes Issue #1723)

### DIFF
--- a/packages/utils/CHANGELOG.json
+++ b/packages/utils/CHANGELOG.json
@@ -1,5 +1,13 @@
 [
     {
+        "version": "4.3.2",
+        "changes": [
+            {
+                "note": "Support for ABI encoding multibyte strings (fixes issue #1723)"
+            }
+        ]
+    },
+    {
         "version": "4.3.1",
         "changes": [
             {

--- a/packages/utils/src/abi_encoder/evm_data_types/string.ts
+++ b/packages/utils/src/abi_encoder/evm_data_types/string.ts
@@ -26,14 +26,15 @@ export class StringDataType extends AbstractBlobDataType {
     /* tslint:disable prefer-function-over-method */
     public encodeValue(value: string): Buffer {
         // Encoded value is of the form: <length><value>, with each field padded to be word-aligned.
-        // 1/3 Construct the length
-        const wordsToStoreValuePadded = Math.ceil(value.length / constants.EVM_WORD_WIDTH_IN_BYTES);
-        const bytesToStoreValuePadded = wordsToStoreValuePadded * constants.EVM_WORD_WIDTH_IN_BYTES;
-        const lengthBuf = ethUtil.toBuffer(value.length);
-        const lengthBufPadded = ethUtil.setLengthLeft(lengthBuf, constants.EVM_WORD_WIDTH_IN_BYTES);
-        // 2/3 Construct the value
+        // 1/3 Construct the value
         const valueBuf = new Buffer(value);
+        const valueLengthInBytes = valueBuf.byteLength;
+        const wordsToStoreValuePadded = Math.ceil(valueLengthInBytes / constants.EVM_WORD_WIDTH_IN_BYTES);
+        const bytesToStoreValuePadded = wordsToStoreValuePadded * constants.EVM_WORD_WIDTH_IN_BYTES;
         const valueBufPadded = ethUtil.setLengthRight(valueBuf, bytesToStoreValuePadded);
+        // 2/3 Construct the length
+        const lengthBuf = ethUtil.toBuffer(valueLengthInBytes);
+        const lengthBufPadded = ethUtil.setLengthLeft(lengthBuf, constants.EVM_WORD_WIDTH_IN_BYTES);
         // 3/3 Combine length and value
         const encodedValue = Buffer.concat([lengthBufPadded, valueBufPadded]);
         return encodedValue;
@@ -49,7 +50,7 @@ export class StringDataType extends AbstractBlobDataType {
         const wordsToStoreValuePadded = Math.ceil(length / constants.EVM_WORD_WIDTH_IN_BYTES);
         const valueBufPadded = calldata.popWords(wordsToStoreValuePadded);
         const valueBuf = valueBufPadded.slice(0, length);
-        const value = valueBuf.toString('ascii');
+        const value = valueBuf.toString('UTF-8');
         return value;
     }
 

--- a/packages/utils/test/abi_encoder/evm_data_types_test.ts
+++ b/packages/utils/test/abi_encoder/evm_data_types_test.ts
@@ -1327,7 +1327,7 @@ describe('ABI Encoder: EVM Data Type Encoding/Decoding', () => {
             const testDataItem = { name: 'String', type: 'string' };
             const dataType = new AbiEncoder.String(testDataItem);
             // Construct args to be encoded
-            const args = "👴🏼";
+            const args = '👴🏼';
             // Encode Args and validate result
             const encodedArgs = dataType.encode(args, encodingRules);
             const expectedEncodedArgs =
@@ -1346,7 +1346,7 @@ describe('ABI Encoder: EVM Data Type Encoding/Decoding', () => {
             const testDataItem = { name: 'String', type: 'string' };
             const dataType = new AbiEncoder.String(testDataItem);
             // Construct args to be encoded
-            const args = "Hello 😀👴🏼😁😂😃 world!";
+            const args = 'Hello 😀👴🏼😁😂😃 world!';
             // Encode Args and validate result
             const encodedArgs = dataType.encode(args, encodingRules);
             const expectedEncodedArgs =

--- a/packages/utils/test/abi_encoder/evm_data_types_test.ts
+++ b/packages/utils/test/abi_encoder/evm_data_types_test.ts
@@ -1322,6 +1322,44 @@ describe('ABI Encoder: EVM Data Type Encoding/Decoding', () => {
             const argsEncodedFromSignature = dataTypeFromSignature.encode(args);
             expect(argsEncodedFromSignature).to.be.deep.equal(expectedEncodedArgs);
         });
+        it('String that has a multibyte UTF-8 character', async () => {
+            // Create DataType object
+            const testDataItem = { name: 'String', type: 'string' };
+            const dataType = new AbiEncoder.String(testDataItem);
+            // Construct args to be encoded
+            const args = "👴🏼";
+            // Encode Args and validate result
+            const encodedArgs = dataType.encode(args, encodingRules);
+            const expectedEncodedArgs =
+                '0x0000000000000000000000000000000000000000000000000000000000000008f09f91b4f09f8fbc000000000000000000000000000000000000000000000000';
+            expect(encodedArgs).to.be.equal(expectedEncodedArgs);
+            // Decode Encoded Args and validate result
+            const decodedArgs = dataType.decode(encodedArgs);
+            expect(decodedArgs).to.be.deep.equal(args);
+            // Validate signature
+            const dataTypeFromSignature = AbiEncoder.create(dataType.getSignature(true));
+            const argsEncodedFromSignature = dataTypeFromSignature.encode(args);
+            expect(argsEncodedFromSignature).to.be.deep.equal(expectedEncodedArgs);
+        });
+        it('String that combines single and multibyte UTF-8 characters', async () => {
+            // Create DataType object
+            const testDataItem = { name: 'String', type: 'string' };
+            const dataType = new AbiEncoder.String(testDataItem);
+            // Construct args to be encoded
+            const args = "Hello 😀👴🏼😁😂😃 world!";
+            // Encode Args and validate result
+            const encodedArgs = dataType.encode(args, encodingRules);
+            const expectedEncodedArgs =
+                '0x000000000000000000000000000000000000000000000000000000000000002548656c6c6f20f09f9880f09f91b4f09f8fbcf09f9881f09f9882f09f988320776f726c6421000000000000000000000000000000000000000000000000000000';
+            expect(encodedArgs).to.be.equal(expectedEncodedArgs);
+            // Decode Encoded Args and validate result
+            const decodedArgs = dataType.decode(encodedArgs);
+            expect(decodedArgs).to.be.deep.equal(args);
+            // Validate signature
+            const dataTypeFromSignature = AbiEncoder.create(dataType.getSignature(true));
+            const argsEncodedFromSignature = dataTypeFromSignature.encode(args);
+            expect(argsEncodedFromSignature).to.be.deep.equal(expectedEncodedArgs);
+        });
         it('Should decode NULL to empty string', async () => {
             // Create DataType object
             const testDataItem = { name: 'String', type: 'string' };


### PR DESCRIPTION
## Description

This fixes Issue #1723: the ABI Encoder was encoding/decoding strings as ASCII rather than UTF-8. This PR includes updated code and test cases for multibyte strings.

## Testing instructions

New tests were created to validate encoding and decoding of multibyte UTF-8 characters.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [x] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
