### PR TITLE
OrderWatcher Deposit/Withdraw events

### DIFF
--- a/packages/order-watcher/CHANGELOG.json
+++ b/packages/order-watcher/CHANGELOG.json
@@ -1,19 +1,14 @@
 [
     {
-        "version": "4.0.8",
-        "changes": [
-            {
-                "note": "Fix bug where WETH deposit/withdrawal events would not trigger an order state update",
-                "pr": 1809
-            }
-        ]
-    },
-    {
         "version": "4.0.7",
         "changes": [
             {
                 "note": "Fix race-condition bug due to async callback modifying shared state",
                 "pr": 1789
+            },
+            {
+                "note": "Fix bug where WETH deposit/withdrawal events would not trigger an order state update",
+                "pr": 1809
             }
         ]
     },

--- a/packages/order-watcher/CHANGELOG.json
+++ b/packages/order-watcher/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "4.0.8",
+        "changes": [
+            {
+                "note": "Fix bug where WETH deposit/withdraw events would not trigger a order state update",
+                "pr": 1809
+            }
+        ]
+    },
+    {
         "version": "4.0.7",
         "changes": [
             {

--- a/packages/order-watcher/CHANGELOG.json
+++ b/packages/order-watcher/CHANGELOG.json
@@ -3,7 +3,7 @@
         "version": "4.0.8",
         "changes": [
             {
-                "note": "Fix bug where WETH deposit/withdraw events would not trigger a order state update",
+                "note": "Fix bug where WETH deposit/withdrawal events would not trigger an order state update",
                 "pr": 1809
             }
         ]

--- a/packages/order-watcher/package.json
+++ b/packages/order-watcher/package.json
@@ -17,7 +17,7 @@
         "lint": "tslint --format stylish --project .",
         "fix": "tslint --fix --format stylish --project .",
         "test:circleci": "run-s test:coverage",
-        "test": "",
+        "test": "yarn run_mocha",
         "rebuild_and_test": "run-s build test",
         "test:coverage": "nyc npm run test --all && yarn coverage:report:lcov",
         "coverage:report:lcov": "nyc report --reporter=text-lcov > coverage/lcov.info",

--- a/packages/order-watcher/src/order_watcher/collision_resistant_abi_decoder.ts
+++ b/packages/order-watcher/src/order_watcher/collision_resistant_abi_decoder.ts
@@ -26,16 +26,19 @@ export class CollisionResistanceAbiDecoder {
         this._restAbiDecoder = new AbiDecoder(abis);
     }
     public tryToDecodeLogOrNoop<ArgsType extends DecodedLogArgs>(log: LogEntry): LogWithDecodedArgs<ArgsType> | RawLog {
+        let maybeDecodedLog = log;
         if (this._knownERC20Tokens.has(log.address)) {
-            const maybeDecodedERC20Log = this._erc20AbiDecoder.tryToDecodeLogOrNoop(log);
-            return maybeDecodedERC20Log;
+            maybeDecodedLog = this._erc20AbiDecoder.tryToDecodeLogOrNoop(log);
         } else if (this._knownERC721Tokens.has(log.address)) {
-            const maybeDecodedERC721Log = this._erc721AbiDecoder.tryToDecodeLogOrNoop(log);
-            return maybeDecodedERC721Log;
-        } else {
-            const maybeDecodedLog = this._restAbiDecoder.tryToDecodeLogOrNoop(log);
-            return maybeDecodedLog;
+            maybeDecodedLog = this._erc721AbiDecoder.tryToDecodeLogOrNoop(log);
         }
+        // Fall back to the supplied ABIs for decoding if the ERC20/ERC721 decoding fails
+        // This ensures we hit events like Deposit and Withdraw given WETH can be a known ERC20Token
+        const isLogDecoded = ((maybeDecodedLog as any) as LogWithDecodedArgs<DecodedLogArgs>).event !== undefined;
+        if (!isLogDecoded) {
+            maybeDecodedLog = this._restAbiDecoder.tryToDecodeLogOrNoop(log);
+        }
+        return maybeDecodedLog;
     }
     // Hints the ABI decoder that a particular token address is ERC20 and events from it should be decoded as ERC20 events
     public addERC20Token(address: string): void {

--- a/packages/order-watcher/src/order_watcher/collision_resistant_abi_decoder.ts
+++ b/packages/order-watcher/src/order_watcher/collision_resistant_abi_decoder.ts
@@ -26,19 +26,16 @@ export class CollisionResistanceAbiDecoder {
         this._restAbiDecoder = new AbiDecoder(abis);
     }
     public tryToDecodeLogOrNoop<ArgsType extends DecodedLogArgs>(log: LogEntry): LogWithDecodedArgs<ArgsType> | RawLog {
-        let maybeDecodedLog = log;
         if (this._knownERC20Tokens.has(log.address)) {
-            maybeDecodedLog = this._erc20AbiDecoder.tryToDecodeLogOrNoop(log);
+            const maybeDecodedERC20Log = this._erc20AbiDecoder.tryToDecodeLogOrNoop(log);
+            return maybeDecodedERC20Log;
         } else if (this._knownERC721Tokens.has(log.address)) {
-            maybeDecodedLog = this._erc721AbiDecoder.tryToDecodeLogOrNoop(log);
+            const maybeDecodedERC721Log = this._erc721AbiDecoder.tryToDecodeLogOrNoop(log);
+            return maybeDecodedERC721Log;
+        } else {
+            const maybeDecodedLog = this._restAbiDecoder.tryToDecodeLogOrNoop(log);
+            return maybeDecodedLog;
         }
-        // Fall back to the supplied ABIs for decoding if the ERC20/ERC721 decoding fails
-        // This ensures we hit events like Deposit and Withdraw given WETH can be a known ERC20Token
-        const isLogDecoded = ((maybeDecodedLog as any) as LogWithDecodedArgs<DecodedLogArgs>).event !== undefined;
-        if (!isLogDecoded) {
-            maybeDecodedLog = this._restAbiDecoder.tryToDecodeLogOrNoop(log);
-        }
-        return maybeDecodedLog;
     }
     // Hints the ABI decoder that a particular token address is ERC20 and events from it should be decoded as ERC20 events
     public addERC20Token(address: string): void {

--- a/packages/order-watcher/src/order_watcher/order_watcher.ts
+++ b/packages/order-watcher/src/order_watcher/order_watcher.ts
@@ -119,20 +119,10 @@ export class OrderWatcher {
         };
 
         this._provider = provider;
-        const wethDepositEvent = _.find(
-            artifacts.WETH9.compilerOutput.abi,
-            item => item.type === 'event' && item.name === 'Deposit',
-        );
-        const wethWithdrawEvent = _.find(
-            artifacts.WETH9.compilerOutput.abi,
-            item => item.type === 'event' && item.name === 'Withdrawal',
-        );
-        // Combine ERC20 and WETH events into a single ABI. This is used as the default ERC20 ABI when decoding
-        const combinedWETHERC20Abi = [...artifacts.ERC20Token.compilerOutput.abi, wethDepositEvent, wethWithdrawEvent];
         this._collisionResistantAbiDecoder = new CollisionResistanceAbiDecoder(
-            combinedWETHERC20Abi,
+            artifacts.ERC20Token.compilerOutput.abi,
             artifacts.ERC721Token.compilerOutput.abi,
-            [artifacts.Exchange.compilerOutput.abi],
+            [artifacts.WETH9.compilerOutput.abi, artifacts.Exchange.compilerOutput.abi],
         );
         const contractWrappers = new ContractWrappers(provider, {
             networkId,
@@ -160,7 +150,6 @@ export class OrderWatcher {
         this._cleanupJobInterval = config.cleanupJobIntervalMs;
         const zrxTokenAddress = assetDataUtils.decodeERC20AssetData(orderFilledCancelledFetcher.getZRXAssetData())
             .tokenAddress;
-        this._collisionResistantAbiDecoder.addERC20Token(zrxTokenAddress);
         this._dependentOrderHashesTracker = new DependentOrderHashesTracker(zrxTokenAddress);
     }
     /**

--- a/packages/order-watcher/src/order_watcher/order_watcher.ts
+++ b/packages/order-watcher/src/order_watcher/order_watcher.ts
@@ -119,10 +119,20 @@ export class OrderWatcher {
         };
 
         this._provider = provider;
+        const wethDepositEvent = _.find(
+            artifacts.WETH9.compilerOutput.abi,
+            item => item.type === 'event' && item.name === 'Deposit',
+        );
+        const wethWithdrawEvent = _.find(
+            artifacts.WETH9.compilerOutput.abi,
+            item => item.type === 'event' && item.name === 'Withdrawal',
+        );
+        // Combine ERC20 and WETH events into a single ABI. This is used as the default ERC20 ABI when decoding
+        const combinedWETHERC20Abi = [...artifacts.ERC20Token.compilerOutput.abi, wethDepositEvent, wethWithdrawEvent];
         this._collisionResistantAbiDecoder = new CollisionResistanceAbiDecoder(
-            artifacts.ERC20Token.compilerOutput.abi,
+            combinedWETHERC20Abi,
             artifacts.ERC721Token.compilerOutput.abi,
-            [artifacts.WETH9.compilerOutput.abi, artifacts.Exchange.compilerOutput.abi],
+            [artifacts.Exchange.compilerOutput.abi],
         );
         const contractWrappers = new ContractWrappers(provider, {
             networkId,
@@ -150,6 +160,7 @@ export class OrderWatcher {
         this._cleanupJobInterval = config.cleanupJobIntervalMs;
         const zrxTokenAddress = assetDataUtils.decodeERC20AssetData(orderFilledCancelledFetcher.getZRXAssetData())
             .tokenAddress;
+        this._collisionResistantAbiDecoder.addERC20Token(zrxTokenAddress);
         this._dependentOrderHashesTracker = new DependentOrderHashesTracker(zrxTokenAddress);
     }
     /**


### PR DESCRIPTION
## Description

OrderWatcher seemed to intermittently handle (call the callback) deposit and withdraw events for WETH.

Before any orders were added the events were handled correctly, though after a WETH order was added it would cease to trigger a callback when a `Withdraw` or `Deposit` event occurred. Without handling these events a subscriber wouldn't be able to invalidate orders where the user withdrew all WETH funds. 

## Testing instructions

Added repro test. Can be tested with Launch-Kit, creating an order, withdrawing WETH, query orders endpoint

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Prefix PR title with `[WIP]` if necessary.
-   [x] Add tests to cover changes as needed.
-   [x] Update documentation as needed.
-   [x] Add new entries to the relevant CHANGELOG.jsons.
