### PR TITLE
Fix bug where remainingTakerAssetAmount is not converted to BigNumber

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,6 +124,7 @@ jobs:
                       - repo-{{ .Environment.CIRCLE_SHA1 }}
             - run: yarn wsrun test:circleci @0x/contracts-test-utils
             - run: yarn wsrun test:circleci @0x/abi-gen
+            - run: yarn wsrun test:circleci @0x/asset-buyer
             - run: yarn wsrun test:circleci @0x/contract-artifacts
             - run: yarn wsrun test:circleci @0x/assert
             - run: yarn wsrun test:circleci @0x/base-contract
@@ -149,6 +150,10 @@ jobs:
                   key: coverage-assert-{{ .Environment.CIRCLE_SHA1 }}
                   paths:
                       - ~/repo/packages/assert/coverage/lcov.info
+            - save_cache:
+                  key: coverage-asset-buyer-{{ .Environment.CIRCLE_SHA1 }}
+                  paths:
+                      - ~/repo/packages/asset-buyer/coverage/lcov.info
             - save_cache:
                   key: coverage-base-contract-{{ .Environment.CIRCLE_SHA1 }}
                   paths:
@@ -327,6 +332,9 @@ jobs:
             - restore_cache:
                   keys:
                       - coverage-assert-{{ .Environment.CIRCLE_SHA1 }}
+            - restore_cache:
+                  keys:
+                      - coverage-asset-buyer-{{ .Environment.CIRCLE_SHA1 }}
             - restore_cache:
                   keys:
                       - coverage-base-contract-{{ .Environment.CIRCLE_SHA1 }}

--- a/packages/asset-buyer/CHANGELOG.json
+++ b/packages/asset-buyer/CHANGELOG.json
@@ -1,5 +1,13 @@
 [
     {
+        "version": "6.1.2",
+        "changes": [
+            {
+                "note": "Convert `metaData.remainingTakerAssetAmount` to BigNumber if present in APIOrder"
+            }
+        ]
+    },
+    {
         "timestamp": 1557507213,
         "version": "6.1.1",
         "changes": [

--- a/packages/asset-buyer/CHANGELOG.json
+++ b/packages/asset-buyer/CHANGELOG.json
@@ -3,7 +3,8 @@
         "version": "6.1.2",
         "changes": [
             {
-                "note": "Convert `metaData.remainingTakerAssetAmount` to BigNumber if present in APIOrder"
+                "note": "Convert `metaData.remainingTakerAssetAmount` to BigNumber if present in APIOrder",
+                "pr": 1810
             }
         ]
     },

--- a/packages/asset-buyer/src/order_providers/standard_relayer_api_order_provider.ts
+++ b/packages/asset-buyer/src/order_providers/standard_relayer_api_order_provider.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@0x/connect';
-import { orderCalculationUtils, orderParsingUtils } from '@0x/order-utils';
+import { orderCalculationUtils } from '@0x/order-utils';
 import { APIOrder, AssetPairsResponse, OrderbookResponse } from '@0x/types';
+import { BigNumber } from '@0x/utils';
 import * as _ from 'lodash';
 
 import {
@@ -27,15 +28,10 @@ export class StandardRelayerAPIOrderProvider implements OrderProvider {
             const { order, metaData } = apiOrder;
             // The contents of metaData is not explicity defined in the spec
             // We check for remainingTakerAssetAmount as a string and use this value if populated
-            const convertedMetaData = orderParsingUtils.convertStringsFieldsToBigNumbers(metaData, [
-                'remainingTakerAssetAmount',
-            ]);
-            // calculate remainingFillableMakerAssetAmount from api metadata, else assume order is completely fillable
-            const remainingFillableTakerAssetAmount = _.get(
-                convertedMetaData,
-                'remainingTakerAssetAmount',
-                order.takerAssetAmount,
-            );
+            const metaDataRemainingTakerAssetAmount = _.get(metaData, 'remainingTakerAssetAmount');
+            const remainingFillableTakerAssetAmount = metaDataRemainingTakerAssetAmount
+                ? new BigNumber(metaDataRemainingTakerAssetAmount)
+                : order.takerAssetAmount;
             const remainingFillableMakerAssetAmount = orderCalculationUtils.getMakerFillAmount(
                 order,
                 remainingFillableTakerAssetAmount,

--- a/packages/asset-buyer/src/order_providers/standard_relayer_api_order_provider.ts
+++ b/packages/asset-buyer/src/order_providers/standard_relayer_api_order_provider.ts
@@ -28,7 +28,9 @@ export class StandardRelayerAPIOrderProvider implements OrderProvider {
             const { order, metaData } = apiOrder;
             // The contents of metaData is not explicity defined in the spec
             // We check for remainingTakerAssetAmount as a string and use this value if populated
-            const metaDataRemainingTakerAssetAmount = _.get(metaData, 'remainingTakerAssetAmount');
+            const metaDataRemainingTakerAssetAmount = _.get(metaData, 'remainingTakerAssetAmount') as
+                | string
+                | undefined;
             const remainingFillableTakerAssetAmount = metaDataRemainingTakerAssetAmount
                 ? new BigNumber(metaDataRemainingTakerAssetAmount)
                 : order.takerAssetAmount;

--- a/packages/asset-buyer/src/order_providers/standard_relayer_api_order_provider.ts
+++ b/packages/asset-buyer/src/order_providers/standard_relayer_api_order_provider.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@0x/connect';
-import { orderCalculationUtils } from '@0x/order-utils';
+import { orderCalculationUtils, orderParsingUtils } from '@0x/order-utils';
 import { APIOrder, AssetPairsResponse, OrderbookResponse } from '@0x/types';
 import * as _ from 'lodash';
 
@@ -25,9 +25,14 @@ export class StandardRelayerAPIOrderProvider implements OrderProvider {
     ): SignedOrderWithRemainingFillableMakerAssetAmount[] {
         const result = _.map(apiOrders, apiOrder => {
             const { order, metaData } = apiOrder;
+            // The contents of metaData is not explicity defined in the spec
+            // We check for remainingTakerAssetAmount as a string and use this value if populated
+            const convertedMetaData = orderParsingUtils.convertStringsFieldsToBigNumbers(metaData, [
+                'remainingTakerAssetAmount',
+            ]);
             // calculate remainingFillableMakerAssetAmount from api metadata, else assume order is completely fillable
             const remainingFillableTakerAssetAmount = _.get(
-                metaData,
+                convertedMetaData,
                 'remainingTakerAssetAmount',
                 order.takerAssetAmount,
             );


### PR DESCRIPTION
## Description

Asset buyer checks for `remainingTakerAssetAmount` MetaData in the APIOrder from the SRA endpoint. This value is not explicitly part of the spec and as such it is not converted from string to BigNumber in `@0x/connect`. Using this value as a string results in errors when calculating the maker asset amount.

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
