### PR TITLE
add prepublish check for write permissions for npmjs packages

### DIFF
--- a/packages/monorepo-scripts/src/prepublish_checks.ts
+++ b/packages/monorepo-scripts/src/prepublish_checks.ts
@@ -18,7 +18,7 @@ async function prepublishChecksAsync(): Promise<void> {
     await checkCurrentVersionMatchesLatestPublishedNPMPackageAsync(updatedPublicPackages);
     await checkChangelogFormatAsync(updatedPublicPackages);
     await checkGitTagsForNextVersionAndDeleteIfExistAsync(updatedPublicPackages);
-    await checkPublishRequiredSetupAsync();
+    await checkPublishRequiredSetupAsync(updatedPublicPackages);
     await checkDockerHubSetupAsync();
 }
 
@@ -130,7 +130,7 @@ async function checkChangelogFormatAsync(updatedPublicPackages: Package[]): Prom
     }
 }
 
-async function checkPublishRequiredSetupAsync(): Promise<void> {
+async function checkPublishRequiredSetupAsync(updatedPublicPackages: Package[]): Promise<void> {
     // check to see if logged into npm before publishing
     try {
         // HACK: for some reason on some setups, the `npm whoami` will not recognize a logged-in user
@@ -139,6 +139,22 @@ async function checkPublishRequiredSetupAsync(): Promise<void> {
         await execAsync(`sudo npm whoami`);
     } catch (err) {
         throw new Error('You must be logged into npm in the commandline to publish. Run `npm login` and try again.');
+    }
+
+    // check to see that all required write permissions exist
+    utils.log(`Checking that all necessary npm write permissions exist...`);
+    const pkgPermissionsResult = await execAsync(`npm access ls-packages`);
+    const pkgPermissions = JSON.parse(pkgPermissionsResult.stdout);
+    const writePermissions = Object.keys(pkgPermissions).filter(pkgName => {
+        return pkgPermissions[pkgName] === 'read-write';
+    });
+    const unwriteablePkgs = updatedPublicPackages.filter(pkg => !writePermissions.includes(pkg.packageJson.name));
+    if (unwriteablePkgs.length > 0) {
+        utils.log(`Missing write permissions for the following packages:`);
+        unwriteablePkgs.forEach(pkg => {
+            utils.log(pkg.packageJson.name);
+        });
+        throw new Error(`Obtain necessary write permissions to continue.`);
     }
 
     // Check to see if Git personal token setup


### PR DESCRIPTION
## Description

Add a prepublish check that the user has write permissions for all packages about to be published to npmjs. Otherwise we risk ending up with only some packages published, which is very tedious to rollback. 

## Testing instructions

```
cd packages/monorepo-scripts
yarn build
node lib/prepublish_checks.js
```

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

 * Bug fix (non-breaking change which fixes an issue) 

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
