### PR TITLE
Add parameter assertions to abi-gen-wrappers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
 *.sol linguist-language=Solidity
 
 # Automatically collapse generated files in GitHub.
-*.svg linguist-generated
-packages/contract-artifacts/artifacts/*json linguist-generated
-packages/abi-gen-wrappers/src/generated-wrappers/*.ts liguist-generated
+*.svg linguist-generated=true
+packages/contract-artifacts/artifacts/*json linguist-generated=true
+packages/abi-gen-wrappers/src/generated-wrappers/*.ts liguist-generated=true
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,5 +3,5 @@
 # Automatically collapse generated files in GitHub.
 *.svg linguist-generated
 packages/contract-artifacts/artifacts/*json linguist-generated
-packages/abi-gen-wrappers/wrappers/*.ts liguist-generated
+packages/abi-gen-wrappers/src/generated-wrappers/*.ts liguist-generated
 

--- a/contracts/asset-proxy/test/erc1155_proxy.ts
+++ b/contracts/asset-proxy/test/erc1155_proxy.ts
@@ -596,6 +596,9 @@ describe('ERC1155Proxy', () => {
             const shouldRejectTransfer = true;
             await erc1155Receiver.setRejectTransferFlag.awaitTransactionSuccessAsync(
                 shouldRejectTransfer,
+                {
+                    from: owner,
+                },
                 constants.AWAIT_TRANSACTION_MINED_MS,
             );
             // setup test parameters

--- a/contracts/asset-proxy/test/proxies.ts
+++ b/contracts/asset-proxy/test/proxies.ts
@@ -199,6 +199,9 @@ describe('Asset Transfer Proxies', () => {
         await noReturnErc20Token.setBalance.awaitTransactionSuccessAsync(
             fromAddress,
             constants.INITIAL_ERC20_BALANCE,
+            {
+                from: owner,
+            },
             constants.AWAIT_TRANSACTION_MINED_MS,
         );
         await noReturnErc20Token.approve.awaitTransactionSuccessAsync(
@@ -210,6 +213,9 @@ describe('Asset Transfer Proxies', () => {
         await multipleReturnErc20Token.setBalance.awaitTransactionSuccessAsync(
             fromAddress,
             constants.INITIAL_ERC20_BALANCE,
+            {
+                from: owner,
+            },
             constants.AWAIT_TRANSACTION_MINED_MS,
         );
         await multipleReturnErc20Token.approve.awaitTransactionSuccessAsync(

--- a/contracts/extensions/test/dev_utils.ts
+++ b/contracts/extensions/test/dev_utils.ts
@@ -456,6 +456,9 @@ describe('DevUtils', () => {
             await erc20Token.setBalance.awaitTransactionSuccessAsync(
                 makerAddress,
                 makerBalance,
+                {
+                    from: makerAddress,
+                },
                 constants.AWAIT_TRANSACTION_MINED_MS,
             );
             await erc20Token.approve.awaitTransactionSuccessAsync(
@@ -469,6 +472,9 @@ describe('DevUtils', () => {
             await zrxToken.setBalance.awaitTransactionSuccessAsync(
                 makerAddress,
                 makerZrxBalance,
+                {
+                    from: makerAddress,
+                },
                 constants.AWAIT_TRANSACTION_MINED_MS,
             );
             await zrxToken.approve.awaitTransactionSuccessAsync(
@@ -482,6 +488,9 @@ describe('DevUtils', () => {
             await erc721Token.mint.awaitTransactionSuccessAsync(
                 takerAddress,
                 tokenId,
+                {
+                    from: takerAddress,
+                },
                 constants.AWAIT_TRANSACTION_MINED_MS,
             );
             const isApproved = true;
@@ -565,6 +574,9 @@ describe('DevUtils', () => {
             await erc20Token.setBalance.awaitTransactionSuccessAsync(
                 makerAddress,
                 makerBalance,
+                {
+                    from: makerAddress,
+                },
                 constants.AWAIT_TRANSACTION_MINED_MS,
             );
             await erc20Token.approve.awaitTransactionSuccessAsync(
@@ -578,6 +590,9 @@ describe('DevUtils', () => {
             await zrxToken.setBalance.awaitTransactionSuccessAsync(
                 makerAddress,
                 makerZrxBalance,
+                {
+                    from: makerAddress,
+                },
                 constants.AWAIT_TRANSACTION_MINED_MS,
             );
             await zrxToken.approve.awaitTransactionSuccessAsync(
@@ -600,6 +615,9 @@ describe('DevUtils', () => {
             await erc721Token.mint.awaitTransactionSuccessAsync(
                 takerAddress,
                 tokenId2,
+                {
+                    from: takerAddress,
+                },
                 constants.AWAIT_TRANSACTION_MINED_MS,
             );
             const orders = [signedOrder, signedOrder2];

--- a/contracts/extensions/test/dev_utils.ts
+++ b/contracts/extensions/test/dev_utils.ts
@@ -453,12 +453,11 @@ describe('DevUtils', () => {
             const makerAllowance = new BigNumber(456);
             const makerZrxBalance = new BigNumber(789);
             const takerZrxAllowance = new BigNumber(987);
+            const txData = undefined;
             await erc20Token.setBalance.awaitTransactionSuccessAsync(
                 makerAddress,
                 makerBalance,
-                {
-                    from: makerAddress,
-                },
+                txData,
                 constants.AWAIT_TRANSACTION_MINED_MS,
             );
             await erc20Token.approve.awaitTransactionSuccessAsync(
@@ -472,9 +471,7 @@ describe('DevUtils', () => {
             await zrxToken.setBalance.awaitTransactionSuccessAsync(
                 makerAddress,
                 makerZrxBalance,
-                {
-                    from: makerAddress,
-                },
+                txData,
                 constants.AWAIT_TRANSACTION_MINED_MS,
             );
             await zrxToken.approve.awaitTransactionSuccessAsync(
@@ -571,12 +568,11 @@ describe('DevUtils', () => {
             const makerAllowance = new BigNumber(456);
             const makerZrxBalance = new BigNumber(789);
             const takerZrxAllowance = new BigNumber(987);
+            const txData = undefined;
             await erc20Token.setBalance.awaitTransactionSuccessAsync(
                 makerAddress,
                 makerBalance,
-                {
-                    from: makerAddress,
-                },
+                txData,
                 constants.AWAIT_TRANSACTION_MINED_MS,
             );
             await erc20Token.approve.awaitTransactionSuccessAsync(
@@ -590,9 +586,7 @@ describe('DevUtils', () => {
             await zrxToken.setBalance.awaitTransactionSuccessAsync(
                 makerAddress,
                 makerZrxBalance,
-                {
-                    from: makerAddress,
-                },
+                txData,
                 constants.AWAIT_TRANSACTION_MINED_MS,
             );
             await zrxToken.approve.awaitTransactionSuccessAsync(

--- a/packages/abi-gen-templates/CHANGELOG.json
+++ b/packages/abi-gen-templates/CHANGELOG.json
@@ -1,5 +1,13 @@
 [
     {
+        "version": "2.2.0",
+        "changes": [
+            {
+                "note": "add parameter assertions to methods"
+            }
+        ]
+    },
+    {
         "version": "2.1.0",
         "changes": [
             {

--- a/packages/abi-gen-templates/CHANGELOG.json
+++ b/packages/abi-gen-templates/CHANGELOG.json
@@ -3,7 +3,8 @@
         "version": "2.2.0",
         "changes": [
             {
-                "note": "add parameter assertions to methods"
+                "note": "add parameter assertions to methods",
+                "pr": 1823
             }
         ]
     },

--- a/packages/abi-gen-templates/contract.handlebars
+++ b/packages/abi-gen-templates/contract.handlebars
@@ -1,6 +1,6 @@
-// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma whitespace class-name
+// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma
+// tslint:disable:whitespace no-unbound-method no-trailing-whitespace
 // tslint:disable:no-unused-variable
-// tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
 import { schemas } from '@0x/json-schemas';
 import {
@@ -114,4 +114,5 @@ export class {{contractName}}Contract extends BaseContract {
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count
-// tslint:enable:no-unbound-method
+// tslint:enable:no-unbound-method no-parameter-reassignment no-consecutive-blank-lines ordered-imports align
+// tslint:enable:trailing-comma whitespace no-trailing-whitespace

--- a/packages/abi-gen-templates/contract.handlebars
+++ b/packages/abi-gen-templates/contract.handlebars
@@ -2,6 +2,7 @@
 // tslint:disable:no-unused-variable
 // tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
+import { schemas } from '@0x/json-schemas';
 import {
     BlockParam,
     BlockParamLiteral,
@@ -18,6 +19,7 @@ import {
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
+import { assert } from '@0x/assert';
 import * as ethers from 'ethers';
 // tslint:enable:no-unused-variable
 
@@ -57,6 +59,11 @@ export class {{contractName}}Contract extends BaseContract {
         txDefaults: Partial<TxData>,
         {{> typed_params inputs=ctor.inputs}}
     ): Promise<{{contractName}}Contract> {
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         if (artifact.compilerOutput === undefined) {
             throw new Error('Compiler output not found in the artifact file');
         }
@@ -72,6 +79,12 @@ export class {{contractName}}Contract extends BaseContract {
         txDefaults: Partial<TxData>,
         {{> typed_params inputs=ctor.inputs}}
     ): Promise<{{contractName}}Contract> {
+        assert.isString('bytecode', bytecode);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
         const constructorAbi = BaseContract._lookupConstructorAbi(abi);
         [{{> params inputs=ctor.inputs}}] = BaseContract._formatABIDataItemList(

--- a/packages/abi-gen-templates/contract.handlebars
+++ b/packages/abi-gen-templates/contract.handlebars
@@ -79,7 +79,7 @@ export class {{contractName}}Contract extends BaseContract {
         txDefaults: Partial<TxData>,
         {{> typed_params inputs=ctor.inputs}}
     ): Promise<{{contractName}}Contract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-templates/partials/callAsync.handlebars
+++ b/packages/abi-gen-templates/partials/callAsync.handlebars
@@ -3,6 +3,17 @@ async callAsync(
     callData: Partial<CallData> = {},
     defaultBlock?: BlockParam,
 ): Promise<{{> return_type outputs=outputs}}> {
+    {{#each inputs}}
+    {{#assertionType name type}}{{/assertionType}}
+    {{/each}}
+    assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+        schemas.addressSchema,
+        schemas.numberSchema,
+        schemas.jsNumber,
+    ]);
+    if (defaultBlock !== undefined) {
+        assert.isBlockParam('defaultBlock', defaultBlock);
+    }
     const self = this as any as {{contractName}}Contract;
     const encodedData = self._strictEncodeArguments('{{this.functionSignature}}', [{{> params inputs=inputs}}]);
     const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(

--- a/packages/abi-gen-templates/partials/tx.handlebars
+++ b/packages/abi-gen-templates/partials/tx.handlebars
@@ -1,19 +1,18 @@
 public {{this.tsName}} = {
     async sendTransactionAsync(
     {{> typed_params inputs=inputs}}
-    {{#this.payable}}
-        txData: Partial<TxDataPayable> = {},
-    {{/this.payable}}
-    {{^this.payable}}
-        txData: Partial<TxData> = {},
-    {{/this.payable}}
+    txData?: Partial<TxData> | undefined,
     ): Promise<string> {
+        {{#each inputs}}
+        {{#assertionType name type}}{{/assertionType}}
+        {{/each}}
         const self = this as any as {{contractName}}Contract;
         const encodedData = self._strictEncodeArguments('{{this.functionSignature}}', [{{> params inputs=inputs}}]);
+        const passedInTxData = txData === undefined ? {} : txData;
         const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
             {
                 to: self.address,
-                ...txData,
+                ...passedInTxData,
                 data: encodedData,
             },
             self._web3Wrapper.getContractDefaults(),
@@ -27,22 +26,13 @@ public {{this.tsName}} = {
     },
     awaitTransactionSuccessAsync(
     {{> typed_params inputs=inputs}}
-    {{#this.payable}}
-        txData?: Partial<TxDataPayable> | number,
-    {{/this.payable}}
-    {{^this.payable}}
-        txData?: Partial<TxData> | number,
-    {{/this.payable}}
+        txData?: Partial<TxData>,
         pollingIntervalMs?: number,
         timeoutMs?: number,
     ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-        // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-        if (typeof(txData) === 'number') {
-            pollingIntervalMs = txData;
-            timeoutMs = pollingIntervalMs;
-            txData = {};
-        }
-        //
+        {{#each inputs}}
+        {{#assertionType name type}}{{/assertionType}}
+        {{/each}}
         const self = this as any as {{contractName}}Contract;
         {{#if inputs}}
         const txHashPromise = self.{{this.tsName}}.sendTransactionAsync({{> params input=inputs}}, txData);
@@ -63,14 +53,18 @@ public {{this.tsName}} = {
     },
     async estimateGasAsync(
     {{> typed_params inputs=inputs}}
-        txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
     ): Promise<number> {
+        {{#each inputs}}
+        {{#assertionType name type}}{{/assertionType}}
+        {{/each}}
         const self = this as any as {{contractName}}Contract;
         const encodedData = self._strictEncodeArguments('{{this.functionSignature}}', [{{> params inputs=inputs}}]);
+        const passedInTxData = txData === undefined ? {} : txData;
         const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
             {
                 to: self.address,
-                ...txData,
+                ...passedInTxData,
                 data: encodedData,
             },
             self._web3Wrapper.getContractDefaults(),
@@ -81,6 +75,9 @@ public {{this.tsName}} = {
     getABIEncodedTransactionData(
     {{> typed_params inputs=inputs}}
     ): string {
+        {{#each inputs}}
+        {{#assertionType name type}}{{/assertionType}}
+        {{/each}}
         const self = this as any as {{contractName}}Contract;
         const abiEncodedTransactionData = self._strictEncodeArguments('{{this.functionSignature}}', [{{> params inputs=inputs}}]);
         return abiEncodedTransactionData;

--- a/packages/abi-gen-templates/partials/tx.handlebars
+++ b/packages/abi-gen-templates/partials/tx.handlebars
@@ -8,11 +8,10 @@ public {{this.tsName}} = {
         {{/each}}
         const self = this as any as {{contractName}}Contract;
         const encodedData = self._strictEncodeArguments('{{this.functionSignature}}', [{{> params inputs=inputs}}]);
-        const passedInTxData = txData === undefined ? {} : txData;
         const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
             {
                 to: self.address,
-                ...passedInTxData,
+                ...txData,
                 data: encodedData,
             },
             self._web3Wrapper.getContractDefaults(),
@@ -60,11 +59,10 @@ public {{this.tsName}} = {
         {{/each}}
         const self = this as any as {{contractName}}Contract;
         const encodedData = self._strictEncodeArguments('{{this.functionSignature}}', [{{> params inputs=inputs}}]);
-        const passedInTxData = txData === undefined ? {} : txData;
         const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
             {
                 to: self.address,
-                ...passedInTxData,
+                ...txData,
                 data: encodedData,
             },
             self._web3Wrapper.getContractDefaults(),

--- a/packages/abi-gen-templates/partials/tx.handlebars
+++ b/packages/abi-gen-templates/partials/tx.handlebars
@@ -8,10 +8,11 @@ public {{this.tsName}} = {
         {{/each}}
         const self = this as any as {{contractName}}Contract;
         const encodedData = self._strictEncodeArguments('{{this.functionSignature}}', [{{> params inputs=inputs}}]);
+        const passedInTxData = txData === undefined ? {} : txData;
         const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
             {
                 to: self.address,
-                ...txData,
+                ...passedInTxData,
                 data: encodedData,
             },
             self._web3Wrapper.getContractDefaults(),
@@ -59,10 +60,11 @@ public {{this.tsName}} = {
         {{/each}}
         const self = this as any as {{contractName}}Contract;
         const encodedData = self._strictEncodeArguments('{{this.functionSignature}}', [{{> params inputs=inputs}}]);
+        const passedInTxData = txData === undefined ? {} : txData;
         const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
             {
                 to: self.address,
-                ...txData,
+                ...passedInTxData,
                 data: encodedData,
             },
             self._web3Wrapper.getContractDefaults(),

--- a/packages/abi-gen-templates/partials/tx.handlebars
+++ b/packages/abi-gen-templates/partials/tx.handlebars
@@ -3,25 +3,25 @@ public {{this.tsName}} = {
     {{> typed_params inputs=inputs}}
     txData?: Partial<TxData> | undefined,
     ): Promise<string> {
-        {{#each inputs}}
-        {{#assertionType name type}}{{/assertionType}}
-        {{/each}}
-        const self = this as any as {{contractName}}Contract;
-        const encodedData = self._strictEncodeArguments('{{this.functionSignature}}', [{{> params inputs=inputs}}]);
-        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-            {
-                to: self.address,
-                ...txData,
-                data: encodedData,
-            },
-            self._web3Wrapper.getContractDefaults(),
-            self.{{this.tsName}}.estimateGasAsync.bind(
-                self,
-                {{> params inputs=inputs}}
-            ),
-        );
-        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-        return txHash;
+    {{#each inputs}}
+    {{#assertionType name type}}{{/assertionType}}
+    {{/each}}
+    const self = this as any as {{contractName}}Contract;
+    const encodedData = self._strictEncodeArguments('{{this.functionSignature}}', [{{> params inputs=inputs}}]);
+    const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+        {
+            to: self.address,
+            ...txData,
+            data: encodedData,
+        },
+        self._web3Wrapper.getContractDefaults(),
+        self.{{this.tsName}}.estimateGasAsync.bind(
+            self,
+            {{> params inputs=inputs}}
+        ),
+    );
+    const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+    return txHash;
     },
     awaitTransactionSuccessAsync(
     {{> typed_params inputs=inputs}}
@@ -29,56 +29,56 @@ public {{this.tsName}} = {
         pollingIntervalMs?: number,
         timeoutMs?: number,
     ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-        {{#each inputs}}
-        {{#assertionType name type}}{{/assertionType}}
-        {{/each}}
-        const self = this as any as {{contractName}}Contract;
-        {{#if inputs}}
-        const txHashPromise = self.{{this.tsName}}.sendTransactionAsync({{> params input=inputs}}, txData);
-        {{else}}
-        const txHashPromise = self.{{this.tsName}}.sendTransactionAsync(txData);
-        {{/if}}
-        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-            txHashPromise,
-            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                // When the transaction hash resolves, wait for it to be mined.
-                return self._web3Wrapper.awaitTransactionSuccessAsync(
-                    await txHashPromise,
-                    pollingIntervalMs,
-                    timeoutMs,
-                );
-            })(),
-        );
+    {{#each inputs}}
+    {{#assertionType name type}}{{/assertionType}}
+    {{/each}}
+    const self = this as any as {{contractName}}Contract;
+    {{#if inputs}}
+    const txHashPromise = self.{{this.tsName}}.sendTransactionAsync({{> params input=inputs}}, txData);
+    {{else}}
+    const txHashPromise = self.{{this.tsName}}.sendTransactionAsync(txData);
+    {{/if}}
+    return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+        txHashPromise,
+        (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+            // When the transaction hash resolves, wait for it to be mined.
+            return self._web3Wrapper.awaitTransactionSuccessAsync(
+                await txHashPromise,
+                pollingIntervalMs,
+                timeoutMs,
+            );
+        })(),
+    );
     },
     async estimateGasAsync(
     {{> typed_params inputs=inputs}}
         txData?: Partial<TxData> | undefined,
     ): Promise<number> {
-        {{#each inputs}}
-        {{#assertionType name type}}{{/assertionType}}
-        {{/each}}
-        const self = this as any as {{contractName}}Contract;
-        const encodedData = self._strictEncodeArguments('{{this.functionSignature}}', [{{> params inputs=inputs}}]);
-        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-            {
-                to: self.address,
-                ...txData,
-                data: encodedData,
-            },
-            self._web3Wrapper.getContractDefaults(),
-        );
-        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-        return gas;
+    {{#each inputs}}
+    {{#assertionType name type}}{{/assertionType}}
+    {{/each}}
+    const self = this as any as {{contractName}}Contract;
+    const encodedData = self._strictEncodeArguments('{{this.functionSignature}}', [{{> params inputs=inputs}}]);
+    const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+        {
+            to: self.address,
+            ...txData,
+            data: encodedData,
+        },
+        self._web3Wrapper.getContractDefaults(),
+    );
+    const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+    return gas;
     },
     getABIEncodedTransactionData(
     {{> typed_params inputs=inputs}}
     ): string {
-        {{#each inputs}}
-        {{#assertionType name type}}{{/assertionType}}
-        {{/each}}
-        const self = this as any as {{contractName}}Contract;
-        const abiEncodedTransactionData = self._strictEncodeArguments('{{this.functionSignature}}', [{{> params inputs=inputs}}]);
-        return abiEncodedTransactionData;
+    {{#each inputs}}
+    {{#assertionType name type}}{{/assertionType}}
+    {{/each}}
+    const self = this as any as {{contractName}}Contract;
+    const abiEncodedTransactionData = self._strictEncodeArguments('{{this.functionSignature}}', [{{> params inputs=inputs}}]);
+    return abiEncodedTransactionData;
     },
     {{> callAsync}}
 };

--- a/packages/abi-gen-wrappers/CHANGELOG.json
+++ b/packages/abi-gen-wrappers/CHANGELOG.json
@@ -1,5 +1,13 @@
 [
     {
+        "version": "4.4.0",
+        "changes": [
+            {
+                "note": "Update wrappers to include parameter assertions"
+            }
+        ]
+    },
+    {
         "version": "4.3.0",
         "changes": [
             {

--- a/packages/abi-gen-wrappers/CHANGELOG.json
+++ b/packages/abi-gen-wrappers/CHANGELOG.json
@@ -3,7 +3,8 @@
         "version": "4.4.0",
         "changes": [
             {
-                "note": "Update wrappers to include parameter assertions"
+                "note": "Update wrappers to include parameter assertions",
+                "pr": 1823
             }
         ]
     },

--- a/packages/abi-gen-wrappers/package.json
+++ b/packages/abi-gen-wrappers/package.json
@@ -33,6 +33,8 @@
     "devDependencies": {
         "@0x/abi-gen": "^2.0.10",
         "@0x/abi-gen-templates": "^2.1.0",
+        "@0x/assert": "^2.0.10",
+        "@0x/json-schemas": "^3.0.10",
         "@0x/tslint-config": "^3.0.1",
         "@0x/types": "^2.2.2",
         "@0x/utils": "^4.3.3",

--- a/packages/abi-gen-wrappers/src/generated-wrappers/asset_proxy_owner.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/asset_proxy_owner.ts
@@ -2,6 +2,7 @@
 // tslint:disable:no-unused-variable
 // tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
+import { schemas } from '@0x/json-schemas';
 import {
     BlockParam,
     BlockParamLiteral,
@@ -18,6 +19,7 @@ import {
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
+import { assert } from '@0x/assert';
 import * as ethers from 'ethers';
 // tslint:enable:no-unused-variable
 
@@ -115,6 +117,15 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.isBigNumber('index_0', index_0);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('owners(uint256)', [index_0
         ]);
@@ -139,15 +150,17 @@ export class AssetProxyOwnerContract extends BaseContract {
     public removeOwner = {
         async sendTransactionAsync(
             owner: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('owner', owner);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('removeOwner(address)', [owner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -161,17 +174,11 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             owner: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('owner', owner);
             const self = this as any as AssetProxyOwnerContract;
             const txHashPromise = self.removeOwner.sendTransactionAsync(owner
     , txData);
@@ -189,15 +196,17 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
         async estimateGasAsync(
             owner: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('owner', owner);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('removeOwner(address)', [owner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -208,6 +217,7 @@ export class AssetProxyOwnerContract extends BaseContract {
         getABIEncodedTransactionData(
             owner: string,
         ): string {
+            assert.isString('owner', owner);
             const self = this as any as AssetProxyOwnerContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('removeOwner(address)', [owner
     ]);
@@ -219,6 +229,15 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('owner', owner);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('removeOwner(address)', [owner
         ]);
@@ -243,15 +262,17 @@ export class AssetProxyOwnerContract extends BaseContract {
     public revokeConfirmation = {
         async sendTransactionAsync(
             transactionId: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isBigNumber('transactionId', transactionId);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('revokeConfirmation(uint256)', [transactionId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -265,17 +286,11 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             transactionId: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isBigNumber('transactionId', transactionId);
             const self = this as any as AssetProxyOwnerContract;
             const txHashPromise = self.revokeConfirmation.sendTransactionAsync(transactionId
     , txData);
@@ -293,15 +308,17 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
         async estimateGasAsync(
             transactionId: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isBigNumber('transactionId', transactionId);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('revokeConfirmation(uint256)', [transactionId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -312,6 +329,7 @@ export class AssetProxyOwnerContract extends BaseContract {
         getABIEncodedTransactionData(
             transactionId: BigNumber,
         ): string {
+            assert.isBigNumber('transactionId', transactionId);
             const self = this as any as AssetProxyOwnerContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('revokeConfirmation(uint256)', [transactionId
     ]);
@@ -323,6 +341,15 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isBigNumber('transactionId', transactionId);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('revokeConfirmation(uint256)', [transactionId
         ]);
@@ -351,6 +378,15 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
+            assert.isString('index_0', index_0);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('isOwner(address)', [index_0
         ]);
@@ -380,6 +416,16 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
+            assert.isBigNumber('index_0', index_0);
+            assert.isString('index_1', index_1);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('confirmations(uint256,address)', [index_0,
         index_1
@@ -405,15 +451,17 @@ export class AssetProxyOwnerContract extends BaseContract {
     public executeRemoveAuthorizedAddressAtIndex = {
         async sendTransactionAsync(
             transactionId: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isBigNumber('transactionId', transactionId);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('executeRemoveAuthorizedAddressAtIndex(uint256)', [transactionId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -427,17 +475,11 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             transactionId: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isBigNumber('transactionId', transactionId);
             const self = this as any as AssetProxyOwnerContract;
             const txHashPromise = self.executeRemoveAuthorizedAddressAtIndex.sendTransactionAsync(transactionId
     , txData);
@@ -455,15 +497,17 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
         async estimateGasAsync(
             transactionId: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isBigNumber('transactionId', transactionId);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('executeRemoveAuthorizedAddressAtIndex(uint256)', [transactionId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -474,6 +518,7 @@ export class AssetProxyOwnerContract extends BaseContract {
         getABIEncodedTransactionData(
             transactionId: BigNumber,
         ): string {
+            assert.isBigNumber('transactionId', transactionId);
             const self = this as any as AssetProxyOwnerContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('executeRemoveAuthorizedAddressAtIndex(uint256)', [transactionId
     ]);
@@ -485,6 +530,15 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isBigNumber('transactionId', transactionId);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('executeRemoveAuthorizedAddressAtIndex(uint256)', [transactionId
         ]);
@@ -512,6 +566,14 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('secondsTimeLocked()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -540,6 +602,16 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+            assert.isBoolean('pending', pending);
+            assert.isBoolean('executed', executed);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('getTransactionCount(bool,bool)', [pending,
         executed
@@ -566,16 +638,19 @@ export class AssetProxyOwnerContract extends BaseContract {
         async sendTransactionAsync(
             assetProxyContract: string,
             isRegistered: boolean,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('assetProxyContract', assetProxyContract);
+            assert.isBoolean('isRegistered', isRegistered);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('registerAssetProxy(address,bool)', [assetProxyContract,
     isRegistered
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -591,17 +666,12 @@ export class AssetProxyOwnerContract extends BaseContract {
         awaitTransactionSuccessAsync(
             assetProxyContract: string,
             isRegistered: boolean,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('assetProxyContract', assetProxyContract);
+            assert.isBoolean('isRegistered', isRegistered);
             const self = this as any as AssetProxyOwnerContract;
             const txHashPromise = self.registerAssetProxy.sendTransactionAsync(assetProxyContract,
     isRegistered
@@ -621,16 +691,19 @@ export class AssetProxyOwnerContract extends BaseContract {
         async estimateGasAsync(
             assetProxyContract: string,
             isRegistered: boolean,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('assetProxyContract', assetProxyContract);
+            assert.isBoolean('isRegistered', isRegistered);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('registerAssetProxy(address,bool)', [assetProxyContract,
     isRegistered
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -642,6 +715,8 @@ export class AssetProxyOwnerContract extends BaseContract {
             assetProxyContract: string,
             isRegistered: boolean,
         ): string {
+            assert.isString('assetProxyContract', assetProxyContract);
+            assert.isBoolean('isRegistered', isRegistered);
             const self = this as any as AssetProxyOwnerContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('registerAssetProxy(address,bool)', [assetProxyContract,
     isRegistered
@@ -655,6 +730,16 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('assetProxyContract', assetProxyContract);
+            assert.isBoolean('isRegistered', isRegistered);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('registerAssetProxy(address,bool)', [assetProxyContract,
         isRegistered
@@ -680,15 +765,17 @@ export class AssetProxyOwnerContract extends BaseContract {
     public addOwner = {
         async sendTransactionAsync(
             owner: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('owner', owner);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('addOwner(address)', [owner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -702,17 +789,11 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             owner: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('owner', owner);
             const self = this as any as AssetProxyOwnerContract;
             const txHashPromise = self.addOwner.sendTransactionAsync(owner
     , txData);
@@ -730,15 +811,17 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
         async estimateGasAsync(
             owner: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('owner', owner);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('addOwner(address)', [owner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -749,6 +832,7 @@ export class AssetProxyOwnerContract extends BaseContract {
         getABIEncodedTransactionData(
             owner: string,
         ): string {
+            assert.isString('owner', owner);
             const self = this as any as AssetProxyOwnerContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('addOwner(address)', [owner
     ]);
@@ -760,6 +844,15 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('owner', owner);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('addOwner(address)', [owner
         ]);
@@ -788,6 +881,15 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
+            assert.isBigNumber('transactionId', transactionId);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('isConfirmed(uint256)', [transactionId
         ]);
@@ -812,15 +914,17 @@ export class AssetProxyOwnerContract extends BaseContract {
     public changeTimeLock = {
         async sendTransactionAsync(
             _secondsTimeLocked: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isBigNumber('_secondsTimeLocked', _secondsTimeLocked);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('changeTimeLock(uint256)', [_secondsTimeLocked
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -834,17 +938,11 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             _secondsTimeLocked: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isBigNumber('_secondsTimeLocked', _secondsTimeLocked);
             const self = this as any as AssetProxyOwnerContract;
             const txHashPromise = self.changeTimeLock.sendTransactionAsync(_secondsTimeLocked
     , txData);
@@ -862,15 +960,17 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
         async estimateGasAsync(
             _secondsTimeLocked: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isBigNumber('_secondsTimeLocked', _secondsTimeLocked);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('changeTimeLock(uint256)', [_secondsTimeLocked
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -881,6 +981,7 @@ export class AssetProxyOwnerContract extends BaseContract {
         getABIEncodedTransactionData(
             _secondsTimeLocked: BigNumber,
         ): string {
+            assert.isBigNumber('_secondsTimeLocked', _secondsTimeLocked);
             const self = this as any as AssetProxyOwnerContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('changeTimeLock(uint256)', [_secondsTimeLocked
     ]);
@@ -892,6 +993,15 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isBigNumber('_secondsTimeLocked', _secondsTimeLocked);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('changeTimeLock(uint256)', [_secondsTimeLocked
         ]);
@@ -920,6 +1030,15 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
+            assert.isString('index_0', index_0);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('isAssetProxyRegistered(address)', [index_0
         ]);
@@ -948,6 +1067,15 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+            assert.isBigNumber('transactionId', transactionId);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('getConfirmationCount(uint256)', [transactionId
         ]);
@@ -976,6 +1104,15 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<[string, BigNumber, string, boolean]
         > {
+            assert.isBigNumber('index_0', index_0);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('transactions(uint256)', [index_0
         ]);
@@ -1003,6 +1140,14 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('getOwners()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -1033,6 +1178,18 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber[]
         > {
+            assert.isBigNumber('from', from);
+            assert.isBigNumber('to', to);
+            assert.isBoolean('pending', pending);
+            assert.isBoolean('executed', executed);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('getTransactionIds(uint256,uint256,bool,bool)', [from,
         to,
@@ -1064,6 +1221,15 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
+            assert.isBigNumber('transactionId', transactionId);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('getConfirmations(uint256)', [transactionId
         ]);
@@ -1091,6 +1257,14 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('transactionCount()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -1114,15 +1288,17 @@ export class AssetProxyOwnerContract extends BaseContract {
     public changeRequirement = {
         async sendTransactionAsync(
             _required: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isBigNumber('_required', _required);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('changeRequirement(uint256)', [_required
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1136,17 +1312,11 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             _required: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isBigNumber('_required', _required);
             const self = this as any as AssetProxyOwnerContract;
             const txHashPromise = self.changeRequirement.sendTransactionAsync(_required
     , txData);
@@ -1164,15 +1334,17 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
         async estimateGasAsync(
             _required: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isBigNumber('_required', _required);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('changeRequirement(uint256)', [_required
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1183,6 +1355,7 @@ export class AssetProxyOwnerContract extends BaseContract {
         getABIEncodedTransactionData(
             _required: BigNumber,
         ): string {
+            assert.isBigNumber('_required', _required);
             const self = this as any as AssetProxyOwnerContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('changeRequirement(uint256)', [_required
     ]);
@@ -1194,6 +1367,15 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isBigNumber('_required', _required);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('changeRequirement(uint256)', [_required
         ]);
@@ -1218,15 +1400,17 @@ export class AssetProxyOwnerContract extends BaseContract {
     public confirmTransaction = {
         async sendTransactionAsync(
             transactionId: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isBigNumber('transactionId', transactionId);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('confirmTransaction(uint256)', [transactionId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1240,17 +1424,11 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             transactionId: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isBigNumber('transactionId', transactionId);
             const self = this as any as AssetProxyOwnerContract;
             const txHashPromise = self.confirmTransaction.sendTransactionAsync(transactionId
     , txData);
@@ -1268,15 +1446,17 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
         async estimateGasAsync(
             transactionId: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isBigNumber('transactionId', transactionId);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('confirmTransaction(uint256)', [transactionId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1287,6 +1467,7 @@ export class AssetProxyOwnerContract extends BaseContract {
         getABIEncodedTransactionData(
             transactionId: BigNumber,
         ): string {
+            assert.isBigNumber('transactionId', transactionId);
             const self = this as any as AssetProxyOwnerContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('confirmTransaction(uint256)', [transactionId
     ]);
@@ -1298,6 +1479,15 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isBigNumber('transactionId', transactionId);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('confirmTransaction(uint256)', [transactionId
         ]);
@@ -1324,17 +1514,21 @@ export class AssetProxyOwnerContract extends BaseContract {
             destination: string,
             value: BigNumber,
             data: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('destination', destination);
+            assert.isBigNumber('value', value);
+            assert.isString('data', data);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('submitTransaction(address,uint256,bytes)', [destination,
     value,
     data
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1352,17 +1546,13 @@ export class AssetProxyOwnerContract extends BaseContract {
             destination: string,
             value: BigNumber,
             data: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('destination', destination);
+            assert.isBigNumber('value', value);
+            assert.isString('data', data);
             const self = this as any as AssetProxyOwnerContract;
             const txHashPromise = self.submitTransaction.sendTransactionAsync(destination,
     value,
@@ -1384,17 +1574,21 @@ export class AssetProxyOwnerContract extends BaseContract {
             destination: string,
             value: BigNumber,
             data: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('destination', destination);
+            assert.isBigNumber('value', value);
+            assert.isString('data', data);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('submitTransaction(address,uint256,bytes)', [destination,
     value,
     data
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1407,6 +1601,9 @@ export class AssetProxyOwnerContract extends BaseContract {
             value: BigNumber,
             data: string,
         ): string {
+            assert.isString('destination', destination);
+            assert.isBigNumber('value', value);
+            assert.isString('data', data);
             const self = this as any as AssetProxyOwnerContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('submitTransaction(address,uint256,bytes)', [destination,
     value,
@@ -1422,6 +1619,17 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+            assert.isString('destination', destination);
+            assert.isBigNumber('value', value);
+            assert.isString('data', data);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('submitTransaction(address,uint256,bytes)', [destination,
         value,
@@ -1452,6 +1660,15 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+            assert.isBigNumber('index_0', index_0);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('confirmationTimes(uint256)', [index_0
         ]);
@@ -1479,6 +1696,14 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('MAX_OWNER_COUNT()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -1505,6 +1730,14 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('required()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -1529,16 +1762,19 @@ export class AssetProxyOwnerContract extends BaseContract {
         async sendTransactionAsync(
             owner: string,
             newOwner: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('owner', owner);
+            assert.isString('newOwner', newOwner);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('replaceOwner(address,address)', [owner,
     newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1554,17 +1790,12 @@ export class AssetProxyOwnerContract extends BaseContract {
         awaitTransactionSuccessAsync(
             owner: string,
             newOwner: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('owner', owner);
+            assert.isString('newOwner', newOwner);
             const self = this as any as AssetProxyOwnerContract;
             const txHashPromise = self.replaceOwner.sendTransactionAsync(owner,
     newOwner
@@ -1584,16 +1815,19 @@ export class AssetProxyOwnerContract extends BaseContract {
         async estimateGasAsync(
             owner: string,
             newOwner: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('owner', owner);
+            assert.isString('newOwner', newOwner);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('replaceOwner(address,address)', [owner,
     newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1605,6 +1839,8 @@ export class AssetProxyOwnerContract extends BaseContract {
             owner: string,
             newOwner: string,
         ): string {
+            assert.isString('owner', owner);
+            assert.isString('newOwner', newOwner);
             const self = this as any as AssetProxyOwnerContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('replaceOwner(address,address)', [owner,
     newOwner
@@ -1618,6 +1854,16 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('owner', owner);
+            assert.isString('newOwner', newOwner);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('replaceOwner(address,address)', [owner,
         newOwner
@@ -1643,15 +1889,17 @@ export class AssetProxyOwnerContract extends BaseContract {
     public executeTransaction = {
         async sendTransactionAsync(
             transactionId: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isBigNumber('transactionId', transactionId);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('executeTransaction(uint256)', [transactionId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1665,17 +1913,11 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             transactionId: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isBigNumber('transactionId', transactionId);
             const self = this as any as AssetProxyOwnerContract;
             const txHashPromise = self.executeTransaction.sendTransactionAsync(transactionId
     , txData);
@@ -1693,15 +1935,17 @@ export class AssetProxyOwnerContract extends BaseContract {
         },
         async estimateGasAsync(
             transactionId: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isBigNumber('transactionId', transactionId);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('executeTransaction(uint256)', [transactionId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1712,6 +1956,7 @@ export class AssetProxyOwnerContract extends BaseContract {
         getABIEncodedTransactionData(
             transactionId: BigNumber,
         ): string {
+            assert.isBigNumber('transactionId', transactionId);
             const self = this as any as AssetProxyOwnerContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('executeTransaction(uint256)', [transactionId
     ]);
@@ -1723,6 +1968,15 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isBigNumber('transactionId', transactionId);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('executeTransaction(uint256)', [transactionId
         ]);
@@ -1753,6 +2007,11 @@ export class AssetProxyOwnerContract extends BaseContract {
             _required: BigNumber,
             _secondsTimeLocked: BigNumber,
     ): Promise<AssetProxyOwnerContract> {
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         if (artifact.compilerOutput === undefined) {
             throw new Error('Compiler output not found in the artifact file');
         }
@@ -1775,6 +2034,12 @@ _secondsTimeLocked
             _required: BigNumber,
             _secondsTimeLocked: BigNumber,
     ): Promise<AssetProxyOwnerContract> {
+        assert.isString('bytecode', bytecode);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
         const constructorAbi = BaseContract._lookupConstructorAbi(abi);
         [_owners,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/asset_proxy_owner.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/asset_proxy_owner.ts
@@ -1,6 +1,6 @@
-// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma whitespace class-name
+// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma
+// tslint:disable:whitespace no-unbound-method no-trailing-whitespace
 // tslint:disable:no-unused-variable
-// tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
 import { schemas } from '@0x/json-schemas';
 import {
@@ -156,11 +156,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('removeOwner(address)', [owner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -202,11 +201,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('removeOwner(address)', [owner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -268,11 +266,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('revokeConfirmation(uint256)', [transactionId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -314,11 +311,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('revokeConfirmation(uint256)', [transactionId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -416,8 +412,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isBigNumber('index_0', index_0);
-            assert.isString('index_1', index_1);
+            assert.isBigNumber('index_0', index_0);assert.isString('index_1', index_1);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -457,11 +452,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('executeRemoveAuthorizedAddressAtIndex(uint256)', [transactionId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -503,11 +497,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('executeRemoveAuthorizedAddressAtIndex(uint256)', [transactionId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -566,6 +559,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -602,8 +596,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-            assert.isBoolean('pending', pending);
-            assert.isBoolean('executed', executed);
+            assert.isBoolean('pending', pending);assert.isBoolean('executed', executed);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -640,17 +633,15 @@ export class AssetProxyOwnerContract extends BaseContract {
             isRegistered: boolean,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('assetProxyContract', assetProxyContract);
-            assert.isBoolean('isRegistered', isRegistered);
+            assert.isString('assetProxyContract', assetProxyContract);assert.isBoolean('isRegistered', isRegistered);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('registerAssetProxy(address,bool)', [assetProxyContract,
     isRegistered
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -670,8 +661,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('assetProxyContract', assetProxyContract);
-            assert.isBoolean('isRegistered', isRegistered);
+            assert.isString('assetProxyContract', assetProxyContract);assert.isBoolean('isRegistered', isRegistered);
             const self = this as any as AssetProxyOwnerContract;
             const txHashPromise = self.registerAssetProxy.sendTransactionAsync(assetProxyContract,
     isRegistered
@@ -693,17 +683,15 @@ export class AssetProxyOwnerContract extends BaseContract {
             isRegistered: boolean,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('assetProxyContract', assetProxyContract);
-            assert.isBoolean('isRegistered', isRegistered);
+            assert.isString('assetProxyContract', assetProxyContract);assert.isBoolean('isRegistered', isRegistered);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('registerAssetProxy(address,bool)', [assetProxyContract,
     isRegistered
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -715,8 +703,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             assetProxyContract: string,
             isRegistered: boolean,
         ): string {
-            assert.isString('assetProxyContract', assetProxyContract);
-            assert.isBoolean('isRegistered', isRegistered);
+            assert.isString('assetProxyContract', assetProxyContract);assert.isBoolean('isRegistered', isRegistered);
             const self = this as any as AssetProxyOwnerContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('registerAssetProxy(address,bool)', [assetProxyContract,
     isRegistered
@@ -730,8 +717,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('assetProxyContract', assetProxyContract);
-            assert.isBoolean('isRegistered', isRegistered);
+            assert.isString('assetProxyContract', assetProxyContract);assert.isBoolean('isRegistered', isRegistered);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -771,11 +757,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('addOwner(address)', [owner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -817,11 +802,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('addOwner(address)', [owner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -920,11 +904,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('changeTimeLock(uint256)', [_secondsTimeLocked
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -966,11 +949,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('changeTimeLock(uint256)', [_secondsTimeLocked
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1140,6 +1122,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1178,10 +1161,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber[]
         > {
-            assert.isBigNumber('from', from);
-            assert.isBigNumber('to', to);
-            assert.isBoolean('pending', pending);
-            assert.isBoolean('executed', executed);
+            assert.isBigNumber('from', from);assert.isBigNumber('to', to);assert.isBoolean('pending', pending);assert.isBoolean('executed', executed);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1257,6 +1237,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1294,11 +1275,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('changeRequirement(uint256)', [_required
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1340,11 +1320,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('changeRequirement(uint256)', [_required
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1406,11 +1385,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('confirmTransaction(uint256)', [transactionId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1452,11 +1430,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('confirmTransaction(uint256)', [transactionId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1516,19 +1493,16 @@ export class AssetProxyOwnerContract extends BaseContract {
             data: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('destination', destination);
-            assert.isBigNumber('value', value);
-            assert.isString('data', data);
+            assert.isString('destination', destination);assert.isBigNumber('value', value);assert.isString('data', data);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('submitTransaction(address,uint256,bytes)', [destination,
     value,
     data
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1550,9 +1524,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('destination', destination);
-            assert.isBigNumber('value', value);
-            assert.isString('data', data);
+            assert.isString('destination', destination);assert.isBigNumber('value', value);assert.isString('data', data);
             const self = this as any as AssetProxyOwnerContract;
             const txHashPromise = self.submitTransaction.sendTransactionAsync(destination,
     value,
@@ -1576,19 +1548,16 @@ export class AssetProxyOwnerContract extends BaseContract {
             data: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('destination', destination);
-            assert.isBigNumber('value', value);
-            assert.isString('data', data);
+            assert.isString('destination', destination);assert.isBigNumber('value', value);assert.isString('data', data);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('submitTransaction(address,uint256,bytes)', [destination,
     value,
     data
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1601,9 +1570,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             value: BigNumber,
             data: string,
         ): string {
-            assert.isString('destination', destination);
-            assert.isBigNumber('value', value);
-            assert.isString('data', data);
+            assert.isString('destination', destination);assert.isBigNumber('value', value);assert.isString('data', data);
             const self = this as any as AssetProxyOwnerContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('submitTransaction(address,uint256,bytes)', [destination,
     value,
@@ -1619,9 +1586,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-            assert.isString('destination', destination);
-            assert.isBigNumber('value', value);
-            assert.isString('data', data);
+            assert.isString('destination', destination);assert.isBigNumber('value', value);assert.isString('data', data);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1696,6 +1661,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1730,6 +1696,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1764,17 +1731,15 @@ export class AssetProxyOwnerContract extends BaseContract {
             newOwner: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('owner', owner);
-            assert.isString('newOwner', newOwner);
+            assert.isString('owner', owner);assert.isString('newOwner', newOwner);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('replaceOwner(address,address)', [owner,
     newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1794,8 +1759,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('owner', owner);
-            assert.isString('newOwner', newOwner);
+            assert.isString('owner', owner);assert.isString('newOwner', newOwner);
             const self = this as any as AssetProxyOwnerContract;
             const txHashPromise = self.replaceOwner.sendTransactionAsync(owner,
     newOwner
@@ -1817,17 +1781,15 @@ export class AssetProxyOwnerContract extends BaseContract {
             newOwner: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('owner', owner);
-            assert.isString('newOwner', newOwner);
+            assert.isString('owner', owner);assert.isString('newOwner', newOwner);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('replaceOwner(address,address)', [owner,
     newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1839,8 +1801,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             owner: string,
             newOwner: string,
         ): string {
-            assert.isString('owner', owner);
-            assert.isString('newOwner', newOwner);
+            assert.isString('owner', owner);assert.isString('newOwner', newOwner);
             const self = this as any as AssetProxyOwnerContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('replaceOwner(address,address)', [owner,
     newOwner
@@ -1854,8 +1815,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('owner', owner);
-            assert.isString('newOwner', newOwner);
+            assert.isString('owner', owner);assert.isString('newOwner', newOwner);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1895,11 +1855,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('executeTransaction(uint256)', [transactionId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1941,11 +1900,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('executeTransaction(uint256)', [transactionId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2034,7 +1992,7 @@ _secondsTimeLocked
             _required: BigNumber,
             _secondsTimeLocked: BigNumber,
     ): Promise<AssetProxyOwnerContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,
@@ -2085,4 +2043,5 @@ _secondsTimeLocked
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count
-// tslint:enable:no-unbound-method
+// tslint:enable:no-unbound-method no-parameter-reassignment no-consecutive-blank-lines ordered-imports align
+// tslint:enable:trailing-comma whitespace no-trailing-whitespace

--- a/packages/abi-gen-wrappers/src/generated-wrappers/asset_proxy_owner.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/asset_proxy_owner.ts
@@ -156,10 +156,11 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('removeOwner(address)', [owner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -201,10 +202,11 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('removeOwner(address)', [owner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -266,10 +268,11 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('revokeConfirmation(uint256)', [transactionId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -311,10 +314,11 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('revokeConfirmation(uint256)', [transactionId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -412,7 +416,8 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isBigNumber('index_0', index_0);assert.isString('index_1', index_1);
+            assert.isBigNumber('index_0', index_0);
+            assert.isString('index_1', index_1);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -452,10 +457,11 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('executeRemoveAuthorizedAddressAtIndex(uint256)', [transactionId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -497,10 +503,11 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('executeRemoveAuthorizedAddressAtIndex(uint256)', [transactionId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -559,7 +566,6 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -596,7 +602,8 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-            assert.isBoolean('pending', pending);assert.isBoolean('executed', executed);
+            assert.isBoolean('pending', pending);
+            assert.isBoolean('executed', executed);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -633,15 +640,17 @@ export class AssetProxyOwnerContract extends BaseContract {
             isRegistered: boolean,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('assetProxyContract', assetProxyContract);assert.isBoolean('isRegistered', isRegistered);
+            assert.isString('assetProxyContract', assetProxyContract);
+            assert.isBoolean('isRegistered', isRegistered);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('registerAssetProxy(address,bool)', [assetProxyContract,
     isRegistered
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -661,7 +670,8 @@ export class AssetProxyOwnerContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('assetProxyContract', assetProxyContract);assert.isBoolean('isRegistered', isRegistered);
+            assert.isString('assetProxyContract', assetProxyContract);
+            assert.isBoolean('isRegistered', isRegistered);
             const self = this as any as AssetProxyOwnerContract;
             const txHashPromise = self.registerAssetProxy.sendTransactionAsync(assetProxyContract,
     isRegistered
@@ -683,15 +693,17 @@ export class AssetProxyOwnerContract extends BaseContract {
             isRegistered: boolean,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('assetProxyContract', assetProxyContract);assert.isBoolean('isRegistered', isRegistered);
+            assert.isString('assetProxyContract', assetProxyContract);
+            assert.isBoolean('isRegistered', isRegistered);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('registerAssetProxy(address,bool)', [assetProxyContract,
     isRegistered
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -703,7 +715,8 @@ export class AssetProxyOwnerContract extends BaseContract {
             assetProxyContract: string,
             isRegistered: boolean,
         ): string {
-            assert.isString('assetProxyContract', assetProxyContract);assert.isBoolean('isRegistered', isRegistered);
+            assert.isString('assetProxyContract', assetProxyContract);
+            assert.isBoolean('isRegistered', isRegistered);
             const self = this as any as AssetProxyOwnerContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('registerAssetProxy(address,bool)', [assetProxyContract,
     isRegistered
@@ -717,7 +730,8 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('assetProxyContract', assetProxyContract);assert.isBoolean('isRegistered', isRegistered);
+            assert.isString('assetProxyContract', assetProxyContract);
+            assert.isBoolean('isRegistered', isRegistered);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -757,10 +771,11 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('addOwner(address)', [owner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -802,10 +817,11 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('addOwner(address)', [owner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -904,10 +920,11 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('changeTimeLock(uint256)', [_secondsTimeLocked
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -949,10 +966,11 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('changeTimeLock(uint256)', [_secondsTimeLocked
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1122,7 +1140,6 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1161,7 +1178,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber[]
         > {
-            assert.isBigNumber('from', from);assert.isBigNumber('to', to);assert.isBoolean('pending', pending);assert.isBoolean('executed', executed);
+            assert.isBigNumber('from', from);
+            assert.isBigNumber('to', to);
+            assert.isBoolean('pending', pending);
+            assert.isBoolean('executed', executed);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1237,7 +1257,6 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1275,10 +1294,11 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('changeRequirement(uint256)', [_required
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1320,10 +1340,11 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('changeRequirement(uint256)', [_required
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1385,10 +1406,11 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('confirmTransaction(uint256)', [transactionId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1430,10 +1452,11 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('confirmTransaction(uint256)', [transactionId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1493,16 +1516,19 @@ export class AssetProxyOwnerContract extends BaseContract {
             data: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('destination', destination);assert.isBigNumber('value', value);assert.isString('data', data);
+            assert.isString('destination', destination);
+            assert.isBigNumber('value', value);
+            assert.isString('data', data);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('submitTransaction(address,uint256,bytes)', [destination,
     value,
     data
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1524,7 +1550,9 @@ export class AssetProxyOwnerContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('destination', destination);assert.isBigNumber('value', value);assert.isString('data', data);
+            assert.isString('destination', destination);
+            assert.isBigNumber('value', value);
+            assert.isString('data', data);
             const self = this as any as AssetProxyOwnerContract;
             const txHashPromise = self.submitTransaction.sendTransactionAsync(destination,
     value,
@@ -1548,16 +1576,19 @@ export class AssetProxyOwnerContract extends BaseContract {
             data: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('destination', destination);assert.isBigNumber('value', value);assert.isString('data', data);
+            assert.isString('destination', destination);
+            assert.isBigNumber('value', value);
+            assert.isString('data', data);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('submitTransaction(address,uint256,bytes)', [destination,
     value,
     data
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1570,7 +1601,9 @@ export class AssetProxyOwnerContract extends BaseContract {
             value: BigNumber,
             data: string,
         ): string {
-            assert.isString('destination', destination);assert.isBigNumber('value', value);assert.isString('data', data);
+            assert.isString('destination', destination);
+            assert.isBigNumber('value', value);
+            assert.isString('data', data);
             const self = this as any as AssetProxyOwnerContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('submitTransaction(address,uint256,bytes)', [destination,
     value,
@@ -1586,7 +1619,9 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-            assert.isString('destination', destination);assert.isBigNumber('value', value);assert.isString('data', data);
+            assert.isString('destination', destination);
+            assert.isBigNumber('value', value);
+            assert.isString('data', data);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1661,7 +1696,6 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1696,7 +1730,6 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1731,15 +1764,17 @@ export class AssetProxyOwnerContract extends BaseContract {
             newOwner: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('owner', owner);assert.isString('newOwner', newOwner);
+            assert.isString('owner', owner);
+            assert.isString('newOwner', newOwner);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('replaceOwner(address,address)', [owner,
     newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1759,7 +1794,8 @@ export class AssetProxyOwnerContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('owner', owner);assert.isString('newOwner', newOwner);
+            assert.isString('owner', owner);
+            assert.isString('newOwner', newOwner);
             const self = this as any as AssetProxyOwnerContract;
             const txHashPromise = self.replaceOwner.sendTransactionAsync(owner,
     newOwner
@@ -1781,15 +1817,17 @@ export class AssetProxyOwnerContract extends BaseContract {
             newOwner: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('owner', owner);assert.isString('newOwner', newOwner);
+            assert.isString('owner', owner);
+            assert.isString('newOwner', newOwner);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('replaceOwner(address,address)', [owner,
     newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1801,7 +1839,8 @@ export class AssetProxyOwnerContract extends BaseContract {
             owner: string,
             newOwner: string,
         ): string {
-            assert.isString('owner', owner);assert.isString('newOwner', newOwner);
+            assert.isString('owner', owner);
+            assert.isString('newOwner', newOwner);
             const self = this as any as AssetProxyOwnerContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('replaceOwner(address,address)', [owner,
     newOwner
@@ -1815,7 +1854,8 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('owner', owner);assert.isString('newOwner', newOwner);
+            assert.isString('owner', owner);
+            assert.isString('newOwner', newOwner);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1855,10 +1895,11 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('executeTransaction(uint256)', [transactionId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1900,10 +1941,11 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('executeTransaction(uint256)', [transactionId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1992,7 +2034,7 @@ _secondsTimeLocked
             _required: BigNumber,
             _secondsTimeLocked: BigNumber,
     ): Promise<AssetProxyOwnerContract> {
-        assert.isHexString('bytecode', bytecode);
+        assert.isString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/asset_proxy_owner.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/asset_proxy_owner.ts
@@ -156,11 +156,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('removeOwner(address)', [owner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -202,11 +201,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('removeOwner(address)', [owner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -268,11 +266,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('revokeConfirmation(uint256)', [transactionId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -314,11 +311,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('revokeConfirmation(uint256)', [transactionId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -416,8 +412,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isBigNumber('index_0', index_0);
-            assert.isString('index_1', index_1);
+            assert.isBigNumber('index_0', index_0);assert.isString('index_1', index_1);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -457,11 +452,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('executeRemoveAuthorizedAddressAtIndex(uint256)', [transactionId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -503,11 +497,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('executeRemoveAuthorizedAddressAtIndex(uint256)', [transactionId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -566,6 +559,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -602,8 +596,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-            assert.isBoolean('pending', pending);
-            assert.isBoolean('executed', executed);
+            assert.isBoolean('pending', pending);assert.isBoolean('executed', executed);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -640,17 +633,15 @@ export class AssetProxyOwnerContract extends BaseContract {
             isRegistered: boolean,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('assetProxyContract', assetProxyContract);
-            assert.isBoolean('isRegistered', isRegistered);
+            assert.isString('assetProxyContract', assetProxyContract);assert.isBoolean('isRegistered', isRegistered);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('registerAssetProxy(address,bool)', [assetProxyContract,
     isRegistered
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -670,8 +661,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('assetProxyContract', assetProxyContract);
-            assert.isBoolean('isRegistered', isRegistered);
+            assert.isString('assetProxyContract', assetProxyContract);assert.isBoolean('isRegistered', isRegistered);
             const self = this as any as AssetProxyOwnerContract;
             const txHashPromise = self.registerAssetProxy.sendTransactionAsync(assetProxyContract,
     isRegistered
@@ -693,17 +683,15 @@ export class AssetProxyOwnerContract extends BaseContract {
             isRegistered: boolean,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('assetProxyContract', assetProxyContract);
-            assert.isBoolean('isRegistered', isRegistered);
+            assert.isString('assetProxyContract', assetProxyContract);assert.isBoolean('isRegistered', isRegistered);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('registerAssetProxy(address,bool)', [assetProxyContract,
     isRegistered
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -715,8 +703,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             assetProxyContract: string,
             isRegistered: boolean,
         ): string {
-            assert.isString('assetProxyContract', assetProxyContract);
-            assert.isBoolean('isRegistered', isRegistered);
+            assert.isString('assetProxyContract', assetProxyContract);assert.isBoolean('isRegistered', isRegistered);
             const self = this as any as AssetProxyOwnerContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('registerAssetProxy(address,bool)', [assetProxyContract,
     isRegistered
@@ -730,8 +717,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('assetProxyContract', assetProxyContract);
-            assert.isBoolean('isRegistered', isRegistered);
+            assert.isString('assetProxyContract', assetProxyContract);assert.isBoolean('isRegistered', isRegistered);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -771,11 +757,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('addOwner(address)', [owner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -817,11 +802,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('addOwner(address)', [owner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -920,11 +904,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('changeTimeLock(uint256)', [_secondsTimeLocked
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -966,11 +949,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('changeTimeLock(uint256)', [_secondsTimeLocked
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1140,6 +1122,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1178,10 +1161,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber[]
         > {
-            assert.isBigNumber('from', from);
-            assert.isBigNumber('to', to);
-            assert.isBoolean('pending', pending);
-            assert.isBoolean('executed', executed);
+            assert.isBigNumber('from', from);assert.isBigNumber('to', to);assert.isBoolean('pending', pending);assert.isBoolean('executed', executed);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1257,6 +1237,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1294,11 +1275,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('changeRequirement(uint256)', [_required
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1340,11 +1320,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('changeRequirement(uint256)', [_required
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1406,11 +1385,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('confirmTransaction(uint256)', [transactionId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1452,11 +1430,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('confirmTransaction(uint256)', [transactionId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1516,19 +1493,16 @@ export class AssetProxyOwnerContract extends BaseContract {
             data: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('destination', destination);
-            assert.isBigNumber('value', value);
-            assert.isString('data', data);
+            assert.isString('destination', destination);assert.isBigNumber('value', value);assert.isString('data', data);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('submitTransaction(address,uint256,bytes)', [destination,
     value,
     data
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1550,9 +1524,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('destination', destination);
-            assert.isBigNumber('value', value);
-            assert.isString('data', data);
+            assert.isString('destination', destination);assert.isBigNumber('value', value);assert.isString('data', data);
             const self = this as any as AssetProxyOwnerContract;
             const txHashPromise = self.submitTransaction.sendTransactionAsync(destination,
     value,
@@ -1576,19 +1548,16 @@ export class AssetProxyOwnerContract extends BaseContract {
             data: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('destination', destination);
-            assert.isBigNumber('value', value);
-            assert.isString('data', data);
+            assert.isString('destination', destination);assert.isBigNumber('value', value);assert.isString('data', data);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('submitTransaction(address,uint256,bytes)', [destination,
     value,
     data
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1601,9 +1570,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             value: BigNumber,
             data: string,
         ): string {
-            assert.isString('destination', destination);
-            assert.isBigNumber('value', value);
-            assert.isString('data', data);
+            assert.isString('destination', destination);assert.isBigNumber('value', value);assert.isString('data', data);
             const self = this as any as AssetProxyOwnerContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('submitTransaction(address,uint256,bytes)', [destination,
     value,
@@ -1619,9 +1586,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-            assert.isString('destination', destination);
-            assert.isBigNumber('value', value);
-            assert.isString('data', data);
+            assert.isString('destination', destination);assert.isBigNumber('value', value);assert.isString('data', data);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1696,6 +1661,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1730,6 +1696,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1764,17 +1731,15 @@ export class AssetProxyOwnerContract extends BaseContract {
             newOwner: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('owner', owner);
-            assert.isString('newOwner', newOwner);
+            assert.isString('owner', owner);assert.isString('newOwner', newOwner);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('replaceOwner(address,address)', [owner,
     newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1794,8 +1759,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('owner', owner);
-            assert.isString('newOwner', newOwner);
+            assert.isString('owner', owner);assert.isString('newOwner', newOwner);
             const self = this as any as AssetProxyOwnerContract;
             const txHashPromise = self.replaceOwner.sendTransactionAsync(owner,
     newOwner
@@ -1817,17 +1781,15 @@ export class AssetProxyOwnerContract extends BaseContract {
             newOwner: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('owner', owner);
-            assert.isString('newOwner', newOwner);
+            assert.isString('owner', owner);assert.isString('newOwner', newOwner);
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('replaceOwner(address,address)', [owner,
     newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1839,8 +1801,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             owner: string,
             newOwner: string,
         ): string {
-            assert.isString('owner', owner);
-            assert.isString('newOwner', newOwner);
+            assert.isString('owner', owner);assert.isString('newOwner', newOwner);
             const self = this as any as AssetProxyOwnerContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('replaceOwner(address,address)', [owner,
     newOwner
@@ -1854,8 +1815,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('owner', owner);
-            assert.isString('newOwner', newOwner);
+            assert.isString('owner', owner);assert.isString('newOwner', newOwner);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1895,11 +1855,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('executeTransaction(uint256)', [transactionId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1941,11 +1900,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             const self = this as any as AssetProxyOwnerContract;
             const encodedData = self._strictEncodeArguments('executeTransaction(uint256)', [transactionId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2034,7 +1992,7 @@ _secondsTimeLocked
             _required: BigNumber,
             _secondsTimeLocked: BigNumber,
     ): Promise<AssetProxyOwnerContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/asset_proxy_owner.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/asset_proxy_owner.ts
@@ -152,24 +152,24 @@ export class AssetProxyOwnerContract extends BaseContract {
             owner: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('owner', owner);
-            const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('removeOwner(address)', [owner
+        assert.isString('owner', owner);
+        const self = this as any as AssetProxyOwnerContract;
+        const encodedData = self._strictEncodeArguments('removeOwner(address)', [owner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.removeOwner.estimateGasAsync.bind(
-                    self,
-                    owner
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.removeOwner.estimateGasAsync.bind(
+                self,
+                owner
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             owner: string,
@@ -177,49 +177,49 @@ export class AssetProxyOwnerContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('owner', owner);
-            const self = this as any as AssetProxyOwnerContract;
-            const txHashPromise = self.removeOwner.sendTransactionAsync(owner
+        assert.isString('owner', owner);
+        const self = this as any as AssetProxyOwnerContract;
+        const txHashPromise = self.removeOwner.sendTransactionAsync(owner
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             owner: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('owner', owner);
-            const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('removeOwner(address)', [owner
+        assert.isString('owner', owner);
+        const self = this as any as AssetProxyOwnerContract;
+        const encodedData = self._strictEncodeArguments('removeOwner(address)', [owner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             owner: string,
         ): string {
-            assert.isString('owner', owner);
-            const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('removeOwner(address)', [owner
+        assert.isString('owner', owner);
+        const self = this as any as AssetProxyOwnerContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('removeOwner(address)', [owner
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             owner: string,
@@ -262,24 +262,24 @@ export class AssetProxyOwnerContract extends BaseContract {
             transactionId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isBigNumber('transactionId', transactionId);
-            const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('revokeConfirmation(uint256)', [transactionId
+        assert.isBigNumber('transactionId', transactionId);
+        const self = this as any as AssetProxyOwnerContract;
+        const encodedData = self._strictEncodeArguments('revokeConfirmation(uint256)', [transactionId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.revokeConfirmation.estimateGasAsync.bind(
-                    self,
-                    transactionId
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.revokeConfirmation.estimateGasAsync.bind(
+                self,
+                transactionId
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             transactionId: BigNumber,
@@ -287,49 +287,49 @@ export class AssetProxyOwnerContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isBigNumber('transactionId', transactionId);
-            const self = this as any as AssetProxyOwnerContract;
-            const txHashPromise = self.revokeConfirmation.sendTransactionAsync(transactionId
+        assert.isBigNumber('transactionId', transactionId);
+        const self = this as any as AssetProxyOwnerContract;
+        const txHashPromise = self.revokeConfirmation.sendTransactionAsync(transactionId
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             transactionId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isBigNumber('transactionId', transactionId);
-            const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('revokeConfirmation(uint256)', [transactionId
+        assert.isBigNumber('transactionId', transactionId);
+        const self = this as any as AssetProxyOwnerContract;
+        const encodedData = self._strictEncodeArguments('revokeConfirmation(uint256)', [transactionId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             transactionId: BigNumber,
         ): string {
-            assert.isBigNumber('transactionId', transactionId);
-            const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('revokeConfirmation(uint256)', [transactionId
+        assert.isBigNumber('transactionId', transactionId);
+        const self = this as any as AssetProxyOwnerContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('revokeConfirmation(uint256)', [transactionId
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             transactionId: BigNumber,
@@ -412,7 +412,8 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isBigNumber('index_0', index_0);assert.isString('index_1', index_1);
+            assert.isBigNumber('index_0', index_0);
+            assert.isString('index_1', index_1);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -448,24 +449,24 @@ export class AssetProxyOwnerContract extends BaseContract {
             transactionId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isBigNumber('transactionId', transactionId);
-            const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('executeRemoveAuthorizedAddressAtIndex(uint256)', [transactionId
+        assert.isBigNumber('transactionId', transactionId);
+        const self = this as any as AssetProxyOwnerContract;
+        const encodedData = self._strictEncodeArguments('executeRemoveAuthorizedAddressAtIndex(uint256)', [transactionId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.executeRemoveAuthorizedAddressAtIndex.estimateGasAsync.bind(
-                    self,
-                    transactionId
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.executeRemoveAuthorizedAddressAtIndex.estimateGasAsync.bind(
+                self,
+                transactionId
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             transactionId: BigNumber,
@@ -473,49 +474,49 @@ export class AssetProxyOwnerContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isBigNumber('transactionId', transactionId);
-            const self = this as any as AssetProxyOwnerContract;
-            const txHashPromise = self.executeRemoveAuthorizedAddressAtIndex.sendTransactionAsync(transactionId
+        assert.isBigNumber('transactionId', transactionId);
+        const self = this as any as AssetProxyOwnerContract;
+        const txHashPromise = self.executeRemoveAuthorizedAddressAtIndex.sendTransactionAsync(transactionId
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             transactionId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isBigNumber('transactionId', transactionId);
-            const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('executeRemoveAuthorizedAddressAtIndex(uint256)', [transactionId
+        assert.isBigNumber('transactionId', transactionId);
+        const self = this as any as AssetProxyOwnerContract;
+        const encodedData = self._strictEncodeArguments('executeRemoveAuthorizedAddressAtIndex(uint256)', [transactionId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             transactionId: BigNumber,
         ): string {
-            assert.isBigNumber('transactionId', transactionId);
-            const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('executeRemoveAuthorizedAddressAtIndex(uint256)', [transactionId
+        assert.isBigNumber('transactionId', transactionId);
+        const self = this as any as AssetProxyOwnerContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('executeRemoveAuthorizedAddressAtIndex(uint256)', [transactionId
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             transactionId: BigNumber,
@@ -559,7 +560,6 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -596,7 +596,8 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-            assert.isBoolean('pending', pending);assert.isBoolean('executed', executed);
+            assert.isBoolean('pending', pending);
+            assert.isBoolean('executed', executed);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -633,26 +634,27 @@ export class AssetProxyOwnerContract extends BaseContract {
             isRegistered: boolean,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('assetProxyContract', assetProxyContract);assert.isBoolean('isRegistered', isRegistered);
-            const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('registerAssetProxy(address,bool)', [assetProxyContract,
+        assert.isString('assetProxyContract', assetProxyContract);
+        assert.isBoolean('isRegistered', isRegistered);
+        const self = this as any as AssetProxyOwnerContract;
+        const encodedData = self._strictEncodeArguments('registerAssetProxy(address,bool)', [assetProxyContract,
     isRegistered
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.registerAssetProxy.estimateGasAsync.bind(
-                    self,
-                    assetProxyContract,
-                    isRegistered
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.registerAssetProxy.estimateGasAsync.bind(
+                self,
+                assetProxyContract,
+                isRegistered
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             assetProxyContract: string,
@@ -661,54 +663,57 @@ export class AssetProxyOwnerContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('assetProxyContract', assetProxyContract);assert.isBoolean('isRegistered', isRegistered);
-            const self = this as any as AssetProxyOwnerContract;
-            const txHashPromise = self.registerAssetProxy.sendTransactionAsync(assetProxyContract,
+        assert.isString('assetProxyContract', assetProxyContract);
+        assert.isBoolean('isRegistered', isRegistered);
+        const self = this as any as AssetProxyOwnerContract;
+        const txHashPromise = self.registerAssetProxy.sendTransactionAsync(assetProxyContract,
     isRegistered
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             assetProxyContract: string,
             isRegistered: boolean,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('assetProxyContract', assetProxyContract);assert.isBoolean('isRegistered', isRegistered);
-            const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('registerAssetProxy(address,bool)', [assetProxyContract,
+        assert.isString('assetProxyContract', assetProxyContract);
+        assert.isBoolean('isRegistered', isRegistered);
+        const self = this as any as AssetProxyOwnerContract;
+        const encodedData = self._strictEncodeArguments('registerAssetProxy(address,bool)', [assetProxyContract,
     isRegistered
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             assetProxyContract: string,
             isRegistered: boolean,
         ): string {
-            assert.isString('assetProxyContract', assetProxyContract);assert.isBoolean('isRegistered', isRegistered);
-            const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('registerAssetProxy(address,bool)', [assetProxyContract,
+        assert.isString('assetProxyContract', assetProxyContract);
+        assert.isBoolean('isRegistered', isRegistered);
+        const self = this as any as AssetProxyOwnerContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('registerAssetProxy(address,bool)', [assetProxyContract,
     isRegistered
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             assetProxyContract: string,
@@ -717,7 +722,8 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('assetProxyContract', assetProxyContract);assert.isBoolean('isRegistered', isRegistered);
+            assert.isString('assetProxyContract', assetProxyContract);
+            assert.isBoolean('isRegistered', isRegistered);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -753,24 +759,24 @@ export class AssetProxyOwnerContract extends BaseContract {
             owner: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('owner', owner);
-            const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('addOwner(address)', [owner
+        assert.isString('owner', owner);
+        const self = this as any as AssetProxyOwnerContract;
+        const encodedData = self._strictEncodeArguments('addOwner(address)', [owner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.addOwner.estimateGasAsync.bind(
-                    self,
-                    owner
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.addOwner.estimateGasAsync.bind(
+                self,
+                owner
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             owner: string,
@@ -778,49 +784,49 @@ export class AssetProxyOwnerContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('owner', owner);
-            const self = this as any as AssetProxyOwnerContract;
-            const txHashPromise = self.addOwner.sendTransactionAsync(owner
+        assert.isString('owner', owner);
+        const self = this as any as AssetProxyOwnerContract;
+        const txHashPromise = self.addOwner.sendTransactionAsync(owner
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             owner: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('owner', owner);
-            const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('addOwner(address)', [owner
+        assert.isString('owner', owner);
+        const self = this as any as AssetProxyOwnerContract;
+        const encodedData = self._strictEncodeArguments('addOwner(address)', [owner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             owner: string,
         ): string {
-            assert.isString('owner', owner);
-            const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('addOwner(address)', [owner
+        assert.isString('owner', owner);
+        const self = this as any as AssetProxyOwnerContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('addOwner(address)', [owner
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             owner: string,
@@ -900,24 +906,24 @@ export class AssetProxyOwnerContract extends BaseContract {
             _secondsTimeLocked: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isBigNumber('_secondsTimeLocked', _secondsTimeLocked);
-            const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('changeTimeLock(uint256)', [_secondsTimeLocked
+        assert.isBigNumber('_secondsTimeLocked', _secondsTimeLocked);
+        const self = this as any as AssetProxyOwnerContract;
+        const encodedData = self._strictEncodeArguments('changeTimeLock(uint256)', [_secondsTimeLocked
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.changeTimeLock.estimateGasAsync.bind(
-                    self,
-                    _secondsTimeLocked
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.changeTimeLock.estimateGasAsync.bind(
+                self,
+                _secondsTimeLocked
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             _secondsTimeLocked: BigNumber,
@@ -925,49 +931,49 @@ export class AssetProxyOwnerContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isBigNumber('_secondsTimeLocked', _secondsTimeLocked);
-            const self = this as any as AssetProxyOwnerContract;
-            const txHashPromise = self.changeTimeLock.sendTransactionAsync(_secondsTimeLocked
+        assert.isBigNumber('_secondsTimeLocked', _secondsTimeLocked);
+        const self = this as any as AssetProxyOwnerContract;
+        const txHashPromise = self.changeTimeLock.sendTransactionAsync(_secondsTimeLocked
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             _secondsTimeLocked: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isBigNumber('_secondsTimeLocked', _secondsTimeLocked);
-            const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('changeTimeLock(uint256)', [_secondsTimeLocked
+        assert.isBigNumber('_secondsTimeLocked', _secondsTimeLocked);
+        const self = this as any as AssetProxyOwnerContract;
+        const encodedData = self._strictEncodeArguments('changeTimeLock(uint256)', [_secondsTimeLocked
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             _secondsTimeLocked: BigNumber,
         ): string {
-            assert.isBigNumber('_secondsTimeLocked', _secondsTimeLocked);
-            const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('changeTimeLock(uint256)', [_secondsTimeLocked
+        assert.isBigNumber('_secondsTimeLocked', _secondsTimeLocked);
+        const self = this as any as AssetProxyOwnerContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('changeTimeLock(uint256)', [_secondsTimeLocked
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             _secondsTimeLocked: BigNumber,
@@ -1122,7 +1128,6 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1161,7 +1166,10 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber[]
         > {
-            assert.isBigNumber('from', from);assert.isBigNumber('to', to);assert.isBoolean('pending', pending);assert.isBoolean('executed', executed);
+            assert.isBigNumber('from', from);
+            assert.isBigNumber('to', to);
+            assert.isBoolean('pending', pending);
+            assert.isBoolean('executed', executed);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1237,7 +1245,6 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1271,24 +1278,24 @@ export class AssetProxyOwnerContract extends BaseContract {
             _required: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isBigNumber('_required', _required);
-            const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('changeRequirement(uint256)', [_required
+        assert.isBigNumber('_required', _required);
+        const self = this as any as AssetProxyOwnerContract;
+        const encodedData = self._strictEncodeArguments('changeRequirement(uint256)', [_required
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.changeRequirement.estimateGasAsync.bind(
-                    self,
-                    _required
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.changeRequirement.estimateGasAsync.bind(
+                self,
+                _required
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             _required: BigNumber,
@@ -1296,49 +1303,49 @@ export class AssetProxyOwnerContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isBigNumber('_required', _required);
-            const self = this as any as AssetProxyOwnerContract;
-            const txHashPromise = self.changeRequirement.sendTransactionAsync(_required
+        assert.isBigNumber('_required', _required);
+        const self = this as any as AssetProxyOwnerContract;
+        const txHashPromise = self.changeRequirement.sendTransactionAsync(_required
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             _required: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isBigNumber('_required', _required);
-            const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('changeRequirement(uint256)', [_required
+        assert.isBigNumber('_required', _required);
+        const self = this as any as AssetProxyOwnerContract;
+        const encodedData = self._strictEncodeArguments('changeRequirement(uint256)', [_required
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             _required: BigNumber,
         ): string {
-            assert.isBigNumber('_required', _required);
-            const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('changeRequirement(uint256)', [_required
+        assert.isBigNumber('_required', _required);
+        const self = this as any as AssetProxyOwnerContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('changeRequirement(uint256)', [_required
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             _required: BigNumber,
@@ -1381,24 +1388,24 @@ export class AssetProxyOwnerContract extends BaseContract {
             transactionId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isBigNumber('transactionId', transactionId);
-            const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('confirmTransaction(uint256)', [transactionId
+        assert.isBigNumber('transactionId', transactionId);
+        const self = this as any as AssetProxyOwnerContract;
+        const encodedData = self._strictEncodeArguments('confirmTransaction(uint256)', [transactionId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.confirmTransaction.estimateGasAsync.bind(
-                    self,
-                    transactionId
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.confirmTransaction.estimateGasAsync.bind(
+                self,
+                transactionId
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             transactionId: BigNumber,
@@ -1406,49 +1413,49 @@ export class AssetProxyOwnerContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isBigNumber('transactionId', transactionId);
-            const self = this as any as AssetProxyOwnerContract;
-            const txHashPromise = self.confirmTransaction.sendTransactionAsync(transactionId
+        assert.isBigNumber('transactionId', transactionId);
+        const self = this as any as AssetProxyOwnerContract;
+        const txHashPromise = self.confirmTransaction.sendTransactionAsync(transactionId
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             transactionId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isBigNumber('transactionId', transactionId);
-            const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('confirmTransaction(uint256)', [transactionId
+        assert.isBigNumber('transactionId', transactionId);
+        const self = this as any as AssetProxyOwnerContract;
+        const encodedData = self._strictEncodeArguments('confirmTransaction(uint256)', [transactionId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             transactionId: BigNumber,
         ): string {
-            assert.isBigNumber('transactionId', transactionId);
-            const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('confirmTransaction(uint256)', [transactionId
+        assert.isBigNumber('transactionId', transactionId);
+        const self = this as any as AssetProxyOwnerContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('confirmTransaction(uint256)', [transactionId
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             transactionId: BigNumber,
@@ -1493,28 +1500,30 @@ export class AssetProxyOwnerContract extends BaseContract {
             data: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('destination', destination);assert.isBigNumber('value', value);assert.isString('data', data);
-            const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('submitTransaction(address,uint256,bytes)', [destination,
+        assert.isString('destination', destination);
+        assert.isBigNumber('value', value);
+        assert.isString('data', data);
+        const self = this as any as AssetProxyOwnerContract;
+        const encodedData = self._strictEncodeArguments('submitTransaction(address,uint256,bytes)', [destination,
     value,
     data
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.submitTransaction.estimateGasAsync.bind(
-                    self,
-                    destination,
-                    value,
-                    data
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.submitTransaction.estimateGasAsync.bind(
+                self,
+                destination,
+                value,
+                data
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             destination: string,
@@ -1524,23 +1533,25 @@ export class AssetProxyOwnerContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('destination', destination);assert.isBigNumber('value', value);assert.isString('data', data);
-            const self = this as any as AssetProxyOwnerContract;
-            const txHashPromise = self.submitTransaction.sendTransactionAsync(destination,
+        assert.isString('destination', destination);
+        assert.isBigNumber('value', value);
+        assert.isString('data', data);
+        const self = this as any as AssetProxyOwnerContract;
+        const txHashPromise = self.submitTransaction.sendTransactionAsync(destination,
     value,
     data
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             destination: string,
@@ -1548,35 +1559,39 @@ export class AssetProxyOwnerContract extends BaseContract {
             data: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('destination', destination);assert.isBigNumber('value', value);assert.isString('data', data);
-            const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('submitTransaction(address,uint256,bytes)', [destination,
+        assert.isString('destination', destination);
+        assert.isBigNumber('value', value);
+        assert.isString('data', data);
+        const self = this as any as AssetProxyOwnerContract;
+        const encodedData = self._strictEncodeArguments('submitTransaction(address,uint256,bytes)', [destination,
     value,
     data
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             destination: string,
             value: BigNumber,
             data: string,
         ): string {
-            assert.isString('destination', destination);assert.isBigNumber('value', value);assert.isString('data', data);
-            const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('submitTransaction(address,uint256,bytes)', [destination,
+        assert.isString('destination', destination);
+        assert.isBigNumber('value', value);
+        assert.isString('data', data);
+        const self = this as any as AssetProxyOwnerContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('submitTransaction(address,uint256,bytes)', [destination,
     value,
     data
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             destination: string,
@@ -1586,7 +1601,9 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-            assert.isString('destination', destination);assert.isBigNumber('value', value);assert.isString('data', data);
+            assert.isString('destination', destination);
+            assert.isBigNumber('value', value);
+            assert.isString('data', data);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1661,7 +1678,6 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1696,7 +1712,6 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1731,26 +1746,27 @@ export class AssetProxyOwnerContract extends BaseContract {
             newOwner: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('owner', owner);assert.isString('newOwner', newOwner);
-            const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('replaceOwner(address,address)', [owner,
+        assert.isString('owner', owner);
+        assert.isString('newOwner', newOwner);
+        const self = this as any as AssetProxyOwnerContract;
+        const encodedData = self._strictEncodeArguments('replaceOwner(address,address)', [owner,
     newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.replaceOwner.estimateGasAsync.bind(
-                    self,
-                    owner,
-                    newOwner
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.replaceOwner.estimateGasAsync.bind(
+                self,
+                owner,
+                newOwner
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             owner: string,
@@ -1759,54 +1775,57 @@ export class AssetProxyOwnerContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('owner', owner);assert.isString('newOwner', newOwner);
-            const self = this as any as AssetProxyOwnerContract;
-            const txHashPromise = self.replaceOwner.sendTransactionAsync(owner,
+        assert.isString('owner', owner);
+        assert.isString('newOwner', newOwner);
+        const self = this as any as AssetProxyOwnerContract;
+        const txHashPromise = self.replaceOwner.sendTransactionAsync(owner,
     newOwner
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             owner: string,
             newOwner: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('owner', owner);assert.isString('newOwner', newOwner);
-            const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('replaceOwner(address,address)', [owner,
+        assert.isString('owner', owner);
+        assert.isString('newOwner', newOwner);
+        const self = this as any as AssetProxyOwnerContract;
+        const encodedData = self._strictEncodeArguments('replaceOwner(address,address)', [owner,
     newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             owner: string,
             newOwner: string,
         ): string {
-            assert.isString('owner', owner);assert.isString('newOwner', newOwner);
-            const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('replaceOwner(address,address)', [owner,
+        assert.isString('owner', owner);
+        assert.isString('newOwner', newOwner);
+        const self = this as any as AssetProxyOwnerContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('replaceOwner(address,address)', [owner,
     newOwner
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             owner: string,
@@ -1815,7 +1834,8 @@ export class AssetProxyOwnerContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('owner', owner);assert.isString('newOwner', newOwner);
+            assert.isString('owner', owner);
+            assert.isString('newOwner', newOwner);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1851,24 +1871,24 @@ export class AssetProxyOwnerContract extends BaseContract {
             transactionId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isBigNumber('transactionId', transactionId);
-            const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('executeTransaction(uint256)', [transactionId
+        assert.isBigNumber('transactionId', transactionId);
+        const self = this as any as AssetProxyOwnerContract;
+        const encodedData = self._strictEncodeArguments('executeTransaction(uint256)', [transactionId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.executeTransaction.estimateGasAsync.bind(
-                    self,
-                    transactionId
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.executeTransaction.estimateGasAsync.bind(
+                self,
+                transactionId
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             transactionId: BigNumber,
@@ -1876,49 +1896,49 @@ export class AssetProxyOwnerContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isBigNumber('transactionId', transactionId);
-            const self = this as any as AssetProxyOwnerContract;
-            const txHashPromise = self.executeTransaction.sendTransactionAsync(transactionId
+        assert.isBigNumber('transactionId', transactionId);
+        const self = this as any as AssetProxyOwnerContract;
+        const txHashPromise = self.executeTransaction.sendTransactionAsync(transactionId
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             transactionId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isBigNumber('transactionId', transactionId);
-            const self = this as any as AssetProxyOwnerContract;
-            const encodedData = self._strictEncodeArguments('executeTransaction(uint256)', [transactionId
+        assert.isBigNumber('transactionId', transactionId);
+        const self = this as any as AssetProxyOwnerContract;
+        const encodedData = self._strictEncodeArguments('executeTransaction(uint256)', [transactionId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             transactionId: BigNumber,
         ): string {
-            assert.isBigNumber('transactionId', transactionId);
-            const self = this as any as AssetProxyOwnerContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('executeTransaction(uint256)', [transactionId
+        assert.isBigNumber('transactionId', transactionId);
+        const self = this as any as AssetProxyOwnerContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('executeTransaction(uint256)', [transactionId
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             transactionId: BigNumber,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/coordinator.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/coordinator.ts
@@ -1,6 +1,6 @@
-// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma whitespace class-name
+// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma
+// tslint:disable:whitespace no-unbound-method no-trailing-whitespace
 // tslint:disable:no-unused-variable
-// tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
 import { schemas } from '@0x/json-schemas';
 import {
@@ -36,8 +36,7 @@ export class CoordinatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-            assert.isString('hash', hash);
-            assert.isString('signature', signature);
+            assert.isString('hash', hash);assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -151,11 +150,7 @@ export class CoordinatorContract extends BaseContract {
             approvalSignatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-
-            assert.isString('txOrigin', txOrigin);
-            assert.isString('transactionSignature', transactionSignature);
-            assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);
-            assert.isArray('approvalSignatures', approvalSignatures);
+            assert.isString('txOrigin', txOrigin);assert.isString('transactionSignature', transactionSignature);assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);assert.isArray('approvalSignatures', approvalSignatures);
             const self = this as any as CoordinatorContract;
             const encodedData = self._strictEncodeArguments('executeTransaction((uint256,address,bytes),address,bytes,uint256[],bytes[])', [transaction,
     txOrigin,
@@ -163,11 +158,10 @@ export class CoordinatorContract extends BaseContract {
     approvalExpirationTimeSeconds,
     approvalSignatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -193,11 +187,7 @@ export class CoordinatorContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-
-            assert.isString('txOrigin', txOrigin);
-            assert.isString('transactionSignature', transactionSignature);
-            assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);
-            assert.isArray('approvalSignatures', approvalSignatures);
+            assert.isString('txOrigin', txOrigin);assert.isString('transactionSignature', transactionSignature);assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);assert.isArray('approvalSignatures', approvalSignatures);
             const self = this as any as CoordinatorContract;
             const txHashPromise = self.executeTransaction.sendTransactionAsync(transaction,
     txOrigin,
@@ -225,11 +215,7 @@ export class CoordinatorContract extends BaseContract {
             approvalSignatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-
-            assert.isString('txOrigin', txOrigin);
-            assert.isString('transactionSignature', transactionSignature);
-            assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);
-            assert.isArray('approvalSignatures', approvalSignatures);
+            assert.isString('txOrigin', txOrigin);assert.isString('transactionSignature', transactionSignature);assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);assert.isArray('approvalSignatures', approvalSignatures);
             const self = this as any as CoordinatorContract;
             const encodedData = self._strictEncodeArguments('executeTransaction((uint256,address,bytes),address,bytes,uint256[],bytes[])', [transaction,
     txOrigin,
@@ -237,11 +223,10 @@ export class CoordinatorContract extends BaseContract {
     approvalExpirationTimeSeconds,
     approvalSignatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -256,11 +241,7 @@ export class CoordinatorContract extends BaseContract {
             approvalExpirationTimeSeconds: BigNumber[],
             approvalSignatures: string[],
         ): string {
-
-            assert.isString('txOrigin', txOrigin);
-            assert.isString('transactionSignature', transactionSignature);
-            assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);
-            assert.isArray('approvalSignatures', approvalSignatures);
+            assert.isString('txOrigin', txOrigin);assert.isString('transactionSignature', transactionSignature);assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);assert.isArray('approvalSignatures', approvalSignatures);
             const self = this as any as CoordinatorContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('executeTransaction((uint256,address,bytes),address,bytes,uint256[],bytes[])', [transaction,
     txOrigin,
@@ -280,11 +261,7 @@ export class CoordinatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-
-            assert.isString('txOrigin', txOrigin);
-            assert.isString('transactionSignature', transactionSignature);
-            assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);
-            assert.isArray('approvalSignatures', approvalSignatures);
+            assert.isString('txOrigin', txOrigin);assert.isString('transactionSignature', transactionSignature);assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);assert.isArray('approvalSignatures', approvalSignatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -324,6 +301,7 @@ export class CoordinatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -363,11 +341,7 @@ export class CoordinatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-
-            assert.isString('txOrigin', txOrigin);
-            assert.isString('transactionSignature', transactionSignature);
-            assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);
-            assert.isArray('approvalSignatures', approvalSignatures);
+            assert.isString('txOrigin', txOrigin);assert.isString('transactionSignature', transactionSignature);assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);assert.isArray('approvalSignatures', approvalSignatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -444,6 +418,7 @@ export class CoordinatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -499,7 +474,7 @@ export class CoordinatorContract extends BaseContract {
         txDefaults: Partial<TxData>,
             _exchange: string,
     ): Promise<CoordinatorContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,
@@ -538,4 +513,5 @@ export class CoordinatorContract extends BaseContract {
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count
-// tslint:enable:no-unbound-method
+// tslint:enable:no-unbound-method no-parameter-reassignment no-consecutive-blank-lines ordered-imports align
+// tslint:enable:trailing-comma whitespace no-trailing-whitespace

--- a/packages/abi-gen-wrappers/src/generated-wrappers/coordinator.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/coordinator.ts
@@ -36,8 +36,7 @@ export class CoordinatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-            assert.isString('hash', hash);
-            assert.isString('signature', signature);
+            assert.isString('hash', hash);assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -151,11 +150,7 @@ export class CoordinatorContract extends BaseContract {
             approvalSignatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-
-            assert.isString('txOrigin', txOrigin);
-            assert.isString('transactionSignature', transactionSignature);
-            assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);
-            assert.isArray('approvalSignatures', approvalSignatures);
+            assert.isString('txOrigin', txOrigin);assert.isString('transactionSignature', transactionSignature);assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);assert.isArray('approvalSignatures', approvalSignatures);
             const self = this as any as CoordinatorContract;
             const encodedData = self._strictEncodeArguments('executeTransaction((uint256,address,bytes),address,bytes,uint256[],bytes[])', [transaction,
     txOrigin,
@@ -163,11 +158,10 @@ export class CoordinatorContract extends BaseContract {
     approvalExpirationTimeSeconds,
     approvalSignatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -193,11 +187,7 @@ export class CoordinatorContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-
-            assert.isString('txOrigin', txOrigin);
-            assert.isString('transactionSignature', transactionSignature);
-            assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);
-            assert.isArray('approvalSignatures', approvalSignatures);
+            assert.isString('txOrigin', txOrigin);assert.isString('transactionSignature', transactionSignature);assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);assert.isArray('approvalSignatures', approvalSignatures);
             const self = this as any as CoordinatorContract;
             const txHashPromise = self.executeTransaction.sendTransactionAsync(transaction,
     txOrigin,
@@ -225,11 +215,7 @@ export class CoordinatorContract extends BaseContract {
             approvalSignatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-
-            assert.isString('txOrigin', txOrigin);
-            assert.isString('transactionSignature', transactionSignature);
-            assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);
-            assert.isArray('approvalSignatures', approvalSignatures);
+            assert.isString('txOrigin', txOrigin);assert.isString('transactionSignature', transactionSignature);assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);assert.isArray('approvalSignatures', approvalSignatures);
             const self = this as any as CoordinatorContract;
             const encodedData = self._strictEncodeArguments('executeTransaction((uint256,address,bytes),address,bytes,uint256[],bytes[])', [transaction,
     txOrigin,
@@ -237,11 +223,10 @@ export class CoordinatorContract extends BaseContract {
     approvalExpirationTimeSeconds,
     approvalSignatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -256,11 +241,7 @@ export class CoordinatorContract extends BaseContract {
             approvalExpirationTimeSeconds: BigNumber[],
             approvalSignatures: string[],
         ): string {
-
-            assert.isString('txOrigin', txOrigin);
-            assert.isString('transactionSignature', transactionSignature);
-            assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);
-            assert.isArray('approvalSignatures', approvalSignatures);
+            assert.isString('txOrigin', txOrigin);assert.isString('transactionSignature', transactionSignature);assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);assert.isArray('approvalSignatures', approvalSignatures);
             const self = this as any as CoordinatorContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('executeTransaction((uint256,address,bytes),address,bytes,uint256[],bytes[])', [transaction,
     txOrigin,
@@ -280,11 +261,7 @@ export class CoordinatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-
-            assert.isString('txOrigin', txOrigin);
-            assert.isString('transactionSignature', transactionSignature);
-            assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);
-            assert.isArray('approvalSignatures', approvalSignatures);
+            assert.isString('txOrigin', txOrigin);assert.isString('transactionSignature', transactionSignature);assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);assert.isArray('approvalSignatures', approvalSignatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -324,6 +301,7 @@ export class CoordinatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -363,11 +341,7 @@ export class CoordinatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-
-            assert.isString('txOrigin', txOrigin);
-            assert.isString('transactionSignature', transactionSignature);
-            assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);
-            assert.isArray('approvalSignatures', approvalSignatures);
+            assert.isString('txOrigin', txOrigin);assert.isString('transactionSignature', transactionSignature);assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);assert.isArray('approvalSignatures', approvalSignatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -444,6 +418,7 @@ export class CoordinatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -499,7 +474,7 @@ export class CoordinatorContract extends BaseContract {
         txDefaults: Partial<TxData>,
             _exchange: string,
     ): Promise<CoordinatorContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/coordinator.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/coordinator.ts
@@ -36,7 +36,8 @@ export class CoordinatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-            assert.isString('hash', hash);assert.isString('signature', signature);
+            assert.isString('hash', hash);
+            assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -150,7 +151,11 @@ export class CoordinatorContract extends BaseContract {
             approvalSignatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('txOrigin', txOrigin);assert.isString('transactionSignature', transactionSignature);assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);assert.isArray('approvalSignatures', approvalSignatures);
+
+            assert.isString('txOrigin', txOrigin);
+            assert.isString('transactionSignature', transactionSignature);
+            assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);
+            assert.isArray('approvalSignatures', approvalSignatures);
             const self = this as any as CoordinatorContract;
             const encodedData = self._strictEncodeArguments('executeTransaction((uint256,address,bytes),address,bytes,uint256[],bytes[])', [transaction,
     txOrigin,
@@ -158,10 +163,11 @@ export class CoordinatorContract extends BaseContract {
     approvalExpirationTimeSeconds,
     approvalSignatures
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -187,7 +193,11 @@ export class CoordinatorContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('txOrigin', txOrigin);assert.isString('transactionSignature', transactionSignature);assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);assert.isArray('approvalSignatures', approvalSignatures);
+
+            assert.isString('txOrigin', txOrigin);
+            assert.isString('transactionSignature', transactionSignature);
+            assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);
+            assert.isArray('approvalSignatures', approvalSignatures);
             const self = this as any as CoordinatorContract;
             const txHashPromise = self.executeTransaction.sendTransactionAsync(transaction,
     txOrigin,
@@ -215,7 +225,11 @@ export class CoordinatorContract extends BaseContract {
             approvalSignatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('txOrigin', txOrigin);assert.isString('transactionSignature', transactionSignature);assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);assert.isArray('approvalSignatures', approvalSignatures);
+
+            assert.isString('txOrigin', txOrigin);
+            assert.isString('transactionSignature', transactionSignature);
+            assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);
+            assert.isArray('approvalSignatures', approvalSignatures);
             const self = this as any as CoordinatorContract;
             const encodedData = self._strictEncodeArguments('executeTransaction((uint256,address,bytes),address,bytes,uint256[],bytes[])', [transaction,
     txOrigin,
@@ -223,10 +237,11 @@ export class CoordinatorContract extends BaseContract {
     approvalExpirationTimeSeconds,
     approvalSignatures
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -241,7 +256,11 @@ export class CoordinatorContract extends BaseContract {
             approvalExpirationTimeSeconds: BigNumber[],
             approvalSignatures: string[],
         ): string {
-            assert.isString('txOrigin', txOrigin);assert.isString('transactionSignature', transactionSignature);assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);assert.isArray('approvalSignatures', approvalSignatures);
+
+            assert.isString('txOrigin', txOrigin);
+            assert.isString('transactionSignature', transactionSignature);
+            assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);
+            assert.isArray('approvalSignatures', approvalSignatures);
             const self = this as any as CoordinatorContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('executeTransaction((uint256,address,bytes),address,bytes,uint256[],bytes[])', [transaction,
     txOrigin,
@@ -261,7 +280,11 @@ export class CoordinatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('txOrigin', txOrigin);assert.isString('transactionSignature', transactionSignature);assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);assert.isArray('approvalSignatures', approvalSignatures);
+
+            assert.isString('txOrigin', txOrigin);
+            assert.isString('transactionSignature', transactionSignature);
+            assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);
+            assert.isArray('approvalSignatures', approvalSignatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -301,7 +324,6 @@ export class CoordinatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -341,7 +363,11 @@ export class CoordinatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('txOrigin', txOrigin);assert.isString('transactionSignature', transactionSignature);assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);assert.isArray('approvalSignatures', approvalSignatures);
+
+            assert.isString('txOrigin', txOrigin);
+            assert.isString('transactionSignature', transactionSignature);
+            assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);
+            assert.isArray('approvalSignatures', approvalSignatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -418,7 +444,6 @@ export class CoordinatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -474,7 +499,7 @@ export class CoordinatorContract extends BaseContract {
         txDefaults: Partial<TxData>,
             _exchange: string,
     ): Promise<CoordinatorContract> {
-        assert.isHexString('bytecode', bytecode);
+        assert.isString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/coordinator.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/coordinator.ts
@@ -36,7 +36,8 @@ export class CoordinatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-            assert.isString('hash', hash);assert.isString('signature', signature);
+            assert.isString('hash', hash);
+            assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -150,32 +151,36 @@ export class CoordinatorContract extends BaseContract {
             approvalSignatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('txOrigin', txOrigin);assert.isString('transactionSignature', transactionSignature);assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);assert.isArray('approvalSignatures', approvalSignatures);
-            const self = this as any as CoordinatorContract;
-            const encodedData = self._strictEncodeArguments('executeTransaction((uint256,address,bytes),address,bytes,uint256[],bytes[])', [transaction,
+
+        assert.isString('txOrigin', txOrigin);
+        assert.isString('transactionSignature', transactionSignature);
+        assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);
+        assert.isArray('approvalSignatures', approvalSignatures);
+        const self = this as any as CoordinatorContract;
+        const encodedData = self._strictEncodeArguments('executeTransaction((uint256,address,bytes),address,bytes,uint256[],bytes[])', [transaction,
     txOrigin,
     transactionSignature,
     approvalExpirationTimeSeconds,
     approvalSignatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.executeTransaction.estimateGasAsync.bind(
-                    self,
-                    transaction,
-                    txOrigin,
-                    transactionSignature,
-                    approvalExpirationTimeSeconds,
-                    approvalSignatures
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.executeTransaction.estimateGasAsync.bind(
+                self,
+                transaction,
+                txOrigin,
+                transactionSignature,
+                approvalExpirationTimeSeconds,
+                approvalSignatures
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             transaction: {salt: BigNumber;signerAddress: string;data: string},
@@ -187,25 +192,29 @@ export class CoordinatorContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('txOrigin', txOrigin);assert.isString('transactionSignature', transactionSignature);assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);assert.isArray('approvalSignatures', approvalSignatures);
-            const self = this as any as CoordinatorContract;
-            const txHashPromise = self.executeTransaction.sendTransactionAsync(transaction,
+
+        assert.isString('txOrigin', txOrigin);
+        assert.isString('transactionSignature', transactionSignature);
+        assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);
+        assert.isArray('approvalSignatures', approvalSignatures);
+        const self = this as any as CoordinatorContract;
+        const txHashPromise = self.executeTransaction.sendTransactionAsync(transaction,
     txOrigin,
     transactionSignature,
     approvalExpirationTimeSeconds,
     approvalSignatures
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             transaction: {salt: BigNumber;signerAddress: string;data: string},
@@ -215,24 +224,28 @@ export class CoordinatorContract extends BaseContract {
             approvalSignatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('txOrigin', txOrigin);assert.isString('transactionSignature', transactionSignature);assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);assert.isArray('approvalSignatures', approvalSignatures);
-            const self = this as any as CoordinatorContract;
-            const encodedData = self._strictEncodeArguments('executeTransaction((uint256,address,bytes),address,bytes,uint256[],bytes[])', [transaction,
+
+        assert.isString('txOrigin', txOrigin);
+        assert.isString('transactionSignature', transactionSignature);
+        assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);
+        assert.isArray('approvalSignatures', approvalSignatures);
+        const self = this as any as CoordinatorContract;
+        const encodedData = self._strictEncodeArguments('executeTransaction((uint256,address,bytes),address,bytes,uint256[],bytes[])', [transaction,
     txOrigin,
     transactionSignature,
     approvalExpirationTimeSeconds,
     approvalSignatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             transaction: {salt: BigNumber;signerAddress: string;data: string},
@@ -241,15 +254,19 @@ export class CoordinatorContract extends BaseContract {
             approvalExpirationTimeSeconds: BigNumber[],
             approvalSignatures: string[],
         ): string {
-            assert.isString('txOrigin', txOrigin);assert.isString('transactionSignature', transactionSignature);assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);assert.isArray('approvalSignatures', approvalSignatures);
-            const self = this as any as CoordinatorContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('executeTransaction((uint256,address,bytes),address,bytes,uint256[],bytes[])', [transaction,
+
+        assert.isString('txOrigin', txOrigin);
+        assert.isString('transactionSignature', transactionSignature);
+        assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);
+        assert.isArray('approvalSignatures', approvalSignatures);
+        const self = this as any as CoordinatorContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('executeTransaction((uint256,address,bytes),address,bytes,uint256[],bytes[])', [transaction,
     txOrigin,
     transactionSignature,
     approvalExpirationTimeSeconds,
     approvalSignatures
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             transaction: {salt: BigNumber;signerAddress: string;data: string},
@@ -261,7 +278,11 @@ export class CoordinatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('txOrigin', txOrigin);assert.isString('transactionSignature', transactionSignature);assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);assert.isArray('approvalSignatures', approvalSignatures);
+
+            assert.isString('txOrigin', txOrigin);
+            assert.isString('transactionSignature', transactionSignature);
+            assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);
+            assert.isArray('approvalSignatures', approvalSignatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -301,7 +322,6 @@ export class CoordinatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -341,7 +361,11 @@ export class CoordinatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('txOrigin', txOrigin);assert.isString('transactionSignature', transactionSignature);assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);assert.isArray('approvalSignatures', approvalSignatures);
+
+            assert.isString('txOrigin', txOrigin);
+            assert.isString('transactionSignature', transactionSignature);
+            assert.isArray('approvalExpirationTimeSeconds', approvalExpirationTimeSeconds);
+            assert.isArray('approvalSignatures', approvalSignatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -418,7 +442,6 @@ export class CoordinatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/coordinator_registry.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/coordinator_registry.ts
@@ -1,6 +1,6 @@
-// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma whitespace class-name
+// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma
+// tslint:disable:whitespace no-unbound-method no-trailing-whitespace
 // tslint:disable:no-unused-variable
-// tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
 import { schemas } from '@0x/json-schemas';
 import {
@@ -49,11 +49,10 @@ export class CoordinatorRegistryContract extends BaseContract {
             const self = this as any as CoordinatorRegistryContract;
             const encodedData = self._strictEncodeArguments('setCoordinatorEndpoint(string)', [coordinatorEndpoint
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -95,11 +94,10 @@ export class CoordinatorRegistryContract extends BaseContract {
             const self = this as any as CoordinatorRegistryContract;
             const encodedData = self._strictEncodeArguments('setCoordinatorEndpoint(string)', [coordinatorEndpoint
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -213,7 +211,7 @@ export class CoordinatorRegistryContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<CoordinatorRegistryContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,
@@ -248,4 +246,5 @@ export class CoordinatorRegistryContract extends BaseContract {
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count
-// tslint:enable:no-unbound-method
+// tslint:enable:no-unbound-method no-parameter-reassignment no-consecutive-blank-lines ordered-imports align
+// tslint:enable:trailing-comma whitespace no-trailing-whitespace

--- a/packages/abi-gen-wrappers/src/generated-wrappers/coordinator_registry.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/coordinator_registry.ts
@@ -2,6 +2,7 @@
 // tslint:disable:no-unused-variable
 // tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
+import { schemas } from '@0x/json-schemas';
 import {
     BlockParam,
     BlockParamLiteral,
@@ -18,6 +19,7 @@ import {
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
+import { assert } from '@0x/assert';
 import * as ethers from 'ethers';
 // tslint:enable:no-unused-variable
 
@@ -41,15 +43,17 @@ export class CoordinatorRegistryContract extends BaseContract {
     public setCoordinatorEndpoint = {
         async sendTransactionAsync(
             coordinatorEndpoint: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('coordinatorEndpoint', coordinatorEndpoint);
             const self = this as any as CoordinatorRegistryContract;
             const encodedData = self._strictEncodeArguments('setCoordinatorEndpoint(string)', [coordinatorEndpoint
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -63,17 +67,11 @@ export class CoordinatorRegistryContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             coordinatorEndpoint: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('coordinatorEndpoint', coordinatorEndpoint);
             const self = this as any as CoordinatorRegistryContract;
             const txHashPromise = self.setCoordinatorEndpoint.sendTransactionAsync(coordinatorEndpoint
     , txData);
@@ -91,15 +89,17 @@ export class CoordinatorRegistryContract extends BaseContract {
         },
         async estimateGasAsync(
             coordinatorEndpoint: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('coordinatorEndpoint', coordinatorEndpoint);
             const self = this as any as CoordinatorRegistryContract;
             const encodedData = self._strictEncodeArguments('setCoordinatorEndpoint(string)', [coordinatorEndpoint
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -110,6 +110,7 @@ export class CoordinatorRegistryContract extends BaseContract {
         getABIEncodedTransactionData(
             coordinatorEndpoint: string,
         ): string {
+            assert.isString('coordinatorEndpoint', coordinatorEndpoint);
             const self = this as any as CoordinatorRegistryContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('setCoordinatorEndpoint(string)', [coordinatorEndpoint
     ]);
@@ -121,6 +122,15 @@ export class CoordinatorRegistryContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('coordinatorEndpoint', coordinatorEndpoint);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as CoordinatorRegistryContract;
             const encodedData = self._strictEncodeArguments('setCoordinatorEndpoint(string)', [coordinatorEndpoint
         ]);
@@ -149,6 +159,15 @@ export class CoordinatorRegistryContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.isString('coordinatorOperator', coordinatorOperator);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as CoordinatorRegistryContract;
             const encodedData = self._strictEncodeArguments('getCoordinatorEndpoint(address)', [coordinatorOperator
         ]);
@@ -175,6 +194,11 @@ export class CoordinatorRegistryContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<CoordinatorRegistryContract> {
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         if (artifact.compilerOutput === undefined) {
             throw new Error('Compiler output not found in the artifact file');
         }
@@ -189,6 +213,12 @@ export class CoordinatorRegistryContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<CoordinatorRegistryContract> {
+        assert.isString('bytecode', bytecode);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
         const constructorAbi = BaseContract._lookupConstructorAbi(abi);
         [] = BaseContract._formatABIDataItemList(

--- a/packages/abi-gen-wrappers/src/generated-wrappers/coordinator_registry.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/coordinator_registry.ts
@@ -49,10 +49,11 @@ export class CoordinatorRegistryContract extends BaseContract {
             const self = this as any as CoordinatorRegistryContract;
             const encodedData = self._strictEncodeArguments('setCoordinatorEndpoint(string)', [coordinatorEndpoint
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -94,10 +95,11 @@ export class CoordinatorRegistryContract extends BaseContract {
             const self = this as any as CoordinatorRegistryContract;
             const encodedData = self._strictEncodeArguments('setCoordinatorEndpoint(string)', [coordinatorEndpoint
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),

--- a/packages/abi-gen-wrappers/src/generated-wrappers/coordinator_registry.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/coordinator_registry.ts
@@ -49,11 +49,10 @@ export class CoordinatorRegistryContract extends BaseContract {
             const self = this as any as CoordinatorRegistryContract;
             const encodedData = self._strictEncodeArguments('setCoordinatorEndpoint(string)', [coordinatorEndpoint
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -95,11 +94,10 @@ export class CoordinatorRegistryContract extends BaseContract {
             const self = this as any as CoordinatorRegistryContract;
             const encodedData = self._strictEncodeArguments('setCoordinatorEndpoint(string)', [coordinatorEndpoint
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),

--- a/packages/abi-gen-wrappers/src/generated-wrappers/coordinator_registry.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/coordinator_registry.ts
@@ -45,24 +45,24 @@ export class CoordinatorRegistryContract extends BaseContract {
             coordinatorEndpoint: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('coordinatorEndpoint', coordinatorEndpoint);
-            const self = this as any as CoordinatorRegistryContract;
-            const encodedData = self._strictEncodeArguments('setCoordinatorEndpoint(string)', [coordinatorEndpoint
+        assert.isString('coordinatorEndpoint', coordinatorEndpoint);
+        const self = this as any as CoordinatorRegistryContract;
+        const encodedData = self._strictEncodeArguments('setCoordinatorEndpoint(string)', [coordinatorEndpoint
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.setCoordinatorEndpoint.estimateGasAsync.bind(
-                    self,
-                    coordinatorEndpoint
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.setCoordinatorEndpoint.estimateGasAsync.bind(
+                self,
+                coordinatorEndpoint
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             coordinatorEndpoint: string,
@@ -70,49 +70,49 @@ export class CoordinatorRegistryContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('coordinatorEndpoint', coordinatorEndpoint);
-            const self = this as any as CoordinatorRegistryContract;
-            const txHashPromise = self.setCoordinatorEndpoint.sendTransactionAsync(coordinatorEndpoint
+        assert.isString('coordinatorEndpoint', coordinatorEndpoint);
+        const self = this as any as CoordinatorRegistryContract;
+        const txHashPromise = self.setCoordinatorEndpoint.sendTransactionAsync(coordinatorEndpoint
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             coordinatorEndpoint: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('coordinatorEndpoint', coordinatorEndpoint);
-            const self = this as any as CoordinatorRegistryContract;
-            const encodedData = self._strictEncodeArguments('setCoordinatorEndpoint(string)', [coordinatorEndpoint
+        assert.isString('coordinatorEndpoint', coordinatorEndpoint);
+        const self = this as any as CoordinatorRegistryContract;
+        const encodedData = self._strictEncodeArguments('setCoordinatorEndpoint(string)', [coordinatorEndpoint
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             coordinatorEndpoint: string,
         ): string {
-            assert.isString('coordinatorEndpoint', coordinatorEndpoint);
-            const self = this as any as CoordinatorRegistryContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('setCoordinatorEndpoint(string)', [coordinatorEndpoint
+        assert.isString('coordinatorEndpoint', coordinatorEndpoint);
+        const self = this as any as CoordinatorRegistryContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('setCoordinatorEndpoint(string)', [coordinatorEndpoint
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             coordinatorEndpoint: string,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc20_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc20_token.ts
@@ -1,6 +1,6 @@
-// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma whitespace class-name
+// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma
+// tslint:disable:whitespace no-unbound-method no-trailing-whitespace
 // tslint:disable:no-unused-variable
-// tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
 import { schemas } from '@0x/json-schemas';
 import {
@@ -55,6 +55,7 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -89,17 +90,15 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_spender', _spender);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -119,8 +118,7 @@ export class DummyERC20TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_spender', _spender);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const txHashPromise = self.approve.sendTransactionAsync(_spender,
     _value
@@ -142,17 +140,15 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_spender', _spender);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -164,8 +160,7 @@ export class DummyERC20TokenContract extends BaseContract {
             _spender: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_spender', _spender);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
@@ -179,8 +174,7 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_spender', _spender);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -217,6 +211,7 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -252,19 +247,16 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -286,9 +278,7 @@ export class DummyERC20TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const txHashPromise = self.transferFrom.sendTransactionAsync(_from,
     _to,
@@ -312,19 +302,16 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -337,9 +324,7 @@ export class DummyERC20TokenContract extends BaseContract {
             _to: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
@@ -355,9 +340,7 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -395,6 +378,7 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -466,6 +450,7 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -500,6 +485,7 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -537,11 +523,10 @@ export class DummyERC20TokenContract extends BaseContract {
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('mint(uint256)', [_value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -583,11 +568,10 @@ export class DummyERC20TokenContract extends BaseContract {
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('mint(uint256)', [_value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -646,17 +630,15 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -676,8 +658,7 @@ export class DummyERC20TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const txHashPromise = self.transfer.sendTransactionAsync(_to,
     _value
@@ -699,17 +680,15 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -721,8 +700,7 @@ export class DummyERC20TokenContract extends BaseContract {
             _to: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
@@ -736,8 +714,7 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -776,8 +753,7 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-            assert.isString('_owner', _owner);
-            assert.isString('_spender', _spender);
+            assert.isString('_owner', _owner);assert.isString('_spender', _spender);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -814,17 +790,15 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_target', _target);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_target', _target);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('setBalance(address,uint256)', [_target,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -844,8 +818,7 @@ export class DummyERC20TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_target', _target);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_target', _target);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const txHashPromise = self.setBalance.sendTransactionAsync(_target,
     _value
@@ -867,17 +840,15 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_target', _target);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_target', _target);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('setBalance(address,uint256)', [_target,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -889,8 +860,7 @@ export class DummyERC20TokenContract extends BaseContract {
             _target: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_target', _target);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_target', _target);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('setBalance(address,uint256)', [_target,
     _value
@@ -904,8 +874,7 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_target', _target);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_target', _target);assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -945,11 +914,10 @@ export class DummyERC20TokenContract extends BaseContract {
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -991,11 +959,10 @@ export class DummyERC20TokenContract extends BaseContract {
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1054,6 +1021,7 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1118,7 +1086,7 @@ _totalSupply
             _decimals: BigNumber,
             _totalSupply: BigNumber,
     ): Promise<DummyERC20TokenContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,
@@ -1169,4 +1137,5 @@ _totalSupply
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count
-// tslint:enable:no-unbound-method
+// tslint:enable:no-unbound-method no-parameter-reassignment no-consecutive-blank-lines ordered-imports align
+// tslint:enable:trailing-comma whitespace no-trailing-whitespace

--- a/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc20_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc20_token.ts
@@ -2,6 +2,7 @@
 // tslint:disable:no-unused-variable
 // tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
+import { schemas } from '@0x/json-schemas';
 import {
     BlockParam,
     BlockParamLiteral,
@@ -18,6 +19,7 @@ import {
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
+import { assert } from '@0x/assert';
 import * as ethers from 'ethers';
 // tslint:enable:no-unused-variable
 
@@ -53,6 +55,14 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('name()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -77,16 +87,19 @@ export class DummyERC20TokenContract extends BaseContract {
         async sendTransactionAsync(
             _spender: string,
             _value: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -102,17 +115,12 @@ export class DummyERC20TokenContract extends BaseContract {
         awaitTransactionSuccessAsync(
             _spender: string,
             _value: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const txHashPromise = self.approve.sendTransactionAsync(_spender,
     _value
@@ -132,16 +140,19 @@ export class DummyERC20TokenContract extends BaseContract {
         async estimateGasAsync(
             _spender: string,
             _value: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -153,6 +164,8 @@ export class DummyERC20TokenContract extends BaseContract {
             _spender: string,
             _value: BigNumber,
         ): string {
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
@@ -166,6 +179,16 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
         _value
@@ -194,6 +217,14 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('totalSupply()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -219,17 +250,21 @@ export class DummyERC20TokenContract extends BaseContract {
             _from: string,
             _to: string,
             _value: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -247,17 +282,13 @@ export class DummyERC20TokenContract extends BaseContract {
             _from: string,
             _to: string,
             _value: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const txHashPromise = self.transferFrom.sendTransactionAsync(_from,
     _to,
@@ -279,17 +310,21 @@ export class DummyERC20TokenContract extends BaseContract {
             _from: string,
             _to: string,
             _value: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -302,6 +337,9 @@ export class DummyERC20TokenContract extends BaseContract {
             _to: string,
             _value: BigNumber,
         ): string {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
@@ -317,6 +355,17 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
         _to,
@@ -346,6 +395,14 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('decimals()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -373,6 +430,15 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+            assert.isString('_owner', _owner);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('balanceOf(address)', [_owner
         ]);
@@ -400,6 +466,14 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('owner()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -426,6 +500,14 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('symbol()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -449,15 +531,17 @@ export class DummyERC20TokenContract extends BaseContract {
     public mint = {
         async sendTransactionAsync(
             _value: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('mint(uint256)', [_value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -471,17 +555,11 @@ export class DummyERC20TokenContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             _value: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const txHashPromise = self.mint.sendTransactionAsync(_value
     , txData);
@@ -499,15 +577,17 @@ export class DummyERC20TokenContract extends BaseContract {
         },
         async estimateGasAsync(
             _value: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('mint(uint256)', [_value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -518,6 +598,7 @@ export class DummyERC20TokenContract extends BaseContract {
         getABIEncodedTransactionData(
             _value: BigNumber,
         ): string {
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('mint(uint256)', [_value
     ]);
@@ -529,6 +610,15 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isBigNumber('_value', _value);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('mint(uint256)', [_value
         ]);
@@ -554,16 +644,19 @@ export class DummyERC20TokenContract extends BaseContract {
         async sendTransactionAsync(
             _to: string,
             _value: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -579,17 +672,12 @@ export class DummyERC20TokenContract extends BaseContract {
         awaitTransactionSuccessAsync(
             _to: string,
             _value: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const txHashPromise = self.transfer.sendTransactionAsync(_to,
     _value
@@ -609,16 +697,19 @@ export class DummyERC20TokenContract extends BaseContract {
         async estimateGasAsync(
             _to: string,
             _value: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -630,6 +721,8 @@ export class DummyERC20TokenContract extends BaseContract {
             _to: string,
             _value: BigNumber,
         ): string {
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
@@ -643,6 +736,16 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
         _value
@@ -673,6 +776,16 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+            assert.isString('_owner', _owner);
+            assert.isString('_spender', _spender);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('allowance(address,address)', [_owner,
         _spender
@@ -699,16 +812,19 @@ export class DummyERC20TokenContract extends BaseContract {
         async sendTransactionAsync(
             _target: string,
             _value: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('_target', _target);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('setBalance(address,uint256)', [_target,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -724,17 +840,12 @@ export class DummyERC20TokenContract extends BaseContract {
         awaitTransactionSuccessAsync(
             _target: string,
             _value: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('_target', _target);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const txHashPromise = self.setBalance.sendTransactionAsync(_target,
     _value
@@ -754,16 +865,19 @@ export class DummyERC20TokenContract extends BaseContract {
         async estimateGasAsync(
             _target: string,
             _value: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('_target', _target);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('setBalance(address,uint256)', [_target,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -775,6 +889,8 @@ export class DummyERC20TokenContract extends BaseContract {
             _target: string,
             _value: BigNumber,
         ): string {
+            assert.isString('_target', _target);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('setBalance(address,uint256)', [_target,
     _value
@@ -788,6 +904,16 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('_target', _target);
+            assert.isBigNumber('_value', _value);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('setBalance(address,uint256)', [_target,
         _value
@@ -813,15 +939,17 @@ export class DummyERC20TokenContract extends BaseContract {
     public transferOwnership = {
         async sendTransactionAsync(
             newOwner: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('newOwner', newOwner);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -835,17 +963,11 @@ export class DummyERC20TokenContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             newOwner: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('newOwner', newOwner);
             const self = this as any as DummyERC20TokenContract;
             const txHashPromise = self.transferOwnership.sendTransactionAsync(newOwner
     , txData);
@@ -863,15 +985,17 @@ export class DummyERC20TokenContract extends BaseContract {
         },
         async estimateGasAsync(
             newOwner: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('newOwner', newOwner);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -882,6 +1006,7 @@ export class DummyERC20TokenContract extends BaseContract {
         getABIEncodedTransactionData(
             newOwner: string,
         ): string {
+            assert.isString('newOwner', newOwner);
             const self = this as any as DummyERC20TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
@@ -893,6 +1018,15 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('newOwner', newOwner);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
         ]);
@@ -920,6 +1054,14 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('MAX_MINT_AMOUNT()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -949,6 +1091,11 @@ export class DummyERC20TokenContract extends BaseContract {
             _decimals: BigNumber,
             _totalSupply: BigNumber,
     ): Promise<DummyERC20TokenContract> {
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         if (artifact.compilerOutput === undefined) {
             throw new Error('Compiler output not found in the artifact file');
         }
@@ -971,6 +1118,12 @@ _totalSupply
             _decimals: BigNumber,
             _totalSupply: BigNumber,
     ): Promise<DummyERC20TokenContract> {
+        assert.isString('bytecode', bytecode);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
         const constructorAbi = BaseContract._lookupConstructorAbi(abi);
         [_name,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc20_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc20_token.ts
@@ -55,7 +55,6 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -90,26 +89,27 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
-            const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
+        assert.isString('_spender', _spender);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as DummyERC20TokenContract;
+        const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.approve.estimateGasAsync.bind(
-                    self,
-                    _spender,
-                    _value
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.approve.estimateGasAsync.bind(
+                self,
+                _spender,
+                _value
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             _spender: string,
@@ -118,54 +118,57 @@ export class DummyERC20TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
-            const self = this as any as DummyERC20TokenContract;
-            const txHashPromise = self.approve.sendTransactionAsync(_spender,
+        assert.isString('_spender', _spender);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as DummyERC20TokenContract;
+        const txHashPromise = self.approve.sendTransactionAsync(_spender,
     _value
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             _spender: string,
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
-            const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
+        assert.isString('_spender', _spender);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as DummyERC20TokenContract;
+        const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             _spender: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
-            const self = this as any as DummyERC20TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
+        assert.isString('_spender', _spender);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as DummyERC20TokenContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             _spender: string,
@@ -174,7 +177,8 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -211,7 +215,6 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -247,28 +250,30 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
-            const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as DummyERC20TokenContract;
+        const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transferFrom.estimateGasAsync.bind(
-                    self,
-                    _from,
-                    _to,
-                    _value
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.transferFrom.estimateGasAsync.bind(
+                self,
+                _from,
+                _to,
+                _value
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             _from: string,
@@ -278,23 +283,25 @@ export class DummyERC20TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
-            const self = this as any as DummyERC20TokenContract;
-            const txHashPromise = self.transferFrom.sendTransactionAsync(_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as DummyERC20TokenContract;
+        const txHashPromise = self.transferFrom.sendTransactionAsync(_from,
     _to,
     _value
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             _from: string,
@@ -302,35 +309,39 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
-            const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as DummyERC20TokenContract;
+        const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             _from: string,
             _to: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
-            const self = this as any as DummyERC20TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as DummyERC20TokenContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             _from: string,
@@ -340,7 +351,9 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -378,7 +391,6 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -450,7 +462,6 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -485,7 +496,6 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -519,24 +529,24 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isBigNumber('_value', _value);
-            const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('mint(uint256)', [_value
+        assert.isBigNumber('_value', _value);
+        const self = this as any as DummyERC20TokenContract;
+        const encodedData = self._strictEncodeArguments('mint(uint256)', [_value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.mint.estimateGasAsync.bind(
-                    self,
-                    _value
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.mint.estimateGasAsync.bind(
+                self,
+                _value
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             _value: BigNumber,
@@ -544,49 +554,49 @@ export class DummyERC20TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isBigNumber('_value', _value);
-            const self = this as any as DummyERC20TokenContract;
-            const txHashPromise = self.mint.sendTransactionAsync(_value
+        assert.isBigNumber('_value', _value);
+        const self = this as any as DummyERC20TokenContract;
+        const txHashPromise = self.mint.sendTransactionAsync(_value
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isBigNumber('_value', _value);
-            const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('mint(uint256)', [_value
+        assert.isBigNumber('_value', _value);
+        const self = this as any as DummyERC20TokenContract;
+        const encodedData = self._strictEncodeArguments('mint(uint256)', [_value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             _value: BigNumber,
         ): string {
-            assert.isBigNumber('_value', _value);
-            const self = this as any as DummyERC20TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('mint(uint256)', [_value
+        assert.isBigNumber('_value', _value);
+        const self = this as any as DummyERC20TokenContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('mint(uint256)', [_value
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             _value: BigNumber,
@@ -630,26 +640,27 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
-            const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
+        assert.isString('_to', _to);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as DummyERC20TokenContract;
+        const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transfer.estimateGasAsync.bind(
-                    self,
-                    _to,
-                    _value
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.transfer.estimateGasAsync.bind(
+                self,
+                _to,
+                _value
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             _to: string,
@@ -658,54 +669,57 @@ export class DummyERC20TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
-            const self = this as any as DummyERC20TokenContract;
-            const txHashPromise = self.transfer.sendTransactionAsync(_to,
+        assert.isString('_to', _to);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as DummyERC20TokenContract;
+        const txHashPromise = self.transfer.sendTransactionAsync(_to,
     _value
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             _to: string,
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
-            const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
+        assert.isString('_to', _to);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as DummyERC20TokenContract;
+        const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             _to: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
-            const self = this as any as DummyERC20TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
+        assert.isString('_to', _to);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as DummyERC20TokenContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             _to: string,
@@ -714,7 +728,8 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -753,7 +768,8 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-            assert.isString('_owner', _owner);assert.isString('_spender', _spender);
+            assert.isString('_owner', _owner);
+            assert.isString('_spender', _spender);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -790,26 +806,27 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_target', _target);assert.isBigNumber('_value', _value);
-            const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('setBalance(address,uint256)', [_target,
+        assert.isString('_target', _target);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as DummyERC20TokenContract;
+        const encodedData = self._strictEncodeArguments('setBalance(address,uint256)', [_target,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.setBalance.estimateGasAsync.bind(
-                    self,
-                    _target,
-                    _value
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.setBalance.estimateGasAsync.bind(
+                self,
+                _target,
+                _value
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             _target: string,
@@ -818,54 +835,57 @@ export class DummyERC20TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_target', _target);assert.isBigNumber('_value', _value);
-            const self = this as any as DummyERC20TokenContract;
-            const txHashPromise = self.setBalance.sendTransactionAsync(_target,
+        assert.isString('_target', _target);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as DummyERC20TokenContract;
+        const txHashPromise = self.setBalance.sendTransactionAsync(_target,
     _value
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             _target: string,
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_target', _target);assert.isBigNumber('_value', _value);
-            const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('setBalance(address,uint256)', [_target,
+        assert.isString('_target', _target);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as DummyERC20TokenContract;
+        const encodedData = self._strictEncodeArguments('setBalance(address,uint256)', [_target,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             _target: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_target', _target);assert.isBigNumber('_value', _value);
-            const self = this as any as DummyERC20TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('setBalance(address,uint256)', [_target,
+        assert.isString('_target', _target);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as DummyERC20TokenContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('setBalance(address,uint256)', [_target,
     _value
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             _target: string,
@@ -874,7 +894,8 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_target', _target);assert.isBigNumber('_value', _value);
+            assert.isString('_target', _target);
+            assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -910,24 +931,24 @@ export class DummyERC20TokenContract extends BaseContract {
             newOwner: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as DummyERC20TokenContract;
+        const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transferOwnership.estimateGasAsync.bind(
-                    self,
-                    newOwner
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.transferOwnership.estimateGasAsync.bind(
+                self,
+                newOwner
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             newOwner: string,
@@ -935,49 +956,49 @@ export class DummyERC20TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as DummyERC20TokenContract;
-            const txHashPromise = self.transferOwnership.sendTransactionAsync(newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as DummyERC20TokenContract;
+        const txHashPromise = self.transferOwnership.sendTransactionAsync(newOwner
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             newOwner: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as DummyERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as DummyERC20TokenContract;
+        const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             newOwner: string,
         ): string {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as DummyERC20TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as DummyERC20TokenContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             newOwner: string,
@@ -1021,7 +1042,6 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc20_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc20_token.ts
@@ -55,7 +55,6 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -90,15 +89,17 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -118,7 +119,8 @@ export class DummyERC20TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const txHashPromise = self.approve.sendTransactionAsync(_spender,
     _value
@@ -140,15 +142,17 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -160,7 +164,8 @@ export class DummyERC20TokenContract extends BaseContract {
             _spender: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
@@ -174,7 +179,8 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -211,7 +217,6 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -247,16 +252,19 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -278,7 +286,9 @@ export class DummyERC20TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const txHashPromise = self.transferFrom.sendTransactionAsync(_from,
     _to,
@@ -302,16 +312,19 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -324,7 +337,9 @@ export class DummyERC20TokenContract extends BaseContract {
             _to: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
@@ -340,7 +355,9 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -378,7 +395,6 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -450,7 +466,6 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -485,7 +500,6 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -523,10 +537,11 @@ export class DummyERC20TokenContract extends BaseContract {
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('mint(uint256)', [_value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -568,10 +583,11 @@ export class DummyERC20TokenContract extends BaseContract {
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('mint(uint256)', [_value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -630,15 +646,17 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -658,7 +676,8 @@ export class DummyERC20TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const txHashPromise = self.transfer.sendTransactionAsync(_to,
     _value
@@ -680,15 +699,17 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -700,7 +721,8 @@ export class DummyERC20TokenContract extends BaseContract {
             _to: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
@@ -714,7 +736,8 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -753,7 +776,8 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-            assert.isString('_owner', _owner);assert.isString('_spender', _spender);
+            assert.isString('_owner', _owner);
+            assert.isString('_spender', _spender);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -790,15 +814,17 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_target', _target);assert.isBigNumber('_value', _value);
+            assert.isString('_target', _target);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('setBalance(address,uint256)', [_target,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -818,7 +844,8 @@ export class DummyERC20TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_target', _target);assert.isBigNumber('_value', _value);
+            assert.isString('_target', _target);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const txHashPromise = self.setBalance.sendTransactionAsync(_target,
     _value
@@ -840,15 +867,17 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_target', _target);assert.isBigNumber('_value', _value);
+            assert.isString('_target', _target);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('setBalance(address,uint256)', [_target,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -860,7 +889,8 @@ export class DummyERC20TokenContract extends BaseContract {
             _target: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_target', _target);assert.isBigNumber('_value', _value);
+            assert.isString('_target', _target);
+            assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('setBalance(address,uint256)', [_target,
     _value
@@ -874,7 +904,8 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_target', _target);assert.isBigNumber('_value', _value);
+            assert.isString('_target', _target);
+            assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -914,10 +945,11 @@ export class DummyERC20TokenContract extends BaseContract {
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -959,10 +991,11 @@ export class DummyERC20TokenContract extends BaseContract {
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1021,7 +1054,6 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1086,7 +1118,7 @@ _totalSupply
             _decimals: BigNumber,
             _totalSupply: BigNumber,
     ): Promise<DummyERC20TokenContract> {
-        assert.isHexString('bytecode', bytecode);
+        assert.isString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc20_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc20_token.ts
@@ -55,6 +55,7 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -89,17 +90,15 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_spender', _spender);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -119,8 +118,7 @@ export class DummyERC20TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_spender', _spender);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const txHashPromise = self.approve.sendTransactionAsync(_spender,
     _value
@@ -142,17 +140,15 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_spender', _spender);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -164,8 +160,7 @@ export class DummyERC20TokenContract extends BaseContract {
             _spender: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_spender', _spender);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
@@ -179,8 +174,7 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_spender', _spender);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -217,6 +211,7 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -252,19 +247,16 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -286,9 +278,7 @@ export class DummyERC20TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const txHashPromise = self.transferFrom.sendTransactionAsync(_from,
     _to,
@@ -312,19 +302,16 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -337,9 +324,7 @@ export class DummyERC20TokenContract extends BaseContract {
             _to: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
@@ -355,9 +340,7 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -395,6 +378,7 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -466,6 +450,7 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -500,6 +485,7 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -537,11 +523,10 @@ export class DummyERC20TokenContract extends BaseContract {
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('mint(uint256)', [_value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -583,11 +568,10 @@ export class DummyERC20TokenContract extends BaseContract {
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('mint(uint256)', [_value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -646,17 +630,15 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -676,8 +658,7 @@ export class DummyERC20TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const txHashPromise = self.transfer.sendTransactionAsync(_to,
     _value
@@ -699,17 +680,15 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -721,8 +700,7 @@ export class DummyERC20TokenContract extends BaseContract {
             _to: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
@@ -736,8 +714,7 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -776,8 +753,7 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-            assert.isString('_owner', _owner);
-            assert.isString('_spender', _spender);
+            assert.isString('_owner', _owner);assert.isString('_spender', _spender);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -814,17 +790,15 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_target', _target);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_target', _target);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('setBalance(address,uint256)', [_target,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -844,8 +818,7 @@ export class DummyERC20TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_target', _target);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_target', _target);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const txHashPromise = self.setBalance.sendTransactionAsync(_target,
     _value
@@ -867,17 +840,15 @@ export class DummyERC20TokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_target', _target);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_target', _target);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('setBalance(address,uint256)', [_target,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -889,8 +860,7 @@ export class DummyERC20TokenContract extends BaseContract {
             _target: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_target', _target);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_target', _target);assert.isBigNumber('_value', _value);
             const self = this as any as DummyERC20TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('setBalance(address,uint256)', [_target,
     _value
@@ -904,8 +874,7 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_target', _target);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_target', _target);assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -945,11 +914,10 @@ export class DummyERC20TokenContract extends BaseContract {
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -991,11 +959,10 @@ export class DummyERC20TokenContract extends BaseContract {
             const self = this as any as DummyERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1054,6 +1021,7 @@ export class DummyERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1118,7 +1086,7 @@ _totalSupply
             _decimals: BigNumber,
             _totalSupply: BigNumber,
     ): Promise<DummyERC20TokenContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc721_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc721_token.ts
@@ -2,6 +2,7 @@
 // tslint:disable:no-unused-variable
 // tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
+import { schemas } from '@0x/json-schemas';
 import {
     BlockParam,
     BlockParamLiteral,
@@ -18,6 +19,7 @@ import {
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
+import { assert } from '@0x/assert';
 import * as ethers from 'ethers';
 // tslint:enable:no-unused-variable
 
@@ -61,6 +63,14 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('name()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -88,6 +98,15 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('getApproved(uint256)', [_tokenId
         ]);
@@ -113,16 +132,19 @@ export class DummyERC721TokenContract extends BaseContract {
         async sendTransactionAsync(
             _approved: string,
             _tokenId: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('_approved', _approved);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -138,17 +160,12 @@ export class DummyERC721TokenContract extends BaseContract {
         awaitTransactionSuccessAsync(
             _approved: string,
             _tokenId: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('_approved', _approved);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const txHashPromise = self.approve.sendTransactionAsync(_approved,
     _tokenId
@@ -168,16 +185,19 @@ export class DummyERC721TokenContract extends BaseContract {
         async estimateGasAsync(
             _approved: string,
             _tokenId: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('_approved', _approved);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -189,6 +209,8 @@ export class DummyERC721TokenContract extends BaseContract {
             _approved: string,
             _tokenId: BigNumber,
         ): string {
+            assert.isString('_approved', _approved);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
@@ -202,6 +224,16 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('_approved', _approved);
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
         _tokenId
@@ -229,17 +261,21 @@ export class DummyERC721TokenContract extends BaseContract {
             _from: string,
             _to: string,
             _tokenId: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -257,17 +293,13 @@ export class DummyERC721TokenContract extends BaseContract {
             _from: string,
             _to: string,
             _tokenId: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const txHashPromise = self.transferFrom.sendTransactionAsync(_from,
     _to,
@@ -289,17 +321,21 @@ export class DummyERC721TokenContract extends BaseContract {
             _from: string,
             _to: string,
             _tokenId: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -312,6 +348,9 @@ export class DummyERC721TokenContract extends BaseContract {
             _to: string,
             _tokenId: BigNumber,
         ): string {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
@@ -327,6 +366,17 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
         _to,
@@ -354,16 +404,19 @@ export class DummyERC721TokenContract extends BaseContract {
         async sendTransactionAsync(
             _to: string,
             _tokenId: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('mint(address,uint256)', [_to,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -379,17 +432,12 @@ export class DummyERC721TokenContract extends BaseContract {
         awaitTransactionSuccessAsync(
             _to: string,
             _tokenId: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const txHashPromise = self.mint.sendTransactionAsync(_to,
     _tokenId
@@ -409,16 +457,19 @@ export class DummyERC721TokenContract extends BaseContract {
         async estimateGasAsync(
             _to: string,
             _tokenId: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('mint(address,uint256)', [_to,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -430,6 +481,8 @@ export class DummyERC721TokenContract extends BaseContract {
             _to: string,
             _tokenId: BigNumber,
         ): string {
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('mint(address,uint256)', [_to,
     _tokenId
@@ -443,6 +496,16 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('mint(address,uint256)', [_to,
         _tokenId
@@ -470,17 +533,21 @@ export class DummyERC721TokenContract extends BaseContract {
             _from: string,
             _to: string,
             _tokenId: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -498,17 +565,13 @@ export class DummyERC721TokenContract extends BaseContract {
             _from: string,
             _to: string,
             _tokenId: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const txHashPromise = self.safeTransferFrom1.sendTransactionAsync(_from,
     _to,
@@ -530,17 +593,21 @@ export class DummyERC721TokenContract extends BaseContract {
             _from: string,
             _to: string,
             _tokenId: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -553,6 +620,9 @@ export class DummyERC721TokenContract extends BaseContract {
             _to: string,
             _tokenId: BigNumber,
         ): string {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
@@ -568,6 +638,17 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
         _to,
@@ -598,6 +679,15 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('ownerOf(uint256)', [_tokenId
         ]);
@@ -626,6 +716,15 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+            assert.isString('_owner', _owner);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('balanceOf(address)', [_owner
         ]);
@@ -653,6 +752,14 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('owner()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -679,6 +786,14 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('symbol()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -703,16 +818,19 @@ export class DummyERC721TokenContract extends BaseContract {
         async sendTransactionAsync(
             _owner: string,
             _tokenId: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('_owner', _owner);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('burn(address,uint256)', [_owner,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -728,17 +846,12 @@ export class DummyERC721TokenContract extends BaseContract {
         awaitTransactionSuccessAsync(
             _owner: string,
             _tokenId: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('_owner', _owner);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const txHashPromise = self.burn.sendTransactionAsync(_owner,
     _tokenId
@@ -758,16 +871,19 @@ export class DummyERC721TokenContract extends BaseContract {
         async estimateGasAsync(
             _owner: string,
             _tokenId: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('_owner', _owner);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('burn(address,uint256)', [_owner,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -779,6 +895,8 @@ export class DummyERC721TokenContract extends BaseContract {
             _owner: string,
             _tokenId: BigNumber,
         ): string {
+            assert.isString('_owner', _owner);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('burn(address,uint256)', [_owner,
     _tokenId
@@ -792,6 +910,16 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('_owner', _owner);
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('burn(address,uint256)', [_owner,
         _tokenId
@@ -818,16 +946,19 @@ export class DummyERC721TokenContract extends BaseContract {
         async sendTransactionAsync(
             _operator: string,
             _approved: boolean,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('_operator', _operator);
+            assert.isBoolean('_approved', _approved);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -843,17 +974,12 @@ export class DummyERC721TokenContract extends BaseContract {
         awaitTransactionSuccessAsync(
             _operator: string,
             _approved: boolean,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('_operator', _operator);
+            assert.isBoolean('_approved', _approved);
             const self = this as any as DummyERC721TokenContract;
             const txHashPromise = self.setApprovalForAll.sendTransactionAsync(_operator,
     _approved
@@ -873,16 +999,19 @@ export class DummyERC721TokenContract extends BaseContract {
         async estimateGasAsync(
             _operator: string,
             _approved: boolean,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('_operator', _operator);
+            assert.isBoolean('_approved', _approved);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -894,6 +1023,8 @@ export class DummyERC721TokenContract extends BaseContract {
             _operator: string,
             _approved: boolean,
         ): string {
+            assert.isString('_operator', _operator);
+            assert.isBoolean('_approved', _approved);
             const self = this as any as DummyERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
@@ -907,6 +1038,16 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('_operator', _operator);
+            assert.isBoolean('_approved', _approved);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
         _approved
@@ -935,18 +1076,23 @@ export class DummyERC721TokenContract extends BaseContract {
             _to: string,
             _tokenId: BigNumber,
             _data: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_data', _data);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
     _tokenId,
     _data
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -966,17 +1112,14 @@ export class DummyERC721TokenContract extends BaseContract {
             _to: string,
             _tokenId: BigNumber,
             _data: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_data', _data);
             const self = this as any as DummyERC721TokenContract;
             const txHashPromise = self.safeTransferFrom2.sendTransactionAsync(_from,
     _to,
@@ -1000,18 +1143,23 @@ export class DummyERC721TokenContract extends BaseContract {
             _to: string,
             _tokenId: BigNumber,
             _data: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_data', _data);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
     _tokenId,
     _data
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1025,6 +1173,10 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             _data: string,
         ): string {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_data', _data);
             const self = this as any as DummyERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
@@ -1042,6 +1194,18 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_data', _data);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
         _to,
@@ -1074,6 +1238,16 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
+            assert.isString('_owner', _owner);
+            assert.isString('_operator', _operator);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('isApprovedForAll(address,address)', [_owner,
         _operator
@@ -1099,15 +1273,17 @@ export class DummyERC721TokenContract extends BaseContract {
     public transferOwnership = {
         async sendTransactionAsync(
             newOwner: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('newOwner', newOwner);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1121,17 +1297,11 @@ export class DummyERC721TokenContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             newOwner: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('newOwner', newOwner);
             const self = this as any as DummyERC721TokenContract;
             const txHashPromise = self.transferOwnership.sendTransactionAsync(newOwner
     , txData);
@@ -1149,15 +1319,17 @@ export class DummyERC721TokenContract extends BaseContract {
         },
         async estimateGasAsync(
             newOwner: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('newOwner', newOwner);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1168,6 +1340,7 @@ export class DummyERC721TokenContract extends BaseContract {
         getABIEncodedTransactionData(
             newOwner: string,
         ): string {
+            assert.isString('newOwner', newOwner);
             const self = this as any as DummyERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
@@ -1179,6 +1352,15 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('newOwner', newOwner);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
         ]);
@@ -1207,6 +1389,11 @@ export class DummyERC721TokenContract extends BaseContract {
             _name: string,
             _symbol: string,
     ): Promise<DummyERC721TokenContract> {
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         if (artifact.compilerOutput === undefined) {
             throw new Error('Compiler output not found in the artifact file');
         }
@@ -1225,6 +1412,12 @@ _symbol
             _name: string,
             _symbol: string,
     ): Promise<DummyERC721TokenContract> {
+        assert.isString('bytecode', bytecode);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
         const constructorAbi = BaseContract._lookupConstructorAbi(abi);
         [_name,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc721_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc721_token.ts
@@ -1,6 +1,6 @@
-// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma whitespace class-name
+// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma
+// tslint:disable:whitespace no-unbound-method no-trailing-whitespace
 // tslint:disable:no-unused-variable
-// tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
 import { schemas } from '@0x/json-schemas';
 import {
@@ -63,6 +63,7 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -134,17 +135,15 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_approved', _approved);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -164,8 +163,7 @@ export class DummyERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_approved', _approved);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const txHashPromise = self.approve.sendTransactionAsync(_approved,
     _tokenId
@@ -187,17 +185,15 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_approved', _approved);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -209,8 +205,7 @@ export class DummyERC721TokenContract extends BaseContract {
             _approved: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_approved', _approved);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
@@ -224,8 +219,7 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_approved', _approved);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -263,19 +257,16 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -297,9 +288,7 @@ export class DummyERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const txHashPromise = self.transferFrom.sendTransactionAsync(_from,
     _to,
@@ -323,19 +312,16 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -348,9 +334,7 @@ export class DummyERC721TokenContract extends BaseContract {
             _to: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
@@ -366,9 +350,7 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -406,17 +388,15 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('mint(address,uint256)', [_to,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -436,8 +416,7 @@ export class DummyERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const txHashPromise = self.mint.sendTransactionAsync(_to,
     _tokenId
@@ -459,17 +438,15 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('mint(address,uint256)', [_to,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -481,8 +458,7 @@ export class DummyERC721TokenContract extends BaseContract {
             _to: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('mint(address,uint256)', [_to,
     _tokenId
@@ -496,8 +472,7 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -535,19 +510,16 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -569,9 +541,7 @@ export class DummyERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const txHashPromise = self.safeTransferFrom1.sendTransactionAsync(_from,
     _to,
@@ -595,19 +565,16 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -620,9 +587,7 @@ export class DummyERC721TokenContract extends BaseContract {
             _to: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
@@ -638,9 +603,7 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -752,6 +715,7 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -786,6 +750,7 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -820,17 +785,15 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_owner', _owner);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_owner', _owner);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('burn(address,uint256)', [_owner,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -850,8 +813,7 @@ export class DummyERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_owner', _owner);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_owner', _owner);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const txHashPromise = self.burn.sendTransactionAsync(_owner,
     _tokenId
@@ -873,17 +835,15 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_owner', _owner);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_owner', _owner);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('burn(address,uint256)', [_owner,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -895,8 +855,7 @@ export class DummyERC721TokenContract extends BaseContract {
             _owner: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_owner', _owner);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_owner', _owner);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('burn(address,uint256)', [_owner,
     _tokenId
@@ -910,8 +869,7 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_owner', _owner);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_owner', _owner);assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -948,17 +906,15 @@ export class DummyERC721TokenContract extends BaseContract {
             _approved: boolean,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_operator', _operator);
-            assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -978,8 +934,7 @@ export class DummyERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_operator', _operator);
-            assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
             const self = this as any as DummyERC721TokenContract;
             const txHashPromise = self.setApprovalForAll.sendTransactionAsync(_operator,
     _approved
@@ -1001,17 +956,15 @@ export class DummyERC721TokenContract extends BaseContract {
             _approved: boolean,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_operator', _operator);
-            assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1023,8 +976,7 @@ export class DummyERC721TokenContract extends BaseContract {
             _operator: string,
             _approved: boolean,
         ): string {
-            assert.isString('_operator', _operator);
-            assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
             const self = this as any as DummyERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
@@ -1038,8 +990,7 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_operator', _operator);
-            assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1078,21 +1029,17 @@ export class DummyERC721TokenContract extends BaseContract {
             _data: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
-            assert.isString('_data', _data);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
     _tokenId,
     _data
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1116,10 +1063,7 @@ export class DummyERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
-            assert.isString('_data', _data);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
             const self = this as any as DummyERC721TokenContract;
             const txHashPromise = self.safeTransferFrom2.sendTransactionAsync(_from,
     _to,
@@ -1145,21 +1089,17 @@ export class DummyERC721TokenContract extends BaseContract {
             _data: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
-            assert.isString('_data', _data);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
     _tokenId,
     _data
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1173,10 +1113,7 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             _data: string,
         ): string {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
-            assert.isString('_data', _data);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
             const self = this as any as DummyERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
@@ -1194,10 +1131,7 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
-            assert.isString('_data', _data);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1238,8 +1172,7 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_owner', _owner);
-            assert.isString('_operator', _operator);
+            assert.isString('_owner', _owner);assert.isString('_operator', _operator);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1279,11 +1212,10 @@ export class DummyERC721TokenContract extends BaseContract {
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1325,11 +1257,10 @@ export class DummyERC721TokenContract extends BaseContract {
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1412,7 +1343,7 @@ _symbol
             _name: string,
             _symbol: string,
     ): Promise<DummyERC721TokenContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,
@@ -1455,4 +1386,5 @@ _symbol
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count
-// tslint:enable:no-unbound-method
+// tslint:enable:no-unbound-method no-parameter-reassignment no-consecutive-blank-lines ordered-imports align
+// tslint:enable:trailing-comma whitespace no-trailing-whitespace

--- a/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc721_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc721_token.ts
@@ -63,7 +63,6 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -135,15 +134,17 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -163,7 +164,8 @@ export class DummyERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const txHashPromise = self.approve.sendTransactionAsync(_approved,
     _tokenId
@@ -185,15 +187,17 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -205,7 +209,8 @@ export class DummyERC721TokenContract extends BaseContract {
             _approved: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
@@ -219,7 +224,8 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);
+            assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -257,16 +263,19 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -288,7 +297,9 @@ export class DummyERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const txHashPromise = self.transferFrom.sendTransactionAsync(_from,
     _to,
@@ -312,16 +323,19 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -334,7 +348,9 @@ export class DummyERC721TokenContract extends BaseContract {
             _to: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
@@ -350,7 +366,9 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -388,15 +406,17 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('mint(address,uint256)', [_to,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -416,7 +436,8 @@ export class DummyERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const txHashPromise = self.mint.sendTransactionAsync(_to,
     _tokenId
@@ -438,15 +459,17 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('mint(address,uint256)', [_to,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -458,7 +481,8 @@ export class DummyERC721TokenContract extends BaseContract {
             _to: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('mint(address,uint256)', [_to,
     _tokenId
@@ -472,7 +496,8 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -510,16 +535,19 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -541,7 +569,9 @@ export class DummyERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const txHashPromise = self.safeTransferFrom1.sendTransactionAsync(_from,
     _to,
@@ -565,16 +595,19 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -587,7 +620,9 @@ export class DummyERC721TokenContract extends BaseContract {
             _to: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
@@ -603,7 +638,9 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -715,7 +752,6 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -750,7 +786,6 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -785,15 +820,17 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_owner', _owner);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_owner', _owner);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('burn(address,uint256)', [_owner,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -813,7 +850,8 @@ export class DummyERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_owner', _owner);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_owner', _owner);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const txHashPromise = self.burn.sendTransactionAsync(_owner,
     _tokenId
@@ -835,15 +873,17 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_owner', _owner);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_owner', _owner);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('burn(address,uint256)', [_owner,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -855,7 +895,8 @@ export class DummyERC721TokenContract extends BaseContract {
             _owner: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_owner', _owner);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_owner', _owner);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('burn(address,uint256)', [_owner,
     _tokenId
@@ -869,7 +910,8 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_owner', _owner);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_owner', _owner);
+            assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -906,15 +948,17 @@ export class DummyERC721TokenContract extends BaseContract {
             _approved: boolean,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);
+            assert.isBoolean('_approved', _approved);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -934,7 +978,8 @@ export class DummyERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);
+            assert.isBoolean('_approved', _approved);
             const self = this as any as DummyERC721TokenContract;
             const txHashPromise = self.setApprovalForAll.sendTransactionAsync(_operator,
     _approved
@@ -956,15 +1001,17 @@ export class DummyERC721TokenContract extends BaseContract {
             _approved: boolean,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);
+            assert.isBoolean('_approved', _approved);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -976,7 +1023,8 @@ export class DummyERC721TokenContract extends BaseContract {
             _operator: string,
             _approved: boolean,
         ): string {
-            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);
+            assert.isBoolean('_approved', _approved);
             const self = this as any as DummyERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
@@ -990,7 +1038,8 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);
+            assert.isBoolean('_approved', _approved);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1029,17 +1078,21 @@ export class DummyERC721TokenContract extends BaseContract {
             _data: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_data', _data);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
     _tokenId,
     _data
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1063,7 +1116,10 @@ export class DummyERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_data', _data);
             const self = this as any as DummyERC721TokenContract;
             const txHashPromise = self.safeTransferFrom2.sendTransactionAsync(_from,
     _to,
@@ -1089,17 +1145,21 @@ export class DummyERC721TokenContract extends BaseContract {
             _data: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_data', _data);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
     _tokenId,
     _data
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1113,7 +1173,10 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             _data: string,
         ): string {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_data', _data);
             const self = this as any as DummyERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
@@ -1131,7 +1194,10 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_data', _data);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1172,7 +1238,8 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_owner', _owner);assert.isString('_operator', _operator);
+            assert.isString('_owner', _owner);
+            assert.isString('_operator', _operator);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1212,10 +1279,11 @@ export class DummyERC721TokenContract extends BaseContract {
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1257,10 +1325,11 @@ export class DummyERC721TokenContract extends BaseContract {
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1343,7 +1412,7 @@ _symbol
             _name: string,
             _symbol: string,
     ): Promise<DummyERC721TokenContract> {
-        assert.isHexString('bytecode', bytecode);
+        assert.isString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc721_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc721_token.ts
@@ -63,6 +63,7 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -134,17 +135,15 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_approved', _approved);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -164,8 +163,7 @@ export class DummyERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_approved', _approved);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const txHashPromise = self.approve.sendTransactionAsync(_approved,
     _tokenId
@@ -187,17 +185,15 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_approved', _approved);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -209,8 +205,7 @@ export class DummyERC721TokenContract extends BaseContract {
             _approved: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_approved', _approved);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
@@ -224,8 +219,7 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_approved', _approved);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -263,19 +257,16 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -297,9 +288,7 @@ export class DummyERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const txHashPromise = self.transferFrom.sendTransactionAsync(_from,
     _to,
@@ -323,19 +312,16 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -348,9 +334,7 @@ export class DummyERC721TokenContract extends BaseContract {
             _to: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
@@ -366,9 +350,7 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -406,17 +388,15 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('mint(address,uint256)', [_to,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -436,8 +416,7 @@ export class DummyERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const txHashPromise = self.mint.sendTransactionAsync(_to,
     _tokenId
@@ -459,17 +438,15 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('mint(address,uint256)', [_to,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -481,8 +458,7 @@ export class DummyERC721TokenContract extends BaseContract {
             _to: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('mint(address,uint256)', [_to,
     _tokenId
@@ -496,8 +472,7 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -535,19 +510,16 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -569,9 +541,7 @@ export class DummyERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const txHashPromise = self.safeTransferFrom1.sendTransactionAsync(_from,
     _to,
@@ -595,19 +565,16 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -620,9 +587,7 @@ export class DummyERC721TokenContract extends BaseContract {
             _to: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
@@ -638,9 +603,7 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -752,6 +715,7 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -786,6 +750,7 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -820,17 +785,15 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_owner', _owner);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_owner', _owner);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('burn(address,uint256)', [_owner,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -850,8 +813,7 @@ export class DummyERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_owner', _owner);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_owner', _owner);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const txHashPromise = self.burn.sendTransactionAsync(_owner,
     _tokenId
@@ -873,17 +835,15 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_owner', _owner);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_owner', _owner);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('burn(address,uint256)', [_owner,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -895,8 +855,7 @@ export class DummyERC721TokenContract extends BaseContract {
             _owner: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_owner', _owner);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_owner', _owner);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as DummyERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('burn(address,uint256)', [_owner,
     _tokenId
@@ -910,8 +869,7 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_owner', _owner);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_owner', _owner);assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -948,17 +906,15 @@ export class DummyERC721TokenContract extends BaseContract {
             _approved: boolean,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_operator', _operator);
-            assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -978,8 +934,7 @@ export class DummyERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_operator', _operator);
-            assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
             const self = this as any as DummyERC721TokenContract;
             const txHashPromise = self.setApprovalForAll.sendTransactionAsync(_operator,
     _approved
@@ -1001,17 +956,15 @@ export class DummyERC721TokenContract extends BaseContract {
             _approved: boolean,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_operator', _operator);
-            assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1023,8 +976,7 @@ export class DummyERC721TokenContract extends BaseContract {
             _operator: string,
             _approved: boolean,
         ): string {
-            assert.isString('_operator', _operator);
-            assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
             const self = this as any as DummyERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
@@ -1038,8 +990,7 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_operator', _operator);
-            assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1078,21 +1029,17 @@ export class DummyERC721TokenContract extends BaseContract {
             _data: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
-            assert.isString('_data', _data);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
     _tokenId,
     _data
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1116,10 +1063,7 @@ export class DummyERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
-            assert.isString('_data', _data);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
             const self = this as any as DummyERC721TokenContract;
             const txHashPromise = self.safeTransferFrom2.sendTransactionAsync(_from,
     _to,
@@ -1145,21 +1089,17 @@ export class DummyERC721TokenContract extends BaseContract {
             _data: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
-            assert.isString('_data', _data);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
     _tokenId,
     _data
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1173,10 +1113,7 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             _data: string,
         ): string {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
-            assert.isString('_data', _data);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
             const self = this as any as DummyERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
@@ -1194,10 +1131,7 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
-            assert.isString('_data', _data);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1238,8 +1172,7 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_owner', _owner);
-            assert.isString('_operator', _operator);
+            assert.isString('_owner', _owner);assert.isString('_operator', _operator);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1279,11 +1212,10 @@ export class DummyERC721TokenContract extends BaseContract {
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1325,11 +1257,10 @@ export class DummyERC721TokenContract extends BaseContract {
             const self = this as any as DummyERC721TokenContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1412,7 +1343,7 @@ _symbol
             _name: string,
             _symbol: string,
     ): Promise<DummyERC721TokenContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc721_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc721_token.ts
@@ -63,7 +63,6 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -135,26 +134,27 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
+        assert.isString('_approved', _approved);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as DummyERC721TokenContract;
+        const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.approve.estimateGasAsync.bind(
-                    self,
-                    _approved,
-                    _tokenId
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.approve.estimateGasAsync.bind(
+                self,
+                _approved,
+                _tokenId
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             _approved: string,
@@ -163,54 +163,57 @@ export class DummyERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as DummyERC721TokenContract;
-            const txHashPromise = self.approve.sendTransactionAsync(_approved,
+        assert.isString('_approved', _approved);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as DummyERC721TokenContract;
+        const txHashPromise = self.approve.sendTransactionAsync(_approved,
     _tokenId
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             _approved: string,
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
+        assert.isString('_approved', _approved);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as DummyERC721TokenContract;
+        const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             _approved: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as DummyERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
+        assert.isString('_approved', _approved);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as DummyERC721TokenContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             _approved: string,
@@ -219,7 +222,8 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);
+            assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -257,28 +261,30 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as DummyERC721TokenContract;
+        const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transferFrom.estimateGasAsync.bind(
-                    self,
-                    _from,
-                    _to,
-                    _tokenId
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.transferFrom.estimateGasAsync.bind(
+                self,
+                _from,
+                _to,
+                _tokenId
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             _from: string,
@@ -288,23 +294,25 @@ export class DummyERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as DummyERC721TokenContract;
-            const txHashPromise = self.transferFrom.sendTransactionAsync(_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as DummyERC721TokenContract;
+        const txHashPromise = self.transferFrom.sendTransactionAsync(_from,
     _to,
     _tokenId
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             _from: string,
@@ -312,35 +320,39 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as DummyERC721TokenContract;
+        const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             _from: string,
             _to: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as DummyERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as DummyERC721TokenContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             _from: string,
@@ -350,7 +362,9 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -388,26 +402,27 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('mint(address,uint256)', [_to,
+        assert.isString('_to', _to);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as DummyERC721TokenContract;
+        const encodedData = self._strictEncodeArguments('mint(address,uint256)', [_to,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.mint.estimateGasAsync.bind(
-                    self,
-                    _to,
-                    _tokenId
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.mint.estimateGasAsync.bind(
+                self,
+                _to,
+                _tokenId
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             _to: string,
@@ -416,54 +431,57 @@ export class DummyERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as DummyERC721TokenContract;
-            const txHashPromise = self.mint.sendTransactionAsync(_to,
+        assert.isString('_to', _to);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as DummyERC721TokenContract;
+        const txHashPromise = self.mint.sendTransactionAsync(_to,
     _tokenId
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             _to: string,
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('mint(address,uint256)', [_to,
+        assert.isString('_to', _to);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as DummyERC721TokenContract;
+        const encodedData = self._strictEncodeArguments('mint(address,uint256)', [_to,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             _to: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as DummyERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('mint(address,uint256)', [_to,
+        assert.isString('_to', _to);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as DummyERC721TokenContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('mint(address,uint256)', [_to,
     _tokenId
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             _to: string,
@@ -472,7 +490,8 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -510,28 +529,30 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as DummyERC721TokenContract;
+        const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.safeTransferFrom1.estimateGasAsync.bind(
-                    self,
-                    _from,
-                    _to,
-                    _tokenId
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.safeTransferFrom1.estimateGasAsync.bind(
+                self,
+                _from,
+                _to,
+                _tokenId
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             _from: string,
@@ -541,23 +562,25 @@ export class DummyERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as DummyERC721TokenContract;
-            const txHashPromise = self.safeTransferFrom1.sendTransactionAsync(_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as DummyERC721TokenContract;
+        const txHashPromise = self.safeTransferFrom1.sendTransactionAsync(_from,
     _to,
     _tokenId
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             _from: string,
@@ -565,35 +588,39 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as DummyERC721TokenContract;
+        const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             _from: string,
             _to: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as DummyERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as DummyERC721TokenContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             _from: string,
@@ -603,7 +630,9 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -715,7 +744,6 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -750,7 +778,6 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -785,26 +812,27 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_owner', _owner);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('burn(address,uint256)', [_owner,
+        assert.isString('_owner', _owner);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as DummyERC721TokenContract;
+        const encodedData = self._strictEncodeArguments('burn(address,uint256)', [_owner,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.burn.estimateGasAsync.bind(
-                    self,
-                    _owner,
-                    _tokenId
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.burn.estimateGasAsync.bind(
+                self,
+                _owner,
+                _tokenId
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             _owner: string,
@@ -813,54 +841,57 @@ export class DummyERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_owner', _owner);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as DummyERC721TokenContract;
-            const txHashPromise = self.burn.sendTransactionAsync(_owner,
+        assert.isString('_owner', _owner);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as DummyERC721TokenContract;
+        const txHashPromise = self.burn.sendTransactionAsync(_owner,
     _tokenId
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             _owner: string,
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_owner', _owner);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('burn(address,uint256)', [_owner,
+        assert.isString('_owner', _owner);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as DummyERC721TokenContract;
+        const encodedData = self._strictEncodeArguments('burn(address,uint256)', [_owner,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             _owner: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_owner', _owner);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as DummyERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('burn(address,uint256)', [_owner,
+        assert.isString('_owner', _owner);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as DummyERC721TokenContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('burn(address,uint256)', [_owner,
     _tokenId
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             _owner: string,
@@ -869,7 +900,8 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_owner', _owner);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_owner', _owner);
+            assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -906,26 +938,27 @@ export class DummyERC721TokenContract extends BaseContract {
             _approved: boolean,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
-            const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
+        assert.isString('_operator', _operator);
+        assert.isBoolean('_approved', _approved);
+        const self = this as any as DummyERC721TokenContract;
+        const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.setApprovalForAll.estimateGasAsync.bind(
-                    self,
-                    _operator,
-                    _approved
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.setApprovalForAll.estimateGasAsync.bind(
+                self,
+                _operator,
+                _approved
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             _operator: string,
@@ -934,54 +967,57 @@ export class DummyERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
-            const self = this as any as DummyERC721TokenContract;
-            const txHashPromise = self.setApprovalForAll.sendTransactionAsync(_operator,
+        assert.isString('_operator', _operator);
+        assert.isBoolean('_approved', _approved);
+        const self = this as any as DummyERC721TokenContract;
+        const txHashPromise = self.setApprovalForAll.sendTransactionAsync(_operator,
     _approved
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             _operator: string,
             _approved: boolean,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
-            const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
+        assert.isString('_operator', _operator);
+        assert.isBoolean('_approved', _approved);
+        const self = this as any as DummyERC721TokenContract;
+        const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             _operator: string,
             _approved: boolean,
         ): string {
-            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
-            const self = this as any as DummyERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
+        assert.isString('_operator', _operator);
+        assert.isBoolean('_approved', _approved);
+        const self = this as any as DummyERC721TokenContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             _operator: string,
@@ -990,7 +1026,8 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);
+            assert.isBoolean('_approved', _approved);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1029,30 +1066,33 @@ export class DummyERC721TokenContract extends BaseContract {
             _data: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
-            const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_tokenId', _tokenId);
+        assert.isString('_data', _data);
+        const self = this as any as DummyERC721TokenContract;
+        const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
     _tokenId,
     _data
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.safeTransferFrom2.estimateGasAsync.bind(
-                    self,
-                    _from,
-                    _to,
-                    _tokenId,
-                    _data
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.safeTransferFrom2.estimateGasAsync.bind(
+                self,
+                _from,
+                _to,
+                _tokenId,
+                _data
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             _from: string,
@@ -1063,24 +1103,27 @@ export class DummyERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
-            const self = this as any as DummyERC721TokenContract;
-            const txHashPromise = self.safeTransferFrom2.sendTransactionAsync(_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_tokenId', _tokenId);
+        assert.isString('_data', _data);
+        const self = this as any as DummyERC721TokenContract;
+        const txHashPromise = self.safeTransferFrom2.sendTransactionAsync(_from,
     _to,
     _tokenId,
     _data
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             _from: string,
@@ -1089,23 +1132,26 @@ export class DummyERC721TokenContract extends BaseContract {
             _data: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
-            const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_tokenId', _tokenId);
+        assert.isString('_data', _data);
+        const self = this as any as DummyERC721TokenContract;
+        const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
     _tokenId,
     _data
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             _from: string,
@@ -1113,14 +1159,17 @@ export class DummyERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             _data: string,
         ): string {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
-            const self = this as any as DummyERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_tokenId', _tokenId);
+        assert.isString('_data', _data);
+        const self = this as any as DummyERC721TokenContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
     _tokenId,
     _data
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             _from: string,
@@ -1131,7 +1180,10 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_data', _data);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1172,7 +1224,8 @@ export class DummyERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_owner', _owner);assert.isString('_operator', _operator);
+            assert.isString('_owner', _owner);
+            assert.isString('_operator', _operator);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1208,24 +1261,24 @@ export class DummyERC721TokenContract extends BaseContract {
             newOwner: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as DummyERC721TokenContract;
+        const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transferOwnership.estimateGasAsync.bind(
-                    self,
-                    newOwner
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.transferOwnership.estimateGasAsync.bind(
+                self,
+                newOwner
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             newOwner: string,
@@ -1233,49 +1286,49 @@ export class DummyERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as DummyERC721TokenContract;
-            const txHashPromise = self.transferOwnership.sendTransactionAsync(newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as DummyERC721TokenContract;
+        const txHashPromise = self.transferOwnership.sendTransactionAsync(newOwner
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             newOwner: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as DummyERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as DummyERC721TokenContract;
+        const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             newOwner: string,
         ): string {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as DummyERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as DummyERC721TokenContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             newOwner: string,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/dutch_auction.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/dutch_auction.ts
@@ -1,6 +1,6 @@
-// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma whitespace class-name
+// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma
+// tslint:disable:whitespace no-unbound-method no-trailing-whitespace
 // tslint:disable:no-unused-variable
-// tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
 import { schemas } from '@0x/json-schemas';
 import {
@@ -37,11 +37,10 @@ export class DutchAuctionContract extends BaseContract {
             const self = this as any as DutchAuctionContract;
             const encodedData = self._strictEncodeArguments('getAuctionDetails((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -83,11 +82,10 @@ export class DutchAuctionContract extends BaseContract {
             const self = this as any as DutchAuctionContract;
             const encodedData = self._strictEncodeArguments('getAuctionDetails((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -148,21 +146,17 @@ export class DutchAuctionContract extends BaseContract {
             sellSignature: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-
-
-            assert.isString('buySignature', buySignature);
-            assert.isString('sellSignature', sellSignature);
+            assert.isString('buySignature', buySignature);assert.isString('sellSignature', sellSignature);
             const self = this as any as DutchAuctionContract;
             const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [buyOrder,
     sellOrder,
     buySignature,
     sellSignature
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -186,10 +180,7 @@ export class DutchAuctionContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-
-
-            assert.isString('buySignature', buySignature);
-            assert.isString('sellSignature', sellSignature);
+            assert.isString('buySignature', buySignature);assert.isString('sellSignature', sellSignature);
             const self = this as any as DutchAuctionContract;
             const txHashPromise = self.matchOrders.sendTransactionAsync(buyOrder,
     sellOrder,
@@ -215,21 +206,17 @@ export class DutchAuctionContract extends BaseContract {
             sellSignature: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-
-
-            assert.isString('buySignature', buySignature);
-            assert.isString('sellSignature', sellSignature);
+            assert.isString('buySignature', buySignature);assert.isString('sellSignature', sellSignature);
             const self = this as any as DutchAuctionContract;
             const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [buyOrder,
     sellOrder,
     buySignature,
     sellSignature
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -243,10 +230,7 @@ export class DutchAuctionContract extends BaseContract {
             buySignature: string,
             sellSignature: string,
         ): string {
-
-
-            assert.isString('buySignature', buySignature);
-            assert.isString('sellSignature', sellSignature);
+            assert.isString('buySignature', buySignature);assert.isString('sellSignature', sellSignature);
             const self = this as any as DutchAuctionContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [buyOrder,
     sellOrder,
@@ -264,10 +248,7 @@ export class DutchAuctionContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{left: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};right: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};leftMakerAssetSpreadAmount: BigNumber}
         > {
-
-
-            assert.isString('buySignature', buySignature);
-            assert.isString('sellSignature', sellSignature);
+            assert.isString('buySignature', buySignature);assert.isString('sellSignature', sellSignature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -327,7 +308,7 @@ export class DutchAuctionContract extends BaseContract {
         txDefaults: Partial<TxData>,
             _exchange: string,
     ): Promise<DutchAuctionContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,
@@ -366,4 +347,5 @@ export class DutchAuctionContract extends BaseContract {
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count
-// tslint:enable:no-unbound-method
+// tslint:enable:no-unbound-method no-parameter-reassignment no-consecutive-blank-lines ordered-imports align
+// tslint:enable:trailing-comma whitespace no-trailing-whitespace

--- a/packages/abi-gen-wrappers/src/generated-wrappers/dutch_auction.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/dutch_auction.ts
@@ -2,6 +2,7 @@
 // tslint:disable:no-unused-variable
 // tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
+import { schemas } from '@0x/json-schemas';
 import {
     BlockParam,
     BlockParamLiteral,
@@ -18,6 +19,7 @@ import {
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
+import { assert } from '@0x/assert';
 import * as ethers from 'ethers';
 // tslint:enable:no-unused-variable
 
@@ -29,15 +31,17 @@ export class DutchAuctionContract extends BaseContract {
     public getAuctionDetails = {
         async sendTransactionAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+
             const self = this as any as DutchAuctionContract;
             const encodedData = self._strictEncodeArguments('getAuctionDetails((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -51,17 +55,11 @@ export class DutchAuctionContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+
             const self = this as any as DutchAuctionContract;
             const txHashPromise = self.getAuctionDetails.sendTransactionAsync(order
     , txData);
@@ -79,15 +77,17 @@ export class DutchAuctionContract extends BaseContract {
         },
         async estimateGasAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+
             const self = this as any as DutchAuctionContract;
             const encodedData = self._strictEncodeArguments('getAuctionDetails((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -98,6 +98,7 @@ export class DutchAuctionContract extends BaseContract {
         getABIEncodedTransactionData(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
         ): string {
+
             const self = this as any as DutchAuctionContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('getAuctionDetails((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
     ]);
@@ -109,6 +110,15 @@ export class DutchAuctionContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{beginTimeSeconds: BigNumber;endTimeSeconds: BigNumber;beginAmount: BigNumber;endAmount: BigNumber;currentAmount: BigNumber;currentTimeSeconds: BigNumber}
         > {
+
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DutchAuctionContract;
             const encodedData = self._strictEncodeArguments('getAuctionDetails((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
         ]);
@@ -136,18 +146,23 @@ export class DutchAuctionContract extends BaseContract {
             sellOrder: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             buySignature: string,
             sellSignature: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+
+
+            assert.isString('buySignature', buySignature);
+            assert.isString('sellSignature', sellSignature);
             const self = this as any as DutchAuctionContract;
             const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [buyOrder,
     sellOrder,
     buySignature,
     sellSignature
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -167,17 +182,14 @@ export class DutchAuctionContract extends BaseContract {
             sellOrder: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             buySignature: string,
             sellSignature: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+
+
+            assert.isString('buySignature', buySignature);
+            assert.isString('sellSignature', sellSignature);
             const self = this as any as DutchAuctionContract;
             const txHashPromise = self.matchOrders.sendTransactionAsync(buyOrder,
     sellOrder,
@@ -201,18 +213,23 @@ export class DutchAuctionContract extends BaseContract {
             sellOrder: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             buySignature: string,
             sellSignature: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+
+
+            assert.isString('buySignature', buySignature);
+            assert.isString('sellSignature', sellSignature);
             const self = this as any as DutchAuctionContract;
             const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [buyOrder,
     sellOrder,
     buySignature,
     sellSignature
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -226,6 +243,10 @@ export class DutchAuctionContract extends BaseContract {
             buySignature: string,
             sellSignature: string,
         ): string {
+
+
+            assert.isString('buySignature', buySignature);
+            assert.isString('sellSignature', sellSignature);
             const self = this as any as DutchAuctionContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [buyOrder,
     sellOrder,
@@ -243,6 +264,18 @@ export class DutchAuctionContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{left: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};right: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};leftMakerAssetSpreadAmount: BigNumber}
         > {
+
+
+            assert.isString('buySignature', buySignature);
+            assert.isString('sellSignature', sellSignature);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as DutchAuctionContract;
             const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [buyOrder,
         sellOrder,
@@ -273,6 +306,11 @@ export class DutchAuctionContract extends BaseContract {
         txDefaults: Partial<TxData>,
             _exchange: string,
     ): Promise<DutchAuctionContract> {
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         if (artifact.compilerOutput === undefined) {
             throw new Error('Compiler output not found in the artifact file');
         }
@@ -289,6 +327,12 @@ export class DutchAuctionContract extends BaseContract {
         txDefaults: Partial<TxData>,
             _exchange: string,
     ): Promise<DutchAuctionContract> {
+        assert.isString('bytecode', bytecode);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
         const constructorAbi = BaseContract._lookupConstructorAbi(abi);
         [_exchange

--- a/packages/abi-gen-wrappers/src/generated-wrappers/dutch_auction.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/dutch_auction.ts
@@ -34,23 +34,23 @@ export class DutchAuctionContract extends BaseContract {
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
 
-            const self = this as any as DutchAuctionContract;
-            const encodedData = self._strictEncodeArguments('getAuctionDetails((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
+        const self = this as any as DutchAuctionContract;
+        const encodedData = self._strictEncodeArguments('getAuctionDetails((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.getAuctionDetails.estimateGasAsync.bind(
-                    self,
-                    order
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.getAuctionDetails.estimateGasAsync.bind(
+                self,
+                order
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
@@ -59,48 +59,48 @@ export class DutchAuctionContract extends BaseContract {
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
 
-            const self = this as any as DutchAuctionContract;
-            const txHashPromise = self.getAuctionDetails.sendTransactionAsync(order
+        const self = this as any as DutchAuctionContract;
+        const txHashPromise = self.getAuctionDetails.sendTransactionAsync(order
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
 
-            const self = this as any as DutchAuctionContract;
-            const encodedData = self._strictEncodeArguments('getAuctionDetails((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
+        const self = this as any as DutchAuctionContract;
+        const encodedData = self._strictEncodeArguments('getAuctionDetails((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
         ): string {
 
-            const self = this as any as DutchAuctionContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('getAuctionDetails((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
+        const self = this as any as DutchAuctionContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('getAuctionDetails((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
@@ -146,30 +146,33 @@ export class DutchAuctionContract extends BaseContract {
             sellSignature: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('buySignature', buySignature);assert.isString('sellSignature', sellSignature);
-            const self = this as any as DutchAuctionContract;
-            const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [buyOrder,
+
+
+        assert.isString('buySignature', buySignature);
+        assert.isString('sellSignature', sellSignature);
+        const self = this as any as DutchAuctionContract;
+        const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [buyOrder,
     sellOrder,
     buySignature,
     sellSignature
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.matchOrders.estimateGasAsync.bind(
-                    self,
-                    buyOrder,
-                    sellOrder,
-                    buySignature,
-                    sellSignature
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.matchOrders.estimateGasAsync.bind(
+                self,
+                buyOrder,
+                sellOrder,
+                buySignature,
+                sellSignature
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             buyOrder: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
@@ -180,24 +183,27 @@ export class DutchAuctionContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('buySignature', buySignature);assert.isString('sellSignature', sellSignature);
-            const self = this as any as DutchAuctionContract;
-            const txHashPromise = self.matchOrders.sendTransactionAsync(buyOrder,
+
+
+        assert.isString('buySignature', buySignature);
+        assert.isString('sellSignature', sellSignature);
+        const self = this as any as DutchAuctionContract;
+        const txHashPromise = self.matchOrders.sendTransactionAsync(buyOrder,
     sellOrder,
     buySignature,
     sellSignature
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             buyOrder: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
@@ -206,23 +212,26 @@ export class DutchAuctionContract extends BaseContract {
             sellSignature: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('buySignature', buySignature);assert.isString('sellSignature', sellSignature);
-            const self = this as any as DutchAuctionContract;
-            const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [buyOrder,
+
+
+        assert.isString('buySignature', buySignature);
+        assert.isString('sellSignature', sellSignature);
+        const self = this as any as DutchAuctionContract;
+        const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [buyOrder,
     sellOrder,
     buySignature,
     sellSignature
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             buyOrder: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
@@ -230,14 +239,17 @@ export class DutchAuctionContract extends BaseContract {
             buySignature: string,
             sellSignature: string,
         ): string {
-            assert.isString('buySignature', buySignature);assert.isString('sellSignature', sellSignature);
-            const self = this as any as DutchAuctionContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [buyOrder,
+
+
+        assert.isString('buySignature', buySignature);
+        assert.isString('sellSignature', sellSignature);
+        const self = this as any as DutchAuctionContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [buyOrder,
     sellOrder,
     buySignature,
     sellSignature
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             buyOrder: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
@@ -248,7 +260,10 @@ export class DutchAuctionContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{left: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};right: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};leftMakerAssetSpreadAmount: BigNumber}
         > {
-            assert.isString('buySignature', buySignature);assert.isString('sellSignature', sellSignature);
+
+
+            assert.isString('buySignature', buySignature);
+            assert.isString('sellSignature', sellSignature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/dutch_auction.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/dutch_auction.ts
@@ -37,10 +37,11 @@ export class DutchAuctionContract extends BaseContract {
             const self = this as any as DutchAuctionContract;
             const encodedData = self._strictEncodeArguments('getAuctionDetails((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -82,10 +83,11 @@ export class DutchAuctionContract extends BaseContract {
             const self = this as any as DutchAuctionContract;
             const encodedData = self._strictEncodeArguments('getAuctionDetails((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -146,17 +148,21 @@ export class DutchAuctionContract extends BaseContract {
             sellSignature: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('buySignature', buySignature);assert.isString('sellSignature', sellSignature);
+
+
+            assert.isString('buySignature', buySignature);
+            assert.isString('sellSignature', sellSignature);
             const self = this as any as DutchAuctionContract;
             const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [buyOrder,
     sellOrder,
     buySignature,
     sellSignature
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -180,7 +186,10 @@ export class DutchAuctionContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('buySignature', buySignature);assert.isString('sellSignature', sellSignature);
+
+
+            assert.isString('buySignature', buySignature);
+            assert.isString('sellSignature', sellSignature);
             const self = this as any as DutchAuctionContract;
             const txHashPromise = self.matchOrders.sendTransactionAsync(buyOrder,
     sellOrder,
@@ -206,17 +215,21 @@ export class DutchAuctionContract extends BaseContract {
             sellSignature: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('buySignature', buySignature);assert.isString('sellSignature', sellSignature);
+
+
+            assert.isString('buySignature', buySignature);
+            assert.isString('sellSignature', sellSignature);
             const self = this as any as DutchAuctionContract;
             const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [buyOrder,
     sellOrder,
     buySignature,
     sellSignature
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -230,7 +243,10 @@ export class DutchAuctionContract extends BaseContract {
             buySignature: string,
             sellSignature: string,
         ): string {
-            assert.isString('buySignature', buySignature);assert.isString('sellSignature', sellSignature);
+
+
+            assert.isString('buySignature', buySignature);
+            assert.isString('sellSignature', sellSignature);
             const self = this as any as DutchAuctionContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [buyOrder,
     sellOrder,
@@ -248,7 +264,10 @@ export class DutchAuctionContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{left: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};right: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};leftMakerAssetSpreadAmount: BigNumber}
         > {
-            assert.isString('buySignature', buySignature);assert.isString('sellSignature', sellSignature);
+
+
+            assert.isString('buySignature', buySignature);
+            assert.isString('sellSignature', sellSignature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -308,7 +327,7 @@ export class DutchAuctionContract extends BaseContract {
         txDefaults: Partial<TxData>,
             _exchange: string,
     ): Promise<DutchAuctionContract> {
-        assert.isHexString('bytecode', bytecode);
+        assert.isString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/dutch_auction.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/dutch_auction.ts
@@ -37,11 +37,10 @@ export class DutchAuctionContract extends BaseContract {
             const self = this as any as DutchAuctionContract;
             const encodedData = self._strictEncodeArguments('getAuctionDetails((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -83,11 +82,10 @@ export class DutchAuctionContract extends BaseContract {
             const self = this as any as DutchAuctionContract;
             const encodedData = self._strictEncodeArguments('getAuctionDetails((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -148,21 +146,17 @@ export class DutchAuctionContract extends BaseContract {
             sellSignature: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-
-
-            assert.isString('buySignature', buySignature);
-            assert.isString('sellSignature', sellSignature);
+            assert.isString('buySignature', buySignature);assert.isString('sellSignature', sellSignature);
             const self = this as any as DutchAuctionContract;
             const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [buyOrder,
     sellOrder,
     buySignature,
     sellSignature
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -186,10 +180,7 @@ export class DutchAuctionContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-
-
-            assert.isString('buySignature', buySignature);
-            assert.isString('sellSignature', sellSignature);
+            assert.isString('buySignature', buySignature);assert.isString('sellSignature', sellSignature);
             const self = this as any as DutchAuctionContract;
             const txHashPromise = self.matchOrders.sendTransactionAsync(buyOrder,
     sellOrder,
@@ -215,21 +206,17 @@ export class DutchAuctionContract extends BaseContract {
             sellSignature: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-
-
-            assert.isString('buySignature', buySignature);
-            assert.isString('sellSignature', sellSignature);
+            assert.isString('buySignature', buySignature);assert.isString('sellSignature', sellSignature);
             const self = this as any as DutchAuctionContract;
             const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [buyOrder,
     sellOrder,
     buySignature,
     sellSignature
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -243,10 +230,7 @@ export class DutchAuctionContract extends BaseContract {
             buySignature: string,
             sellSignature: string,
         ): string {
-
-
-            assert.isString('buySignature', buySignature);
-            assert.isString('sellSignature', sellSignature);
+            assert.isString('buySignature', buySignature);assert.isString('sellSignature', sellSignature);
             const self = this as any as DutchAuctionContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [buyOrder,
     sellOrder,
@@ -264,10 +248,7 @@ export class DutchAuctionContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{left: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};right: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};leftMakerAssetSpreadAmount: BigNumber}
         > {
-
-
-            assert.isString('buySignature', buySignature);
-            assert.isString('sellSignature', sellSignature);
+            assert.isString('buySignature', buySignature);assert.isString('sellSignature', sellSignature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -327,7 +308,7 @@ export class DutchAuctionContract extends BaseContract {
         txDefaults: Partial<TxData>,
             _exchange: string,
     ): Promise<DutchAuctionContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc20_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc20_proxy.ts
@@ -1,6 +1,6 @@
-// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma whitespace class-name
+// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma
+// tslint:disable:whitespace no-unbound-method no-trailing-whitespace
 // tslint:disable:no-unused-variable
-// tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
 import { schemas } from '@0x/json-schemas';
 import {
@@ -56,11 +56,10 @@ export class ERC20ProxyContract extends BaseContract {
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -102,11 +101,10 @@ export class ERC20ProxyContract extends BaseContract {
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -205,11 +203,10 @@ export class ERC20ProxyContract extends BaseContract {
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -251,11 +248,10 @@ export class ERC20ProxyContract extends BaseContract {
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -314,6 +310,7 @@ export class ERC20ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -348,17 +345,15 @@ export class ERC20ProxyContract extends BaseContract {
             index: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -378,8 +373,7 @@ export class ERC20ProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as ERC20ProxyContract;
             const txHashPromise = self.removeAuthorizedAddressAtIndex.sendTransactionAsync(target,
     index
@@ -401,17 +395,15 @@ export class ERC20ProxyContract extends BaseContract {
             index: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -423,8 +415,7 @@ export class ERC20ProxyContract extends BaseContract {
             target: string,
             index: BigNumber,
         ): string {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as ERC20ProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
@@ -438,8 +429,7 @@ export class ERC20ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -476,6 +466,7 @@ export class ERC20ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -547,6 +538,7 @@ export class ERC20ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -584,11 +576,10 @@ export class ERC20ProxyContract extends BaseContract {
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -630,11 +621,10 @@ export class ERC20ProxyContract extends BaseContract {
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -711,7 +701,7 @@ export class ERC20ProxyContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<ERC20ProxyContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,
@@ -746,4 +736,5 @@ export class ERC20ProxyContract extends BaseContract {
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count
-// tslint:enable:no-unbound-method
+// tslint:enable:no-unbound-method no-parameter-reassignment no-consecutive-blank-lines ordered-imports align
+// tslint:enable:trailing-comma whitespace no-trailing-whitespace

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc20_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc20_proxy.ts
@@ -2,6 +2,7 @@
 // tslint:disable:no-unused-variable
 // tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
+import { schemas } from '@0x/json-schemas';
 import {
     BlockParam,
     BlockParamLiteral,
@@ -18,6 +19,7 @@ import {
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
+import { assert } from '@0x/assert';
 import * as ethers from 'ethers';
 // tslint:enable:no-unused-variable
 
@@ -48,15 +50,17 @@ export class ERC20ProxyContract extends BaseContract {
     public addAuthorizedAddress = {
         async sendTransactionAsync(
             target: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('target', target);
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -70,17 +74,11 @@ export class ERC20ProxyContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             target: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('target', target);
             const self = this as any as ERC20ProxyContract;
             const txHashPromise = self.addAuthorizedAddress.sendTransactionAsync(target
     , txData);
@@ -98,15 +96,17 @@ export class ERC20ProxyContract extends BaseContract {
         },
         async estimateGasAsync(
             target: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('target', target);
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -117,6 +117,7 @@ export class ERC20ProxyContract extends BaseContract {
         getABIEncodedTransactionData(
             target: string,
         ): string {
+            assert.isString('target', target);
             const self = this as any as ERC20ProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
@@ -128,6 +129,15 @@ export class ERC20ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('target', target);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
         ]);
@@ -156,6 +166,15 @@ export class ERC20ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.isBigNumber('index_0', index_0);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('authorities(uint256)', [index_0
         ]);
@@ -180,15 +199,17 @@ export class ERC20ProxyContract extends BaseContract {
     public removeAuthorizedAddress = {
         async sendTransactionAsync(
             target: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('target', target);
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -202,17 +223,11 @@ export class ERC20ProxyContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             target: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('target', target);
             const self = this as any as ERC20ProxyContract;
             const txHashPromise = self.removeAuthorizedAddress.sendTransactionAsync(target
     , txData);
@@ -230,15 +245,17 @@ export class ERC20ProxyContract extends BaseContract {
         },
         async estimateGasAsync(
             target: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('target', target);
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -249,6 +266,7 @@ export class ERC20ProxyContract extends BaseContract {
         getABIEncodedTransactionData(
             target: string,
         ): string {
+            assert.isString('target', target);
             const self = this as any as ERC20ProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
@@ -260,6 +278,15 @@ export class ERC20ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('target', target);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
         ]);
@@ -287,6 +314,14 @@ export class ERC20ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('owner()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -311,16 +346,19 @@ export class ERC20ProxyContract extends BaseContract {
         async sendTransactionAsync(
             target: string,
             index: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -336,17 +374,12 @@ export class ERC20ProxyContract extends BaseContract {
         awaitTransactionSuccessAsync(
             target: string,
             index: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as ERC20ProxyContract;
             const txHashPromise = self.removeAuthorizedAddressAtIndex.sendTransactionAsync(target,
     index
@@ -366,16 +399,19 @@ export class ERC20ProxyContract extends BaseContract {
         async estimateGasAsync(
             target: string,
             index: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -387,6 +423,8 @@ export class ERC20ProxyContract extends BaseContract {
             target: string,
             index: BigNumber,
         ): string {
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as ERC20ProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
@@ -400,6 +438,16 @@ export class ERC20ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
         index
@@ -428,6 +476,14 @@ export class ERC20ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('getProxyId()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -455,6 +511,15 @@ export class ERC20ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
+            assert.isString('index_0', index_0);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('authorized(address)', [index_0
         ]);
@@ -482,6 +547,14 @@ export class ERC20ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('getAuthorizedAddresses()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -505,15 +578,17 @@ export class ERC20ProxyContract extends BaseContract {
     public transferOwnership = {
         async sendTransactionAsync(
             newOwner: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('newOwner', newOwner);
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -527,17 +602,11 @@ export class ERC20ProxyContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             newOwner: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('newOwner', newOwner);
             const self = this as any as ERC20ProxyContract;
             const txHashPromise = self.transferOwnership.sendTransactionAsync(newOwner
     , txData);
@@ -555,15 +624,17 @@ export class ERC20ProxyContract extends BaseContract {
         },
         async estimateGasAsync(
             newOwner: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('newOwner', newOwner);
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -574,6 +645,7 @@ export class ERC20ProxyContract extends BaseContract {
         getABIEncodedTransactionData(
             newOwner: string,
         ): string {
+            assert.isString('newOwner', newOwner);
             const self = this as any as ERC20ProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
@@ -585,6 +657,15 @@ export class ERC20ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('newOwner', newOwner);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
         ]);
@@ -611,6 +692,11 @@ export class ERC20ProxyContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<ERC20ProxyContract> {
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         if (artifact.compilerOutput === undefined) {
             throw new Error('Compiler output not found in the artifact file');
         }
@@ -625,6 +711,12 @@ export class ERC20ProxyContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<ERC20ProxyContract> {
+        assert.isString('bytecode', bytecode);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
         const constructorAbi = BaseContract._lookupConstructorAbi(abi);
         [] = BaseContract._formatABIDataItemList(

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc20_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc20_proxy.ts
@@ -52,24 +52,24 @@ export class ERC20ProxyContract extends BaseContract {
             target: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('target', target);
-            const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
+        assert.isString('target', target);
+        const self = this as any as ERC20ProxyContract;
+        const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.addAuthorizedAddress.estimateGasAsync.bind(
-                    self,
-                    target
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.addAuthorizedAddress.estimateGasAsync.bind(
+                self,
+                target
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             target: string,
@@ -77,49 +77,49 @@ export class ERC20ProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('target', target);
-            const self = this as any as ERC20ProxyContract;
-            const txHashPromise = self.addAuthorizedAddress.sendTransactionAsync(target
+        assert.isString('target', target);
+        const self = this as any as ERC20ProxyContract;
+        const txHashPromise = self.addAuthorizedAddress.sendTransactionAsync(target
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             target: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('target', target);
-            const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
+        assert.isString('target', target);
+        const self = this as any as ERC20ProxyContract;
+        const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             target: string,
         ): string {
-            assert.isString('target', target);
-            const self = this as any as ERC20ProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
+        assert.isString('target', target);
+        const self = this as any as ERC20ProxyContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             target: string,
@@ -199,24 +199,24 @@ export class ERC20ProxyContract extends BaseContract {
             target: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('target', target);
-            const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
+        assert.isString('target', target);
+        const self = this as any as ERC20ProxyContract;
+        const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.removeAuthorizedAddress.estimateGasAsync.bind(
-                    self,
-                    target
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.removeAuthorizedAddress.estimateGasAsync.bind(
+                self,
+                target
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             target: string,
@@ -224,49 +224,49 @@ export class ERC20ProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('target', target);
-            const self = this as any as ERC20ProxyContract;
-            const txHashPromise = self.removeAuthorizedAddress.sendTransactionAsync(target
+        assert.isString('target', target);
+        const self = this as any as ERC20ProxyContract;
+        const txHashPromise = self.removeAuthorizedAddress.sendTransactionAsync(target
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             target: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('target', target);
-            const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
+        assert.isString('target', target);
+        const self = this as any as ERC20ProxyContract;
+        const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             target: string,
         ): string {
-            assert.isString('target', target);
-            const self = this as any as ERC20ProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
+        assert.isString('target', target);
+        const self = this as any as ERC20ProxyContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             target: string,
@@ -310,7 +310,6 @@ export class ERC20ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -345,26 +344,27 @@ export class ERC20ProxyContract extends BaseContract {
             index: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('target', target);assert.isBigNumber('index', index);
-            const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
+        assert.isString('target', target);
+        assert.isBigNumber('index', index);
+        const self = this as any as ERC20ProxyContract;
+        const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.removeAuthorizedAddressAtIndex.estimateGasAsync.bind(
-                    self,
-                    target,
-                    index
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.removeAuthorizedAddressAtIndex.estimateGasAsync.bind(
+                self,
+                target,
+                index
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             target: string,
@@ -373,54 +373,57 @@ export class ERC20ProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('target', target);assert.isBigNumber('index', index);
-            const self = this as any as ERC20ProxyContract;
-            const txHashPromise = self.removeAuthorizedAddressAtIndex.sendTransactionAsync(target,
+        assert.isString('target', target);
+        assert.isBigNumber('index', index);
+        const self = this as any as ERC20ProxyContract;
+        const txHashPromise = self.removeAuthorizedAddressAtIndex.sendTransactionAsync(target,
     index
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             target: string,
             index: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('target', target);assert.isBigNumber('index', index);
-            const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
+        assert.isString('target', target);
+        assert.isBigNumber('index', index);
+        const self = this as any as ERC20ProxyContract;
+        const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             target: string,
             index: BigNumber,
         ): string {
-            assert.isString('target', target);assert.isBigNumber('index', index);
-            const self = this as any as ERC20ProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
+        assert.isString('target', target);
+        assert.isBigNumber('index', index);
+        const self = this as any as ERC20ProxyContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             target: string,
@@ -429,7 +432,8 @@ export class ERC20ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('target', target);assert.isBigNumber('index', index);
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -466,7 +470,6 @@ export class ERC20ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -538,7 +541,6 @@ export class ERC20ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -572,24 +574,24 @@ export class ERC20ProxyContract extends BaseContract {
             newOwner: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as ERC20ProxyContract;
+        const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transferOwnership.estimateGasAsync.bind(
-                    self,
-                    newOwner
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.transferOwnership.estimateGasAsync.bind(
+                self,
+                newOwner
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             newOwner: string,
@@ -597,49 +599,49 @@ export class ERC20ProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as ERC20ProxyContract;
-            const txHashPromise = self.transferOwnership.sendTransactionAsync(newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as ERC20ProxyContract;
+        const txHashPromise = self.transferOwnership.sendTransactionAsync(newOwner
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             newOwner: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as ERC20ProxyContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as ERC20ProxyContract;
+        const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             newOwner: string,
         ): string {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as ERC20ProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as ERC20ProxyContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             newOwner: string,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc20_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc20_proxy.ts
@@ -56,11 +56,10 @@ export class ERC20ProxyContract extends BaseContract {
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -102,11 +101,10 @@ export class ERC20ProxyContract extends BaseContract {
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -205,11 +203,10 @@ export class ERC20ProxyContract extends BaseContract {
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -251,11 +248,10 @@ export class ERC20ProxyContract extends BaseContract {
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -314,6 +310,7 @@ export class ERC20ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -348,17 +345,15 @@ export class ERC20ProxyContract extends BaseContract {
             index: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -378,8 +373,7 @@ export class ERC20ProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as ERC20ProxyContract;
             const txHashPromise = self.removeAuthorizedAddressAtIndex.sendTransactionAsync(target,
     index
@@ -401,17 +395,15 @@ export class ERC20ProxyContract extends BaseContract {
             index: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -423,8 +415,7 @@ export class ERC20ProxyContract extends BaseContract {
             target: string,
             index: BigNumber,
         ): string {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as ERC20ProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
@@ -438,8 +429,7 @@ export class ERC20ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -476,6 +466,7 @@ export class ERC20ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -547,6 +538,7 @@ export class ERC20ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -584,11 +576,10 @@ export class ERC20ProxyContract extends BaseContract {
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -630,11 +621,10 @@ export class ERC20ProxyContract extends BaseContract {
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -711,7 +701,7 @@ export class ERC20ProxyContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<ERC20ProxyContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc20_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc20_proxy.ts
@@ -56,10 +56,11 @@ export class ERC20ProxyContract extends BaseContract {
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -101,10 +102,11 @@ export class ERC20ProxyContract extends BaseContract {
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -203,10 +205,11 @@ export class ERC20ProxyContract extends BaseContract {
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -248,10 +251,11 @@ export class ERC20ProxyContract extends BaseContract {
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -310,7 +314,6 @@ export class ERC20ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -345,15 +348,17 @@ export class ERC20ProxyContract extends BaseContract {
             index: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('target', target);assert.isBigNumber('index', index);
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -373,7 +378,8 @@ export class ERC20ProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('target', target);assert.isBigNumber('index', index);
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as ERC20ProxyContract;
             const txHashPromise = self.removeAuthorizedAddressAtIndex.sendTransactionAsync(target,
     index
@@ -395,15 +401,17 @@ export class ERC20ProxyContract extends BaseContract {
             index: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('target', target);assert.isBigNumber('index', index);
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -415,7 +423,8 @@ export class ERC20ProxyContract extends BaseContract {
             target: string,
             index: BigNumber,
         ): string {
-            assert.isString('target', target);assert.isBigNumber('index', index);
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as ERC20ProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
@@ -429,7 +438,8 @@ export class ERC20ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('target', target);assert.isBigNumber('index', index);
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -466,7 +476,6 @@ export class ERC20ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -538,7 +547,6 @@ export class ERC20ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -576,10 +584,11 @@ export class ERC20ProxyContract extends BaseContract {
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -621,10 +630,11 @@ export class ERC20ProxyContract extends BaseContract {
             const self = this as any as ERC20ProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -701,7 +711,7 @@ export class ERC20ProxyContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<ERC20ProxyContract> {
-        assert.isHexString('bytecode', bytecode);
+        assert.isString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc20_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc20_token.ts
@@ -2,6 +2,7 @@
 // tslint:disable:no-unused-variable
 // tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
+import { schemas } from '@0x/json-schemas';
 import {
     BlockParam,
     BlockParamLiteral,
@@ -18,6 +19,7 @@ import {
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
+import { assert } from '@0x/assert';
 import * as ethers from 'ethers';
 // tslint:enable:no-unused-variable
 
@@ -51,16 +53,19 @@ export class ERC20TokenContract extends BaseContract {
         async sendTransactionAsync(
             _spender: string,
             _value: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -76,17 +81,12 @@ export class ERC20TokenContract extends BaseContract {
         awaitTransactionSuccessAsync(
             _spender: string,
             _value: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const txHashPromise = self.approve.sendTransactionAsync(_spender,
     _value
@@ -106,16 +106,19 @@ export class ERC20TokenContract extends BaseContract {
         async estimateGasAsync(
             _spender: string,
             _value: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -127,6 +130,8 @@ export class ERC20TokenContract extends BaseContract {
             _spender: string,
             _value: BigNumber,
         ): string {
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
@@ -140,6 +145,16 @@ export class ERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC20TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
         _value
@@ -168,6 +183,14 @@ export class ERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC20TokenContract;
             const encodedData = self._strictEncodeArguments('totalSupply()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -193,17 +216,21 @@ export class ERC20TokenContract extends BaseContract {
             _from: string,
             _to: string,
             _value: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -221,17 +248,13 @@ export class ERC20TokenContract extends BaseContract {
             _from: string,
             _to: string,
             _value: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const txHashPromise = self.transferFrom.sendTransactionAsync(_from,
     _to,
@@ -253,17 +276,21 @@ export class ERC20TokenContract extends BaseContract {
             _from: string,
             _to: string,
             _value: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -276,6 +303,9 @@ export class ERC20TokenContract extends BaseContract {
             _to: string,
             _value: BigNumber,
         ): string {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
@@ -291,6 +321,17 @@ export class ERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
         _to,
@@ -321,6 +362,15 @@ export class ERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+            assert.isString('_owner', _owner);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC20TokenContract;
             const encodedData = self._strictEncodeArguments('balanceOf(address)', [_owner
         ]);
@@ -346,16 +396,19 @@ export class ERC20TokenContract extends BaseContract {
         async sendTransactionAsync(
             _to: string,
             _value: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -371,17 +424,12 @@ export class ERC20TokenContract extends BaseContract {
         awaitTransactionSuccessAsync(
             _to: string,
             _value: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const txHashPromise = self.transfer.sendTransactionAsync(_to,
     _value
@@ -401,16 +449,19 @@ export class ERC20TokenContract extends BaseContract {
         async estimateGasAsync(
             _to: string,
             _value: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -422,6 +473,8 @@ export class ERC20TokenContract extends BaseContract {
             _to: string,
             _value: BigNumber,
         ): string {
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
@@ -435,6 +488,16 @@ export class ERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
         _value
@@ -465,6 +528,16 @@ export class ERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+            assert.isString('_owner', _owner);
+            assert.isString('_spender', _spender);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC20TokenContract;
             const encodedData = self._strictEncodeArguments('allowance(address,address)', [_owner,
         _spender
@@ -492,6 +565,11 @@ export class ERC20TokenContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<ERC20TokenContract> {
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         if (artifact.compilerOutput === undefined) {
             throw new Error('Compiler output not found in the artifact file');
         }
@@ -506,6 +584,12 @@ export class ERC20TokenContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<ERC20TokenContract> {
+        assert.isString('bytecode', bytecode);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
         const constructorAbi = BaseContract._lookupConstructorAbi(abi);
         [] = BaseContract._formatABIDataItemList(

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc20_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc20_token.ts
@@ -1,6 +1,6 @@
-// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma whitespace class-name
+// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma
+// tslint:disable:whitespace no-unbound-method no-trailing-whitespace
 // tslint:disable:no-unused-variable
-// tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
 import { schemas } from '@0x/json-schemas';
 import {
@@ -55,17 +55,15 @@ export class ERC20TokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_spender', _spender);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -85,8 +83,7 @@ export class ERC20TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_spender', _spender);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const txHashPromise = self.approve.sendTransactionAsync(_spender,
     _value
@@ -108,17 +105,15 @@ export class ERC20TokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_spender', _spender);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -130,8 +125,7 @@ export class ERC20TokenContract extends BaseContract {
             _spender: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_spender', _spender);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
@@ -145,8 +139,7 @@ export class ERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_spender', _spender);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -183,6 +176,7 @@ export class ERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -218,19 +212,16 @@ export class ERC20TokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -252,9 +243,7 @@ export class ERC20TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const txHashPromise = self.transferFrom.sendTransactionAsync(_from,
     _to,
@@ -278,19 +267,16 @@ export class ERC20TokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -303,9 +289,7 @@ export class ERC20TokenContract extends BaseContract {
             _to: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
@@ -321,9 +305,7 @@ export class ERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -398,17 +380,15 @@ export class ERC20TokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -428,8 +408,7 @@ export class ERC20TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const txHashPromise = self.transfer.sendTransactionAsync(_to,
     _value
@@ -451,17 +430,15 @@ export class ERC20TokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -473,8 +450,7 @@ export class ERC20TokenContract extends BaseContract {
             _to: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
@@ -488,8 +464,7 @@ export class ERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -528,8 +503,7 @@ export class ERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-            assert.isString('_owner', _owner);
-            assert.isString('_spender', _spender);
+            assert.isString('_owner', _owner);assert.isString('_spender', _spender);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -584,7 +558,7 @@ export class ERC20TokenContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<ERC20TokenContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,
@@ -619,4 +593,5 @@ export class ERC20TokenContract extends BaseContract {
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count
-// tslint:enable:no-unbound-method
+// tslint:enable:no-unbound-method no-parameter-reassignment no-consecutive-blank-lines ordered-imports align
+// tslint:enable:trailing-comma whitespace no-trailing-whitespace

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc20_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc20_token.ts
@@ -55,26 +55,27 @@ export class ERC20TokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
-            const self = this as any as ERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
+        assert.isString('_spender', _spender);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as ERC20TokenContract;
+        const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.approve.estimateGasAsync.bind(
-                    self,
-                    _spender,
-                    _value
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.approve.estimateGasAsync.bind(
+                self,
+                _spender,
+                _value
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             _spender: string,
@@ -83,54 +84,57 @@ export class ERC20TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
-            const self = this as any as ERC20TokenContract;
-            const txHashPromise = self.approve.sendTransactionAsync(_spender,
+        assert.isString('_spender', _spender);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as ERC20TokenContract;
+        const txHashPromise = self.approve.sendTransactionAsync(_spender,
     _value
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             _spender: string,
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
-            const self = this as any as ERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
+        assert.isString('_spender', _spender);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as ERC20TokenContract;
+        const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             _spender: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
-            const self = this as any as ERC20TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
+        assert.isString('_spender', _spender);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as ERC20TokenContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             _spender: string,
@@ -139,7 +143,8 @@ export class ERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -176,7 +181,6 @@ export class ERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -212,28 +216,30 @@ export class ERC20TokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
-            const self = this as any as ERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as ERC20TokenContract;
+        const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transferFrom.estimateGasAsync.bind(
-                    self,
-                    _from,
-                    _to,
-                    _value
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.transferFrom.estimateGasAsync.bind(
+                self,
+                _from,
+                _to,
+                _value
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             _from: string,
@@ -243,23 +249,25 @@ export class ERC20TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
-            const self = this as any as ERC20TokenContract;
-            const txHashPromise = self.transferFrom.sendTransactionAsync(_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as ERC20TokenContract;
+        const txHashPromise = self.transferFrom.sendTransactionAsync(_from,
     _to,
     _value
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             _from: string,
@@ -267,35 +275,39 @@ export class ERC20TokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
-            const self = this as any as ERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as ERC20TokenContract;
+        const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             _from: string,
             _to: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
-            const self = this as any as ERC20TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as ERC20TokenContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             _from: string,
@@ -305,7 +317,9 @@ export class ERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -380,26 +394,27 @@ export class ERC20TokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
-            const self = this as any as ERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
+        assert.isString('_to', _to);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as ERC20TokenContract;
+        const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transfer.estimateGasAsync.bind(
-                    self,
-                    _to,
-                    _value
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.transfer.estimateGasAsync.bind(
+                self,
+                _to,
+                _value
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             _to: string,
@@ -408,54 +423,57 @@ export class ERC20TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
-            const self = this as any as ERC20TokenContract;
-            const txHashPromise = self.transfer.sendTransactionAsync(_to,
+        assert.isString('_to', _to);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as ERC20TokenContract;
+        const txHashPromise = self.transfer.sendTransactionAsync(_to,
     _value
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             _to: string,
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
-            const self = this as any as ERC20TokenContract;
-            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
+        assert.isString('_to', _to);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as ERC20TokenContract;
+        const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             _to: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
-            const self = this as any as ERC20TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
+        assert.isString('_to', _to);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as ERC20TokenContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             _to: string,
@@ -464,7 +482,8 @@ export class ERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -503,7 +522,8 @@ export class ERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-            assert.isString('_owner', _owner);assert.isString('_spender', _spender);
+            assert.isString('_owner', _owner);
+            assert.isString('_spender', _spender);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc20_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc20_token.ts
@@ -55,15 +55,17 @@ export class ERC20TokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -83,7 +85,8 @@ export class ERC20TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const txHashPromise = self.approve.sendTransactionAsync(_spender,
     _value
@@ -105,15 +108,17 @@ export class ERC20TokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -125,7 +130,8 @@ export class ERC20TokenContract extends BaseContract {
             _spender: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
@@ -139,7 +145,8 @@ export class ERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -176,7 +183,6 @@ export class ERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -212,16 +218,19 @@ export class ERC20TokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -243,7 +252,9 @@ export class ERC20TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const txHashPromise = self.transferFrom.sendTransactionAsync(_from,
     _to,
@@ -267,16 +278,19 @@ export class ERC20TokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -289,7 +303,9 @@ export class ERC20TokenContract extends BaseContract {
             _to: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
@@ -305,7 +321,9 @@ export class ERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -380,15 +398,17 @@ export class ERC20TokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -408,7 +428,8 @@ export class ERC20TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const txHashPromise = self.transfer.sendTransactionAsync(_to,
     _value
@@ -430,15 +451,17 @@ export class ERC20TokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -450,7 +473,8 @@ export class ERC20TokenContract extends BaseContract {
             _to: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
@@ -464,7 +488,8 @@ export class ERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -503,7 +528,8 @@ export class ERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-            assert.isString('_owner', _owner);assert.isString('_spender', _spender);
+            assert.isString('_owner', _owner);
+            assert.isString('_spender', _spender);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -558,7 +584,7 @@ export class ERC20TokenContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<ERC20TokenContract> {
-        assert.isHexString('bytecode', bytecode);
+        assert.isString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc20_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc20_token.ts
@@ -55,17 +55,15 @@ export class ERC20TokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_spender', _spender);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -85,8 +83,7 @@ export class ERC20TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_spender', _spender);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const txHashPromise = self.approve.sendTransactionAsync(_spender,
     _value
@@ -108,17 +105,15 @@ export class ERC20TokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_spender', _spender);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -130,8 +125,7 @@ export class ERC20TokenContract extends BaseContract {
             _spender: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_spender', _spender);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
@@ -145,8 +139,7 @@ export class ERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_spender', _spender);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -183,6 +176,7 @@ export class ERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -218,19 +212,16 @@ export class ERC20TokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -252,9 +243,7 @@ export class ERC20TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const txHashPromise = self.transferFrom.sendTransactionAsync(_from,
     _to,
@@ -278,19 +267,16 @@ export class ERC20TokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -303,9 +289,7 @@ export class ERC20TokenContract extends BaseContract {
             _to: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
@@ -321,9 +305,7 @@ export class ERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -398,17 +380,15 @@ export class ERC20TokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -428,8 +408,7 @@ export class ERC20TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const txHashPromise = self.transfer.sendTransactionAsync(_to,
     _value
@@ -451,17 +430,15 @@ export class ERC20TokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -473,8 +450,7 @@ export class ERC20TokenContract extends BaseContract {
             _to: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ERC20TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
@@ -488,8 +464,7 @@ export class ERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -528,8 +503,7 @@ export class ERC20TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-            assert.isString('_owner', _owner);
-            assert.isString('_spender', _spender);
+            assert.isString('_owner', _owner);assert.isString('_spender', _spender);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -584,7 +558,7 @@ export class ERC20TokenContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<ERC20TokenContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc721_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc721_proxy.ts
@@ -2,6 +2,7 @@
 // tslint:disable:no-unused-variable
 // tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
+import { schemas } from '@0x/json-schemas';
 import {
     BlockParam,
     BlockParamLiteral,
@@ -18,6 +19,7 @@ import {
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
+import { assert } from '@0x/assert';
 import * as ethers from 'ethers';
 // tslint:enable:no-unused-variable
 
@@ -48,15 +50,17 @@ export class ERC721ProxyContract extends BaseContract {
     public addAuthorizedAddress = {
         async sendTransactionAsync(
             target: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('target', target);
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -70,17 +74,11 @@ export class ERC721ProxyContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             target: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('target', target);
             const self = this as any as ERC721ProxyContract;
             const txHashPromise = self.addAuthorizedAddress.sendTransactionAsync(target
     , txData);
@@ -98,15 +96,17 @@ export class ERC721ProxyContract extends BaseContract {
         },
         async estimateGasAsync(
             target: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('target', target);
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -117,6 +117,7 @@ export class ERC721ProxyContract extends BaseContract {
         getABIEncodedTransactionData(
             target: string,
         ): string {
+            assert.isString('target', target);
             const self = this as any as ERC721ProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
@@ -128,6 +129,15 @@ export class ERC721ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('target', target);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
         ]);
@@ -156,6 +166,15 @@ export class ERC721ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.isBigNumber('index_0', index_0);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('authorities(uint256)', [index_0
         ]);
@@ -180,15 +199,17 @@ export class ERC721ProxyContract extends BaseContract {
     public removeAuthorizedAddress = {
         async sendTransactionAsync(
             target: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('target', target);
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -202,17 +223,11 @@ export class ERC721ProxyContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             target: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('target', target);
             const self = this as any as ERC721ProxyContract;
             const txHashPromise = self.removeAuthorizedAddress.sendTransactionAsync(target
     , txData);
@@ -230,15 +245,17 @@ export class ERC721ProxyContract extends BaseContract {
         },
         async estimateGasAsync(
             target: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('target', target);
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -249,6 +266,7 @@ export class ERC721ProxyContract extends BaseContract {
         getABIEncodedTransactionData(
             target: string,
         ): string {
+            assert.isString('target', target);
             const self = this as any as ERC721ProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
@@ -260,6 +278,15 @@ export class ERC721ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('target', target);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
         ]);
@@ -287,6 +314,14 @@ export class ERC721ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('owner()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -311,16 +346,19 @@ export class ERC721ProxyContract extends BaseContract {
         async sendTransactionAsync(
             target: string,
             index: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -336,17 +374,12 @@ export class ERC721ProxyContract extends BaseContract {
         awaitTransactionSuccessAsync(
             target: string,
             index: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as ERC721ProxyContract;
             const txHashPromise = self.removeAuthorizedAddressAtIndex.sendTransactionAsync(target,
     index
@@ -366,16 +399,19 @@ export class ERC721ProxyContract extends BaseContract {
         async estimateGasAsync(
             target: string,
             index: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -387,6 +423,8 @@ export class ERC721ProxyContract extends BaseContract {
             target: string,
             index: BigNumber,
         ): string {
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as ERC721ProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
@@ -400,6 +438,16 @@ export class ERC721ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
         index
@@ -428,6 +476,14 @@ export class ERC721ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('getProxyId()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -455,6 +511,15 @@ export class ERC721ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
+            assert.isString('index_0', index_0);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('authorized(address)', [index_0
         ]);
@@ -482,6 +547,14 @@ export class ERC721ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('getAuthorizedAddresses()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -505,15 +578,17 @@ export class ERC721ProxyContract extends BaseContract {
     public transferOwnership = {
         async sendTransactionAsync(
             newOwner: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('newOwner', newOwner);
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -527,17 +602,11 @@ export class ERC721ProxyContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             newOwner: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('newOwner', newOwner);
             const self = this as any as ERC721ProxyContract;
             const txHashPromise = self.transferOwnership.sendTransactionAsync(newOwner
     , txData);
@@ -555,15 +624,17 @@ export class ERC721ProxyContract extends BaseContract {
         },
         async estimateGasAsync(
             newOwner: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('newOwner', newOwner);
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -574,6 +645,7 @@ export class ERC721ProxyContract extends BaseContract {
         getABIEncodedTransactionData(
             newOwner: string,
         ): string {
+            assert.isString('newOwner', newOwner);
             const self = this as any as ERC721ProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
@@ -585,6 +657,15 @@ export class ERC721ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('newOwner', newOwner);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
         ]);
@@ -611,6 +692,11 @@ export class ERC721ProxyContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<ERC721ProxyContract> {
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         if (artifact.compilerOutput === undefined) {
             throw new Error('Compiler output not found in the artifact file');
         }
@@ -625,6 +711,12 @@ export class ERC721ProxyContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<ERC721ProxyContract> {
+        assert.isString('bytecode', bytecode);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
         const constructorAbi = BaseContract._lookupConstructorAbi(abi);
         [] = BaseContract._formatABIDataItemList(

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc721_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc721_proxy.ts
@@ -1,6 +1,6 @@
-// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma whitespace class-name
+// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma
+// tslint:disable:whitespace no-unbound-method no-trailing-whitespace
 // tslint:disable:no-unused-variable
-// tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
 import { schemas } from '@0x/json-schemas';
 import {
@@ -56,11 +56,10 @@ export class ERC721ProxyContract extends BaseContract {
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -102,11 +101,10 @@ export class ERC721ProxyContract extends BaseContract {
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -205,11 +203,10 @@ export class ERC721ProxyContract extends BaseContract {
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -251,11 +248,10 @@ export class ERC721ProxyContract extends BaseContract {
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -314,6 +310,7 @@ export class ERC721ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -348,17 +345,15 @@ export class ERC721ProxyContract extends BaseContract {
             index: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -378,8 +373,7 @@ export class ERC721ProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as ERC721ProxyContract;
             const txHashPromise = self.removeAuthorizedAddressAtIndex.sendTransactionAsync(target,
     index
@@ -401,17 +395,15 @@ export class ERC721ProxyContract extends BaseContract {
             index: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -423,8 +415,7 @@ export class ERC721ProxyContract extends BaseContract {
             target: string,
             index: BigNumber,
         ): string {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as ERC721ProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
@@ -438,8 +429,7 @@ export class ERC721ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -476,6 +466,7 @@ export class ERC721ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -547,6 +538,7 @@ export class ERC721ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -584,11 +576,10 @@ export class ERC721ProxyContract extends BaseContract {
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -630,11 +621,10 @@ export class ERC721ProxyContract extends BaseContract {
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -711,7 +701,7 @@ export class ERC721ProxyContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<ERC721ProxyContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,
@@ -746,4 +736,5 @@ export class ERC721ProxyContract extends BaseContract {
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count
-// tslint:enable:no-unbound-method
+// tslint:enable:no-unbound-method no-parameter-reassignment no-consecutive-blank-lines ordered-imports align
+// tslint:enable:trailing-comma whitespace no-trailing-whitespace

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc721_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc721_proxy.ts
@@ -56,10 +56,11 @@ export class ERC721ProxyContract extends BaseContract {
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -101,10 +102,11 @@ export class ERC721ProxyContract extends BaseContract {
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -203,10 +205,11 @@ export class ERC721ProxyContract extends BaseContract {
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -248,10 +251,11 @@ export class ERC721ProxyContract extends BaseContract {
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -310,7 +314,6 @@ export class ERC721ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -345,15 +348,17 @@ export class ERC721ProxyContract extends BaseContract {
             index: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('target', target);assert.isBigNumber('index', index);
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -373,7 +378,8 @@ export class ERC721ProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('target', target);assert.isBigNumber('index', index);
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as ERC721ProxyContract;
             const txHashPromise = self.removeAuthorizedAddressAtIndex.sendTransactionAsync(target,
     index
@@ -395,15 +401,17 @@ export class ERC721ProxyContract extends BaseContract {
             index: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('target', target);assert.isBigNumber('index', index);
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -415,7 +423,8 @@ export class ERC721ProxyContract extends BaseContract {
             target: string,
             index: BigNumber,
         ): string {
-            assert.isString('target', target);assert.isBigNumber('index', index);
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as ERC721ProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
@@ -429,7 +438,8 @@ export class ERC721ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('target', target);assert.isBigNumber('index', index);
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -466,7 +476,6 @@ export class ERC721ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -538,7 +547,6 @@ export class ERC721ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -576,10 +584,11 @@ export class ERC721ProxyContract extends BaseContract {
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -621,10 +630,11 @@ export class ERC721ProxyContract extends BaseContract {
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -701,7 +711,7 @@ export class ERC721ProxyContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<ERC721ProxyContract> {
-        assert.isHexString('bytecode', bytecode);
+        assert.isString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc721_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc721_proxy.ts
@@ -52,24 +52,24 @@ export class ERC721ProxyContract extends BaseContract {
             target: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('target', target);
-            const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
+        assert.isString('target', target);
+        const self = this as any as ERC721ProxyContract;
+        const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.addAuthorizedAddress.estimateGasAsync.bind(
-                    self,
-                    target
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.addAuthorizedAddress.estimateGasAsync.bind(
+                self,
+                target
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             target: string,
@@ -77,49 +77,49 @@ export class ERC721ProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('target', target);
-            const self = this as any as ERC721ProxyContract;
-            const txHashPromise = self.addAuthorizedAddress.sendTransactionAsync(target
+        assert.isString('target', target);
+        const self = this as any as ERC721ProxyContract;
+        const txHashPromise = self.addAuthorizedAddress.sendTransactionAsync(target
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             target: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('target', target);
-            const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
+        assert.isString('target', target);
+        const self = this as any as ERC721ProxyContract;
+        const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             target: string,
         ): string {
-            assert.isString('target', target);
-            const self = this as any as ERC721ProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
+        assert.isString('target', target);
+        const self = this as any as ERC721ProxyContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             target: string,
@@ -199,24 +199,24 @@ export class ERC721ProxyContract extends BaseContract {
             target: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('target', target);
-            const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
+        assert.isString('target', target);
+        const self = this as any as ERC721ProxyContract;
+        const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.removeAuthorizedAddress.estimateGasAsync.bind(
-                    self,
-                    target
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.removeAuthorizedAddress.estimateGasAsync.bind(
+                self,
+                target
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             target: string,
@@ -224,49 +224,49 @@ export class ERC721ProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('target', target);
-            const self = this as any as ERC721ProxyContract;
-            const txHashPromise = self.removeAuthorizedAddress.sendTransactionAsync(target
+        assert.isString('target', target);
+        const self = this as any as ERC721ProxyContract;
+        const txHashPromise = self.removeAuthorizedAddress.sendTransactionAsync(target
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             target: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('target', target);
-            const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
+        assert.isString('target', target);
+        const self = this as any as ERC721ProxyContract;
+        const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             target: string,
         ): string {
-            assert.isString('target', target);
-            const self = this as any as ERC721ProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
+        assert.isString('target', target);
+        const self = this as any as ERC721ProxyContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             target: string,
@@ -310,7 +310,6 @@ export class ERC721ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -345,26 +344,27 @@ export class ERC721ProxyContract extends BaseContract {
             index: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('target', target);assert.isBigNumber('index', index);
-            const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
+        assert.isString('target', target);
+        assert.isBigNumber('index', index);
+        const self = this as any as ERC721ProxyContract;
+        const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.removeAuthorizedAddressAtIndex.estimateGasAsync.bind(
-                    self,
-                    target,
-                    index
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.removeAuthorizedAddressAtIndex.estimateGasAsync.bind(
+                self,
+                target,
+                index
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             target: string,
@@ -373,54 +373,57 @@ export class ERC721ProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('target', target);assert.isBigNumber('index', index);
-            const self = this as any as ERC721ProxyContract;
-            const txHashPromise = self.removeAuthorizedAddressAtIndex.sendTransactionAsync(target,
+        assert.isString('target', target);
+        assert.isBigNumber('index', index);
+        const self = this as any as ERC721ProxyContract;
+        const txHashPromise = self.removeAuthorizedAddressAtIndex.sendTransactionAsync(target,
     index
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             target: string,
             index: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('target', target);assert.isBigNumber('index', index);
-            const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
+        assert.isString('target', target);
+        assert.isBigNumber('index', index);
+        const self = this as any as ERC721ProxyContract;
+        const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             target: string,
             index: BigNumber,
         ): string {
-            assert.isString('target', target);assert.isBigNumber('index', index);
-            const self = this as any as ERC721ProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
+        assert.isString('target', target);
+        assert.isBigNumber('index', index);
+        const self = this as any as ERC721ProxyContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             target: string,
@@ -429,7 +432,8 @@ export class ERC721ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('target', target);assert.isBigNumber('index', index);
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -466,7 +470,6 @@ export class ERC721ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -538,7 +541,6 @@ export class ERC721ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -572,24 +574,24 @@ export class ERC721ProxyContract extends BaseContract {
             newOwner: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as ERC721ProxyContract;
+        const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transferOwnership.estimateGasAsync.bind(
-                    self,
-                    newOwner
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.transferOwnership.estimateGasAsync.bind(
+                self,
+                newOwner
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             newOwner: string,
@@ -597,49 +599,49 @@ export class ERC721ProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as ERC721ProxyContract;
-            const txHashPromise = self.transferOwnership.sendTransactionAsync(newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as ERC721ProxyContract;
+        const txHashPromise = self.transferOwnership.sendTransactionAsync(newOwner
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             newOwner: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as ERC721ProxyContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as ERC721ProxyContract;
+        const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             newOwner: string,
         ): string {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as ERC721ProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as ERC721ProxyContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             newOwner: string,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc721_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc721_proxy.ts
@@ -56,11 +56,10 @@ export class ERC721ProxyContract extends BaseContract {
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -102,11 +101,10 @@ export class ERC721ProxyContract extends BaseContract {
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -205,11 +203,10 @@ export class ERC721ProxyContract extends BaseContract {
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -251,11 +248,10 @@ export class ERC721ProxyContract extends BaseContract {
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -314,6 +310,7 @@ export class ERC721ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -348,17 +345,15 @@ export class ERC721ProxyContract extends BaseContract {
             index: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -378,8 +373,7 @@ export class ERC721ProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as ERC721ProxyContract;
             const txHashPromise = self.removeAuthorizedAddressAtIndex.sendTransactionAsync(target,
     index
@@ -401,17 +395,15 @@ export class ERC721ProxyContract extends BaseContract {
             index: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -423,8 +415,7 @@ export class ERC721ProxyContract extends BaseContract {
             target: string,
             index: BigNumber,
         ): string {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as ERC721ProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
@@ -438,8 +429,7 @@ export class ERC721ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -476,6 +466,7 @@ export class ERC721ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -547,6 +538,7 @@ export class ERC721ProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -584,11 +576,10 @@ export class ERC721ProxyContract extends BaseContract {
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -630,11 +621,10 @@ export class ERC721ProxyContract extends BaseContract {
             const self = this as any as ERC721ProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -711,7 +701,7 @@ export class ERC721ProxyContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<ERC721ProxyContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc721_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc721_token.ts
@@ -1,6 +1,6 @@
-// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma whitespace class-name
+// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma
+// tslint:disable:whitespace no-unbound-method no-trailing-whitespace
 // tslint:disable:no-unused-variable
-// tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
 import { schemas } from '@0x/json-schemas';
 import {
@@ -100,17 +100,15 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_approved', _approved);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -130,8 +128,7 @@ export class ERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_approved', _approved);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const txHashPromise = self.approve.sendTransactionAsync(_approved,
     _tokenId
@@ -153,17 +150,15 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_approved', _approved);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -175,8 +170,7 @@ export class ERC721TokenContract extends BaseContract {
             _approved: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_approved', _approved);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
@@ -190,8 +184,7 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_approved', _approved);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -229,19 +222,16 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -263,9 +253,7 @@ export class ERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const txHashPromise = self.transferFrom.sendTransactionAsync(_from,
     _to,
@@ -289,19 +277,16 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -314,9 +299,7 @@ export class ERC721TokenContract extends BaseContract {
             _to: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
@@ -332,9 +315,7 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -373,19 +354,16 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -407,9 +385,7 @@ export class ERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const txHashPromise = self.safeTransferFrom1.sendTransactionAsync(_from,
     _to,
@@ -433,19 +409,16 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -458,9 +431,7 @@ export class ERC721TokenContract extends BaseContract {
             _to: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
@@ -476,9 +447,7 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -590,17 +559,15 @@ export class ERC721TokenContract extends BaseContract {
             _approved: boolean,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_operator', _operator);
-            assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -620,8 +587,7 @@ export class ERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_operator', _operator);
-            assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
             const self = this as any as ERC721TokenContract;
             const txHashPromise = self.setApprovalForAll.sendTransactionAsync(_operator,
     _approved
@@ -643,17 +609,15 @@ export class ERC721TokenContract extends BaseContract {
             _approved: boolean,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_operator', _operator);
-            assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -665,8 +629,7 @@ export class ERC721TokenContract extends BaseContract {
             _operator: string,
             _approved: boolean,
         ): string {
-            assert.isString('_operator', _operator);
-            assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
             const self = this as any as ERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
@@ -680,8 +643,7 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_operator', _operator);
-            assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -720,21 +682,17 @@ export class ERC721TokenContract extends BaseContract {
             _data: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
-            assert.isString('_data', _data);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
     _tokenId,
     _data
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -758,10 +716,7 @@ export class ERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
-            assert.isString('_data', _data);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
             const self = this as any as ERC721TokenContract;
             const txHashPromise = self.safeTransferFrom2.sendTransactionAsync(_from,
     _to,
@@ -787,21 +742,17 @@ export class ERC721TokenContract extends BaseContract {
             _data: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
-            assert.isString('_data', _data);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
     _tokenId,
     _data
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -815,10 +766,7 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             _data: string,
         ): string {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
-            assert.isString('_data', _data);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
             const self = this as any as ERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
@@ -836,10 +784,7 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
-            assert.isString('_data', _data);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -880,8 +825,7 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_owner', _owner);
-            assert.isString('_operator', _operator);
+            assert.isString('_owner', _owner);assert.isString('_operator', _operator);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -936,7 +880,7 @@ export class ERC721TokenContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<ERC721TokenContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,
@@ -971,4 +915,5 @@ export class ERC721TokenContract extends BaseContract {
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count
-// tslint:enable:no-unbound-method
+// tslint:enable:no-unbound-method no-parameter-reassignment no-consecutive-blank-lines ordered-imports align
+// tslint:enable:trailing-comma whitespace no-trailing-whitespace

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc721_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc721_token.ts
@@ -2,6 +2,7 @@
 // tslint:disable:no-unused-variable
 // tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
+import { schemas } from '@0x/json-schemas';
 import {
     BlockParam,
     BlockParamLiteral,
@@ -18,6 +19,7 @@ import {
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
+import { assert } from '@0x/assert';
 import * as ethers from 'ethers';
 // tslint:enable:no-unused-variable
 
@@ -62,6 +64,15 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('getApproved(uint256)', [_tokenId
         ]);
@@ -87,16 +98,19 @@ export class ERC721TokenContract extends BaseContract {
         async sendTransactionAsync(
             _approved: string,
             _tokenId: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('_approved', _approved);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -112,17 +126,12 @@ export class ERC721TokenContract extends BaseContract {
         awaitTransactionSuccessAsync(
             _approved: string,
             _tokenId: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('_approved', _approved);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const txHashPromise = self.approve.sendTransactionAsync(_approved,
     _tokenId
@@ -142,16 +151,19 @@ export class ERC721TokenContract extends BaseContract {
         async estimateGasAsync(
             _approved: string,
             _tokenId: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('_approved', _approved);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -163,6 +175,8 @@ export class ERC721TokenContract extends BaseContract {
             _approved: string,
             _tokenId: BigNumber,
         ): string {
+            assert.isString('_approved', _approved);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
@@ -176,6 +190,16 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('_approved', _approved);
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
         _tokenId
@@ -203,17 +227,21 @@ export class ERC721TokenContract extends BaseContract {
             _from: string,
             _to: string,
             _tokenId: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -231,17 +259,13 @@ export class ERC721TokenContract extends BaseContract {
             _from: string,
             _to: string,
             _tokenId: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const txHashPromise = self.transferFrom.sendTransactionAsync(_from,
     _to,
@@ -263,17 +287,21 @@ export class ERC721TokenContract extends BaseContract {
             _from: string,
             _to: string,
             _tokenId: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -286,6 +314,9 @@ export class ERC721TokenContract extends BaseContract {
             _to: string,
             _tokenId: BigNumber,
         ): string {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
@@ -301,6 +332,17 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
         _to,
@@ -329,17 +371,21 @@ export class ERC721TokenContract extends BaseContract {
             _from: string,
             _to: string,
             _tokenId: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -357,17 +403,13 @@ export class ERC721TokenContract extends BaseContract {
             _from: string,
             _to: string,
             _tokenId: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const txHashPromise = self.safeTransferFrom1.sendTransactionAsync(_from,
     _to,
@@ -389,17 +431,21 @@ export class ERC721TokenContract extends BaseContract {
             _from: string,
             _to: string,
             _tokenId: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -412,6 +458,9 @@ export class ERC721TokenContract extends BaseContract {
             _to: string,
             _tokenId: BigNumber,
         ): string {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
@@ -427,6 +476,17 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
         _to,
@@ -457,6 +517,15 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('ownerOf(uint256)', [_tokenId
         ]);
@@ -485,6 +554,15 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+            assert.isString('_owner', _owner);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('balanceOf(address)', [_owner
         ]);
@@ -510,16 +588,19 @@ export class ERC721TokenContract extends BaseContract {
         async sendTransactionAsync(
             _operator: string,
             _approved: boolean,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('_operator', _operator);
+            assert.isBoolean('_approved', _approved);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -535,17 +616,12 @@ export class ERC721TokenContract extends BaseContract {
         awaitTransactionSuccessAsync(
             _operator: string,
             _approved: boolean,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('_operator', _operator);
+            assert.isBoolean('_approved', _approved);
             const self = this as any as ERC721TokenContract;
             const txHashPromise = self.setApprovalForAll.sendTransactionAsync(_operator,
     _approved
@@ -565,16 +641,19 @@ export class ERC721TokenContract extends BaseContract {
         async estimateGasAsync(
             _operator: string,
             _approved: boolean,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('_operator', _operator);
+            assert.isBoolean('_approved', _approved);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -586,6 +665,8 @@ export class ERC721TokenContract extends BaseContract {
             _operator: string,
             _approved: boolean,
         ): string {
+            assert.isString('_operator', _operator);
+            assert.isBoolean('_approved', _approved);
             const self = this as any as ERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
@@ -599,6 +680,16 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('_operator', _operator);
+            assert.isBoolean('_approved', _approved);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
         _approved
@@ -627,18 +718,23 @@ export class ERC721TokenContract extends BaseContract {
             _to: string,
             _tokenId: BigNumber,
             _data: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_data', _data);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
     _tokenId,
     _data
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -658,17 +754,14 @@ export class ERC721TokenContract extends BaseContract {
             _to: string,
             _tokenId: BigNumber,
             _data: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_data', _data);
             const self = this as any as ERC721TokenContract;
             const txHashPromise = self.safeTransferFrom2.sendTransactionAsync(_from,
     _to,
@@ -692,18 +785,23 @@ export class ERC721TokenContract extends BaseContract {
             _to: string,
             _tokenId: BigNumber,
             _data: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_data', _data);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
     _tokenId,
     _data
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -717,6 +815,10 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             _data: string,
         ): string {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_data', _data);
             const self = this as any as ERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
@@ -734,6 +836,18 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_data', _data);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
         _to,
@@ -766,6 +880,16 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
+            assert.isString('_owner', _owner);
+            assert.isString('_operator', _operator);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('isApprovedForAll(address,address)', [_owner,
         _operator
@@ -793,6 +917,11 @@ export class ERC721TokenContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<ERC721TokenContract> {
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         if (artifact.compilerOutput === undefined) {
             throw new Error('Compiler output not found in the artifact file');
         }
@@ -807,6 +936,12 @@ export class ERC721TokenContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<ERC721TokenContract> {
+        assert.isString('bytecode', bytecode);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
         const constructorAbi = BaseContract._lookupConstructorAbi(abi);
         [] = BaseContract._formatABIDataItemList(

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc721_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc721_token.ts
@@ -100,15 +100,17 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -128,7 +130,8 @@ export class ERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const txHashPromise = self.approve.sendTransactionAsync(_approved,
     _tokenId
@@ -150,15 +153,17 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -170,7 +175,8 @@ export class ERC721TokenContract extends BaseContract {
             _approved: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
@@ -184,7 +190,8 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);
+            assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -222,16 +229,19 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -253,7 +263,9 @@ export class ERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const txHashPromise = self.transferFrom.sendTransactionAsync(_from,
     _to,
@@ -277,16 +289,19 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -299,7 +314,9 @@ export class ERC721TokenContract extends BaseContract {
             _to: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
@@ -315,7 +332,9 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -354,16 +373,19 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -385,7 +407,9 @@ export class ERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const txHashPromise = self.safeTransferFrom1.sendTransactionAsync(_from,
     _to,
@@ -409,16 +433,19 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -431,7 +458,9 @@ export class ERC721TokenContract extends BaseContract {
             _to: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
@@ -447,7 +476,9 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -559,15 +590,17 @@ export class ERC721TokenContract extends BaseContract {
             _approved: boolean,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);
+            assert.isBoolean('_approved', _approved);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -587,7 +620,8 @@ export class ERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);
+            assert.isBoolean('_approved', _approved);
             const self = this as any as ERC721TokenContract;
             const txHashPromise = self.setApprovalForAll.sendTransactionAsync(_operator,
     _approved
@@ -609,15 +643,17 @@ export class ERC721TokenContract extends BaseContract {
             _approved: boolean,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);
+            assert.isBoolean('_approved', _approved);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -629,7 +665,8 @@ export class ERC721TokenContract extends BaseContract {
             _operator: string,
             _approved: boolean,
         ): string {
-            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);
+            assert.isBoolean('_approved', _approved);
             const self = this as any as ERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
@@ -643,7 +680,8 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);
+            assert.isBoolean('_approved', _approved);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -682,17 +720,21 @@ export class ERC721TokenContract extends BaseContract {
             _data: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_data', _data);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
     _tokenId,
     _data
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -716,7 +758,10 @@ export class ERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_data', _data);
             const self = this as any as ERC721TokenContract;
             const txHashPromise = self.safeTransferFrom2.sendTransactionAsync(_from,
     _to,
@@ -742,17 +787,21 @@ export class ERC721TokenContract extends BaseContract {
             _data: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_data', _data);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
     _tokenId,
     _data
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -766,7 +815,10 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             _data: string,
         ): string {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_data', _data);
             const self = this as any as ERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
@@ -784,7 +836,10 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_data', _data);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -825,7 +880,8 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_owner', _owner);assert.isString('_operator', _operator);
+            assert.isString('_owner', _owner);
+            assert.isString('_operator', _operator);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -880,7 +936,7 @@ export class ERC721TokenContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<ERC721TokenContract> {
-        assert.isHexString('bytecode', bytecode);
+        assert.isString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc721_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc721_token.ts
@@ -100,26 +100,27 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
+        assert.isString('_approved', _approved);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as ERC721TokenContract;
+        const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.approve.estimateGasAsync.bind(
-                    self,
-                    _approved,
-                    _tokenId
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.approve.estimateGasAsync.bind(
+                self,
+                _approved,
+                _tokenId
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             _approved: string,
@@ -128,54 +129,57 @@ export class ERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as ERC721TokenContract;
-            const txHashPromise = self.approve.sendTransactionAsync(_approved,
+        assert.isString('_approved', _approved);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as ERC721TokenContract;
+        const txHashPromise = self.approve.sendTransactionAsync(_approved,
     _tokenId
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             _approved: string,
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
+        assert.isString('_approved', _approved);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as ERC721TokenContract;
+        const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             _approved: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as ERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
+        assert.isString('_approved', _approved);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as ERC721TokenContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             _approved: string,
@@ -184,7 +188,8 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);
+            assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -222,28 +227,30 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as ERC721TokenContract;
+        const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transferFrom.estimateGasAsync.bind(
-                    self,
-                    _from,
-                    _to,
-                    _tokenId
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.transferFrom.estimateGasAsync.bind(
+                self,
+                _from,
+                _to,
+                _tokenId
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             _from: string,
@@ -253,23 +260,25 @@ export class ERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as ERC721TokenContract;
-            const txHashPromise = self.transferFrom.sendTransactionAsync(_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as ERC721TokenContract;
+        const txHashPromise = self.transferFrom.sendTransactionAsync(_from,
     _to,
     _tokenId
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             _from: string,
@@ -277,35 +286,39 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as ERC721TokenContract;
+        const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             _from: string,
             _to: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as ERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as ERC721TokenContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             _from: string,
@@ -315,7 +328,9 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -354,28 +369,30 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as ERC721TokenContract;
+        const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.safeTransferFrom1.estimateGasAsync.bind(
-                    self,
-                    _from,
-                    _to,
-                    _tokenId
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.safeTransferFrom1.estimateGasAsync.bind(
+                self,
+                _from,
+                _to,
+                _tokenId
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             _from: string,
@@ -385,23 +402,25 @@ export class ERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as ERC721TokenContract;
-            const txHashPromise = self.safeTransferFrom1.sendTransactionAsync(_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as ERC721TokenContract;
+        const txHashPromise = self.safeTransferFrom1.sendTransactionAsync(_from,
     _to,
     _tokenId
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             _from: string,
@@ -409,35 +428,39 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as ERC721TokenContract;
+        const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             _from: string,
             _to: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
-            const self = this as any as ERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_tokenId', _tokenId);
+        const self = this as any as ERC721TokenContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             _from: string,
@@ -447,7 +470,9 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -559,26 +584,27 @@ export class ERC721TokenContract extends BaseContract {
             _approved: boolean,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
-            const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
+        assert.isString('_operator', _operator);
+        assert.isBoolean('_approved', _approved);
+        const self = this as any as ERC721TokenContract;
+        const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.setApprovalForAll.estimateGasAsync.bind(
-                    self,
-                    _operator,
-                    _approved
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.setApprovalForAll.estimateGasAsync.bind(
+                self,
+                _operator,
+                _approved
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             _operator: string,
@@ -587,54 +613,57 @@ export class ERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
-            const self = this as any as ERC721TokenContract;
-            const txHashPromise = self.setApprovalForAll.sendTransactionAsync(_operator,
+        assert.isString('_operator', _operator);
+        assert.isBoolean('_approved', _approved);
+        const self = this as any as ERC721TokenContract;
+        const txHashPromise = self.setApprovalForAll.sendTransactionAsync(_operator,
     _approved
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             _operator: string,
             _approved: boolean,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
-            const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
+        assert.isString('_operator', _operator);
+        assert.isBoolean('_approved', _approved);
+        const self = this as any as ERC721TokenContract;
+        const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             _operator: string,
             _approved: boolean,
         ): string {
-            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
-            const self = this as any as ERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
+        assert.isString('_operator', _operator);
+        assert.isBoolean('_approved', _approved);
+        const self = this as any as ERC721TokenContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             _operator: string,
@@ -643,7 +672,8 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);
+            assert.isBoolean('_approved', _approved);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -682,30 +712,33 @@ export class ERC721TokenContract extends BaseContract {
             _data: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
-            const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_tokenId', _tokenId);
+        assert.isString('_data', _data);
+        const self = this as any as ERC721TokenContract;
+        const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
     _tokenId,
     _data
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.safeTransferFrom2.estimateGasAsync.bind(
-                    self,
-                    _from,
-                    _to,
-                    _tokenId,
-                    _data
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.safeTransferFrom2.estimateGasAsync.bind(
+                self,
+                _from,
+                _to,
+                _tokenId,
+                _data
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             _from: string,
@@ -716,24 +749,27 @@ export class ERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
-            const self = this as any as ERC721TokenContract;
-            const txHashPromise = self.safeTransferFrom2.sendTransactionAsync(_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_tokenId', _tokenId);
+        assert.isString('_data', _data);
+        const self = this as any as ERC721TokenContract;
+        const txHashPromise = self.safeTransferFrom2.sendTransactionAsync(_from,
     _to,
     _tokenId,
     _data
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             _from: string,
@@ -742,23 +778,26 @@ export class ERC721TokenContract extends BaseContract {
             _data: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
-            const self = this as any as ERC721TokenContract;
-            const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_tokenId', _tokenId);
+        assert.isString('_data', _data);
+        const self = this as any as ERC721TokenContract;
+        const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
     _tokenId,
     _data
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             _from: string,
@@ -766,14 +805,17 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             _data: string,
         ): string {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
-            const self = this as any as ERC721TokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_tokenId', _tokenId);
+        assert.isString('_data', _data);
+        const self = this as any as ERC721TokenContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
     _tokenId,
     _data
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             _from: string,
@@ -784,7 +826,10 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_data', _data);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -825,7 +870,8 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_owner', _owner);assert.isString('_operator', _operator);
+            assert.isString('_owner', _owner);
+            assert.isString('_operator', _operator);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc721_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc721_token.ts
@@ -100,17 +100,15 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_approved', _approved);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -130,8 +128,7 @@ export class ERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_approved', _approved);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const txHashPromise = self.approve.sendTransactionAsync(_approved,
     _tokenId
@@ -153,17 +150,15 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_approved', _approved);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -175,8 +170,7 @@ export class ERC721TokenContract extends BaseContract {
             _approved: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_approved', _approved);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_approved,
     _tokenId
@@ -190,8 +184,7 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_approved', _approved);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_approved', _approved);assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -229,19 +222,16 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -263,9 +253,7 @@ export class ERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const txHashPromise = self.transferFrom.sendTransactionAsync(_from,
     _to,
@@ -289,19 +277,16 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -314,9 +299,7 @@ export class ERC721TokenContract extends BaseContract {
             _to: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
@@ -332,9 +315,7 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -373,19 +354,16 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -407,9 +385,7 @@ export class ERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const txHashPromise = self.safeTransferFrom1.sendTransactionAsync(_from,
     _to,
@@ -433,19 +409,16 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
     _tokenId
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -458,9 +431,7 @@ export class ERC721TokenContract extends BaseContract {
             _to: string,
             _tokenId: BigNumber,
         ): string {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             const self = this as any as ERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256)', [_from,
     _to,
@@ -476,9 +447,7 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -590,17 +559,15 @@ export class ERC721TokenContract extends BaseContract {
             _approved: boolean,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_operator', _operator);
-            assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -620,8 +587,7 @@ export class ERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_operator', _operator);
-            assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
             const self = this as any as ERC721TokenContract;
             const txHashPromise = self.setApprovalForAll.sendTransactionAsync(_operator,
     _approved
@@ -643,17 +609,15 @@ export class ERC721TokenContract extends BaseContract {
             _approved: boolean,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_operator', _operator);
-            assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -665,8 +629,7 @@ export class ERC721TokenContract extends BaseContract {
             _operator: string,
             _approved: boolean,
         ): string {
-            assert.isString('_operator', _operator);
-            assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
             const self = this as any as ERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('setApprovalForAll(address,bool)', [_operator,
     _approved
@@ -680,8 +643,7 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_operator', _operator);
-            assert.isBoolean('_approved', _approved);
+            assert.isString('_operator', _operator);assert.isBoolean('_approved', _approved);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -720,21 +682,17 @@ export class ERC721TokenContract extends BaseContract {
             _data: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
-            assert.isString('_data', _data);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
     _tokenId,
     _data
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -758,10 +716,7 @@ export class ERC721TokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
-            assert.isString('_data', _data);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
             const self = this as any as ERC721TokenContract;
             const txHashPromise = self.safeTransferFrom2.sendTransactionAsync(_from,
     _to,
@@ -787,21 +742,17 @@ export class ERC721TokenContract extends BaseContract {
             _data: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
-            assert.isString('_data', _data);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
             const self = this as any as ERC721TokenContract;
             const encodedData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
     _tokenId,
     _data
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -815,10 +766,7 @@ export class ERC721TokenContract extends BaseContract {
             _tokenId: BigNumber,
             _data: string,
         ): string {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
-            assert.isString('_data', _data);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
             const self = this as any as ERC721TokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('safeTransferFrom(address,address,uint256,bytes)', [_from,
     _to,
@@ -836,10 +784,7 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_tokenId', _tokenId);
-            assert.isString('_data', _data);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_tokenId', _tokenId);assert.isString('_data', _data);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -880,8 +825,7 @@ export class ERC721TokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_owner', _owner);
-            assert.isString('_operator', _operator);
+            assert.isString('_owner', _owner);assert.isString('_operator', _operator);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -936,7 +880,7 @@ export class ERC721TokenContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<ERC721TokenContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/exchange.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/exchange.ts
@@ -2,6 +2,7 @@
 // tslint:disable:no-unused-variable
 // tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
+import { schemas } from '@0x/json-schemas';
 import {
     BlockParam,
     BlockParamLiteral,
@@ -18,6 +19,7 @@ import {
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
+import { assert } from '@0x/assert';
 import * as ethers from 'ethers';
 // tslint:enable:no-unused-variable
 
@@ -88,6 +90,15 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+            assert.isString('index_0', index_0);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('filled(bytes32)', [index_0
         ]);
@@ -114,17 +125,21 @@ export class ExchangeContract extends BaseContract {
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAssetFillAmounts: BigNumber[],
             signatures: string[],
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -142,17 +157,13 @@ export class ExchangeContract extends BaseContract {
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAssetFillAmounts: BigNumber[],
             signatures: string[],
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.batchFillOrders.sendTransactionAsync(orders,
     takerAssetFillAmounts,
@@ -174,17 +185,21 @@ export class ExchangeContract extends BaseContract {
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAssetFillAmounts: BigNumber[],
             signatures: string[],
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -197,6 +212,9 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmounts: BigNumber[],
             signatures: string[],
         ): string {
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
@@ -212,6 +230,17 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
         takerAssetFillAmounts,
@@ -242,6 +271,15 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
+            assert.isString('index_0', index_0);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('cancelled(bytes32)', [index_0
         ]);
@@ -268,17 +306,21 @@ export class ExchangeContract extends BaseContract {
             hash: string,
             signerAddress: string,
             signature: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('hash', hash);
+            assert.isString('signerAddress', signerAddress);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('preSign(bytes32,address,bytes)', [hash,
     signerAddress,
     signature
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -296,17 +338,13 @@ export class ExchangeContract extends BaseContract {
             hash: string,
             signerAddress: string,
             signature: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('hash', hash);
+            assert.isString('signerAddress', signerAddress);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.preSign.sendTransactionAsync(hash,
     signerAddress,
@@ -328,17 +366,21 @@ export class ExchangeContract extends BaseContract {
             hash: string,
             signerAddress: string,
             signature: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('hash', hash);
+            assert.isString('signerAddress', signerAddress);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('preSign(bytes32,address,bytes)', [hash,
     signerAddress,
     signature
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -351,6 +393,9 @@ export class ExchangeContract extends BaseContract {
             signerAddress: string,
             signature: string,
         ): string {
+            assert.isString('hash', hash);
+            assert.isString('signerAddress', signerAddress);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('preSign(bytes32,address,bytes)', [hash,
     signerAddress,
@@ -366,6 +411,17 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('hash', hash);
+            assert.isString('signerAddress', signerAddress);
+            assert.isString('signature', signature);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('preSign(bytes32,address,bytes)', [hash,
         signerAddress,
@@ -395,18 +451,23 @@ export class ExchangeContract extends BaseContract {
             rightOrder: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             leftSignature: string,
             rightSignature: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+
+
+            assert.isString('leftSignature', leftSignature);
+            assert.isString('rightSignature', rightSignature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [leftOrder,
     rightOrder,
     leftSignature,
     rightSignature
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -426,17 +487,14 @@ export class ExchangeContract extends BaseContract {
             rightOrder: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             leftSignature: string,
             rightSignature: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+
+
+            assert.isString('leftSignature', leftSignature);
+            assert.isString('rightSignature', rightSignature);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.matchOrders.sendTransactionAsync(leftOrder,
     rightOrder,
@@ -460,18 +518,23 @@ export class ExchangeContract extends BaseContract {
             rightOrder: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             leftSignature: string,
             rightSignature: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+
+
+            assert.isString('leftSignature', leftSignature);
+            assert.isString('rightSignature', rightSignature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [leftOrder,
     rightOrder,
     leftSignature,
     rightSignature
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -485,6 +548,10 @@ export class ExchangeContract extends BaseContract {
             leftSignature: string,
             rightSignature: string,
         ): string {
+
+
+            assert.isString('leftSignature', leftSignature);
+            assert.isString('rightSignature', rightSignature);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [leftOrder,
     rightOrder,
@@ -502,6 +569,18 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{left: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};right: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};leftMakerAssetSpreadAmount: BigNumber}
         > {
+
+
+            assert.isString('leftSignature', leftSignature);
+            assert.isString('rightSignature', rightSignature);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [leftOrder,
         rightOrder,
@@ -531,17 +610,21 @@ export class ExchangeContract extends BaseContract {
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             takerAssetFillAmount: BigNumber,
             signature: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -559,17 +642,13 @@ export class ExchangeContract extends BaseContract {
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             takerAssetFillAmount: BigNumber,
             signature: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.fillOrderNoThrow.sendTransactionAsync(order,
     takerAssetFillAmount,
@@ -591,17 +670,21 @@ export class ExchangeContract extends BaseContract {
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             takerAssetFillAmount: BigNumber,
             signature: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -614,6 +697,9 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmount: BigNumber,
             signature: string,
         ): string {
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
@@ -629,6 +715,17 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
         takerAssetFillAmount,
@@ -659,6 +756,15 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.isString('index_0', index_0);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('assetProxies(bytes4)', [index_0
         ]);
@@ -683,15 +789,17 @@ export class ExchangeContract extends BaseContract {
     public batchCancelOrders = {
         async sendTransactionAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isArray('orders', orders);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchCancelOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])', [orders
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -705,17 +813,11 @@ export class ExchangeContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isArray('orders', orders);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.batchCancelOrders.sendTransactionAsync(orders
     , txData);
@@ -733,15 +835,17 @@ export class ExchangeContract extends BaseContract {
         },
         async estimateGasAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isArray('orders', orders);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchCancelOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])', [orders
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -752,6 +856,7 @@ export class ExchangeContract extends BaseContract {
         getABIEncodedTransactionData(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
         ): string {
+            assert.isArray('orders', orders);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('batchCancelOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])', [orders
     ]);
@@ -763,6 +868,15 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isArray('orders', orders);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchCancelOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])', [orders
         ]);
@@ -789,17 +903,21 @@ export class ExchangeContract extends BaseContract {
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAssetFillAmounts: BigNumber[],
             signatures: string[],
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -817,17 +935,13 @@ export class ExchangeContract extends BaseContract {
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAssetFillAmounts: BigNumber[],
             signatures: string[],
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.batchFillOrKillOrders.sendTransactionAsync(orders,
     takerAssetFillAmounts,
@@ -849,17 +963,21 @@ export class ExchangeContract extends BaseContract {
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAssetFillAmounts: BigNumber[],
             signatures: string[],
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -872,6 +990,9 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmounts: BigNumber[],
             signatures: string[],
         ): string {
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
@@ -887,6 +1008,17 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
         takerAssetFillAmounts,
@@ -913,15 +1045,17 @@ export class ExchangeContract extends BaseContract {
     public cancelOrdersUpTo = {
         async sendTransactionAsync(
             targetOrderEpoch: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isBigNumber('targetOrderEpoch', targetOrderEpoch);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('cancelOrdersUpTo(uint256)', [targetOrderEpoch
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -935,17 +1069,11 @@ export class ExchangeContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             targetOrderEpoch: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isBigNumber('targetOrderEpoch', targetOrderEpoch);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.cancelOrdersUpTo.sendTransactionAsync(targetOrderEpoch
     , txData);
@@ -963,15 +1091,17 @@ export class ExchangeContract extends BaseContract {
         },
         async estimateGasAsync(
             targetOrderEpoch: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isBigNumber('targetOrderEpoch', targetOrderEpoch);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('cancelOrdersUpTo(uint256)', [targetOrderEpoch
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -982,6 +1112,7 @@ export class ExchangeContract extends BaseContract {
         getABIEncodedTransactionData(
             targetOrderEpoch: BigNumber,
         ): string {
+            assert.isBigNumber('targetOrderEpoch', targetOrderEpoch);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('cancelOrdersUpTo(uint256)', [targetOrderEpoch
     ]);
@@ -993,6 +1124,15 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isBigNumber('targetOrderEpoch', targetOrderEpoch);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('cancelOrdersUpTo(uint256)', [targetOrderEpoch
         ]);
@@ -1019,17 +1159,21 @@ export class ExchangeContract extends BaseContract {
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAssetFillAmounts: BigNumber[],
             signatures: string[],
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1047,17 +1191,13 @@ export class ExchangeContract extends BaseContract {
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAssetFillAmounts: BigNumber[],
             signatures: string[],
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.batchFillOrdersNoThrow.sendTransactionAsync(orders,
     takerAssetFillAmounts,
@@ -1079,17 +1219,21 @@ export class ExchangeContract extends BaseContract {
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAssetFillAmounts: BigNumber[],
             signatures: string[],
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1102,6 +1246,9 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmounts: BigNumber[],
             signatures: string[],
         ): string {
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
@@ -1117,6 +1264,17 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
         takerAssetFillAmounts,
@@ -1147,6 +1305,15 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.isString('assetProxyId', assetProxyId);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('getAssetProxy(bytes4)', [assetProxyId
         ]);
@@ -1175,6 +1342,15 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
+            assert.isString('index_0', index_0);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('transactions(bytes32)', [index_0
         ]);
@@ -1201,17 +1377,21 @@ export class ExchangeContract extends BaseContract {
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             takerAssetFillAmount: BigNumber,
             signature: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1229,17 +1409,13 @@ export class ExchangeContract extends BaseContract {
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             takerAssetFillAmount: BigNumber,
             signature: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.fillOrKillOrder.sendTransactionAsync(order,
     takerAssetFillAmount,
@@ -1261,17 +1437,21 @@ export class ExchangeContract extends BaseContract {
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             takerAssetFillAmount: BigNumber,
             signature: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1284,6 +1464,9 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmount: BigNumber,
             signature: string,
         ): string {
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
@@ -1299,6 +1482,17 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
         takerAssetFillAmount,
@@ -1326,16 +1520,19 @@ export class ExchangeContract extends BaseContract {
         async sendTransactionAsync(
             validatorAddress: string,
             approval: boolean,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('validatorAddress', validatorAddress);
+            assert.isBoolean('approval', approval);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('setSignatureValidatorApproval(address,bool)', [validatorAddress,
     approval
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1351,17 +1548,12 @@ export class ExchangeContract extends BaseContract {
         awaitTransactionSuccessAsync(
             validatorAddress: string,
             approval: boolean,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('validatorAddress', validatorAddress);
+            assert.isBoolean('approval', approval);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.setSignatureValidatorApproval.sendTransactionAsync(validatorAddress,
     approval
@@ -1381,16 +1573,19 @@ export class ExchangeContract extends BaseContract {
         async estimateGasAsync(
             validatorAddress: string,
             approval: boolean,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('validatorAddress', validatorAddress);
+            assert.isBoolean('approval', approval);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('setSignatureValidatorApproval(address,bool)', [validatorAddress,
     approval
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1402,6 +1597,8 @@ export class ExchangeContract extends BaseContract {
             validatorAddress: string,
             approval: boolean,
         ): string {
+            assert.isString('validatorAddress', validatorAddress);
+            assert.isBoolean('approval', approval);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('setSignatureValidatorApproval(address,bool)', [validatorAddress,
     approval
@@ -1415,6 +1612,16 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('validatorAddress', validatorAddress);
+            assert.isBoolean('approval', approval);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('setSignatureValidatorApproval(address,bool)', [validatorAddress,
         approval
@@ -1445,6 +1652,16 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
+            assert.isString('index_0', index_0);
+            assert.isString('index_1', index_1);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('allowedValidators(address,address)', [index_0,
         index_1
@@ -1472,17 +1689,21 @@ export class ExchangeContract extends BaseContract {
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAssetFillAmount: BigNumber,
             signatures: string[],
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isArray('orders', orders);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
     signatures
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1500,17 +1721,13 @@ export class ExchangeContract extends BaseContract {
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAssetFillAmount: BigNumber,
             signatures: string[],
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isArray('orders', orders);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.marketSellOrders.sendTransactionAsync(orders,
     takerAssetFillAmount,
@@ -1532,17 +1749,21 @@ export class ExchangeContract extends BaseContract {
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAssetFillAmount: BigNumber,
             signatures: string[],
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isArray('orders', orders);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
     signatures
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1555,6 +1776,9 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmount: BigNumber,
             signatures: string[],
         ): string {
+            assert.isArray('orders', orders);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
@@ -1570,6 +1794,17 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
+            assert.isArray('orders', orders);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isArray('signatures', signatures);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
         takerAssetFillAmount,
@@ -1600,6 +1835,15 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<Array<{orderStatus: number;orderHash: string;orderTakerAssetFilledAmount: BigNumber}>
         > {
+            assert.isArray('orders', orders);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('getOrdersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])', [orders
         ]);
@@ -1629,6 +1873,16 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
+            assert.isString('index_0', index_0);
+            assert.isString('index_1', index_1);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('preSigned(bytes32,address)', [index_0,
         index_1
@@ -1657,6 +1911,14 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('owner()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -1686,6 +1948,17 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
+            assert.isString('hash', hash);
+            assert.isString('signerAddress', signerAddress);
+            assert.isString('signature', signature);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('isValidSignature(bytes32,address,bytes)', [hash,
         signerAddress,
@@ -1714,17 +1987,21 @@ export class ExchangeContract extends BaseContract {
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             makerAssetFillAmount: BigNumber,
             signatures: string[],
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
     signatures
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1742,17 +2019,13 @@ export class ExchangeContract extends BaseContract {
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             makerAssetFillAmount: BigNumber,
             signatures: string[],
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.marketBuyOrdersNoThrow.sendTransactionAsync(orders,
     makerAssetFillAmount,
@@ -1774,17 +2047,21 @@ export class ExchangeContract extends BaseContract {
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             makerAssetFillAmount: BigNumber,
             signatures: string[],
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
     signatures
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1797,6 +2074,9 @@ export class ExchangeContract extends BaseContract {
             makerAssetFillAmount: BigNumber,
             signatures: string[],
         ): string {
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
@@ -1812,6 +2092,17 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
         makerAssetFillAmount,
@@ -1840,17 +2131,21 @@ export class ExchangeContract extends BaseContract {
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             takerAssetFillAmount: BigNumber,
             signature: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1868,17 +2163,13 @@ export class ExchangeContract extends BaseContract {
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             takerAssetFillAmount: BigNumber,
             signature: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.fillOrder.sendTransactionAsync(order,
     takerAssetFillAmount,
@@ -1900,17 +2191,21 @@ export class ExchangeContract extends BaseContract {
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             takerAssetFillAmount: BigNumber,
             signature: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1923,6 +2218,9 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmount: BigNumber,
             signature: string,
         ): string {
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
@@ -1938,6 +2236,17 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
         takerAssetFillAmount,
@@ -1967,18 +2276,23 @@ export class ExchangeContract extends BaseContract {
             signerAddress: string,
             data: string,
             signature: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isBigNumber('salt', salt);
+            assert.isString('signerAddress', signerAddress);
+            assert.isString('data', data);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('executeTransaction(uint256,address,bytes,bytes)', [salt,
     signerAddress,
     data,
     signature
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1998,17 +2312,14 @@ export class ExchangeContract extends BaseContract {
             signerAddress: string,
             data: string,
             signature: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isBigNumber('salt', salt);
+            assert.isString('signerAddress', signerAddress);
+            assert.isString('data', data);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.executeTransaction.sendTransactionAsync(salt,
     signerAddress,
@@ -2032,18 +2343,23 @@ export class ExchangeContract extends BaseContract {
             signerAddress: string,
             data: string,
             signature: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isBigNumber('salt', salt);
+            assert.isString('signerAddress', signerAddress);
+            assert.isString('data', data);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('executeTransaction(uint256,address,bytes,bytes)', [salt,
     signerAddress,
     data,
     signature
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2057,6 +2373,10 @@ export class ExchangeContract extends BaseContract {
             data: string,
             signature: string,
         ): string {
+            assert.isBigNumber('salt', salt);
+            assert.isString('signerAddress', signerAddress);
+            assert.isString('data', data);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('executeTransaction(uint256,address,bytes,bytes)', [salt,
     signerAddress,
@@ -2074,6 +2394,18 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isBigNumber('salt', salt);
+            assert.isString('signerAddress', signerAddress);
+            assert.isString('data', data);
+            assert.isString('signature', signature);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('executeTransaction(uint256,address,bytes,bytes)', [salt,
         signerAddress,
@@ -2101,15 +2433,17 @@ export class ExchangeContract extends BaseContract {
     public registerAssetProxy = {
         async sendTransactionAsync(
             assetProxy: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('assetProxy', assetProxy);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2123,17 +2457,11 @@ export class ExchangeContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             assetProxy: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('assetProxy', assetProxy);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.registerAssetProxy.sendTransactionAsync(assetProxy
     , txData);
@@ -2151,15 +2479,17 @@ export class ExchangeContract extends BaseContract {
         },
         async estimateGasAsync(
             assetProxy: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('assetProxy', assetProxy);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2170,6 +2500,7 @@ export class ExchangeContract extends BaseContract {
         getABIEncodedTransactionData(
             assetProxy: string,
         ): string {
+            assert.isString('assetProxy', assetProxy);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
     ]);
@@ -2181,6 +2512,15 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('assetProxy', assetProxy);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
         ]);
@@ -2209,6 +2549,15 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{orderStatus: number;orderHash: string;orderTakerAssetFilledAmount: BigNumber}
         > {
+
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('getOrderInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
         ]);
@@ -2233,15 +2582,17 @@ export class ExchangeContract extends BaseContract {
     public cancelOrder = {
         async sendTransactionAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('cancelOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2255,17 +2606,11 @@ export class ExchangeContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+
             const self = this as any as ExchangeContract;
             const txHashPromise = self.cancelOrder.sendTransactionAsync(order
     , txData);
@@ -2283,15 +2628,17 @@ export class ExchangeContract extends BaseContract {
         },
         async estimateGasAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('cancelOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2302,6 +2649,7 @@ export class ExchangeContract extends BaseContract {
         getABIEncodedTransactionData(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
         ): string {
+
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('cancelOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
     ]);
@@ -2313,6 +2661,15 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('cancelOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
         ]);
@@ -2342,6 +2699,16 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+            assert.isString('index_0', index_0);
+            assert.isString('index_1', index_1);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('orderEpoch(address,address)', [index_0,
         index_1
@@ -2370,6 +2737,14 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('ZRX_ASSET_DATA()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -2395,17 +2770,21 @@ export class ExchangeContract extends BaseContract {
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAssetFillAmount: BigNumber,
             signatures: string[],
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isArray('orders', orders);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
     signatures
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2423,17 +2802,13 @@ export class ExchangeContract extends BaseContract {
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAssetFillAmount: BigNumber,
             signatures: string[],
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isArray('orders', orders);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.marketSellOrdersNoThrow.sendTransactionAsync(orders,
     takerAssetFillAmount,
@@ -2455,17 +2830,21 @@ export class ExchangeContract extends BaseContract {
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAssetFillAmount: BigNumber,
             signatures: string[],
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isArray('orders', orders);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
     signatures
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2478,6 +2857,9 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmount: BigNumber,
             signatures: string[],
         ): string {
+            assert.isArray('orders', orders);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
@@ -2493,6 +2875,17 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
+            assert.isArray('orders', orders);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isArray('signatures', signatures);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
         takerAssetFillAmount,
@@ -2522,6 +2915,14 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('EIP712_DOMAIN_HASH()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -2547,17 +2948,21 @@ export class ExchangeContract extends BaseContract {
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             makerAssetFillAmount: BigNumber,
             signatures: string[],
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
     signatures
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2575,17 +2980,13 @@ export class ExchangeContract extends BaseContract {
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             makerAssetFillAmount: BigNumber,
             signatures: string[],
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.marketBuyOrders.sendTransactionAsync(orders,
     makerAssetFillAmount,
@@ -2607,17 +3008,21 @@ export class ExchangeContract extends BaseContract {
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             makerAssetFillAmount: BigNumber,
             signatures: string[],
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
     signatures
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2630,6 +3035,9 @@ export class ExchangeContract extends BaseContract {
             makerAssetFillAmount: BigNumber,
             signatures: string[],
         ): string {
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
@@ -2645,6 +3053,17 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
         makerAssetFillAmount,
@@ -2674,6 +3093,14 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('currentContextAddress()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -2697,15 +3124,17 @@ export class ExchangeContract extends BaseContract {
     public transferOwnership = {
         async sendTransactionAsync(
             newOwner: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('newOwner', newOwner);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2719,17 +3148,11 @@ export class ExchangeContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             newOwner: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('newOwner', newOwner);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.transferOwnership.sendTransactionAsync(newOwner
     , txData);
@@ -2747,15 +3170,17 @@ export class ExchangeContract extends BaseContract {
         },
         async estimateGasAsync(
             newOwner: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('newOwner', newOwner);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2766,6 +3191,7 @@ export class ExchangeContract extends BaseContract {
         getABIEncodedTransactionData(
             newOwner: string,
         ): string {
+            assert.isString('newOwner', newOwner);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
@@ -2777,6 +3203,15 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('newOwner', newOwner);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
         ]);
@@ -2804,6 +3239,14 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('VERSION()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -2830,6 +3273,11 @@ export class ExchangeContract extends BaseContract {
         txDefaults: Partial<TxData>,
             _zrxAssetData: string,
     ): Promise<ExchangeContract> {
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         if (artifact.compilerOutput === undefined) {
             throw new Error('Compiler output not found in the artifact file');
         }
@@ -2846,6 +3294,12 @@ export class ExchangeContract extends BaseContract {
         txDefaults: Partial<TxData>,
             _zrxAssetData: string,
     ): Promise<ExchangeContract> {
+        assert.isString('bytecode', bytecode);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
         const constructorAbi = BaseContract._lookupConstructorAbi(abi);
         [_zrxAssetData

--- a/packages/abi-gen-wrappers/src/generated-wrappers/exchange.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/exchange.ts
@@ -1,6 +1,6 @@
-// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma whitespace class-name
+// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma
+// tslint:disable:whitespace no-unbound-method no-trailing-whitespace
 // tslint:disable:no-unused-variable
-// tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
 import { schemas } from '@0x/json-schemas';
 import {
@@ -127,19 +127,16 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -161,9 +158,7 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.batchFillOrders.sendTransactionAsync(orders,
     takerAssetFillAmounts,
@@ -187,19 +182,16 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -212,9 +204,7 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmounts: BigNumber[],
             signatures: string[],
         ): string {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
@@ -230,9 +220,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -308,19 +296,16 @@ export class ExchangeContract extends BaseContract {
             signature: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('hash', hash);
-            assert.isString('signerAddress', signerAddress);
-            assert.isString('signature', signature);
+            assert.isString('hash', hash);assert.isString('signerAddress', signerAddress);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('preSign(bytes32,address,bytes)', [hash,
     signerAddress,
     signature
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -342,9 +327,7 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('hash', hash);
-            assert.isString('signerAddress', signerAddress);
-            assert.isString('signature', signature);
+            assert.isString('hash', hash);assert.isString('signerAddress', signerAddress);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.preSign.sendTransactionAsync(hash,
     signerAddress,
@@ -368,19 +351,16 @@ export class ExchangeContract extends BaseContract {
             signature: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('hash', hash);
-            assert.isString('signerAddress', signerAddress);
-            assert.isString('signature', signature);
+            assert.isString('hash', hash);assert.isString('signerAddress', signerAddress);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('preSign(bytes32,address,bytes)', [hash,
     signerAddress,
     signature
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -393,9 +373,7 @@ export class ExchangeContract extends BaseContract {
             signerAddress: string,
             signature: string,
         ): string {
-            assert.isString('hash', hash);
-            assert.isString('signerAddress', signerAddress);
-            assert.isString('signature', signature);
+            assert.isString('hash', hash);assert.isString('signerAddress', signerAddress);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('preSign(bytes32,address,bytes)', [hash,
     signerAddress,
@@ -411,9 +389,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('hash', hash);
-            assert.isString('signerAddress', signerAddress);
-            assert.isString('signature', signature);
+            assert.isString('hash', hash);assert.isString('signerAddress', signerAddress);assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -453,21 +429,17 @@ export class ExchangeContract extends BaseContract {
             rightSignature: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-
-
-            assert.isString('leftSignature', leftSignature);
-            assert.isString('rightSignature', rightSignature);
+            assert.isString('leftSignature', leftSignature);assert.isString('rightSignature', rightSignature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [leftOrder,
     rightOrder,
     leftSignature,
     rightSignature
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -491,10 +463,7 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-
-
-            assert.isString('leftSignature', leftSignature);
-            assert.isString('rightSignature', rightSignature);
+            assert.isString('leftSignature', leftSignature);assert.isString('rightSignature', rightSignature);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.matchOrders.sendTransactionAsync(leftOrder,
     rightOrder,
@@ -520,21 +489,17 @@ export class ExchangeContract extends BaseContract {
             rightSignature: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-
-
-            assert.isString('leftSignature', leftSignature);
-            assert.isString('rightSignature', rightSignature);
+            assert.isString('leftSignature', leftSignature);assert.isString('rightSignature', rightSignature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [leftOrder,
     rightOrder,
     leftSignature,
     rightSignature
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -548,10 +513,7 @@ export class ExchangeContract extends BaseContract {
             leftSignature: string,
             rightSignature: string,
         ): string {
-
-
-            assert.isString('leftSignature', leftSignature);
-            assert.isString('rightSignature', rightSignature);
+            assert.isString('leftSignature', leftSignature);assert.isString('rightSignature', rightSignature);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [leftOrder,
     rightOrder,
@@ -569,10 +531,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{left: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};right: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};leftMakerAssetSpreadAmount: BigNumber}
         > {
-
-
-            assert.isString('leftSignature', leftSignature);
-            assert.isString('rightSignature', rightSignature);
+            assert.isString('leftSignature', leftSignature);assert.isString('rightSignature', rightSignature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -612,19 +571,16 @@ export class ExchangeContract extends BaseContract {
             signature: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isString('signature', signature);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -646,9 +602,7 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isString('signature', signature);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.fillOrderNoThrow.sendTransactionAsync(order,
     takerAssetFillAmount,
@@ -672,19 +626,16 @@ export class ExchangeContract extends BaseContract {
             signature: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isString('signature', signature);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -697,9 +648,7 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmount: BigNumber,
             signature: string,
         ): string {
-
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isString('signature', signature);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
@@ -715,9 +664,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isString('signature', signature);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -795,11 +742,10 @@ export class ExchangeContract extends BaseContract {
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchCancelOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])', [orders
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -841,11 +787,10 @@ export class ExchangeContract extends BaseContract {
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchCancelOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])', [orders
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -905,19 +850,16 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -939,9 +881,7 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.batchFillOrKillOrders.sendTransactionAsync(orders,
     takerAssetFillAmounts,
@@ -965,19 +905,16 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -990,9 +927,7 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmounts: BigNumber[],
             signatures: string[],
         ): string {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
@@ -1008,9 +943,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1051,11 +984,10 @@ export class ExchangeContract extends BaseContract {
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('cancelOrdersUpTo(uint256)', [targetOrderEpoch
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1097,11 +1029,10 @@ export class ExchangeContract extends BaseContract {
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('cancelOrdersUpTo(uint256)', [targetOrderEpoch
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1161,19 +1092,16 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1195,9 +1123,7 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.batchFillOrdersNoThrow.sendTransactionAsync(orders,
     takerAssetFillAmounts,
@@ -1221,19 +1147,16 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1246,9 +1169,7 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmounts: BigNumber[],
             signatures: string[],
         ): string {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
@@ -1264,9 +1185,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1379,19 +1298,16 @@ export class ExchangeContract extends BaseContract {
             signature: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isString('signature', signature);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1413,9 +1329,7 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isString('signature', signature);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.fillOrKillOrder.sendTransactionAsync(order,
     takerAssetFillAmount,
@@ -1439,19 +1353,16 @@ export class ExchangeContract extends BaseContract {
             signature: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isString('signature', signature);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1464,9 +1375,7 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmount: BigNumber,
             signature: string,
         ): string {
-
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isString('signature', signature);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
@@ -1482,9 +1391,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isString('signature', signature);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1522,17 +1429,15 @@ export class ExchangeContract extends BaseContract {
             approval: boolean,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('validatorAddress', validatorAddress);
-            assert.isBoolean('approval', approval);
+            assert.isString('validatorAddress', validatorAddress);assert.isBoolean('approval', approval);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('setSignatureValidatorApproval(address,bool)', [validatorAddress,
     approval
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1552,8 +1457,7 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('validatorAddress', validatorAddress);
-            assert.isBoolean('approval', approval);
+            assert.isString('validatorAddress', validatorAddress);assert.isBoolean('approval', approval);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.setSignatureValidatorApproval.sendTransactionAsync(validatorAddress,
     approval
@@ -1575,17 +1479,15 @@ export class ExchangeContract extends BaseContract {
             approval: boolean,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('validatorAddress', validatorAddress);
-            assert.isBoolean('approval', approval);
+            assert.isString('validatorAddress', validatorAddress);assert.isBoolean('approval', approval);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('setSignatureValidatorApproval(address,bool)', [validatorAddress,
     approval
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1597,8 +1499,7 @@ export class ExchangeContract extends BaseContract {
             validatorAddress: string,
             approval: boolean,
         ): string {
-            assert.isString('validatorAddress', validatorAddress);
-            assert.isBoolean('approval', approval);
+            assert.isString('validatorAddress', validatorAddress);assert.isBoolean('approval', approval);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('setSignatureValidatorApproval(address,bool)', [validatorAddress,
     approval
@@ -1612,8 +1513,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('validatorAddress', validatorAddress);
-            assert.isBoolean('approval', approval);
+            assert.isString('validatorAddress', validatorAddress);assert.isBoolean('approval', approval);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1652,8 +1552,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('index_0', index_0);
-            assert.isString('index_1', index_1);
+            assert.isString('index_0', index_0);assert.isString('index_1', index_1);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1691,19 +1590,16 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
     signatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1725,9 +1621,7 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.marketSellOrders.sendTransactionAsync(orders,
     takerAssetFillAmount,
@@ -1751,19 +1645,16 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
     signatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1776,9 +1667,7 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmount: BigNumber,
             signatures: string[],
         ): string {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
@@ -1794,9 +1683,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1873,8 +1760,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('index_0', index_0);
-            assert.isString('index_1', index_1);
+            assert.isString('index_0', index_0);assert.isString('index_1', index_1);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1911,6 +1797,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1948,9 +1835,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('hash', hash);
-            assert.isString('signerAddress', signerAddress);
-            assert.isString('signature', signature);
+            assert.isString('hash', hash);assert.isString('signerAddress', signerAddress);assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1989,19 +1874,16 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
     signatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2023,9 +1905,7 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.marketBuyOrdersNoThrow.sendTransactionAsync(orders,
     makerAssetFillAmount,
@@ -2049,19 +1929,16 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
     signatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2074,9 +1951,7 @@ export class ExchangeContract extends BaseContract {
             makerAssetFillAmount: BigNumber,
             signatures: string[],
         ): string {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
@@ -2092,9 +1967,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2133,19 +2006,16 @@ export class ExchangeContract extends BaseContract {
             signature: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isString('signature', signature);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2167,9 +2037,7 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isString('signature', signature);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.fillOrder.sendTransactionAsync(order,
     takerAssetFillAmount,
@@ -2193,19 +2061,16 @@ export class ExchangeContract extends BaseContract {
             signature: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isString('signature', signature);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2218,9 +2083,7 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmount: BigNumber,
             signature: string,
         ): string {
-
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isString('signature', signature);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
@@ -2236,9 +2099,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isString('signature', signature);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2278,21 +2139,17 @@ export class ExchangeContract extends BaseContract {
             signature: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isBigNumber('salt', salt);
-            assert.isString('signerAddress', signerAddress);
-            assert.isString('data', data);
-            assert.isString('signature', signature);
+            assert.isBigNumber('salt', salt);assert.isString('signerAddress', signerAddress);assert.isString('data', data);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('executeTransaction(uint256,address,bytes,bytes)', [salt,
     signerAddress,
     data,
     signature
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2316,10 +2173,7 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isBigNumber('salt', salt);
-            assert.isString('signerAddress', signerAddress);
-            assert.isString('data', data);
-            assert.isString('signature', signature);
+            assert.isBigNumber('salt', salt);assert.isString('signerAddress', signerAddress);assert.isString('data', data);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.executeTransaction.sendTransactionAsync(salt,
     signerAddress,
@@ -2345,21 +2199,17 @@ export class ExchangeContract extends BaseContract {
             signature: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isBigNumber('salt', salt);
-            assert.isString('signerAddress', signerAddress);
-            assert.isString('data', data);
-            assert.isString('signature', signature);
+            assert.isBigNumber('salt', salt);assert.isString('signerAddress', signerAddress);assert.isString('data', data);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('executeTransaction(uint256,address,bytes,bytes)', [salt,
     signerAddress,
     data,
     signature
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2373,10 +2223,7 @@ export class ExchangeContract extends BaseContract {
             data: string,
             signature: string,
         ): string {
-            assert.isBigNumber('salt', salt);
-            assert.isString('signerAddress', signerAddress);
-            assert.isString('data', data);
-            assert.isString('signature', signature);
+            assert.isBigNumber('salt', salt);assert.isString('signerAddress', signerAddress);assert.isString('data', data);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('executeTransaction(uint256,address,bytes,bytes)', [salt,
     signerAddress,
@@ -2394,10 +2241,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isBigNumber('salt', salt);
-            assert.isString('signerAddress', signerAddress);
-            assert.isString('data', data);
-            assert.isString('signature', signature);
+            assert.isBigNumber('salt', salt);assert.isString('signerAddress', signerAddress);assert.isString('data', data);assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2439,11 +2283,10 @@ export class ExchangeContract extends BaseContract {
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2485,11 +2328,10 @@ export class ExchangeContract extends BaseContract {
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2588,11 +2430,10 @@ export class ExchangeContract extends BaseContract {
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('cancelOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2634,11 +2475,10 @@ export class ExchangeContract extends BaseContract {
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('cancelOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2699,8 +2539,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-            assert.isString('index_0', index_0);
-            assert.isString('index_1', index_1);
+            assert.isString('index_0', index_0);assert.isString('index_1', index_1);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2737,6 +2576,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2772,19 +2612,16 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
     signatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2806,9 +2643,7 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.marketSellOrdersNoThrow.sendTransactionAsync(orders,
     takerAssetFillAmount,
@@ -2832,19 +2667,16 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
     signatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2857,9 +2689,7 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmount: BigNumber,
             signatures: string[],
         ): string {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
@@ -2875,9 +2705,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2915,6 +2743,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2950,19 +2779,16 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
     signatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2984,9 +2810,7 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.marketBuyOrders.sendTransactionAsync(orders,
     makerAssetFillAmount,
@@ -3010,19 +2834,16 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
     signatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -3035,9 +2856,7 @@ export class ExchangeContract extends BaseContract {
             makerAssetFillAmount: BigNumber,
             signatures: string[],
         ): string {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
@@ -3053,9 +2872,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -3093,6 +2910,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -3130,11 +2948,10 @@ export class ExchangeContract extends BaseContract {
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -3176,11 +2993,10 @@ export class ExchangeContract extends BaseContract {
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -3239,6 +3055,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -3294,7 +3111,7 @@ export class ExchangeContract extends BaseContract {
         txDefaults: Partial<TxData>,
             _zrxAssetData: string,
     ): Promise<ExchangeContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,
@@ -3333,4 +3150,5 @@ export class ExchangeContract extends BaseContract {
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count
-// tslint:enable:no-unbound-method
+// tslint:enable:no-unbound-method no-parameter-reassignment no-consecutive-blank-lines ordered-imports align
+// tslint:enable:trailing-comma whitespace no-trailing-whitespace

--- a/packages/abi-gen-wrappers/src/generated-wrappers/exchange.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/exchange.ts
@@ -127,19 +127,16 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -161,9 +158,7 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.batchFillOrders.sendTransactionAsync(orders,
     takerAssetFillAmounts,
@@ -187,19 +182,16 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -212,9 +204,7 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmounts: BigNumber[],
             signatures: string[],
         ): string {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
@@ -230,9 +220,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -308,19 +296,16 @@ export class ExchangeContract extends BaseContract {
             signature: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('hash', hash);
-            assert.isString('signerAddress', signerAddress);
-            assert.isString('signature', signature);
+            assert.isString('hash', hash);assert.isString('signerAddress', signerAddress);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('preSign(bytes32,address,bytes)', [hash,
     signerAddress,
     signature
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -342,9 +327,7 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('hash', hash);
-            assert.isString('signerAddress', signerAddress);
-            assert.isString('signature', signature);
+            assert.isString('hash', hash);assert.isString('signerAddress', signerAddress);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.preSign.sendTransactionAsync(hash,
     signerAddress,
@@ -368,19 +351,16 @@ export class ExchangeContract extends BaseContract {
             signature: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('hash', hash);
-            assert.isString('signerAddress', signerAddress);
-            assert.isString('signature', signature);
+            assert.isString('hash', hash);assert.isString('signerAddress', signerAddress);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('preSign(bytes32,address,bytes)', [hash,
     signerAddress,
     signature
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -393,9 +373,7 @@ export class ExchangeContract extends BaseContract {
             signerAddress: string,
             signature: string,
         ): string {
-            assert.isString('hash', hash);
-            assert.isString('signerAddress', signerAddress);
-            assert.isString('signature', signature);
+            assert.isString('hash', hash);assert.isString('signerAddress', signerAddress);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('preSign(bytes32,address,bytes)', [hash,
     signerAddress,
@@ -411,9 +389,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('hash', hash);
-            assert.isString('signerAddress', signerAddress);
-            assert.isString('signature', signature);
+            assert.isString('hash', hash);assert.isString('signerAddress', signerAddress);assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -453,21 +429,17 @@ export class ExchangeContract extends BaseContract {
             rightSignature: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-
-
-            assert.isString('leftSignature', leftSignature);
-            assert.isString('rightSignature', rightSignature);
+            assert.isString('leftSignature', leftSignature);assert.isString('rightSignature', rightSignature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [leftOrder,
     rightOrder,
     leftSignature,
     rightSignature
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -491,10 +463,7 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-
-
-            assert.isString('leftSignature', leftSignature);
-            assert.isString('rightSignature', rightSignature);
+            assert.isString('leftSignature', leftSignature);assert.isString('rightSignature', rightSignature);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.matchOrders.sendTransactionAsync(leftOrder,
     rightOrder,
@@ -520,21 +489,17 @@ export class ExchangeContract extends BaseContract {
             rightSignature: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-
-
-            assert.isString('leftSignature', leftSignature);
-            assert.isString('rightSignature', rightSignature);
+            assert.isString('leftSignature', leftSignature);assert.isString('rightSignature', rightSignature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [leftOrder,
     rightOrder,
     leftSignature,
     rightSignature
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -548,10 +513,7 @@ export class ExchangeContract extends BaseContract {
             leftSignature: string,
             rightSignature: string,
         ): string {
-
-
-            assert.isString('leftSignature', leftSignature);
-            assert.isString('rightSignature', rightSignature);
+            assert.isString('leftSignature', leftSignature);assert.isString('rightSignature', rightSignature);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [leftOrder,
     rightOrder,
@@ -569,10 +531,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{left: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};right: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};leftMakerAssetSpreadAmount: BigNumber}
         > {
-
-
-            assert.isString('leftSignature', leftSignature);
-            assert.isString('rightSignature', rightSignature);
+            assert.isString('leftSignature', leftSignature);assert.isString('rightSignature', rightSignature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -612,19 +571,16 @@ export class ExchangeContract extends BaseContract {
             signature: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isString('signature', signature);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -646,9 +602,7 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isString('signature', signature);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.fillOrderNoThrow.sendTransactionAsync(order,
     takerAssetFillAmount,
@@ -672,19 +626,16 @@ export class ExchangeContract extends BaseContract {
             signature: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isString('signature', signature);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -697,9 +648,7 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmount: BigNumber,
             signature: string,
         ): string {
-
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isString('signature', signature);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
@@ -715,9 +664,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isString('signature', signature);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -795,11 +742,10 @@ export class ExchangeContract extends BaseContract {
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchCancelOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])', [orders
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -841,11 +787,10 @@ export class ExchangeContract extends BaseContract {
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchCancelOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])', [orders
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -905,19 +850,16 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -939,9 +881,7 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.batchFillOrKillOrders.sendTransactionAsync(orders,
     takerAssetFillAmounts,
@@ -965,19 +905,16 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -990,9 +927,7 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmounts: BigNumber[],
             signatures: string[],
         ): string {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
@@ -1008,9 +943,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1051,11 +984,10 @@ export class ExchangeContract extends BaseContract {
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('cancelOrdersUpTo(uint256)', [targetOrderEpoch
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1097,11 +1029,10 @@ export class ExchangeContract extends BaseContract {
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('cancelOrdersUpTo(uint256)', [targetOrderEpoch
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1161,19 +1092,16 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1195,9 +1123,7 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.batchFillOrdersNoThrow.sendTransactionAsync(orders,
     takerAssetFillAmounts,
@@ -1221,19 +1147,16 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1246,9 +1169,7 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmounts: BigNumber[],
             signatures: string[],
         ): string {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
@@ -1264,9 +1185,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1379,19 +1298,16 @@ export class ExchangeContract extends BaseContract {
             signature: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isString('signature', signature);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1413,9 +1329,7 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isString('signature', signature);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.fillOrKillOrder.sendTransactionAsync(order,
     takerAssetFillAmount,
@@ -1439,19 +1353,16 @@ export class ExchangeContract extends BaseContract {
             signature: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isString('signature', signature);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1464,9 +1375,7 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmount: BigNumber,
             signature: string,
         ): string {
-
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isString('signature', signature);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
@@ -1482,9 +1391,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isString('signature', signature);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1522,17 +1429,15 @@ export class ExchangeContract extends BaseContract {
             approval: boolean,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('validatorAddress', validatorAddress);
-            assert.isBoolean('approval', approval);
+            assert.isString('validatorAddress', validatorAddress);assert.isBoolean('approval', approval);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('setSignatureValidatorApproval(address,bool)', [validatorAddress,
     approval
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1552,8 +1457,7 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('validatorAddress', validatorAddress);
-            assert.isBoolean('approval', approval);
+            assert.isString('validatorAddress', validatorAddress);assert.isBoolean('approval', approval);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.setSignatureValidatorApproval.sendTransactionAsync(validatorAddress,
     approval
@@ -1575,17 +1479,15 @@ export class ExchangeContract extends BaseContract {
             approval: boolean,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('validatorAddress', validatorAddress);
-            assert.isBoolean('approval', approval);
+            assert.isString('validatorAddress', validatorAddress);assert.isBoolean('approval', approval);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('setSignatureValidatorApproval(address,bool)', [validatorAddress,
     approval
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1597,8 +1499,7 @@ export class ExchangeContract extends BaseContract {
             validatorAddress: string,
             approval: boolean,
         ): string {
-            assert.isString('validatorAddress', validatorAddress);
-            assert.isBoolean('approval', approval);
+            assert.isString('validatorAddress', validatorAddress);assert.isBoolean('approval', approval);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('setSignatureValidatorApproval(address,bool)', [validatorAddress,
     approval
@@ -1612,8 +1513,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('validatorAddress', validatorAddress);
-            assert.isBoolean('approval', approval);
+            assert.isString('validatorAddress', validatorAddress);assert.isBoolean('approval', approval);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1652,8 +1552,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('index_0', index_0);
-            assert.isString('index_1', index_1);
+            assert.isString('index_0', index_0);assert.isString('index_1', index_1);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1691,19 +1590,16 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
     signatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1725,9 +1621,7 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.marketSellOrders.sendTransactionAsync(orders,
     takerAssetFillAmount,
@@ -1751,19 +1645,16 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
     signatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1776,9 +1667,7 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmount: BigNumber,
             signatures: string[],
         ): string {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
@@ -1794,9 +1683,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1873,8 +1760,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('index_0', index_0);
-            assert.isString('index_1', index_1);
+            assert.isString('index_0', index_0);assert.isString('index_1', index_1);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1911,6 +1797,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1948,9 +1835,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('hash', hash);
-            assert.isString('signerAddress', signerAddress);
-            assert.isString('signature', signature);
+            assert.isString('hash', hash);assert.isString('signerAddress', signerAddress);assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1989,19 +1874,16 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
     signatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2023,9 +1905,7 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.marketBuyOrdersNoThrow.sendTransactionAsync(orders,
     makerAssetFillAmount,
@@ -2049,19 +1929,16 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
     signatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2074,9 +1951,7 @@ export class ExchangeContract extends BaseContract {
             makerAssetFillAmount: BigNumber,
             signatures: string[],
         ): string {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
@@ -2092,9 +1967,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2133,19 +2006,16 @@ export class ExchangeContract extends BaseContract {
             signature: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isString('signature', signature);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2167,9 +2037,7 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isString('signature', signature);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.fillOrder.sendTransactionAsync(order,
     takerAssetFillAmount,
@@ -2193,19 +2061,16 @@ export class ExchangeContract extends BaseContract {
             signature: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isString('signature', signature);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2218,9 +2083,7 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmount: BigNumber,
             signature: string,
         ): string {
-
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isString('signature', signature);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
@@ -2236,9 +2099,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isString('signature', signature);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2278,21 +2139,17 @@ export class ExchangeContract extends BaseContract {
             signature: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isBigNumber('salt', salt);
-            assert.isString('signerAddress', signerAddress);
-            assert.isString('data', data);
-            assert.isString('signature', signature);
+            assert.isBigNumber('salt', salt);assert.isString('signerAddress', signerAddress);assert.isString('data', data);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('executeTransaction(uint256,address,bytes,bytes)', [salt,
     signerAddress,
     data,
     signature
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2316,10 +2173,7 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isBigNumber('salt', salt);
-            assert.isString('signerAddress', signerAddress);
-            assert.isString('data', data);
-            assert.isString('signature', signature);
+            assert.isBigNumber('salt', salt);assert.isString('signerAddress', signerAddress);assert.isString('data', data);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.executeTransaction.sendTransactionAsync(salt,
     signerAddress,
@@ -2345,21 +2199,17 @@ export class ExchangeContract extends BaseContract {
             signature: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isBigNumber('salt', salt);
-            assert.isString('signerAddress', signerAddress);
-            assert.isString('data', data);
-            assert.isString('signature', signature);
+            assert.isBigNumber('salt', salt);assert.isString('signerAddress', signerAddress);assert.isString('data', data);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('executeTransaction(uint256,address,bytes,bytes)', [salt,
     signerAddress,
     data,
     signature
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2373,10 +2223,7 @@ export class ExchangeContract extends BaseContract {
             data: string,
             signature: string,
         ): string {
-            assert.isBigNumber('salt', salt);
-            assert.isString('signerAddress', signerAddress);
-            assert.isString('data', data);
-            assert.isString('signature', signature);
+            assert.isBigNumber('salt', salt);assert.isString('signerAddress', signerAddress);assert.isString('data', data);assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('executeTransaction(uint256,address,bytes,bytes)', [salt,
     signerAddress,
@@ -2394,10 +2241,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isBigNumber('salt', salt);
-            assert.isString('signerAddress', signerAddress);
-            assert.isString('data', data);
-            assert.isString('signature', signature);
+            assert.isBigNumber('salt', salt);assert.isString('signerAddress', signerAddress);assert.isString('data', data);assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2439,11 +2283,10 @@ export class ExchangeContract extends BaseContract {
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2485,11 +2328,10 @@ export class ExchangeContract extends BaseContract {
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2588,11 +2430,10 @@ export class ExchangeContract extends BaseContract {
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('cancelOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2634,11 +2475,10 @@ export class ExchangeContract extends BaseContract {
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('cancelOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2699,8 +2539,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-            assert.isString('index_0', index_0);
-            assert.isString('index_1', index_1);
+            assert.isString('index_0', index_0);assert.isString('index_1', index_1);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2737,6 +2576,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2772,19 +2612,16 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
     signatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2806,9 +2643,7 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.marketSellOrdersNoThrow.sendTransactionAsync(orders,
     takerAssetFillAmount,
@@ -2832,19 +2667,16 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
     signatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2857,9 +2689,7 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmount: BigNumber,
             signatures: string[],
         ): string {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
@@ -2875,9 +2705,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2915,6 +2743,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2950,19 +2779,16 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
     signatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2984,9 +2810,7 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.marketBuyOrders.sendTransactionAsync(orders,
     makerAssetFillAmount,
@@ -3010,19 +2834,16 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
     signatures
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -3035,9 +2856,7 @@ export class ExchangeContract extends BaseContract {
             makerAssetFillAmount: BigNumber,
             signatures: string[],
         ): string {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
@@ -3053,9 +2872,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-            assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -3093,6 +2910,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -3130,11 +2948,10 @@ export class ExchangeContract extends BaseContract {
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -3176,11 +2993,10 @@ export class ExchangeContract extends BaseContract {
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -3239,6 +3055,7 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -3294,7 +3111,7 @@ export class ExchangeContract extends BaseContract {
         txDefaults: Partial<TxData>,
             _zrxAssetData: string,
     ): Promise<ExchangeContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/exchange.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/exchange.ts
@@ -127,28 +127,30 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
+        assert.isArray('orders', orders);
+        assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+        assert.isArray('signatures', signatures);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.batchFillOrders.estimateGasAsync.bind(
-                    self,
-                    orders,
-                    takerAssetFillAmounts,
-                    signatures
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.batchFillOrders.estimateGasAsync.bind(
+                self,
+                orders,
+                takerAssetFillAmounts,
+                signatures
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -158,23 +160,25 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
-            const self = this as any as ExchangeContract;
-            const txHashPromise = self.batchFillOrders.sendTransactionAsync(orders,
+        assert.isArray('orders', orders);
+        assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+        assert.isArray('signatures', signatures);
+        const self = this as any as ExchangeContract;
+        const txHashPromise = self.batchFillOrders.sendTransactionAsync(orders,
     takerAssetFillAmounts,
     signatures
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -182,35 +186,39 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
+        assert.isArray('orders', orders);
+        assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+        assert.isArray('signatures', signatures);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAssetFillAmounts: BigNumber[],
             signatures: string[],
         ): string {
-            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
-            const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
+        assert.isArray('orders', orders);
+        assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+        assert.isArray('signatures', signatures);
+        const self = this as any as ExchangeContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -220,7 +228,9 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -296,28 +306,30 @@ export class ExchangeContract extends BaseContract {
             signature: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('hash', hash);assert.isString('signerAddress', signerAddress);assert.isString('signature', signature);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('preSign(bytes32,address,bytes)', [hash,
+        assert.isString('hash', hash);
+        assert.isString('signerAddress', signerAddress);
+        assert.isString('signature', signature);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('preSign(bytes32,address,bytes)', [hash,
     signerAddress,
     signature
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.preSign.estimateGasAsync.bind(
-                    self,
-                    hash,
-                    signerAddress,
-                    signature
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.preSign.estimateGasAsync.bind(
+                self,
+                hash,
+                signerAddress,
+                signature
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             hash: string,
@@ -327,23 +339,25 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('hash', hash);assert.isString('signerAddress', signerAddress);assert.isString('signature', signature);
-            const self = this as any as ExchangeContract;
-            const txHashPromise = self.preSign.sendTransactionAsync(hash,
+        assert.isString('hash', hash);
+        assert.isString('signerAddress', signerAddress);
+        assert.isString('signature', signature);
+        const self = this as any as ExchangeContract;
+        const txHashPromise = self.preSign.sendTransactionAsync(hash,
     signerAddress,
     signature
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             hash: string,
@@ -351,35 +365,39 @@ export class ExchangeContract extends BaseContract {
             signature: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('hash', hash);assert.isString('signerAddress', signerAddress);assert.isString('signature', signature);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('preSign(bytes32,address,bytes)', [hash,
+        assert.isString('hash', hash);
+        assert.isString('signerAddress', signerAddress);
+        assert.isString('signature', signature);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('preSign(bytes32,address,bytes)', [hash,
     signerAddress,
     signature
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             hash: string,
             signerAddress: string,
             signature: string,
         ): string {
-            assert.isString('hash', hash);assert.isString('signerAddress', signerAddress);assert.isString('signature', signature);
-            const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('preSign(bytes32,address,bytes)', [hash,
+        assert.isString('hash', hash);
+        assert.isString('signerAddress', signerAddress);
+        assert.isString('signature', signature);
+        const self = this as any as ExchangeContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('preSign(bytes32,address,bytes)', [hash,
     signerAddress,
     signature
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             hash: string,
@@ -389,7 +407,9 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('hash', hash);assert.isString('signerAddress', signerAddress);assert.isString('signature', signature);
+            assert.isString('hash', hash);
+            assert.isString('signerAddress', signerAddress);
+            assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -429,30 +449,33 @@ export class ExchangeContract extends BaseContract {
             rightSignature: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('leftSignature', leftSignature);assert.isString('rightSignature', rightSignature);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [leftOrder,
+
+
+        assert.isString('leftSignature', leftSignature);
+        assert.isString('rightSignature', rightSignature);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [leftOrder,
     rightOrder,
     leftSignature,
     rightSignature
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.matchOrders.estimateGasAsync.bind(
-                    self,
-                    leftOrder,
-                    rightOrder,
-                    leftSignature,
-                    rightSignature
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.matchOrders.estimateGasAsync.bind(
+                self,
+                leftOrder,
+                rightOrder,
+                leftSignature,
+                rightSignature
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             leftOrder: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
@@ -463,24 +486,27 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('leftSignature', leftSignature);assert.isString('rightSignature', rightSignature);
-            const self = this as any as ExchangeContract;
-            const txHashPromise = self.matchOrders.sendTransactionAsync(leftOrder,
+
+
+        assert.isString('leftSignature', leftSignature);
+        assert.isString('rightSignature', rightSignature);
+        const self = this as any as ExchangeContract;
+        const txHashPromise = self.matchOrders.sendTransactionAsync(leftOrder,
     rightOrder,
     leftSignature,
     rightSignature
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             leftOrder: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
@@ -489,23 +515,26 @@ export class ExchangeContract extends BaseContract {
             rightSignature: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('leftSignature', leftSignature);assert.isString('rightSignature', rightSignature);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [leftOrder,
+
+
+        assert.isString('leftSignature', leftSignature);
+        assert.isString('rightSignature', rightSignature);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [leftOrder,
     rightOrder,
     leftSignature,
     rightSignature
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             leftOrder: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
@@ -513,14 +542,17 @@ export class ExchangeContract extends BaseContract {
             leftSignature: string,
             rightSignature: string,
         ): string {
-            assert.isString('leftSignature', leftSignature);assert.isString('rightSignature', rightSignature);
-            const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [leftOrder,
+
+
+        assert.isString('leftSignature', leftSignature);
+        assert.isString('rightSignature', rightSignature);
+        const self = this as any as ExchangeContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [leftOrder,
     rightOrder,
     leftSignature,
     rightSignature
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             leftOrder: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
@@ -531,7 +563,10 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{left: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};right: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};leftMakerAssetSpreadAmount: BigNumber}
         > {
-            assert.isString('leftSignature', leftSignature);assert.isString('rightSignature', rightSignature);
+
+
+            assert.isString('leftSignature', leftSignature);
+            assert.isString('rightSignature', rightSignature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -571,28 +606,30 @@ export class ExchangeContract extends BaseContract {
             signature: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
+
+        assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+        assert.isString('signature', signature);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.fillOrderNoThrow.estimateGasAsync.bind(
-                    self,
-                    order,
-                    takerAssetFillAmount,
-                    signature
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.fillOrderNoThrow.estimateGasAsync.bind(
+                self,
+                order,
+                takerAssetFillAmount,
+                signature
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
@@ -602,23 +639,25 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
-            const self = this as any as ExchangeContract;
-            const txHashPromise = self.fillOrderNoThrow.sendTransactionAsync(order,
+
+        assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+        assert.isString('signature', signature);
+        const self = this as any as ExchangeContract;
+        const txHashPromise = self.fillOrderNoThrow.sendTransactionAsync(order,
     takerAssetFillAmount,
     signature
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
@@ -626,35 +665,39 @@ export class ExchangeContract extends BaseContract {
             signature: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
+
+        assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+        assert.isString('signature', signature);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             takerAssetFillAmount: BigNumber,
             signature: string,
         ): string {
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
-            const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
+
+        assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+        assert.isString('signature', signature);
+        const self = this as any as ExchangeContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
@@ -664,7 +707,9 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -738,24 +783,24 @@ export class ExchangeContract extends BaseContract {
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('batchCancelOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])', [orders
+        assert.isArray('orders', orders);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('batchCancelOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])', [orders
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.batchCancelOrders.estimateGasAsync.bind(
-                    self,
-                    orders
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.batchCancelOrders.estimateGasAsync.bind(
+                self,
+                orders
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -763,49 +808,49 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);
-            const self = this as any as ExchangeContract;
-            const txHashPromise = self.batchCancelOrders.sendTransactionAsync(orders
+        assert.isArray('orders', orders);
+        const self = this as any as ExchangeContract;
+        const txHashPromise = self.batchCancelOrders.sendTransactionAsync(orders
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('batchCancelOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])', [orders
+        assert.isArray('orders', orders);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('batchCancelOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])', [orders
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
         ): string {
-            assert.isArray('orders', orders);
-            const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('batchCancelOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])', [orders
+        assert.isArray('orders', orders);
+        const self = this as any as ExchangeContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('batchCancelOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])', [orders
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -850,28 +895,30 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
+        assert.isArray('orders', orders);
+        assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+        assert.isArray('signatures', signatures);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.batchFillOrKillOrders.estimateGasAsync.bind(
-                    self,
-                    orders,
-                    takerAssetFillAmounts,
-                    signatures
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.batchFillOrKillOrders.estimateGasAsync.bind(
+                self,
+                orders,
+                takerAssetFillAmounts,
+                signatures
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -881,23 +928,25 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
-            const self = this as any as ExchangeContract;
-            const txHashPromise = self.batchFillOrKillOrders.sendTransactionAsync(orders,
+        assert.isArray('orders', orders);
+        assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+        assert.isArray('signatures', signatures);
+        const self = this as any as ExchangeContract;
+        const txHashPromise = self.batchFillOrKillOrders.sendTransactionAsync(orders,
     takerAssetFillAmounts,
     signatures
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -905,35 +954,39 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
+        assert.isArray('orders', orders);
+        assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+        assert.isArray('signatures', signatures);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAssetFillAmounts: BigNumber[],
             signatures: string[],
         ): string {
-            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
-            const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
+        assert.isArray('orders', orders);
+        assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+        assert.isArray('signatures', signatures);
+        const self = this as any as ExchangeContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -943,7 +996,9 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -980,24 +1035,24 @@ export class ExchangeContract extends BaseContract {
             targetOrderEpoch: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isBigNumber('targetOrderEpoch', targetOrderEpoch);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('cancelOrdersUpTo(uint256)', [targetOrderEpoch
+        assert.isBigNumber('targetOrderEpoch', targetOrderEpoch);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('cancelOrdersUpTo(uint256)', [targetOrderEpoch
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.cancelOrdersUpTo.estimateGasAsync.bind(
-                    self,
-                    targetOrderEpoch
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.cancelOrdersUpTo.estimateGasAsync.bind(
+                self,
+                targetOrderEpoch
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             targetOrderEpoch: BigNumber,
@@ -1005,49 +1060,49 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isBigNumber('targetOrderEpoch', targetOrderEpoch);
-            const self = this as any as ExchangeContract;
-            const txHashPromise = self.cancelOrdersUpTo.sendTransactionAsync(targetOrderEpoch
+        assert.isBigNumber('targetOrderEpoch', targetOrderEpoch);
+        const self = this as any as ExchangeContract;
+        const txHashPromise = self.cancelOrdersUpTo.sendTransactionAsync(targetOrderEpoch
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             targetOrderEpoch: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isBigNumber('targetOrderEpoch', targetOrderEpoch);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('cancelOrdersUpTo(uint256)', [targetOrderEpoch
+        assert.isBigNumber('targetOrderEpoch', targetOrderEpoch);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('cancelOrdersUpTo(uint256)', [targetOrderEpoch
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             targetOrderEpoch: BigNumber,
         ): string {
-            assert.isBigNumber('targetOrderEpoch', targetOrderEpoch);
-            const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('cancelOrdersUpTo(uint256)', [targetOrderEpoch
+        assert.isBigNumber('targetOrderEpoch', targetOrderEpoch);
+        const self = this as any as ExchangeContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('cancelOrdersUpTo(uint256)', [targetOrderEpoch
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             targetOrderEpoch: BigNumber,
@@ -1092,28 +1147,30 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
+        assert.isArray('orders', orders);
+        assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+        assert.isArray('signatures', signatures);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.batchFillOrdersNoThrow.estimateGasAsync.bind(
-                    self,
-                    orders,
-                    takerAssetFillAmounts,
-                    signatures
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.batchFillOrdersNoThrow.estimateGasAsync.bind(
+                self,
+                orders,
+                takerAssetFillAmounts,
+                signatures
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -1123,23 +1180,25 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
-            const self = this as any as ExchangeContract;
-            const txHashPromise = self.batchFillOrdersNoThrow.sendTransactionAsync(orders,
+        assert.isArray('orders', orders);
+        assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+        assert.isArray('signatures', signatures);
+        const self = this as any as ExchangeContract;
+        const txHashPromise = self.batchFillOrdersNoThrow.sendTransactionAsync(orders,
     takerAssetFillAmounts,
     signatures
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -1147,35 +1206,39 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
+        assert.isArray('orders', orders);
+        assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+        assert.isArray('signatures', signatures);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAssetFillAmounts: BigNumber[],
             signatures: string[],
         ): string {
-            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
-            const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
+        assert.isArray('orders', orders);
+        assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+        assert.isArray('signatures', signatures);
+        const self = this as any as ExchangeContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -1185,7 +1248,9 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1298,28 +1363,30 @@ export class ExchangeContract extends BaseContract {
             signature: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
+
+        assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+        assert.isString('signature', signature);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.fillOrKillOrder.estimateGasAsync.bind(
-                    self,
-                    order,
-                    takerAssetFillAmount,
-                    signature
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.fillOrKillOrder.estimateGasAsync.bind(
+                self,
+                order,
+                takerAssetFillAmount,
+                signature
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
@@ -1329,23 +1396,25 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
-            const self = this as any as ExchangeContract;
-            const txHashPromise = self.fillOrKillOrder.sendTransactionAsync(order,
+
+        assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+        assert.isString('signature', signature);
+        const self = this as any as ExchangeContract;
+        const txHashPromise = self.fillOrKillOrder.sendTransactionAsync(order,
     takerAssetFillAmount,
     signature
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
@@ -1353,35 +1422,39 @@ export class ExchangeContract extends BaseContract {
             signature: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
+
+        assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+        assert.isString('signature', signature);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             takerAssetFillAmount: BigNumber,
             signature: string,
         ): string {
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
-            const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
+
+        assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+        assert.isString('signature', signature);
+        const self = this as any as ExchangeContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
@@ -1391,7 +1464,9 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1429,26 +1504,27 @@ export class ExchangeContract extends BaseContract {
             approval: boolean,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('validatorAddress', validatorAddress);assert.isBoolean('approval', approval);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('setSignatureValidatorApproval(address,bool)', [validatorAddress,
+        assert.isString('validatorAddress', validatorAddress);
+        assert.isBoolean('approval', approval);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('setSignatureValidatorApproval(address,bool)', [validatorAddress,
     approval
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.setSignatureValidatorApproval.estimateGasAsync.bind(
-                    self,
-                    validatorAddress,
-                    approval
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.setSignatureValidatorApproval.estimateGasAsync.bind(
+                self,
+                validatorAddress,
+                approval
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             validatorAddress: string,
@@ -1457,54 +1533,57 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('validatorAddress', validatorAddress);assert.isBoolean('approval', approval);
-            const self = this as any as ExchangeContract;
-            const txHashPromise = self.setSignatureValidatorApproval.sendTransactionAsync(validatorAddress,
+        assert.isString('validatorAddress', validatorAddress);
+        assert.isBoolean('approval', approval);
+        const self = this as any as ExchangeContract;
+        const txHashPromise = self.setSignatureValidatorApproval.sendTransactionAsync(validatorAddress,
     approval
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             validatorAddress: string,
             approval: boolean,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('validatorAddress', validatorAddress);assert.isBoolean('approval', approval);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('setSignatureValidatorApproval(address,bool)', [validatorAddress,
+        assert.isString('validatorAddress', validatorAddress);
+        assert.isBoolean('approval', approval);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('setSignatureValidatorApproval(address,bool)', [validatorAddress,
     approval
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             validatorAddress: string,
             approval: boolean,
         ): string {
-            assert.isString('validatorAddress', validatorAddress);assert.isBoolean('approval', approval);
-            const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('setSignatureValidatorApproval(address,bool)', [validatorAddress,
+        assert.isString('validatorAddress', validatorAddress);
+        assert.isBoolean('approval', approval);
+        const self = this as any as ExchangeContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('setSignatureValidatorApproval(address,bool)', [validatorAddress,
     approval
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             validatorAddress: string,
@@ -1513,7 +1592,8 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('validatorAddress', validatorAddress);assert.isBoolean('approval', approval);
+            assert.isString('validatorAddress', validatorAddress);
+            assert.isBoolean('approval', approval);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1552,7 +1632,8 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('index_0', index_0);assert.isString('index_1', index_1);
+            assert.isString('index_0', index_0);
+            assert.isString('index_1', index_1);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1590,28 +1671,30 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
+        assert.isArray('orders', orders);
+        assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+        assert.isArray('signatures', signatures);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
     signatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.marketSellOrders.estimateGasAsync.bind(
-                    self,
-                    orders,
-                    takerAssetFillAmount,
-                    signatures
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.marketSellOrders.estimateGasAsync.bind(
+                self,
+                orders,
+                takerAssetFillAmount,
+                signatures
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -1621,23 +1704,25 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
-            const self = this as any as ExchangeContract;
-            const txHashPromise = self.marketSellOrders.sendTransactionAsync(orders,
+        assert.isArray('orders', orders);
+        assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+        assert.isArray('signatures', signatures);
+        const self = this as any as ExchangeContract;
+        const txHashPromise = self.marketSellOrders.sendTransactionAsync(orders,
     takerAssetFillAmount,
     signatures
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -1645,35 +1730,39 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
+        assert.isArray('orders', orders);
+        assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+        assert.isArray('signatures', signatures);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
     signatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAssetFillAmount: BigNumber,
             signatures: string[],
         ): string {
-            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
-            const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
+        assert.isArray('orders', orders);
+        assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+        assert.isArray('signatures', signatures);
+        const self = this as any as ExchangeContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
     signatures
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -1683,7 +1772,9 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1760,7 +1851,8 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('index_0', index_0);assert.isString('index_1', index_1);
+            assert.isString('index_0', index_0);
+            assert.isString('index_1', index_1);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1797,7 +1889,6 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1835,7 +1926,9 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('hash', hash);assert.isString('signerAddress', signerAddress);assert.isString('signature', signature);
+            assert.isString('hash', hash);
+            assert.isString('signerAddress', signerAddress);
+            assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1874,28 +1967,30 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
+        assert.isArray('orders', orders);
+        assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+        assert.isArray('signatures', signatures);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
     signatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.marketBuyOrdersNoThrow.estimateGasAsync.bind(
-                    self,
-                    orders,
-                    makerAssetFillAmount,
-                    signatures
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.marketBuyOrdersNoThrow.estimateGasAsync.bind(
+                self,
+                orders,
+                makerAssetFillAmount,
+                signatures
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -1905,23 +2000,25 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
-            const self = this as any as ExchangeContract;
-            const txHashPromise = self.marketBuyOrdersNoThrow.sendTransactionAsync(orders,
+        assert.isArray('orders', orders);
+        assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+        assert.isArray('signatures', signatures);
+        const self = this as any as ExchangeContract;
+        const txHashPromise = self.marketBuyOrdersNoThrow.sendTransactionAsync(orders,
     makerAssetFillAmount,
     signatures
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -1929,35 +2026,39 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
+        assert.isArray('orders', orders);
+        assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+        assert.isArray('signatures', signatures);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
     signatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             makerAssetFillAmount: BigNumber,
             signatures: string[],
         ): string {
-            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
-            const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
+        assert.isArray('orders', orders);
+        assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+        assert.isArray('signatures', signatures);
+        const self = this as any as ExchangeContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
     signatures
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -1967,7 +2068,9 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2006,28 +2109,30 @@ export class ExchangeContract extends BaseContract {
             signature: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
+
+        assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+        assert.isString('signature', signature);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.fillOrder.estimateGasAsync.bind(
-                    self,
-                    order,
-                    takerAssetFillAmount,
-                    signature
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.fillOrder.estimateGasAsync.bind(
+                self,
+                order,
+                takerAssetFillAmount,
+                signature
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
@@ -2037,23 +2142,25 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
-            const self = this as any as ExchangeContract;
-            const txHashPromise = self.fillOrder.sendTransactionAsync(order,
+
+        assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+        assert.isString('signature', signature);
+        const self = this as any as ExchangeContract;
+        const txHashPromise = self.fillOrder.sendTransactionAsync(order,
     takerAssetFillAmount,
     signature
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
@@ -2061,35 +2168,39 @@ export class ExchangeContract extends BaseContract {
             signature: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
+
+        assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+        assert.isString('signature', signature);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             takerAssetFillAmount: BigNumber,
             signature: string,
         ): string {
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
-            const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
+
+        assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+        assert.isString('signature', signature);
+        const self = this as any as ExchangeContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
@@ -2099,7 +2210,9 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2139,30 +2252,33 @@ export class ExchangeContract extends BaseContract {
             signature: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isBigNumber('salt', salt);assert.isString('signerAddress', signerAddress);assert.isString('data', data);assert.isString('signature', signature);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('executeTransaction(uint256,address,bytes,bytes)', [salt,
+        assert.isBigNumber('salt', salt);
+        assert.isString('signerAddress', signerAddress);
+        assert.isString('data', data);
+        assert.isString('signature', signature);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('executeTransaction(uint256,address,bytes,bytes)', [salt,
     signerAddress,
     data,
     signature
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.executeTransaction.estimateGasAsync.bind(
-                    self,
-                    salt,
-                    signerAddress,
-                    data,
-                    signature
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.executeTransaction.estimateGasAsync.bind(
+                self,
+                salt,
+                signerAddress,
+                data,
+                signature
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             salt: BigNumber,
@@ -2173,24 +2289,27 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isBigNumber('salt', salt);assert.isString('signerAddress', signerAddress);assert.isString('data', data);assert.isString('signature', signature);
-            const self = this as any as ExchangeContract;
-            const txHashPromise = self.executeTransaction.sendTransactionAsync(salt,
+        assert.isBigNumber('salt', salt);
+        assert.isString('signerAddress', signerAddress);
+        assert.isString('data', data);
+        assert.isString('signature', signature);
+        const self = this as any as ExchangeContract;
+        const txHashPromise = self.executeTransaction.sendTransactionAsync(salt,
     signerAddress,
     data,
     signature
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             salt: BigNumber,
@@ -2199,23 +2318,26 @@ export class ExchangeContract extends BaseContract {
             signature: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isBigNumber('salt', salt);assert.isString('signerAddress', signerAddress);assert.isString('data', data);assert.isString('signature', signature);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('executeTransaction(uint256,address,bytes,bytes)', [salt,
+        assert.isBigNumber('salt', salt);
+        assert.isString('signerAddress', signerAddress);
+        assert.isString('data', data);
+        assert.isString('signature', signature);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('executeTransaction(uint256,address,bytes,bytes)', [salt,
     signerAddress,
     data,
     signature
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             salt: BigNumber,
@@ -2223,14 +2345,17 @@ export class ExchangeContract extends BaseContract {
             data: string,
             signature: string,
         ): string {
-            assert.isBigNumber('salt', salt);assert.isString('signerAddress', signerAddress);assert.isString('data', data);assert.isString('signature', signature);
-            const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('executeTransaction(uint256,address,bytes,bytes)', [salt,
+        assert.isBigNumber('salt', salt);
+        assert.isString('signerAddress', signerAddress);
+        assert.isString('data', data);
+        assert.isString('signature', signature);
+        const self = this as any as ExchangeContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('executeTransaction(uint256,address,bytes,bytes)', [salt,
     signerAddress,
     data,
     signature
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             salt: BigNumber,
@@ -2241,7 +2366,10 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isBigNumber('salt', salt);assert.isString('signerAddress', signerAddress);assert.isString('data', data);assert.isString('signature', signature);
+            assert.isBigNumber('salt', salt);
+            assert.isString('signerAddress', signerAddress);
+            assert.isString('data', data);
+            assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2279,24 +2407,24 @@ export class ExchangeContract extends BaseContract {
             assetProxy: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('assetProxy', assetProxy);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
+        assert.isString('assetProxy', assetProxy);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.registerAssetProxy.estimateGasAsync.bind(
-                    self,
-                    assetProxy
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.registerAssetProxy.estimateGasAsync.bind(
+                self,
+                assetProxy
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             assetProxy: string,
@@ -2304,49 +2432,49 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('assetProxy', assetProxy);
-            const self = this as any as ExchangeContract;
-            const txHashPromise = self.registerAssetProxy.sendTransactionAsync(assetProxy
+        assert.isString('assetProxy', assetProxy);
+        const self = this as any as ExchangeContract;
+        const txHashPromise = self.registerAssetProxy.sendTransactionAsync(assetProxy
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             assetProxy: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('assetProxy', assetProxy);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
+        assert.isString('assetProxy', assetProxy);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             assetProxy: string,
         ): string {
-            assert.isString('assetProxy', assetProxy);
-            const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
+        assert.isString('assetProxy', assetProxy);
+        const self = this as any as ExchangeContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             assetProxy: string,
@@ -2427,23 +2555,23 @@ export class ExchangeContract extends BaseContract {
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
 
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('cancelOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('cancelOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.cancelOrder.estimateGasAsync.bind(
-                    self,
-                    order
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.cancelOrder.estimateGasAsync.bind(
+                self,
+                order
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
@@ -2452,48 +2580,48 @@ export class ExchangeContract extends BaseContract {
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
 
-            const self = this as any as ExchangeContract;
-            const txHashPromise = self.cancelOrder.sendTransactionAsync(order
+        const self = this as any as ExchangeContract;
+        const txHashPromise = self.cancelOrder.sendTransactionAsync(order
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
 
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('cancelOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('cancelOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
         ): string {
 
-            const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('cancelOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
+        const self = this as any as ExchangeContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('cancelOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             order: {makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string},
@@ -2539,7 +2667,8 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-            assert.isString('index_0', index_0);assert.isString('index_1', index_1);
+            assert.isString('index_0', index_0);
+            assert.isString('index_1', index_1);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2576,7 +2705,6 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2612,28 +2740,30 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
+        assert.isArray('orders', orders);
+        assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+        assert.isArray('signatures', signatures);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
     signatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.marketSellOrdersNoThrow.estimateGasAsync.bind(
-                    self,
-                    orders,
-                    takerAssetFillAmount,
-                    signatures
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.marketSellOrdersNoThrow.estimateGasAsync.bind(
+                self,
+                orders,
+                takerAssetFillAmount,
+                signatures
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -2643,23 +2773,25 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
-            const self = this as any as ExchangeContract;
-            const txHashPromise = self.marketSellOrdersNoThrow.sendTransactionAsync(orders,
+        assert.isArray('orders', orders);
+        assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+        assert.isArray('signatures', signatures);
+        const self = this as any as ExchangeContract;
+        const txHashPromise = self.marketSellOrdersNoThrow.sendTransactionAsync(orders,
     takerAssetFillAmount,
     signatures
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -2667,35 +2799,39 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
+        assert.isArray('orders', orders);
+        assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+        assert.isArray('signatures', signatures);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
     signatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             takerAssetFillAmount: BigNumber,
             signatures: string[],
         ): string {
-            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
-            const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
+        assert.isArray('orders', orders);
+        assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+        assert.isArray('signatures', signatures);
+        const self = this as any as ExchangeContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
     signatures
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -2705,7 +2841,9 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2743,7 +2881,6 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2779,28 +2916,30 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
+        assert.isArray('orders', orders);
+        assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+        assert.isArray('signatures', signatures);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
     signatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.marketBuyOrders.estimateGasAsync.bind(
-                    self,
-                    orders,
-                    makerAssetFillAmount,
-                    signatures
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.marketBuyOrders.estimateGasAsync.bind(
+                self,
+                orders,
+                makerAssetFillAmount,
+                signatures
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -2810,23 +2949,25 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
-            const self = this as any as ExchangeContract;
-            const txHashPromise = self.marketBuyOrders.sendTransactionAsync(orders,
+        assert.isArray('orders', orders);
+        assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+        assert.isArray('signatures', signatures);
+        const self = this as any as ExchangeContract;
+        const txHashPromise = self.marketBuyOrders.sendTransactionAsync(orders,
     makerAssetFillAmount,
     signatures
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -2834,35 +2975,39 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
+        assert.isArray('orders', orders);
+        assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+        assert.isArray('signatures', signatures);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
     signatures
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
             makerAssetFillAmount: BigNumber,
             signatures: string[],
         ): string {
-            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
-            const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
+        assert.isArray('orders', orders);
+        assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+        assert.isArray('signatures', signatures);
+        const self = this as any as ExchangeContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
     signatures
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -2872,7 +3017,9 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2910,7 +3057,6 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2944,24 +3090,24 @@ export class ExchangeContract extends BaseContract {
             newOwner: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transferOwnership.estimateGasAsync.bind(
-                    self,
-                    newOwner
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.transferOwnership.estimateGasAsync.bind(
+                self,
+                newOwner
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             newOwner: string,
@@ -2969,49 +3115,49 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as ExchangeContract;
-            const txHashPromise = self.transferOwnership.sendTransactionAsync(newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as ExchangeContract;
+        const txHashPromise = self.transferOwnership.sendTransactionAsync(newOwner
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             newOwner: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as ExchangeContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as ExchangeContract;
+        const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             newOwner: string,
         ): string {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as ExchangeContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as ExchangeContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             newOwner: string,
@@ -3055,7 +3201,6 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/exchange.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/exchange.ts
@@ -127,16 +127,19 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -158,7 +161,9 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.batchFillOrders.sendTransactionAsync(orders,
     takerAssetFillAmounts,
@@ -182,16 +187,19 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -204,7 +212,9 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmounts: BigNumber[],
             signatures: string[],
         ): string {
-            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('batchFillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
@@ -220,7 +230,9 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -296,16 +308,19 @@ export class ExchangeContract extends BaseContract {
             signature: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('hash', hash);assert.isString('signerAddress', signerAddress);assert.isString('signature', signature);
+            assert.isString('hash', hash);
+            assert.isString('signerAddress', signerAddress);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('preSign(bytes32,address,bytes)', [hash,
     signerAddress,
     signature
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -327,7 +342,9 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('hash', hash);assert.isString('signerAddress', signerAddress);assert.isString('signature', signature);
+            assert.isString('hash', hash);
+            assert.isString('signerAddress', signerAddress);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.preSign.sendTransactionAsync(hash,
     signerAddress,
@@ -351,16 +368,19 @@ export class ExchangeContract extends BaseContract {
             signature: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('hash', hash);assert.isString('signerAddress', signerAddress);assert.isString('signature', signature);
+            assert.isString('hash', hash);
+            assert.isString('signerAddress', signerAddress);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('preSign(bytes32,address,bytes)', [hash,
     signerAddress,
     signature
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -373,7 +393,9 @@ export class ExchangeContract extends BaseContract {
             signerAddress: string,
             signature: string,
         ): string {
-            assert.isString('hash', hash);assert.isString('signerAddress', signerAddress);assert.isString('signature', signature);
+            assert.isString('hash', hash);
+            assert.isString('signerAddress', signerAddress);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('preSign(bytes32,address,bytes)', [hash,
     signerAddress,
@@ -389,7 +411,9 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('hash', hash);assert.isString('signerAddress', signerAddress);assert.isString('signature', signature);
+            assert.isString('hash', hash);
+            assert.isString('signerAddress', signerAddress);
+            assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -429,17 +453,21 @@ export class ExchangeContract extends BaseContract {
             rightSignature: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('leftSignature', leftSignature);assert.isString('rightSignature', rightSignature);
+
+
+            assert.isString('leftSignature', leftSignature);
+            assert.isString('rightSignature', rightSignature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [leftOrder,
     rightOrder,
     leftSignature,
     rightSignature
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -463,7 +491,10 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('leftSignature', leftSignature);assert.isString('rightSignature', rightSignature);
+
+
+            assert.isString('leftSignature', leftSignature);
+            assert.isString('rightSignature', rightSignature);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.matchOrders.sendTransactionAsync(leftOrder,
     rightOrder,
@@ -489,17 +520,21 @@ export class ExchangeContract extends BaseContract {
             rightSignature: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('leftSignature', leftSignature);assert.isString('rightSignature', rightSignature);
+
+
+            assert.isString('leftSignature', leftSignature);
+            assert.isString('rightSignature', rightSignature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [leftOrder,
     rightOrder,
     leftSignature,
     rightSignature
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -513,7 +548,10 @@ export class ExchangeContract extends BaseContract {
             leftSignature: string,
             rightSignature: string,
         ): string {
-            assert.isString('leftSignature', leftSignature);assert.isString('rightSignature', rightSignature);
+
+
+            assert.isString('leftSignature', leftSignature);
+            assert.isString('rightSignature', rightSignature);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('matchOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes,bytes)', [leftOrder,
     rightOrder,
@@ -531,7 +569,10 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{left: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};right: {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber};leftMakerAssetSpreadAmount: BigNumber}
         > {
-            assert.isString('leftSignature', leftSignature);assert.isString('rightSignature', rightSignature);
+
+
+            assert.isString('leftSignature', leftSignature);
+            assert.isString('rightSignature', rightSignature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -571,16 +612,19 @@ export class ExchangeContract extends BaseContract {
             signature: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -602,7 +646,9 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.fillOrderNoThrow.sendTransactionAsync(order,
     takerAssetFillAmount,
@@ -626,16 +672,19 @@ export class ExchangeContract extends BaseContract {
             signature: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -648,7 +697,9 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmount: BigNumber,
             signature: string,
         ): string {
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('fillOrderNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
@@ -664,7 +715,9 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -742,10 +795,11 @@ export class ExchangeContract extends BaseContract {
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchCancelOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])', [orders
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -787,10 +841,11 @@ export class ExchangeContract extends BaseContract {
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchCancelOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])', [orders
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -850,16 +905,19 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -881,7 +939,9 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.batchFillOrKillOrders.sendTransactionAsync(orders,
     takerAssetFillAmounts,
@@ -905,16 +965,19 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -927,7 +990,9 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmounts: BigNumber[],
             signatures: string[],
         ): string {
-            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('batchFillOrKillOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
@@ -943,7 +1008,9 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -984,10 +1051,11 @@ export class ExchangeContract extends BaseContract {
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('cancelOrdersUpTo(uint256)', [targetOrderEpoch
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1029,10 +1097,11 @@ export class ExchangeContract extends BaseContract {
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('cancelOrdersUpTo(uint256)', [targetOrderEpoch
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1092,16 +1161,19 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1123,7 +1195,9 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.batchFillOrdersNoThrow.sendTransactionAsync(orders,
     takerAssetFillAmounts,
@@ -1147,16 +1221,19 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
     signatures
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1169,7 +1246,9 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmounts: BigNumber[],
             signatures: string[],
         ): string {
-            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('batchFillOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256[],bytes[])', [orders,
     takerAssetFillAmounts,
@@ -1185,7 +1264,9 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isArray('orders', orders);assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isArray('takerAssetFillAmounts', takerAssetFillAmounts);
+            assert.isArray('signatures', signatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1298,16 +1379,19 @@ export class ExchangeContract extends BaseContract {
             signature: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1329,7 +1413,9 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.fillOrKillOrder.sendTransactionAsync(order,
     takerAssetFillAmount,
@@ -1353,16 +1439,19 @@ export class ExchangeContract extends BaseContract {
             signature: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1375,7 +1464,9 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmount: BigNumber,
             signature: string,
         ): string {
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('fillOrKillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
@@ -1391,7 +1482,9 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1429,15 +1522,17 @@ export class ExchangeContract extends BaseContract {
             approval: boolean,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('validatorAddress', validatorAddress);assert.isBoolean('approval', approval);
+            assert.isString('validatorAddress', validatorAddress);
+            assert.isBoolean('approval', approval);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('setSignatureValidatorApproval(address,bool)', [validatorAddress,
     approval
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1457,7 +1552,8 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('validatorAddress', validatorAddress);assert.isBoolean('approval', approval);
+            assert.isString('validatorAddress', validatorAddress);
+            assert.isBoolean('approval', approval);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.setSignatureValidatorApproval.sendTransactionAsync(validatorAddress,
     approval
@@ -1479,15 +1575,17 @@ export class ExchangeContract extends BaseContract {
             approval: boolean,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('validatorAddress', validatorAddress);assert.isBoolean('approval', approval);
+            assert.isString('validatorAddress', validatorAddress);
+            assert.isBoolean('approval', approval);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('setSignatureValidatorApproval(address,bool)', [validatorAddress,
     approval
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1499,7 +1597,8 @@ export class ExchangeContract extends BaseContract {
             validatorAddress: string,
             approval: boolean,
         ): string {
-            assert.isString('validatorAddress', validatorAddress);assert.isBoolean('approval', approval);
+            assert.isString('validatorAddress', validatorAddress);
+            assert.isBoolean('approval', approval);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('setSignatureValidatorApproval(address,bool)', [validatorAddress,
     approval
@@ -1513,7 +1612,8 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('validatorAddress', validatorAddress);assert.isBoolean('approval', approval);
+            assert.isString('validatorAddress', validatorAddress);
+            assert.isBoolean('approval', approval);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1552,7 +1652,8 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('index_0', index_0);assert.isString('index_1', index_1);
+            assert.isString('index_0', index_0);
+            assert.isString('index_1', index_1);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1590,16 +1691,19 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
     signatures
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1621,7 +1725,9 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.marketSellOrders.sendTransactionAsync(orders,
     takerAssetFillAmount,
@@ -1645,16 +1751,19 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
     signatures
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1667,7 +1776,9 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmount: BigNumber,
             signatures: string[],
         ): string {
-            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('marketSellOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
@@ -1683,7 +1794,9 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1760,7 +1873,8 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('index_0', index_0);assert.isString('index_1', index_1);
+            assert.isString('index_0', index_0);
+            assert.isString('index_1', index_1);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1797,7 +1911,6 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1835,7 +1948,9 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('hash', hash);assert.isString('signerAddress', signerAddress);assert.isString('signature', signature);
+            assert.isString('hash', hash);
+            assert.isString('signerAddress', signerAddress);
+            assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -1874,16 +1989,19 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
     signatures
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1905,7 +2023,9 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.marketBuyOrdersNoThrow.sendTransactionAsync(orders,
     makerAssetFillAmount,
@@ -1929,16 +2049,19 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
     signatures
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -1951,7 +2074,9 @@ export class ExchangeContract extends BaseContract {
             makerAssetFillAmount: BigNumber,
             signatures: string[],
         ): string {
-            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('marketBuyOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
@@ -1967,7 +2092,9 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2006,16 +2133,19 @@ export class ExchangeContract extends BaseContract {
             signature: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2037,7 +2167,9 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.fillOrder.sendTransactionAsync(order,
     takerAssetFillAmount,
@@ -2061,16 +2193,19 @@ export class ExchangeContract extends BaseContract {
             signature: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
     signature
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2083,7 +2218,9 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmount: BigNumber,
             signature: string,
         ): string {
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('fillOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),uint256,bytes)', [order,
     takerAssetFillAmount,
@@ -2099,7 +2236,9 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isString('signature', signature);
+
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2139,17 +2278,21 @@ export class ExchangeContract extends BaseContract {
             signature: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isBigNumber('salt', salt);assert.isString('signerAddress', signerAddress);assert.isString('data', data);assert.isString('signature', signature);
+            assert.isBigNumber('salt', salt);
+            assert.isString('signerAddress', signerAddress);
+            assert.isString('data', data);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('executeTransaction(uint256,address,bytes,bytes)', [salt,
     signerAddress,
     data,
     signature
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2173,7 +2316,10 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isBigNumber('salt', salt);assert.isString('signerAddress', signerAddress);assert.isString('data', data);assert.isString('signature', signature);
+            assert.isBigNumber('salt', salt);
+            assert.isString('signerAddress', signerAddress);
+            assert.isString('data', data);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.executeTransaction.sendTransactionAsync(salt,
     signerAddress,
@@ -2199,17 +2345,21 @@ export class ExchangeContract extends BaseContract {
             signature: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isBigNumber('salt', salt);assert.isString('signerAddress', signerAddress);assert.isString('data', data);assert.isString('signature', signature);
+            assert.isBigNumber('salt', salt);
+            assert.isString('signerAddress', signerAddress);
+            assert.isString('data', data);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('executeTransaction(uint256,address,bytes,bytes)', [salt,
     signerAddress,
     data,
     signature
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2223,7 +2373,10 @@ export class ExchangeContract extends BaseContract {
             data: string,
             signature: string,
         ): string {
-            assert.isBigNumber('salt', salt);assert.isString('signerAddress', signerAddress);assert.isString('data', data);assert.isString('signature', signature);
+            assert.isBigNumber('salt', salt);
+            assert.isString('signerAddress', signerAddress);
+            assert.isString('data', data);
+            assert.isString('signature', signature);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('executeTransaction(uint256,address,bytes,bytes)', [salt,
     signerAddress,
@@ -2241,7 +2394,10 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isBigNumber('salt', salt);assert.isString('signerAddress', signerAddress);assert.isString('data', data);assert.isString('signature', signature);
+            assert.isBigNumber('salt', salt);
+            assert.isString('signerAddress', signerAddress);
+            assert.isString('data', data);
+            assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2283,10 +2439,11 @@ export class ExchangeContract extends BaseContract {
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2328,10 +2485,11 @@ export class ExchangeContract extends BaseContract {
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2430,10 +2588,11 @@ export class ExchangeContract extends BaseContract {
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('cancelOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2475,10 +2634,11 @@ export class ExchangeContract extends BaseContract {
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('cancelOrder((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes))', [order
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2539,7 +2699,8 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-            assert.isString('index_0', index_0);assert.isString('index_1', index_1);
+            assert.isString('index_0', index_0);
+            assert.isString('index_1', index_1);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2576,7 +2737,6 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2612,16 +2772,19 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
     signatures
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2643,7 +2806,9 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.marketSellOrdersNoThrow.sendTransactionAsync(orders,
     takerAssetFillAmount,
@@ -2667,16 +2832,19 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
     signatures
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2689,7 +2857,9 @@ export class ExchangeContract extends BaseContract {
             takerAssetFillAmount: BigNumber,
             signatures: string[],
         ): string {
-            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('marketSellOrdersNoThrow((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     takerAssetFillAmount,
@@ -2705,7 +2875,9 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isArray('orders', orders);assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isBigNumber('takerAssetFillAmount', takerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2743,7 +2915,6 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2779,16 +2950,19 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
     signatures
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2810,7 +2984,9 @@ export class ExchangeContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const txHashPromise = self.marketBuyOrders.sendTransactionAsync(orders,
     makerAssetFillAmount,
@@ -2834,16 +3010,19 @@ export class ExchangeContract extends BaseContract {
             signatures: string[],
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
     signatures
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2856,7 +3035,9 @@ export class ExchangeContract extends BaseContract {
             makerAssetFillAmount: BigNumber,
             signatures: string[],
         ): string {
-            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             const self = this as any as ExchangeContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('marketBuyOrders((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[])', [orders,
     makerAssetFillAmount,
@@ -2872,7 +3053,9 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}
         > {
-            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2910,7 +3093,6 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -2948,10 +3130,11 @@ export class ExchangeContract extends BaseContract {
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -2993,10 +3176,11 @@ export class ExchangeContract extends BaseContract {
             const self = this as any as ExchangeContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -3055,7 +3239,6 @@ export class ExchangeContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -3111,7 +3294,7 @@ export class ExchangeContract extends BaseContract {
         txDefaults: Partial<TxData>,
             _zrxAssetData: string,
     ): Promise<ExchangeContract> {
-        assert.isHexString('bytecode', bytecode);
+        assert.isString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/forwarder.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/forwarder.ts
@@ -2,6 +2,7 @@
 // tslint:disable:no-unused-variable
 // tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
+import { schemas } from '@0x/json-schemas';
 import {
     BlockParam,
     BlockParamLiteral,
@@ -18,6 +19,7 @@ import {
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
+import { assert } from '@0x/assert';
 import * as ethers from 'ethers';
 // tslint:enable:no-unused-variable
 
@@ -35,8 +37,15 @@ export class ForwarderContract extends BaseContract {
             feeSignatures: string[],
             feePercentage: BigNumber,
             feeRecipient: string,
-            txData: Partial<TxDataPayable> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
+            assert.isArray('feeOrders', feeOrders);
+            assert.isArray('feeSignatures', feeSignatures);
+            assert.isBigNumber('feePercentage', feePercentage);
+            assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     makerAssetFillAmount,
@@ -46,10 +55,11 @@ export class ForwarderContract extends BaseContract {
     feePercentage,
     feeRecipient
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -75,17 +85,17 @@ export class ForwarderContract extends BaseContract {
             feeSignatures: string[],
             feePercentage: BigNumber,
             feeRecipient: string,
-            txData?: Partial<TxDataPayable> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
+            assert.isArray('feeOrders', feeOrders);
+            assert.isArray('feeSignatures', feeSignatures);
+            assert.isBigNumber('feePercentage', feePercentage);
+            assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const txHashPromise = self.marketBuyOrdersWithEth.sendTransactionAsync(orders,
     makerAssetFillAmount,
@@ -115,8 +125,15 @@ export class ForwarderContract extends BaseContract {
             feeSignatures: string[],
             feePercentage: BigNumber,
             feeRecipient: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
+            assert.isArray('feeOrders', feeOrders);
+            assert.isArray('feeSignatures', feeSignatures);
+            assert.isBigNumber('feePercentage', feePercentage);
+            assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     makerAssetFillAmount,
@@ -126,10 +143,11 @@ export class ForwarderContract extends BaseContract {
     feePercentage,
     feeRecipient
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -146,6 +164,13 @@ export class ForwarderContract extends BaseContract {
             feePercentage: BigNumber,
             feeRecipient: string,
         ): string {
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
+            assert.isArray('feeOrders', feeOrders);
+            assert.isArray('feeSignatures', feeSignatures);
+            assert.isBigNumber('feePercentage', feePercentage);
+            assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     makerAssetFillAmount,
@@ -169,6 +194,21 @@ export class ForwarderContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<[{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}, {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}]
         > {
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
+            assert.isArray('feeOrders', feeOrders);
+            assert.isArray('feeSignatures', feeSignatures);
+            assert.isBigNumber('feePercentage', feePercentage);
+            assert.isString('feeRecipient', feeRecipient);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
         makerAssetFillAmount,
@@ -200,16 +240,19 @@ export class ForwarderContract extends BaseContract {
         async sendTransactionAsync(
             assetData: string,
             amount: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('assetData', assetData);
+            assert.isBigNumber('amount', amount);
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('withdrawAsset(bytes,uint256)', [assetData,
     amount
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -225,17 +268,12 @@ export class ForwarderContract extends BaseContract {
         awaitTransactionSuccessAsync(
             assetData: string,
             amount: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('assetData', assetData);
+            assert.isBigNumber('amount', amount);
             const self = this as any as ForwarderContract;
             const txHashPromise = self.withdrawAsset.sendTransactionAsync(assetData,
     amount
@@ -255,16 +293,19 @@ export class ForwarderContract extends BaseContract {
         async estimateGasAsync(
             assetData: string,
             amount: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('assetData', assetData);
+            assert.isBigNumber('amount', amount);
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('withdrawAsset(bytes,uint256)', [assetData,
     amount
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -276,6 +317,8 @@ export class ForwarderContract extends BaseContract {
             assetData: string,
             amount: BigNumber,
         ): string {
+            assert.isString('assetData', assetData);
+            assert.isBigNumber('amount', amount);
             const self = this as any as ForwarderContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('withdrawAsset(bytes,uint256)', [assetData,
     amount
@@ -289,6 +332,16 @@ export class ForwarderContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('assetData', assetData);
+            assert.isBigNumber('amount', amount);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('withdrawAsset(bytes,uint256)', [assetData,
         amount
@@ -317,6 +370,14 @@ export class ForwarderContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('owner()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -345,8 +406,14 @@ export class ForwarderContract extends BaseContract {
             feeSignatures: string[],
             feePercentage: BigNumber,
             feeRecipient: string,
-            txData: Partial<TxDataPayable> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isArray('orders', orders);
+            assert.isArray('signatures', signatures);
+            assert.isArray('feeOrders', feeOrders);
+            assert.isArray('feeSignatures', feeSignatures);
+            assert.isBigNumber('feePercentage', feePercentage);
+            assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     signatures,
@@ -355,10 +422,11 @@ export class ForwarderContract extends BaseContract {
     feePercentage,
     feeRecipient
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -382,17 +450,16 @@ export class ForwarderContract extends BaseContract {
             feeSignatures: string[],
             feePercentage: BigNumber,
             feeRecipient: string,
-            txData?: Partial<TxDataPayable> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isArray('orders', orders);
+            assert.isArray('signatures', signatures);
+            assert.isArray('feeOrders', feeOrders);
+            assert.isArray('feeSignatures', feeSignatures);
+            assert.isBigNumber('feePercentage', feePercentage);
+            assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const txHashPromise = self.marketSellOrdersWithEth.sendTransactionAsync(orders,
     signatures,
@@ -420,8 +487,14 @@ export class ForwarderContract extends BaseContract {
             feeSignatures: string[],
             feePercentage: BigNumber,
             feeRecipient: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isArray('orders', orders);
+            assert.isArray('signatures', signatures);
+            assert.isArray('feeOrders', feeOrders);
+            assert.isArray('feeSignatures', feeSignatures);
+            assert.isBigNumber('feePercentage', feePercentage);
+            assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     signatures,
@@ -430,10 +503,11 @@ export class ForwarderContract extends BaseContract {
     feePercentage,
     feeRecipient
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -449,6 +523,12 @@ export class ForwarderContract extends BaseContract {
             feePercentage: BigNumber,
             feeRecipient: string,
         ): string {
+            assert.isArray('orders', orders);
+            assert.isArray('signatures', signatures);
+            assert.isArray('feeOrders', feeOrders);
+            assert.isArray('feeSignatures', feeSignatures);
+            assert.isBigNumber('feePercentage', feePercentage);
+            assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     signatures,
@@ -470,6 +550,20 @@ export class ForwarderContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<[{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}, {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}]
         > {
+            assert.isArray('orders', orders);
+            assert.isArray('signatures', signatures);
+            assert.isArray('feeOrders', feeOrders);
+            assert.isArray('feeSignatures', feeSignatures);
+            assert.isBigNumber('feePercentage', feePercentage);
+            assert.isString('feeRecipient', feeRecipient);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
         signatures,
@@ -499,15 +593,17 @@ export class ForwarderContract extends BaseContract {
     public transferOwnership = {
         async sendTransactionAsync(
             newOwner: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('newOwner', newOwner);
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -521,17 +617,11 @@ export class ForwarderContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             newOwner: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('newOwner', newOwner);
             const self = this as any as ForwarderContract;
             const txHashPromise = self.transferOwnership.sendTransactionAsync(newOwner
     , txData);
@@ -549,15 +639,17 @@ export class ForwarderContract extends BaseContract {
         },
         async estimateGasAsync(
             newOwner: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('newOwner', newOwner);
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -568,6 +660,7 @@ export class ForwarderContract extends BaseContract {
         getABIEncodedTransactionData(
             newOwner: string,
         ): string {
+            assert.isString('newOwner', newOwner);
             const self = this as any as ForwarderContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
@@ -579,6 +672,15 @@ export class ForwarderContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('newOwner', newOwner);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
         ]);
@@ -608,6 +710,11 @@ export class ForwarderContract extends BaseContract {
             _zrxAssetData: string,
             _wethAssetData: string,
     ): Promise<ForwarderContract> {
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         if (artifact.compilerOutput === undefined) {
             throw new Error('Compiler output not found in the artifact file');
         }
@@ -628,6 +735,12 @@ _wethAssetData
             _zrxAssetData: string,
             _wethAssetData: string,
     ): Promise<ForwarderContract> {
+        assert.isString('bytecode', bytecode);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
         const constructorAbi = BaseContract._lookupConstructorAbi(abi);
         [_exchange,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/forwarder.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/forwarder.ts
@@ -1,6 +1,6 @@
-// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma whitespace class-name
+// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma
+// tslint:disable:whitespace no-unbound-method no-trailing-whitespace
 // tslint:disable:no-unused-variable
-// tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
 import { schemas } from '@0x/json-schemas';
 import {
@@ -39,13 +39,7 @@ export class ForwarderContract extends BaseContract {
             feeRecipient: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-            assert.isArray('signatures', signatures);
-            assert.isArray('feeOrders', feeOrders);
-            assert.isArray('feeSignatures', feeSignatures);
-            assert.isBigNumber('feePercentage', feePercentage);
-            assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     makerAssetFillAmount,
@@ -55,11 +49,10 @@ export class ForwarderContract extends BaseContract {
     feePercentage,
     feeRecipient
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -89,13 +82,7 @@ export class ForwarderContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-            assert.isArray('signatures', signatures);
-            assert.isArray('feeOrders', feeOrders);
-            assert.isArray('feeSignatures', feeSignatures);
-            assert.isBigNumber('feePercentage', feePercentage);
-            assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const txHashPromise = self.marketBuyOrdersWithEth.sendTransactionAsync(orders,
     makerAssetFillAmount,
@@ -127,13 +114,7 @@ export class ForwarderContract extends BaseContract {
             feeRecipient: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-            assert.isArray('signatures', signatures);
-            assert.isArray('feeOrders', feeOrders);
-            assert.isArray('feeSignatures', feeSignatures);
-            assert.isBigNumber('feePercentage', feePercentage);
-            assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     makerAssetFillAmount,
@@ -143,11 +124,10 @@ export class ForwarderContract extends BaseContract {
     feePercentage,
     feeRecipient
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -164,13 +144,7 @@ export class ForwarderContract extends BaseContract {
             feePercentage: BigNumber,
             feeRecipient: string,
         ): string {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-            assert.isArray('signatures', signatures);
-            assert.isArray('feeOrders', feeOrders);
-            assert.isArray('feeSignatures', feeSignatures);
-            assert.isBigNumber('feePercentage', feePercentage);
-            assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     makerAssetFillAmount,
@@ -194,13 +168,7 @@ export class ForwarderContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<[{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}, {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}]
         > {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-            assert.isArray('signatures', signatures);
-            assert.isArray('feeOrders', feeOrders);
-            assert.isArray('feeSignatures', feeSignatures);
-            assert.isBigNumber('feePercentage', feePercentage);
-            assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -242,17 +210,15 @@ export class ForwarderContract extends BaseContract {
             amount: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('assetData', assetData);
-            assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);assert.isBigNumber('amount', amount);
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('withdrawAsset(bytes,uint256)', [assetData,
     amount
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -272,8 +238,7 @@ export class ForwarderContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('assetData', assetData);
-            assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);assert.isBigNumber('amount', amount);
             const self = this as any as ForwarderContract;
             const txHashPromise = self.withdrawAsset.sendTransactionAsync(assetData,
     amount
@@ -295,17 +260,15 @@ export class ForwarderContract extends BaseContract {
             amount: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('assetData', assetData);
-            assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);assert.isBigNumber('amount', amount);
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('withdrawAsset(bytes,uint256)', [assetData,
     amount
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -317,8 +280,7 @@ export class ForwarderContract extends BaseContract {
             assetData: string,
             amount: BigNumber,
         ): string {
-            assert.isString('assetData', assetData);
-            assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);assert.isBigNumber('amount', amount);
             const self = this as any as ForwarderContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('withdrawAsset(bytes,uint256)', [assetData,
     amount
@@ -332,8 +294,7 @@ export class ForwarderContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('assetData', assetData);
-            assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);assert.isBigNumber('amount', amount);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -370,6 +331,7 @@ export class ForwarderContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -408,12 +370,7 @@ export class ForwarderContract extends BaseContract {
             feeRecipient: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);
-            assert.isArray('signatures', signatures);
-            assert.isArray('feeOrders', feeOrders);
-            assert.isArray('feeSignatures', feeSignatures);
-            assert.isBigNumber('feePercentage', feePercentage);
-            assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     signatures,
@@ -422,11 +379,10 @@ export class ForwarderContract extends BaseContract {
     feePercentage,
     feeRecipient
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -454,12 +410,7 @@ export class ForwarderContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);
-            assert.isArray('signatures', signatures);
-            assert.isArray('feeOrders', feeOrders);
-            assert.isArray('feeSignatures', feeSignatures);
-            assert.isBigNumber('feePercentage', feePercentage);
-            assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const txHashPromise = self.marketSellOrdersWithEth.sendTransactionAsync(orders,
     signatures,
@@ -489,12 +440,7 @@ export class ForwarderContract extends BaseContract {
             feeRecipient: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);
-            assert.isArray('signatures', signatures);
-            assert.isArray('feeOrders', feeOrders);
-            assert.isArray('feeSignatures', feeSignatures);
-            assert.isBigNumber('feePercentage', feePercentage);
-            assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     signatures,
@@ -503,11 +449,10 @@ export class ForwarderContract extends BaseContract {
     feePercentage,
     feeRecipient
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -523,12 +468,7 @@ export class ForwarderContract extends BaseContract {
             feePercentage: BigNumber,
             feeRecipient: string,
         ): string {
-            assert.isArray('orders', orders);
-            assert.isArray('signatures', signatures);
-            assert.isArray('feeOrders', feeOrders);
-            assert.isArray('feeSignatures', feeSignatures);
-            assert.isBigNumber('feePercentage', feePercentage);
-            assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     signatures,
@@ -550,12 +490,7 @@ export class ForwarderContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<[{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}, {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}]
         > {
-            assert.isArray('orders', orders);
-            assert.isArray('signatures', signatures);
-            assert.isArray('feeOrders', feeOrders);
-            assert.isArray('feeSignatures', feeSignatures);
-            assert.isBigNumber('feePercentage', feePercentage);
-            assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -599,11 +534,10 @@ export class ForwarderContract extends BaseContract {
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -645,11 +579,10 @@ export class ForwarderContract extends BaseContract {
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -735,7 +668,7 @@ _wethAssetData
             _zrxAssetData: string,
             _wethAssetData: string,
     ): Promise<ForwarderContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,
@@ -782,4 +715,5 @@ _wethAssetData
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count
-// tslint:enable:no-unbound-method
+// tslint:enable:no-unbound-method no-parameter-reassignment no-consecutive-blank-lines ordered-imports align
+// tslint:enable:trailing-comma whitespace no-trailing-whitespace

--- a/packages/abi-gen-wrappers/src/generated-wrappers/forwarder.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/forwarder.ts
@@ -39,13 +39,7 @@ export class ForwarderContract extends BaseContract {
             feeRecipient: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-            assert.isArray('signatures', signatures);
-            assert.isArray('feeOrders', feeOrders);
-            assert.isArray('feeSignatures', feeSignatures);
-            assert.isBigNumber('feePercentage', feePercentage);
-            assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     makerAssetFillAmount,
@@ -55,11 +49,10 @@ export class ForwarderContract extends BaseContract {
     feePercentage,
     feeRecipient
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -89,13 +82,7 @@ export class ForwarderContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-            assert.isArray('signatures', signatures);
-            assert.isArray('feeOrders', feeOrders);
-            assert.isArray('feeSignatures', feeSignatures);
-            assert.isBigNumber('feePercentage', feePercentage);
-            assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const txHashPromise = self.marketBuyOrdersWithEth.sendTransactionAsync(orders,
     makerAssetFillAmount,
@@ -127,13 +114,7 @@ export class ForwarderContract extends BaseContract {
             feeRecipient: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-            assert.isArray('signatures', signatures);
-            assert.isArray('feeOrders', feeOrders);
-            assert.isArray('feeSignatures', feeSignatures);
-            assert.isBigNumber('feePercentage', feePercentage);
-            assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     makerAssetFillAmount,
@@ -143,11 +124,10 @@ export class ForwarderContract extends BaseContract {
     feePercentage,
     feeRecipient
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -164,13 +144,7 @@ export class ForwarderContract extends BaseContract {
             feePercentage: BigNumber,
             feeRecipient: string,
         ): string {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-            assert.isArray('signatures', signatures);
-            assert.isArray('feeOrders', feeOrders);
-            assert.isArray('feeSignatures', feeSignatures);
-            assert.isBigNumber('feePercentage', feePercentage);
-            assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     makerAssetFillAmount,
@@ -194,13 +168,7 @@ export class ForwarderContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<[{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}, {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}]
         > {
-            assert.isArray('orders', orders);
-            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
-            assert.isArray('signatures', signatures);
-            assert.isArray('feeOrders', feeOrders);
-            assert.isArray('feeSignatures', feeSignatures);
-            assert.isBigNumber('feePercentage', feePercentage);
-            assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -242,17 +210,15 @@ export class ForwarderContract extends BaseContract {
             amount: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('assetData', assetData);
-            assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);assert.isBigNumber('amount', amount);
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('withdrawAsset(bytes,uint256)', [assetData,
     amount
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -272,8 +238,7 @@ export class ForwarderContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('assetData', assetData);
-            assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);assert.isBigNumber('amount', amount);
             const self = this as any as ForwarderContract;
             const txHashPromise = self.withdrawAsset.sendTransactionAsync(assetData,
     amount
@@ -295,17 +260,15 @@ export class ForwarderContract extends BaseContract {
             amount: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('assetData', assetData);
-            assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);assert.isBigNumber('amount', amount);
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('withdrawAsset(bytes,uint256)', [assetData,
     amount
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -317,8 +280,7 @@ export class ForwarderContract extends BaseContract {
             assetData: string,
             amount: BigNumber,
         ): string {
-            assert.isString('assetData', assetData);
-            assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);assert.isBigNumber('amount', amount);
             const self = this as any as ForwarderContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('withdrawAsset(bytes,uint256)', [assetData,
     amount
@@ -332,8 +294,7 @@ export class ForwarderContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('assetData', assetData);
-            assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);assert.isBigNumber('amount', amount);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -370,6 +331,7 @@ export class ForwarderContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -408,12 +370,7 @@ export class ForwarderContract extends BaseContract {
             feeRecipient: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);
-            assert.isArray('signatures', signatures);
-            assert.isArray('feeOrders', feeOrders);
-            assert.isArray('feeSignatures', feeSignatures);
-            assert.isBigNumber('feePercentage', feePercentage);
-            assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     signatures,
@@ -422,11 +379,10 @@ export class ForwarderContract extends BaseContract {
     feePercentage,
     feeRecipient
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -454,12 +410,7 @@ export class ForwarderContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);
-            assert.isArray('signatures', signatures);
-            assert.isArray('feeOrders', feeOrders);
-            assert.isArray('feeSignatures', feeSignatures);
-            assert.isBigNumber('feePercentage', feePercentage);
-            assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const txHashPromise = self.marketSellOrdersWithEth.sendTransactionAsync(orders,
     signatures,
@@ -489,12 +440,7 @@ export class ForwarderContract extends BaseContract {
             feeRecipient: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);
-            assert.isArray('signatures', signatures);
-            assert.isArray('feeOrders', feeOrders);
-            assert.isArray('feeSignatures', feeSignatures);
-            assert.isBigNumber('feePercentage', feePercentage);
-            assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     signatures,
@@ -503,11 +449,10 @@ export class ForwarderContract extends BaseContract {
     feePercentage,
     feeRecipient
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -523,12 +468,7 @@ export class ForwarderContract extends BaseContract {
             feePercentage: BigNumber,
             feeRecipient: string,
         ): string {
-            assert.isArray('orders', orders);
-            assert.isArray('signatures', signatures);
-            assert.isArray('feeOrders', feeOrders);
-            assert.isArray('feeSignatures', feeSignatures);
-            assert.isBigNumber('feePercentage', feePercentage);
-            assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     signatures,
@@ -550,12 +490,7 @@ export class ForwarderContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<[{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}, {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}]
         > {
-            assert.isArray('orders', orders);
-            assert.isArray('signatures', signatures);
-            assert.isArray('feeOrders', feeOrders);
-            assert.isArray('feeSignatures', feeSignatures);
-            assert.isBigNumber('feePercentage', feePercentage);
-            assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -599,11 +534,10 @@ export class ForwarderContract extends BaseContract {
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -645,11 +579,10 @@ export class ForwarderContract extends BaseContract {
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -735,7 +668,7 @@ _wethAssetData
             _zrxAssetData: string,
             _wethAssetData: string,
     ): Promise<ForwarderContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/forwarder.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/forwarder.ts
@@ -39,9 +39,15 @@ export class ForwarderContract extends BaseContract {
             feeRecipient: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
-            const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments('marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
+        assert.isArray('orders', orders);
+        assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+        assert.isArray('signatures', signatures);
+        assert.isArray('feeOrders', feeOrders);
+        assert.isArray('feeSignatures', feeSignatures);
+        assert.isBigNumber('feePercentage', feePercentage);
+        assert.isString('feeRecipient', feeRecipient);
+        const self = this as any as ForwarderContract;
+        const encodedData = self._strictEncodeArguments('marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     makerAssetFillAmount,
     signatures,
     feeOrders,
@@ -49,26 +55,26 @@ export class ForwarderContract extends BaseContract {
     feePercentage,
     feeRecipient
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.marketBuyOrdersWithEth.estimateGasAsync.bind(
-                    self,
-                    orders,
-                    makerAssetFillAmount,
-                    signatures,
-                    feeOrders,
-                    feeSignatures,
-                    feePercentage,
-                    feeRecipient
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.marketBuyOrdersWithEth.estimateGasAsync.bind(
+                self,
+                orders,
+                makerAssetFillAmount,
+                signatures,
+                feeOrders,
+                feeSignatures,
+                feePercentage,
+                feeRecipient
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -82,9 +88,15 @@ export class ForwarderContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
-            const self = this as any as ForwarderContract;
-            const txHashPromise = self.marketBuyOrdersWithEth.sendTransactionAsync(orders,
+        assert.isArray('orders', orders);
+        assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+        assert.isArray('signatures', signatures);
+        assert.isArray('feeOrders', feeOrders);
+        assert.isArray('feeSignatures', feeSignatures);
+        assert.isBigNumber('feePercentage', feePercentage);
+        assert.isString('feeRecipient', feeRecipient);
+        const self = this as any as ForwarderContract;
+        const txHashPromise = self.marketBuyOrdersWithEth.sendTransactionAsync(orders,
     makerAssetFillAmount,
     signatures,
     feeOrders,
@@ -92,17 +104,17 @@ export class ForwarderContract extends BaseContract {
     feePercentage,
     feeRecipient
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -114,9 +126,15 @@ export class ForwarderContract extends BaseContract {
             feeRecipient: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
-            const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments('marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
+        assert.isArray('orders', orders);
+        assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+        assert.isArray('signatures', signatures);
+        assert.isArray('feeOrders', feeOrders);
+        assert.isArray('feeSignatures', feeSignatures);
+        assert.isBigNumber('feePercentage', feePercentage);
+        assert.isString('feeRecipient', feeRecipient);
+        const self = this as any as ForwarderContract;
+        const encodedData = self._strictEncodeArguments('marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     makerAssetFillAmount,
     signatures,
     feeOrders,
@@ -124,16 +142,16 @@ export class ForwarderContract extends BaseContract {
     feePercentage,
     feeRecipient
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -144,9 +162,15 @@ export class ForwarderContract extends BaseContract {
             feePercentage: BigNumber,
             feeRecipient: string,
         ): string {
-            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
-            const self = this as any as ForwarderContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
+        assert.isArray('orders', orders);
+        assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+        assert.isArray('signatures', signatures);
+        assert.isArray('feeOrders', feeOrders);
+        assert.isArray('feeSignatures', feeSignatures);
+        assert.isBigNumber('feePercentage', feePercentage);
+        assert.isString('feeRecipient', feeRecipient);
+        const self = this as any as ForwarderContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     makerAssetFillAmount,
     signatures,
     feeOrders,
@@ -154,7 +178,7 @@ export class ForwarderContract extends BaseContract {
     feePercentage,
     feeRecipient
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -168,7 +192,13 @@ export class ForwarderContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<[{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}, {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}]
         > {
-            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
+            assert.isArray('feeOrders', feeOrders);
+            assert.isArray('feeSignatures', feeSignatures);
+            assert.isBigNumber('feePercentage', feePercentage);
+            assert.isString('feeRecipient', feeRecipient);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -210,26 +240,27 @@ export class ForwarderContract extends BaseContract {
             amount: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('assetData', assetData);assert.isBigNumber('amount', amount);
-            const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments('withdrawAsset(bytes,uint256)', [assetData,
+        assert.isString('assetData', assetData);
+        assert.isBigNumber('amount', amount);
+        const self = this as any as ForwarderContract;
+        const encodedData = self._strictEncodeArguments('withdrawAsset(bytes,uint256)', [assetData,
     amount
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.withdrawAsset.estimateGasAsync.bind(
-                    self,
-                    assetData,
-                    amount
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.withdrawAsset.estimateGasAsync.bind(
+                self,
+                assetData,
+                amount
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             assetData: string,
@@ -238,54 +269,57 @@ export class ForwarderContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('assetData', assetData);assert.isBigNumber('amount', amount);
-            const self = this as any as ForwarderContract;
-            const txHashPromise = self.withdrawAsset.sendTransactionAsync(assetData,
+        assert.isString('assetData', assetData);
+        assert.isBigNumber('amount', amount);
+        const self = this as any as ForwarderContract;
+        const txHashPromise = self.withdrawAsset.sendTransactionAsync(assetData,
     amount
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             assetData: string,
             amount: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('assetData', assetData);assert.isBigNumber('amount', amount);
-            const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments('withdrawAsset(bytes,uint256)', [assetData,
+        assert.isString('assetData', assetData);
+        assert.isBigNumber('amount', amount);
+        const self = this as any as ForwarderContract;
+        const encodedData = self._strictEncodeArguments('withdrawAsset(bytes,uint256)', [assetData,
     amount
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             assetData: string,
             amount: BigNumber,
         ): string {
-            assert.isString('assetData', assetData);assert.isBigNumber('amount', amount);
-            const self = this as any as ForwarderContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('withdrawAsset(bytes,uint256)', [assetData,
+        assert.isString('assetData', assetData);
+        assert.isBigNumber('amount', amount);
+        const self = this as any as ForwarderContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('withdrawAsset(bytes,uint256)', [assetData,
     amount
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             assetData: string,
@@ -294,7 +328,8 @@ export class ForwarderContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('assetData', assetData);assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);
+            assert.isBigNumber('amount', amount);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -331,7 +366,6 @@ export class ForwarderContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -370,34 +404,39 @@ export class ForwarderContract extends BaseContract {
             feeRecipient: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
-            const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments('marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
+        assert.isArray('orders', orders);
+        assert.isArray('signatures', signatures);
+        assert.isArray('feeOrders', feeOrders);
+        assert.isArray('feeSignatures', feeSignatures);
+        assert.isBigNumber('feePercentage', feePercentage);
+        assert.isString('feeRecipient', feeRecipient);
+        const self = this as any as ForwarderContract;
+        const encodedData = self._strictEncodeArguments('marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     signatures,
     feeOrders,
     feeSignatures,
     feePercentage,
     feeRecipient
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.marketSellOrdersWithEth.estimateGasAsync.bind(
-                    self,
-                    orders,
-                    signatures,
-                    feeOrders,
-                    feeSignatures,
-                    feePercentage,
-                    feeRecipient
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.marketSellOrdersWithEth.estimateGasAsync.bind(
+                self,
+                orders,
+                signatures,
+                feeOrders,
+                feeSignatures,
+                feePercentage,
+                feeRecipient
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -410,26 +449,31 @@ export class ForwarderContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
-            const self = this as any as ForwarderContract;
-            const txHashPromise = self.marketSellOrdersWithEth.sendTransactionAsync(orders,
+        assert.isArray('orders', orders);
+        assert.isArray('signatures', signatures);
+        assert.isArray('feeOrders', feeOrders);
+        assert.isArray('feeSignatures', feeSignatures);
+        assert.isBigNumber('feePercentage', feePercentage);
+        assert.isString('feeRecipient', feeRecipient);
+        const self = this as any as ForwarderContract;
+        const txHashPromise = self.marketSellOrdersWithEth.sendTransactionAsync(orders,
     signatures,
     feeOrders,
     feeSignatures,
     feePercentage,
     feeRecipient
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -440,25 +484,30 @@ export class ForwarderContract extends BaseContract {
             feeRecipient: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
-            const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments('marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
+        assert.isArray('orders', orders);
+        assert.isArray('signatures', signatures);
+        assert.isArray('feeOrders', feeOrders);
+        assert.isArray('feeSignatures', feeSignatures);
+        assert.isBigNumber('feePercentage', feePercentage);
+        assert.isString('feeRecipient', feeRecipient);
+        const self = this as any as ForwarderContract;
+        const encodedData = self._strictEncodeArguments('marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     signatures,
     feeOrders,
     feeSignatures,
     feePercentage,
     feeRecipient
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -468,16 +517,21 @@ export class ForwarderContract extends BaseContract {
             feePercentage: BigNumber,
             feeRecipient: string,
         ): string {
-            assert.isArray('orders', orders);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
-            const self = this as any as ForwarderContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
+        assert.isArray('orders', orders);
+        assert.isArray('signatures', signatures);
+        assert.isArray('feeOrders', feeOrders);
+        assert.isArray('feeSignatures', feeSignatures);
+        assert.isBigNumber('feePercentage', feePercentage);
+        assert.isString('feeRecipient', feeRecipient);
+        const self = this as any as ForwarderContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     signatures,
     feeOrders,
     feeSignatures,
     feePercentage,
     feeRecipient
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             orders: Array<{makerAddress: string;takerAddress: string;feeRecipientAddress: string;senderAddress: string;makerAssetAmount: BigNumber;takerAssetAmount: BigNumber;makerFee: BigNumber;takerFee: BigNumber;expirationTimeSeconds: BigNumber;salt: BigNumber;makerAssetData: string;takerAssetData: string}>,
@@ -490,7 +544,12 @@ export class ForwarderContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<[{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}, {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}]
         > {
-            assert.isArray('orders', orders);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);
+            assert.isArray('signatures', signatures);
+            assert.isArray('feeOrders', feeOrders);
+            assert.isArray('feeSignatures', feeSignatures);
+            assert.isBigNumber('feePercentage', feePercentage);
+            assert.isString('feeRecipient', feeRecipient);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -530,24 +589,24 @@ export class ForwarderContract extends BaseContract {
             newOwner: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as ForwarderContract;
+        const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transferOwnership.estimateGasAsync.bind(
-                    self,
-                    newOwner
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.transferOwnership.estimateGasAsync.bind(
+                self,
+                newOwner
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             newOwner: string,
@@ -555,49 +614,49 @@ export class ForwarderContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as ForwarderContract;
-            const txHashPromise = self.transferOwnership.sendTransactionAsync(newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as ForwarderContract;
+        const txHashPromise = self.transferOwnership.sendTransactionAsync(newOwner
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             newOwner: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as ForwarderContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as ForwarderContract;
+        const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             newOwner: string,
         ): string {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as ForwarderContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as ForwarderContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             newOwner: string,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/forwarder.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/forwarder.ts
@@ -39,7 +39,13 @@ export class ForwarderContract extends BaseContract {
             feeRecipient: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
+            assert.isArray('feeOrders', feeOrders);
+            assert.isArray('feeSignatures', feeSignatures);
+            assert.isBigNumber('feePercentage', feePercentage);
+            assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     makerAssetFillAmount,
@@ -49,10 +55,11 @@ export class ForwarderContract extends BaseContract {
     feePercentage,
     feeRecipient
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -82,7 +89,13 @@ export class ForwarderContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
+            assert.isArray('feeOrders', feeOrders);
+            assert.isArray('feeSignatures', feeSignatures);
+            assert.isBigNumber('feePercentage', feePercentage);
+            assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const txHashPromise = self.marketBuyOrdersWithEth.sendTransactionAsync(orders,
     makerAssetFillAmount,
@@ -114,7 +127,13 @@ export class ForwarderContract extends BaseContract {
             feeRecipient: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
+            assert.isArray('feeOrders', feeOrders);
+            assert.isArray('feeSignatures', feeSignatures);
+            assert.isBigNumber('feePercentage', feePercentage);
+            assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     makerAssetFillAmount,
@@ -124,10 +143,11 @@ export class ForwarderContract extends BaseContract {
     feePercentage,
     feeRecipient
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -144,7 +164,13 @@ export class ForwarderContract extends BaseContract {
             feePercentage: BigNumber,
             feeRecipient: string,
         ): string {
-            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
+            assert.isArray('feeOrders', feeOrders);
+            assert.isArray('feeSignatures', feeSignatures);
+            assert.isBigNumber('feePercentage', feePercentage);
+            assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('marketBuyOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],uint256,bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     makerAssetFillAmount,
@@ -168,7 +194,13 @@ export class ForwarderContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<[{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}, {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}]
         > {
-            assert.isArray('orders', orders);assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);
+            assert.isBigNumber('makerAssetFillAmount', makerAssetFillAmount);
+            assert.isArray('signatures', signatures);
+            assert.isArray('feeOrders', feeOrders);
+            assert.isArray('feeSignatures', feeSignatures);
+            assert.isBigNumber('feePercentage', feePercentage);
+            assert.isString('feeRecipient', feeRecipient);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -210,15 +242,17 @@ export class ForwarderContract extends BaseContract {
             amount: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('assetData', assetData);assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);
+            assert.isBigNumber('amount', amount);
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('withdrawAsset(bytes,uint256)', [assetData,
     amount
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -238,7 +272,8 @@ export class ForwarderContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('assetData', assetData);assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);
+            assert.isBigNumber('amount', amount);
             const self = this as any as ForwarderContract;
             const txHashPromise = self.withdrawAsset.sendTransactionAsync(assetData,
     amount
@@ -260,15 +295,17 @@ export class ForwarderContract extends BaseContract {
             amount: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('assetData', assetData);assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);
+            assert.isBigNumber('amount', amount);
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('withdrawAsset(bytes,uint256)', [assetData,
     amount
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -280,7 +317,8 @@ export class ForwarderContract extends BaseContract {
             assetData: string,
             amount: BigNumber,
         ): string {
-            assert.isString('assetData', assetData);assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);
+            assert.isBigNumber('amount', amount);
             const self = this as any as ForwarderContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('withdrawAsset(bytes,uint256)', [assetData,
     amount
@@ -294,7 +332,8 @@ export class ForwarderContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('assetData', assetData);assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);
+            assert.isBigNumber('amount', amount);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -331,7 +370,6 @@ export class ForwarderContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -370,7 +408,12 @@ export class ForwarderContract extends BaseContract {
             feeRecipient: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isArray('orders', orders);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);
+            assert.isArray('signatures', signatures);
+            assert.isArray('feeOrders', feeOrders);
+            assert.isArray('feeSignatures', feeSignatures);
+            assert.isBigNumber('feePercentage', feePercentage);
+            assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     signatures,
@@ -379,10 +422,11 @@ export class ForwarderContract extends BaseContract {
     feePercentage,
     feeRecipient
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -410,7 +454,12 @@ export class ForwarderContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isArray('orders', orders);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);
+            assert.isArray('signatures', signatures);
+            assert.isArray('feeOrders', feeOrders);
+            assert.isArray('feeSignatures', feeSignatures);
+            assert.isBigNumber('feePercentage', feePercentage);
+            assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const txHashPromise = self.marketSellOrdersWithEth.sendTransactionAsync(orders,
     signatures,
@@ -440,7 +489,12 @@ export class ForwarderContract extends BaseContract {
             feeRecipient: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isArray('orders', orders);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);
+            assert.isArray('signatures', signatures);
+            assert.isArray('feeOrders', feeOrders);
+            assert.isArray('feeSignatures', feeSignatures);
+            assert.isBigNumber('feePercentage', feePercentage);
+            assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     signatures,
@@ -449,10 +503,11 @@ export class ForwarderContract extends BaseContract {
     feePercentage,
     feeRecipient
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -468,7 +523,12 @@ export class ForwarderContract extends BaseContract {
             feePercentage: BigNumber,
             feeRecipient: string,
         ): string {
-            assert.isArray('orders', orders);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);
+            assert.isArray('signatures', signatures);
+            assert.isArray('feeOrders', feeOrders);
+            assert.isArray('feeSignatures', feeSignatures);
+            assert.isBigNumber('feePercentage', feePercentage);
+            assert.isString('feeRecipient', feeRecipient);
             const self = this as any as ForwarderContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('marketSellOrdersWithEth((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],(address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],bytes[],uint256,address)', [orders,
     signatures,
@@ -490,7 +550,12 @@ export class ForwarderContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<[{makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}, {makerAssetFilledAmount: BigNumber;takerAssetFilledAmount: BigNumber;makerFeePaid: BigNumber;takerFeePaid: BigNumber}]
         > {
-            assert.isArray('orders', orders);assert.isArray('signatures', signatures);assert.isArray('feeOrders', feeOrders);assert.isArray('feeSignatures', feeSignatures);assert.isBigNumber('feePercentage', feePercentage);assert.isString('feeRecipient', feeRecipient);
+            assert.isArray('orders', orders);
+            assert.isArray('signatures', signatures);
+            assert.isArray('feeOrders', feeOrders);
+            assert.isArray('feeSignatures', feeSignatures);
+            assert.isBigNumber('feePercentage', feePercentage);
+            assert.isString('feeRecipient', feeRecipient);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -534,10 +599,11 @@ export class ForwarderContract extends BaseContract {
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -579,10 +645,11 @@ export class ForwarderContract extends BaseContract {
             const self = this as any as ForwarderContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -668,7 +735,7 @@ _wethAssetData
             _zrxAssetData: string,
             _wethAssetData: string,
     ): Promise<ForwarderContract> {
-        assert.isHexString('bytecode', bytecode);
+        assert.isString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/i_asset_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/i_asset_proxy.ts
@@ -1,6 +1,6 @@
-// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma whitespace class-name
+// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma
+// tslint:disable:whitespace no-unbound-method no-trailing-whitespace
 // tslint:disable:no-unused-variable
-// tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
 import { schemas } from '@0x/json-schemas';
 import {
@@ -37,11 +37,10 @@ export class IAssetProxyContract extends BaseContract {
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -83,11 +82,10 @@ export class IAssetProxyContract extends BaseContract {
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -149,11 +147,10 @@ export class IAssetProxyContract extends BaseContract {
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -195,11 +192,10 @@ export class IAssetProxyContract extends BaseContract {
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -258,17 +254,15 @@ export class IAssetProxyContract extends BaseContract {
             index: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -288,8 +282,7 @@ export class IAssetProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as IAssetProxyContract;
             const txHashPromise = self.removeAuthorizedAddressAtIndex.sendTransactionAsync(target,
     index
@@ -311,17 +304,15 @@ export class IAssetProxyContract extends BaseContract {
             index: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -333,8 +324,7 @@ export class IAssetProxyContract extends BaseContract {
             target: string,
             index: BigNumber,
         ): string {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as IAssetProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
@@ -348,8 +338,7 @@ export class IAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -388,21 +377,17 @@ export class IAssetProxyContract extends BaseContract {
             amount: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('assetData', assetData);
-            assert.isString('from', from);
-            assert.isString('to', to);
-            assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);assert.isString('from', from);assert.isString('to', to);assert.isBigNumber('amount', amount);
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('transferFrom(bytes,address,address,uint256)', [assetData,
     from,
     to,
     amount
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -426,10 +411,7 @@ export class IAssetProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('assetData', assetData);
-            assert.isString('from', from);
-            assert.isString('to', to);
-            assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);assert.isString('from', from);assert.isString('to', to);assert.isBigNumber('amount', amount);
             const self = this as any as IAssetProxyContract;
             const txHashPromise = self.transferFrom.sendTransactionAsync(assetData,
     from,
@@ -455,21 +437,17 @@ export class IAssetProxyContract extends BaseContract {
             amount: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('assetData', assetData);
-            assert.isString('from', from);
-            assert.isString('to', to);
-            assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);assert.isString('from', from);assert.isString('to', to);assert.isBigNumber('amount', amount);
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('transferFrom(bytes,address,address,uint256)', [assetData,
     from,
     to,
     amount
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -483,10 +461,7 @@ export class IAssetProxyContract extends BaseContract {
             to: string,
             amount: BigNumber,
         ): string {
-            assert.isString('assetData', assetData);
-            assert.isString('from', from);
-            assert.isString('to', to);
-            assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);assert.isString('from', from);assert.isString('to', to);assert.isBigNumber('amount', amount);
             const self = this as any as IAssetProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(bytes,address,address,uint256)', [assetData,
     from,
@@ -504,10 +479,7 @@ export class IAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('assetData', assetData);
-            assert.isString('from', from);
-            assert.isString('to', to);
-            assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);assert.isString('from', from);assert.isString('to', to);assert.isBigNumber('amount', amount);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -546,6 +518,7 @@ export class IAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -580,6 +553,7 @@ export class IAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -617,11 +591,10 @@ export class IAssetProxyContract extends BaseContract {
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -663,11 +636,10 @@ export class IAssetProxyContract extends BaseContract {
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -744,7 +716,7 @@ export class IAssetProxyContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<IAssetProxyContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,
@@ -779,4 +751,5 @@ export class IAssetProxyContract extends BaseContract {
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count
-// tslint:enable:no-unbound-method
+// tslint:enable:no-unbound-method no-parameter-reassignment no-consecutive-blank-lines ordered-imports align
+// tslint:enable:trailing-comma whitespace no-trailing-whitespace

--- a/packages/abi-gen-wrappers/src/generated-wrappers/i_asset_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/i_asset_proxy.ts
@@ -2,6 +2,7 @@
 // tslint:disable:no-unused-variable
 // tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
+import { schemas } from '@0x/json-schemas';
 import {
     BlockParam,
     BlockParamLiteral,
@@ -18,6 +19,7 @@ import {
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
+import { assert } from '@0x/assert';
 import * as ethers from 'ethers';
 // tslint:enable:no-unused-variable
 
@@ -29,15 +31,17 @@ export class IAssetProxyContract extends BaseContract {
     public addAuthorizedAddress = {
         async sendTransactionAsync(
             target: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('target', target);
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -51,17 +55,11 @@ export class IAssetProxyContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             target: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('target', target);
             const self = this as any as IAssetProxyContract;
             const txHashPromise = self.addAuthorizedAddress.sendTransactionAsync(target
     , txData);
@@ -79,15 +77,17 @@ export class IAssetProxyContract extends BaseContract {
         },
         async estimateGasAsync(
             target: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('target', target);
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -98,6 +98,7 @@ export class IAssetProxyContract extends BaseContract {
         getABIEncodedTransactionData(
             target: string,
         ): string {
+            assert.isString('target', target);
             const self = this as any as IAssetProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
@@ -109,6 +110,15 @@ export class IAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('target', target);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
         ]);
@@ -133,15 +143,17 @@ export class IAssetProxyContract extends BaseContract {
     public removeAuthorizedAddress = {
         async sendTransactionAsync(
             target: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('target', target);
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -155,17 +167,11 @@ export class IAssetProxyContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             target: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('target', target);
             const self = this as any as IAssetProxyContract;
             const txHashPromise = self.removeAuthorizedAddress.sendTransactionAsync(target
     , txData);
@@ -183,15 +189,17 @@ export class IAssetProxyContract extends BaseContract {
         },
         async estimateGasAsync(
             target: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('target', target);
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -202,6 +210,7 @@ export class IAssetProxyContract extends BaseContract {
         getABIEncodedTransactionData(
             target: string,
         ): string {
+            assert.isString('target', target);
             const self = this as any as IAssetProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
@@ -213,6 +222,15 @@ export class IAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('target', target);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
         ]);
@@ -238,16 +256,19 @@ export class IAssetProxyContract extends BaseContract {
         async sendTransactionAsync(
             target: string,
             index: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -263,17 +284,12 @@ export class IAssetProxyContract extends BaseContract {
         awaitTransactionSuccessAsync(
             target: string,
             index: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as IAssetProxyContract;
             const txHashPromise = self.removeAuthorizedAddressAtIndex.sendTransactionAsync(target,
     index
@@ -293,16 +309,19 @@ export class IAssetProxyContract extends BaseContract {
         async estimateGasAsync(
             target: string,
             index: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -314,6 +333,8 @@ export class IAssetProxyContract extends BaseContract {
             target: string,
             index: BigNumber,
         ): string {
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as IAssetProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
@@ -327,6 +348,16 @@ export class IAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
         index
@@ -355,18 +386,23 @@ export class IAssetProxyContract extends BaseContract {
             from: string,
             to: string,
             amount: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('assetData', assetData);
+            assert.isString('from', from);
+            assert.isString('to', to);
+            assert.isBigNumber('amount', amount);
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('transferFrom(bytes,address,address,uint256)', [assetData,
     from,
     to,
     amount
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -386,17 +422,14 @@ export class IAssetProxyContract extends BaseContract {
             from: string,
             to: string,
             amount: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('assetData', assetData);
+            assert.isString('from', from);
+            assert.isString('to', to);
+            assert.isBigNumber('amount', amount);
             const self = this as any as IAssetProxyContract;
             const txHashPromise = self.transferFrom.sendTransactionAsync(assetData,
     from,
@@ -420,18 +453,23 @@ export class IAssetProxyContract extends BaseContract {
             from: string,
             to: string,
             amount: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('assetData', assetData);
+            assert.isString('from', from);
+            assert.isString('to', to);
+            assert.isBigNumber('amount', amount);
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('transferFrom(bytes,address,address,uint256)', [assetData,
     from,
     to,
     amount
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -445,6 +483,10 @@ export class IAssetProxyContract extends BaseContract {
             to: string,
             amount: BigNumber,
         ): string {
+            assert.isString('assetData', assetData);
+            assert.isString('from', from);
+            assert.isString('to', to);
+            assert.isBigNumber('amount', amount);
             const self = this as any as IAssetProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(bytes,address,address,uint256)', [assetData,
     from,
@@ -462,6 +504,18 @@ export class IAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('assetData', assetData);
+            assert.isString('from', from);
+            assert.isString('to', to);
+            assert.isBigNumber('amount', amount);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('transferFrom(bytes,address,address,uint256)', [assetData,
         from,
@@ -492,6 +546,14 @@ export class IAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('getProxyId()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -518,6 +580,14 @@ export class IAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('getAuthorizedAddresses()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -541,15 +611,17 @@ export class IAssetProxyContract extends BaseContract {
     public transferOwnership = {
         async sendTransactionAsync(
             newOwner: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('newOwner', newOwner);
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -563,17 +635,11 @@ export class IAssetProxyContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             newOwner: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('newOwner', newOwner);
             const self = this as any as IAssetProxyContract;
             const txHashPromise = self.transferOwnership.sendTransactionAsync(newOwner
     , txData);
@@ -591,15 +657,17 @@ export class IAssetProxyContract extends BaseContract {
         },
         async estimateGasAsync(
             newOwner: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('newOwner', newOwner);
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -610,6 +678,7 @@ export class IAssetProxyContract extends BaseContract {
         getABIEncodedTransactionData(
             newOwner: string,
         ): string {
+            assert.isString('newOwner', newOwner);
             const self = this as any as IAssetProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
@@ -621,6 +690,15 @@ export class IAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('newOwner', newOwner);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
         ]);
@@ -647,6 +725,11 @@ export class IAssetProxyContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<IAssetProxyContract> {
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         if (artifact.compilerOutput === undefined) {
             throw new Error('Compiler output not found in the artifact file');
         }
@@ -661,6 +744,12 @@ export class IAssetProxyContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<IAssetProxyContract> {
+        assert.isString('bytecode', bytecode);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
         const constructorAbi = BaseContract._lookupConstructorAbi(abi);
         [] = BaseContract._formatABIDataItemList(

--- a/packages/abi-gen-wrappers/src/generated-wrappers/i_asset_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/i_asset_proxy.ts
@@ -37,11 +37,10 @@ export class IAssetProxyContract extends BaseContract {
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -83,11 +82,10 @@ export class IAssetProxyContract extends BaseContract {
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -149,11 +147,10 @@ export class IAssetProxyContract extends BaseContract {
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -195,11 +192,10 @@ export class IAssetProxyContract extends BaseContract {
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -258,17 +254,15 @@ export class IAssetProxyContract extends BaseContract {
             index: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -288,8 +282,7 @@ export class IAssetProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as IAssetProxyContract;
             const txHashPromise = self.removeAuthorizedAddressAtIndex.sendTransactionAsync(target,
     index
@@ -311,17 +304,15 @@ export class IAssetProxyContract extends BaseContract {
             index: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -333,8 +324,7 @@ export class IAssetProxyContract extends BaseContract {
             target: string,
             index: BigNumber,
         ): string {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as IAssetProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
@@ -348,8 +338,7 @@ export class IAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -388,21 +377,17 @@ export class IAssetProxyContract extends BaseContract {
             amount: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('assetData', assetData);
-            assert.isString('from', from);
-            assert.isString('to', to);
-            assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);assert.isString('from', from);assert.isString('to', to);assert.isBigNumber('amount', amount);
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('transferFrom(bytes,address,address,uint256)', [assetData,
     from,
     to,
     amount
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -426,10 +411,7 @@ export class IAssetProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('assetData', assetData);
-            assert.isString('from', from);
-            assert.isString('to', to);
-            assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);assert.isString('from', from);assert.isString('to', to);assert.isBigNumber('amount', amount);
             const self = this as any as IAssetProxyContract;
             const txHashPromise = self.transferFrom.sendTransactionAsync(assetData,
     from,
@@ -455,21 +437,17 @@ export class IAssetProxyContract extends BaseContract {
             amount: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('assetData', assetData);
-            assert.isString('from', from);
-            assert.isString('to', to);
-            assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);assert.isString('from', from);assert.isString('to', to);assert.isBigNumber('amount', amount);
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('transferFrom(bytes,address,address,uint256)', [assetData,
     from,
     to,
     amount
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -483,10 +461,7 @@ export class IAssetProxyContract extends BaseContract {
             to: string,
             amount: BigNumber,
         ): string {
-            assert.isString('assetData', assetData);
-            assert.isString('from', from);
-            assert.isString('to', to);
-            assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);assert.isString('from', from);assert.isString('to', to);assert.isBigNumber('amount', amount);
             const self = this as any as IAssetProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(bytes,address,address,uint256)', [assetData,
     from,
@@ -504,10 +479,7 @@ export class IAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('assetData', assetData);
-            assert.isString('from', from);
-            assert.isString('to', to);
-            assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);assert.isString('from', from);assert.isString('to', to);assert.isBigNumber('amount', amount);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -546,6 +518,7 @@ export class IAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -580,6 +553,7 @@ export class IAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -617,11 +591,10 @@ export class IAssetProxyContract extends BaseContract {
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -663,11 +636,10 @@ export class IAssetProxyContract extends BaseContract {
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -744,7 +716,7 @@ export class IAssetProxyContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<IAssetProxyContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/i_asset_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/i_asset_proxy.ts
@@ -33,24 +33,24 @@ export class IAssetProxyContract extends BaseContract {
             target: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('target', target);
-            const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
+        assert.isString('target', target);
+        const self = this as any as IAssetProxyContract;
+        const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.addAuthorizedAddress.estimateGasAsync.bind(
-                    self,
-                    target
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.addAuthorizedAddress.estimateGasAsync.bind(
+                self,
+                target
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             target: string,
@@ -58,49 +58,49 @@ export class IAssetProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('target', target);
-            const self = this as any as IAssetProxyContract;
-            const txHashPromise = self.addAuthorizedAddress.sendTransactionAsync(target
+        assert.isString('target', target);
+        const self = this as any as IAssetProxyContract;
+        const txHashPromise = self.addAuthorizedAddress.sendTransactionAsync(target
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             target: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('target', target);
-            const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
+        assert.isString('target', target);
+        const self = this as any as IAssetProxyContract;
+        const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             target: string,
         ): string {
-            assert.isString('target', target);
-            const self = this as any as IAssetProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
+        assert.isString('target', target);
+        const self = this as any as IAssetProxyContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             target: string,
@@ -143,24 +143,24 @@ export class IAssetProxyContract extends BaseContract {
             target: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('target', target);
-            const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
+        assert.isString('target', target);
+        const self = this as any as IAssetProxyContract;
+        const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.removeAuthorizedAddress.estimateGasAsync.bind(
-                    self,
-                    target
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.removeAuthorizedAddress.estimateGasAsync.bind(
+                self,
+                target
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             target: string,
@@ -168,49 +168,49 @@ export class IAssetProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('target', target);
-            const self = this as any as IAssetProxyContract;
-            const txHashPromise = self.removeAuthorizedAddress.sendTransactionAsync(target
+        assert.isString('target', target);
+        const self = this as any as IAssetProxyContract;
+        const txHashPromise = self.removeAuthorizedAddress.sendTransactionAsync(target
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             target: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('target', target);
-            const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
+        assert.isString('target', target);
+        const self = this as any as IAssetProxyContract;
+        const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             target: string,
         ): string {
-            assert.isString('target', target);
-            const self = this as any as IAssetProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
+        assert.isString('target', target);
+        const self = this as any as IAssetProxyContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             target: string,
@@ -254,26 +254,27 @@ export class IAssetProxyContract extends BaseContract {
             index: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('target', target);assert.isBigNumber('index', index);
-            const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
+        assert.isString('target', target);
+        assert.isBigNumber('index', index);
+        const self = this as any as IAssetProxyContract;
+        const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.removeAuthorizedAddressAtIndex.estimateGasAsync.bind(
-                    self,
-                    target,
-                    index
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.removeAuthorizedAddressAtIndex.estimateGasAsync.bind(
+                self,
+                target,
+                index
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             target: string,
@@ -282,54 +283,57 @@ export class IAssetProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('target', target);assert.isBigNumber('index', index);
-            const self = this as any as IAssetProxyContract;
-            const txHashPromise = self.removeAuthorizedAddressAtIndex.sendTransactionAsync(target,
+        assert.isString('target', target);
+        assert.isBigNumber('index', index);
+        const self = this as any as IAssetProxyContract;
+        const txHashPromise = self.removeAuthorizedAddressAtIndex.sendTransactionAsync(target,
     index
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             target: string,
             index: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('target', target);assert.isBigNumber('index', index);
-            const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
+        assert.isString('target', target);
+        assert.isBigNumber('index', index);
+        const self = this as any as IAssetProxyContract;
+        const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             target: string,
             index: BigNumber,
         ): string {
-            assert.isString('target', target);assert.isBigNumber('index', index);
-            const self = this as any as IAssetProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
+        assert.isString('target', target);
+        assert.isBigNumber('index', index);
+        const self = this as any as IAssetProxyContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             target: string,
@@ -338,7 +342,8 @@ export class IAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('target', target);assert.isBigNumber('index', index);
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -377,30 +382,33 @@ export class IAssetProxyContract extends BaseContract {
             amount: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('assetData', assetData);assert.isString('from', from);assert.isString('to', to);assert.isBigNumber('amount', amount);
-            const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('transferFrom(bytes,address,address,uint256)', [assetData,
+        assert.isString('assetData', assetData);
+        assert.isString('from', from);
+        assert.isString('to', to);
+        assert.isBigNumber('amount', amount);
+        const self = this as any as IAssetProxyContract;
+        const encodedData = self._strictEncodeArguments('transferFrom(bytes,address,address,uint256)', [assetData,
     from,
     to,
     amount
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transferFrom.estimateGasAsync.bind(
-                    self,
-                    assetData,
-                    from,
-                    to,
-                    amount
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.transferFrom.estimateGasAsync.bind(
+                self,
+                assetData,
+                from,
+                to,
+                amount
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             assetData: string,
@@ -411,24 +419,27 @@ export class IAssetProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('assetData', assetData);assert.isString('from', from);assert.isString('to', to);assert.isBigNumber('amount', amount);
-            const self = this as any as IAssetProxyContract;
-            const txHashPromise = self.transferFrom.sendTransactionAsync(assetData,
+        assert.isString('assetData', assetData);
+        assert.isString('from', from);
+        assert.isString('to', to);
+        assert.isBigNumber('amount', amount);
+        const self = this as any as IAssetProxyContract;
+        const txHashPromise = self.transferFrom.sendTransactionAsync(assetData,
     from,
     to,
     amount
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             assetData: string,
@@ -437,23 +448,26 @@ export class IAssetProxyContract extends BaseContract {
             amount: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('assetData', assetData);assert.isString('from', from);assert.isString('to', to);assert.isBigNumber('amount', amount);
-            const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('transferFrom(bytes,address,address,uint256)', [assetData,
+        assert.isString('assetData', assetData);
+        assert.isString('from', from);
+        assert.isString('to', to);
+        assert.isBigNumber('amount', amount);
+        const self = this as any as IAssetProxyContract;
+        const encodedData = self._strictEncodeArguments('transferFrom(bytes,address,address,uint256)', [assetData,
     from,
     to,
     amount
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             assetData: string,
@@ -461,14 +475,17 @@ export class IAssetProxyContract extends BaseContract {
             to: string,
             amount: BigNumber,
         ): string {
-            assert.isString('assetData', assetData);assert.isString('from', from);assert.isString('to', to);assert.isBigNumber('amount', amount);
-            const self = this as any as IAssetProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(bytes,address,address,uint256)', [assetData,
+        assert.isString('assetData', assetData);
+        assert.isString('from', from);
+        assert.isString('to', to);
+        assert.isBigNumber('amount', amount);
+        const self = this as any as IAssetProxyContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(bytes,address,address,uint256)', [assetData,
     from,
     to,
     amount
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             assetData: string,
@@ -479,7 +496,10 @@ export class IAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('assetData', assetData);assert.isString('from', from);assert.isString('to', to);assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);
+            assert.isString('from', from);
+            assert.isString('to', to);
+            assert.isBigNumber('amount', amount);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -518,7 +538,6 @@ export class IAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -553,7 +572,6 @@ export class IAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -587,24 +605,24 @@ export class IAssetProxyContract extends BaseContract {
             newOwner: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as IAssetProxyContract;
+        const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transferOwnership.estimateGasAsync.bind(
-                    self,
-                    newOwner
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.transferOwnership.estimateGasAsync.bind(
+                self,
+                newOwner
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             newOwner: string,
@@ -612,49 +630,49 @@ export class IAssetProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as IAssetProxyContract;
-            const txHashPromise = self.transferOwnership.sendTransactionAsync(newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as IAssetProxyContract;
+        const txHashPromise = self.transferOwnership.sendTransactionAsync(newOwner
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             newOwner: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as IAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as IAssetProxyContract;
+        const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             newOwner: string,
         ): string {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as IAssetProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as IAssetProxyContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             newOwner: string,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/i_asset_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/i_asset_proxy.ts
@@ -37,10 +37,11 @@ export class IAssetProxyContract extends BaseContract {
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -82,10 +83,11 @@ export class IAssetProxyContract extends BaseContract {
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -147,10 +149,11 @@ export class IAssetProxyContract extends BaseContract {
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -192,10 +195,11 @@ export class IAssetProxyContract extends BaseContract {
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -254,15 +258,17 @@ export class IAssetProxyContract extends BaseContract {
             index: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('target', target);assert.isBigNumber('index', index);
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -282,7 +288,8 @@ export class IAssetProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('target', target);assert.isBigNumber('index', index);
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as IAssetProxyContract;
             const txHashPromise = self.removeAuthorizedAddressAtIndex.sendTransactionAsync(target,
     index
@@ -304,15 +311,17 @@ export class IAssetProxyContract extends BaseContract {
             index: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('target', target);assert.isBigNumber('index', index);
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -324,7 +333,8 @@ export class IAssetProxyContract extends BaseContract {
             target: string,
             index: BigNumber,
         ): string {
-            assert.isString('target', target);assert.isBigNumber('index', index);
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as IAssetProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
@@ -338,7 +348,8 @@ export class IAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('target', target);assert.isBigNumber('index', index);
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -377,17 +388,21 @@ export class IAssetProxyContract extends BaseContract {
             amount: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('assetData', assetData);assert.isString('from', from);assert.isString('to', to);assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);
+            assert.isString('from', from);
+            assert.isString('to', to);
+            assert.isBigNumber('amount', amount);
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('transferFrom(bytes,address,address,uint256)', [assetData,
     from,
     to,
     amount
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -411,7 +426,10 @@ export class IAssetProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('assetData', assetData);assert.isString('from', from);assert.isString('to', to);assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);
+            assert.isString('from', from);
+            assert.isString('to', to);
+            assert.isBigNumber('amount', amount);
             const self = this as any as IAssetProxyContract;
             const txHashPromise = self.transferFrom.sendTransactionAsync(assetData,
     from,
@@ -437,17 +455,21 @@ export class IAssetProxyContract extends BaseContract {
             amount: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('assetData', assetData);assert.isString('from', from);assert.isString('to', to);assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);
+            assert.isString('from', from);
+            assert.isString('to', to);
+            assert.isBigNumber('amount', amount);
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('transferFrom(bytes,address,address,uint256)', [assetData,
     from,
     to,
     amount
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -461,7 +483,10 @@ export class IAssetProxyContract extends BaseContract {
             to: string,
             amount: BigNumber,
         ): string {
-            assert.isString('assetData', assetData);assert.isString('from', from);assert.isString('to', to);assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);
+            assert.isString('from', from);
+            assert.isString('to', to);
+            assert.isBigNumber('amount', amount);
             const self = this as any as IAssetProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(bytes,address,address,uint256)', [assetData,
     from,
@@ -479,7 +504,10 @@ export class IAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('assetData', assetData);assert.isString('from', from);assert.isString('to', to);assert.isBigNumber('amount', amount);
+            assert.isString('assetData', assetData);
+            assert.isString('from', from);
+            assert.isString('to', to);
+            assert.isBigNumber('amount', amount);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -518,7 +546,6 @@ export class IAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -553,7 +580,6 @@ export class IAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -591,10 +617,11 @@ export class IAssetProxyContract extends BaseContract {
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -636,10 +663,11 @@ export class IAssetProxyContract extends BaseContract {
             const self = this as any as IAssetProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -716,7 +744,7 @@ export class IAssetProxyContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<IAssetProxyContract> {
-        assert.isHexString('bytecode', bytecode);
+        assert.isString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/i_validator.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/i_validator.ts
@@ -1,6 +1,6 @@
-// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma whitespace class-name
+// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma
+// tslint:disable:whitespace no-unbound-method no-trailing-whitespace
 // tslint:disable:no-unused-variable
-// tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
 import { schemas } from '@0x/json-schemas';
 import {
@@ -37,9 +37,7 @@ export class IValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('hash', hash);
-            assert.isString('signerAddress', signerAddress);
-            assert.isString('signature', signature);
+            assert.isString('hash', hash);assert.isString('signerAddress', signerAddress);assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -95,7 +93,7 @@ export class IValidatorContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<IValidatorContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,
@@ -130,4 +128,5 @@ export class IValidatorContract extends BaseContract {
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count
-// tslint:enable:no-unbound-method
+// tslint:enable:no-unbound-method no-parameter-reassignment no-consecutive-blank-lines ordered-imports align
+// tslint:enable:trailing-comma whitespace no-trailing-whitespace

--- a/packages/abi-gen-wrappers/src/generated-wrappers/i_validator.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/i_validator.ts
@@ -2,6 +2,7 @@
 // tslint:disable:no-unused-variable
 // tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
+import { schemas } from '@0x/json-schemas';
 import {
     BlockParam,
     BlockParamLiteral,
@@ -18,6 +19,7 @@ import {
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
+import { assert } from '@0x/assert';
 import * as ethers from 'ethers';
 // tslint:enable:no-unused-variable
 
@@ -35,6 +37,17 @@ export class IValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
+            assert.isString('hash', hash);
+            assert.isString('signerAddress', signerAddress);
+            assert.isString('signature', signature);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as IValidatorContract;
             const encodedData = self._strictEncodeArguments('isValidSignature(bytes32,address,bytes)', [hash,
         signerAddress,
@@ -63,6 +76,11 @@ export class IValidatorContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<IValidatorContract> {
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         if (artifact.compilerOutput === undefined) {
             throw new Error('Compiler output not found in the artifact file');
         }
@@ -77,6 +95,12 @@ export class IValidatorContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<IValidatorContract> {
+        assert.isString('bytecode', bytecode);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
         const constructorAbi = BaseContract._lookupConstructorAbi(abi);
         [] = BaseContract._formatABIDataItemList(

--- a/packages/abi-gen-wrappers/src/generated-wrappers/i_validator.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/i_validator.ts
@@ -37,9 +37,7 @@ export class IValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('hash', hash);
-            assert.isString('signerAddress', signerAddress);
-            assert.isString('signature', signature);
+            assert.isString('hash', hash);assert.isString('signerAddress', signerAddress);assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -95,7 +93,7 @@ export class IValidatorContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<IValidatorContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/i_validator.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/i_validator.ts
@@ -37,7 +37,9 @@ export class IValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('hash', hash);assert.isString('signerAddress', signerAddress);assert.isString('signature', signature);
+            assert.isString('hash', hash);
+            assert.isString('signerAddress', signerAddress);
+            assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -93,7 +95,7 @@ export class IValidatorContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<IValidatorContract> {
-        assert.isHexString('bytecode', bytecode);
+        assert.isString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/i_validator.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/i_validator.ts
@@ -37,7 +37,9 @@ export class IValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('hash', hash);assert.isString('signerAddress', signerAddress);assert.isString('signature', signature);
+            assert.isString('hash', hash);
+            assert.isString('signerAddress', signerAddress);
+            assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/i_wallet.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/i_wallet.ts
@@ -2,6 +2,7 @@
 // tslint:disable:no-unused-variable
 // tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
+import { schemas } from '@0x/json-schemas';
 import {
     BlockParam,
     BlockParamLiteral,
@@ -18,6 +19,7 @@ import {
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
+import { assert } from '@0x/assert';
 import * as ethers from 'ethers';
 // tslint:enable:no-unused-variable
 
@@ -34,6 +36,16 @@ export class IWalletContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
+            assert.isString('hash', hash);
+            assert.isString('signature', signature);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as IWalletContract;
             const encodedData = self._strictEncodeArguments('isValidSignature(bytes32,bytes)', [hash,
         signature
@@ -61,6 +73,11 @@ export class IWalletContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<IWalletContract> {
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         if (artifact.compilerOutput === undefined) {
             throw new Error('Compiler output not found in the artifact file');
         }
@@ -75,6 +92,12 @@ export class IWalletContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<IWalletContract> {
+        assert.isString('bytecode', bytecode);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
         const constructorAbi = BaseContract._lookupConstructorAbi(abi);
         [] = BaseContract._formatABIDataItemList(

--- a/packages/abi-gen-wrappers/src/generated-wrappers/i_wallet.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/i_wallet.ts
@@ -1,6 +1,6 @@
-// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma whitespace class-name
+// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma
+// tslint:disable:whitespace no-unbound-method no-trailing-whitespace
 // tslint:disable:no-unused-variable
-// tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
 import { schemas } from '@0x/json-schemas';
 import {
@@ -36,8 +36,7 @@ export class IWalletContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('hash', hash);
-            assert.isString('signature', signature);
+            assert.isString('hash', hash);assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -92,7 +91,7 @@ export class IWalletContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<IWalletContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,
@@ -127,4 +126,5 @@ export class IWalletContract extends BaseContract {
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count
-// tslint:enable:no-unbound-method
+// tslint:enable:no-unbound-method no-parameter-reassignment no-consecutive-blank-lines ordered-imports align
+// tslint:enable:trailing-comma whitespace no-trailing-whitespace

--- a/packages/abi-gen-wrappers/src/generated-wrappers/i_wallet.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/i_wallet.ts
@@ -36,7 +36,8 @@ export class IWalletContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('hash', hash);assert.isString('signature', signature);
+            assert.isString('hash', hash);
+            assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/i_wallet.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/i_wallet.ts
@@ -36,8 +36,7 @@ export class IWalletContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('hash', hash);
-            assert.isString('signature', signature);
+            assert.isString('hash', hash);assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -92,7 +91,7 @@ export class IWalletContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<IWalletContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/i_wallet.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/i_wallet.ts
@@ -36,7 +36,8 @@ export class IWalletContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('hash', hash);assert.isString('signature', signature);
+            assert.isString('hash', hash);
+            assert.isString('signature', signature);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -91,7 +92,7 @@ export class IWalletContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<IWalletContract> {
-        assert.isHexString('bytecode', bytecode);
+        assert.isString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/multi_asset_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/multi_asset_proxy.ts
@@ -1,6 +1,6 @@
-// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma whitespace class-name
+// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma
+// tslint:disable:whitespace no-unbound-method no-trailing-whitespace
 // tslint:disable:no-unused-variable
-// tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
 import { schemas } from '@0x/json-schemas';
 import {
@@ -100,11 +100,10 @@ export class MultiAssetProxyContract extends BaseContract {
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -146,11 +145,10 @@ export class MultiAssetProxyContract extends BaseContract {
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -286,11 +284,10 @@ export class MultiAssetProxyContract extends BaseContract {
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -332,11 +329,10 @@ export class MultiAssetProxyContract extends BaseContract {
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -395,6 +391,7 @@ export class MultiAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -429,17 +426,15 @@ export class MultiAssetProxyContract extends BaseContract {
             index: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -459,8 +454,7 @@ export class MultiAssetProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as MultiAssetProxyContract;
             const txHashPromise = self.removeAuthorizedAddressAtIndex.sendTransactionAsync(target,
     index
@@ -482,17 +476,15 @@ export class MultiAssetProxyContract extends BaseContract {
             index: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -504,8 +496,7 @@ export class MultiAssetProxyContract extends BaseContract {
             target: string,
             index: BigNumber,
         ): string {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as MultiAssetProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
@@ -519,8 +510,7 @@ export class MultiAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -557,6 +547,7 @@ export class MultiAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -631,11 +622,10 @@ export class MultiAssetProxyContract extends BaseContract {
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -677,11 +667,10 @@ export class MultiAssetProxyContract extends BaseContract {
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -740,6 +729,7 @@ export class MultiAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -777,11 +767,10 @@ export class MultiAssetProxyContract extends BaseContract {
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -823,11 +812,10 @@ export class MultiAssetProxyContract extends BaseContract {
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -904,7 +892,7 @@ export class MultiAssetProxyContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<MultiAssetProxyContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,
@@ -939,4 +927,5 @@ export class MultiAssetProxyContract extends BaseContract {
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count
-// tslint:enable:no-unbound-method
+// tslint:enable:no-unbound-method no-parameter-reassignment no-consecutive-blank-lines ordered-imports align
+// tslint:enable:trailing-comma whitespace no-trailing-whitespace

--- a/packages/abi-gen-wrappers/src/generated-wrappers/multi_asset_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/multi_asset_proxy.ts
@@ -2,6 +2,7 @@
 // tslint:disable:no-unused-variable
 // tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
+import { schemas } from '@0x/json-schemas';
 import {
     BlockParam,
     BlockParamLiteral,
@@ -18,6 +19,7 @@ import {
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
+import { assert } from '@0x/assert';
 import * as ethers from 'ethers';
 // tslint:enable:no-unused-variable
 
@@ -59,6 +61,15 @@ export class MultiAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.isString('index_0', index_0);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('assetProxies(bytes4)', [index_0
         ]);
@@ -83,15 +94,17 @@ export class MultiAssetProxyContract extends BaseContract {
     public addAuthorizedAddress = {
         async sendTransactionAsync(
             target: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('target', target);
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -105,17 +118,11 @@ export class MultiAssetProxyContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             target: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('target', target);
             const self = this as any as MultiAssetProxyContract;
             const txHashPromise = self.addAuthorizedAddress.sendTransactionAsync(target
     , txData);
@@ -133,15 +140,17 @@ export class MultiAssetProxyContract extends BaseContract {
         },
         async estimateGasAsync(
             target: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('target', target);
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -152,6 +161,7 @@ export class MultiAssetProxyContract extends BaseContract {
         getABIEncodedTransactionData(
             target: string,
         ): string {
+            assert.isString('target', target);
             const self = this as any as MultiAssetProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
@@ -163,6 +173,15 @@ export class MultiAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('target', target);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
         ]);
@@ -191,6 +210,15 @@ export class MultiAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.isBigNumber('index_0', index_0);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('authorities(uint256)', [index_0
         ]);
@@ -219,6 +247,15 @@ export class MultiAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.isString('assetProxyId', assetProxyId);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('getAssetProxy(bytes4)', [assetProxyId
         ]);
@@ -243,15 +280,17 @@ export class MultiAssetProxyContract extends BaseContract {
     public removeAuthorizedAddress = {
         async sendTransactionAsync(
             target: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('target', target);
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -265,17 +304,11 @@ export class MultiAssetProxyContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             target: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('target', target);
             const self = this as any as MultiAssetProxyContract;
             const txHashPromise = self.removeAuthorizedAddress.sendTransactionAsync(target
     , txData);
@@ -293,15 +326,17 @@ export class MultiAssetProxyContract extends BaseContract {
         },
         async estimateGasAsync(
             target: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('target', target);
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -312,6 +347,7 @@ export class MultiAssetProxyContract extends BaseContract {
         getABIEncodedTransactionData(
             target: string,
         ): string {
+            assert.isString('target', target);
             const self = this as any as MultiAssetProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
@@ -323,6 +359,15 @@ export class MultiAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('target', target);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
         ]);
@@ -350,6 +395,14 @@ export class MultiAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('owner()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -374,16 +427,19 @@ export class MultiAssetProxyContract extends BaseContract {
         async sendTransactionAsync(
             target: string,
             index: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -399,17 +455,12 @@ export class MultiAssetProxyContract extends BaseContract {
         awaitTransactionSuccessAsync(
             target: string,
             index: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as MultiAssetProxyContract;
             const txHashPromise = self.removeAuthorizedAddressAtIndex.sendTransactionAsync(target,
     index
@@ -429,16 +480,19 @@ export class MultiAssetProxyContract extends BaseContract {
         async estimateGasAsync(
             target: string,
             index: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -450,6 +504,8 @@ export class MultiAssetProxyContract extends BaseContract {
             target: string,
             index: BigNumber,
         ): string {
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as MultiAssetProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
@@ -463,6 +519,16 @@ export class MultiAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
         index
@@ -491,6 +557,14 @@ export class MultiAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('getProxyId()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -518,6 +592,15 @@ export class MultiAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
+            assert.isString('index_0', index_0);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('authorized(address)', [index_0
         ]);
@@ -542,15 +625,17 @@ export class MultiAssetProxyContract extends BaseContract {
     public registerAssetProxy = {
         async sendTransactionAsync(
             assetProxy: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('assetProxy', assetProxy);
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -564,17 +649,11 @@ export class MultiAssetProxyContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             assetProxy: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('assetProxy', assetProxy);
             const self = this as any as MultiAssetProxyContract;
             const txHashPromise = self.registerAssetProxy.sendTransactionAsync(assetProxy
     , txData);
@@ -592,15 +671,17 @@ export class MultiAssetProxyContract extends BaseContract {
         },
         async estimateGasAsync(
             assetProxy: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('assetProxy', assetProxy);
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -611,6 +692,7 @@ export class MultiAssetProxyContract extends BaseContract {
         getABIEncodedTransactionData(
             assetProxy: string,
         ): string {
+            assert.isString('assetProxy', assetProxy);
             const self = this as any as MultiAssetProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
     ]);
@@ -622,6 +704,15 @@ export class MultiAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('assetProxy', assetProxy);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
         ]);
@@ -649,6 +740,14 @@ export class MultiAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('getAuthorizedAddresses()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -672,15 +771,17 @@ export class MultiAssetProxyContract extends BaseContract {
     public transferOwnership = {
         async sendTransactionAsync(
             newOwner: string,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('newOwner', newOwner);
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -694,17 +795,11 @@ export class MultiAssetProxyContract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             newOwner: string,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('newOwner', newOwner);
             const self = this as any as MultiAssetProxyContract;
             const txHashPromise = self.transferOwnership.sendTransactionAsync(newOwner
     , txData);
@@ -722,15 +817,17 @@ export class MultiAssetProxyContract extends BaseContract {
         },
         async estimateGasAsync(
             newOwner: string,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('newOwner', newOwner);
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -741,6 +838,7 @@ export class MultiAssetProxyContract extends BaseContract {
         getABIEncodedTransactionData(
             newOwner: string,
         ): string {
+            assert.isString('newOwner', newOwner);
             const self = this as any as MultiAssetProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
@@ -752,6 +850,15 @@ export class MultiAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isString('newOwner', newOwner);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
         ]);
@@ -778,6 +885,11 @@ export class MultiAssetProxyContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<MultiAssetProxyContract> {
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         if (artifact.compilerOutput === undefined) {
             throw new Error('Compiler output not found in the artifact file');
         }
@@ -792,6 +904,12 @@ export class MultiAssetProxyContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<MultiAssetProxyContract> {
+        assert.isString('bytecode', bytecode);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
         const constructorAbi = BaseContract._lookupConstructorAbi(abi);
         [] = BaseContract._formatABIDataItemList(

--- a/packages/abi-gen-wrappers/src/generated-wrappers/multi_asset_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/multi_asset_proxy.ts
@@ -100,11 +100,10 @@ export class MultiAssetProxyContract extends BaseContract {
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -146,11 +145,10 @@ export class MultiAssetProxyContract extends BaseContract {
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -286,11 +284,10 @@ export class MultiAssetProxyContract extends BaseContract {
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -332,11 +329,10 @@ export class MultiAssetProxyContract extends BaseContract {
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -395,6 +391,7 @@ export class MultiAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -429,17 +426,15 @@ export class MultiAssetProxyContract extends BaseContract {
             index: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -459,8 +454,7 @@ export class MultiAssetProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as MultiAssetProxyContract;
             const txHashPromise = self.removeAuthorizedAddressAtIndex.sendTransactionAsync(target,
     index
@@ -482,17 +476,15 @@ export class MultiAssetProxyContract extends BaseContract {
             index: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -504,8 +496,7 @@ export class MultiAssetProxyContract extends BaseContract {
             target: string,
             index: BigNumber,
         ): string {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             const self = this as any as MultiAssetProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
@@ -519,8 +510,7 @@ export class MultiAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('target', target);
-            assert.isBigNumber('index', index);
+            assert.isString('target', target);assert.isBigNumber('index', index);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -557,6 +547,7 @@ export class MultiAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -631,11 +622,10 @@ export class MultiAssetProxyContract extends BaseContract {
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -677,11 +667,10 @@ export class MultiAssetProxyContract extends BaseContract {
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -740,6 +729,7 @@ export class MultiAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -777,11 +767,10 @@ export class MultiAssetProxyContract extends BaseContract {
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -823,11 +812,10 @@ export class MultiAssetProxyContract extends BaseContract {
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -904,7 +892,7 @@ export class MultiAssetProxyContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<MultiAssetProxyContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/multi_asset_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/multi_asset_proxy.ts
@@ -96,24 +96,24 @@ export class MultiAssetProxyContract extends BaseContract {
             target: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('target', target);
-            const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
+        assert.isString('target', target);
+        const self = this as any as MultiAssetProxyContract;
+        const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.addAuthorizedAddress.estimateGasAsync.bind(
-                    self,
-                    target
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.addAuthorizedAddress.estimateGasAsync.bind(
+                self,
+                target
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             target: string,
@@ -121,49 +121,49 @@ export class MultiAssetProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('target', target);
-            const self = this as any as MultiAssetProxyContract;
-            const txHashPromise = self.addAuthorizedAddress.sendTransactionAsync(target
+        assert.isString('target', target);
+        const self = this as any as MultiAssetProxyContract;
+        const txHashPromise = self.addAuthorizedAddress.sendTransactionAsync(target
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             target: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('target', target);
-            const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
+        assert.isString('target', target);
+        const self = this as any as MultiAssetProxyContract;
+        const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             target: string,
         ): string {
-            assert.isString('target', target);
-            const self = this as any as MultiAssetProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
+        assert.isString('target', target);
+        const self = this as any as MultiAssetProxyContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             target: string,
@@ -280,24 +280,24 @@ export class MultiAssetProxyContract extends BaseContract {
             target: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('target', target);
-            const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
+        assert.isString('target', target);
+        const self = this as any as MultiAssetProxyContract;
+        const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.removeAuthorizedAddress.estimateGasAsync.bind(
-                    self,
-                    target
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.removeAuthorizedAddress.estimateGasAsync.bind(
+                self,
+                target
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             target: string,
@@ -305,49 +305,49 @@ export class MultiAssetProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('target', target);
-            const self = this as any as MultiAssetProxyContract;
-            const txHashPromise = self.removeAuthorizedAddress.sendTransactionAsync(target
+        assert.isString('target', target);
+        const self = this as any as MultiAssetProxyContract;
+        const txHashPromise = self.removeAuthorizedAddress.sendTransactionAsync(target
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             target: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('target', target);
-            const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
+        assert.isString('target', target);
+        const self = this as any as MultiAssetProxyContract;
+        const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             target: string,
         ): string {
-            assert.isString('target', target);
-            const self = this as any as MultiAssetProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
+        assert.isString('target', target);
+        const self = this as any as MultiAssetProxyContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             target: string,
@@ -391,7 +391,6 @@ export class MultiAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -426,26 +425,27 @@ export class MultiAssetProxyContract extends BaseContract {
             index: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('target', target);assert.isBigNumber('index', index);
-            const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
+        assert.isString('target', target);
+        assert.isBigNumber('index', index);
+        const self = this as any as MultiAssetProxyContract;
+        const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.removeAuthorizedAddressAtIndex.estimateGasAsync.bind(
-                    self,
-                    target,
-                    index
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.removeAuthorizedAddressAtIndex.estimateGasAsync.bind(
+                self,
+                target,
+                index
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             target: string,
@@ -454,54 +454,57 @@ export class MultiAssetProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('target', target);assert.isBigNumber('index', index);
-            const self = this as any as MultiAssetProxyContract;
-            const txHashPromise = self.removeAuthorizedAddressAtIndex.sendTransactionAsync(target,
+        assert.isString('target', target);
+        assert.isBigNumber('index', index);
+        const self = this as any as MultiAssetProxyContract;
+        const txHashPromise = self.removeAuthorizedAddressAtIndex.sendTransactionAsync(target,
     index
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             target: string,
             index: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('target', target);assert.isBigNumber('index', index);
-            const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
+        assert.isString('target', target);
+        assert.isBigNumber('index', index);
+        const self = this as any as MultiAssetProxyContract;
+        const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             target: string,
             index: BigNumber,
         ): string {
-            assert.isString('target', target);assert.isBigNumber('index', index);
-            const self = this as any as MultiAssetProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
+        assert.isString('target', target);
+        assert.isBigNumber('index', index);
+        const self = this as any as MultiAssetProxyContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             target: string,
@@ -510,7 +513,8 @@ export class MultiAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('target', target);assert.isBigNumber('index', index);
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -547,7 +551,6 @@ export class MultiAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -618,24 +621,24 @@ export class MultiAssetProxyContract extends BaseContract {
             assetProxy: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('assetProxy', assetProxy);
-            const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
+        assert.isString('assetProxy', assetProxy);
+        const self = this as any as MultiAssetProxyContract;
+        const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.registerAssetProxy.estimateGasAsync.bind(
-                    self,
-                    assetProxy
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.registerAssetProxy.estimateGasAsync.bind(
+                self,
+                assetProxy
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             assetProxy: string,
@@ -643,49 +646,49 @@ export class MultiAssetProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('assetProxy', assetProxy);
-            const self = this as any as MultiAssetProxyContract;
-            const txHashPromise = self.registerAssetProxy.sendTransactionAsync(assetProxy
+        assert.isString('assetProxy', assetProxy);
+        const self = this as any as MultiAssetProxyContract;
+        const txHashPromise = self.registerAssetProxy.sendTransactionAsync(assetProxy
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             assetProxy: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('assetProxy', assetProxy);
-            const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
+        assert.isString('assetProxy', assetProxy);
+        const self = this as any as MultiAssetProxyContract;
+        const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             assetProxy: string,
         ): string {
-            assert.isString('assetProxy', assetProxy);
-            const self = this as any as MultiAssetProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
+        assert.isString('assetProxy', assetProxy);
+        const self = this as any as MultiAssetProxyContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             assetProxy: string,
@@ -729,7 +732,6 @@ export class MultiAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -763,24 +765,24 @@ export class MultiAssetProxyContract extends BaseContract {
             newOwner: string,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as MultiAssetProxyContract;
+        const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transferOwnership.estimateGasAsync.bind(
-                    self,
-                    newOwner
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.transferOwnership.estimateGasAsync.bind(
+                self,
+                newOwner
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             newOwner: string,
@@ -788,49 +790,49 @@ export class MultiAssetProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as MultiAssetProxyContract;
-            const txHashPromise = self.transferOwnership.sendTransactionAsync(newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as MultiAssetProxyContract;
+        const txHashPromise = self.transferOwnership.sendTransactionAsync(newOwner
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             newOwner: string,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as MultiAssetProxyContract;
-            const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as MultiAssetProxyContract;
+        const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             newOwner: string,
         ): string {
-            assert.isString('newOwner', newOwner);
-            const self = this as any as MultiAssetProxyContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
+        assert.isString('newOwner', newOwner);
+        const self = this as any as MultiAssetProxyContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             newOwner: string,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/multi_asset_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/multi_asset_proxy.ts
@@ -100,10 +100,11 @@ export class MultiAssetProxyContract extends BaseContract {
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -145,10 +146,11 @@ export class MultiAssetProxyContract extends BaseContract {
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('addAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -284,10 +286,11 @@ export class MultiAssetProxyContract extends BaseContract {
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -329,10 +332,11 @@ export class MultiAssetProxyContract extends BaseContract {
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddress(address)', [target
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -391,7 +395,6 @@ export class MultiAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -426,15 +429,17 @@ export class MultiAssetProxyContract extends BaseContract {
             index: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('target', target);assert.isBigNumber('index', index);
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -454,7 +459,8 @@ export class MultiAssetProxyContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('target', target);assert.isBigNumber('index', index);
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as MultiAssetProxyContract;
             const txHashPromise = self.removeAuthorizedAddressAtIndex.sendTransactionAsync(target,
     index
@@ -476,15 +482,17 @@ export class MultiAssetProxyContract extends BaseContract {
             index: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('target', target);assert.isBigNumber('index', index);
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -496,7 +504,8 @@ export class MultiAssetProxyContract extends BaseContract {
             target: string,
             index: BigNumber,
         ): string {
-            assert.isString('target', target);assert.isBigNumber('index', index);
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             const self = this as any as MultiAssetProxyContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('removeAuthorizedAddressAtIndex(address,uint256)', [target,
     index
@@ -510,7 +519,8 @@ export class MultiAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-            assert.isString('target', target);assert.isBigNumber('index', index);
+            assert.isString('target', target);
+            assert.isBigNumber('index', index);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -547,7 +557,6 @@ export class MultiAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -622,10 +631,11 @@ export class MultiAssetProxyContract extends BaseContract {
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -667,10 +677,11 @@ export class MultiAssetProxyContract extends BaseContract {
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('registerAssetProxy(address)', [assetProxy
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -729,7 +740,6 @@ export class MultiAssetProxyContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string[]
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -767,10 +777,11 @@ export class MultiAssetProxyContract extends BaseContract {
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -812,10 +823,11 @@ export class MultiAssetProxyContract extends BaseContract {
             const self = this as any as MultiAssetProxyContract;
             const encodedData = self._strictEncodeArguments('transferOwnership(address)', [newOwner
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -892,7 +904,7 @@ export class MultiAssetProxyContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<MultiAssetProxyContract> {
-        assert.isHexString('bytecode', bytecode);
+        assert.isString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/order_validator.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/order_validator.ts
@@ -2,6 +2,7 @@
 // tslint:disable:no-unused-variable
 // tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
+import { schemas } from '@0x/json-schemas';
 import {
     BlockParam,
     BlockParamLiteral,
@@ -18,6 +19,7 @@ import {
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
+import { assert } from '@0x/assert';
 import * as ethers from 'ethers';
 // tslint:enable:no-unused-variable
 
@@ -34,6 +36,16 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<[{orderStatus: number;orderHash: string;orderTakerAssetFilledAmount: BigNumber}, {makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}]
         > {
+
+            assert.isString('takerAddress', takerAddress);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as OrderValidatorContract;
             const encodedData = self._strictEncodeArguments('getOrderAndTraderInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),address)', [order,
         takerAddress
@@ -64,6 +76,16 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<[BigNumber, BigNumber]
         > {
+            assert.isString('target', target);
+            assert.isString('assetData', assetData);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as OrderValidatorContract;
             const encodedData = self._strictEncodeArguments('getBalanceAndAllowance(address,bytes)', [target,
         assetData
@@ -94,6 +116,16 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<[Array<{orderStatus: number;orderHash: string;orderTakerAssetFilledAmount: BigNumber}>, Array<{makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}>]
         > {
+            assert.isArray('orders', orders);
+            assert.isArray('takerAddresses', takerAddresses);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as OrderValidatorContract;
             const encodedData = self._strictEncodeArguments('getOrdersAndTradersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],address[])', [orders,
         takerAddresses
@@ -124,6 +156,16 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<Array<{makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}>
         > {
+            assert.isArray('orders', orders);
+            assert.isArray('takerAddresses', takerAddresses);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as OrderValidatorContract;
             const encodedData = self._strictEncodeArguments('getTradersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[],address[])', [orders,
         takerAddresses
@@ -154,6 +196,16 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.isString('token', token);
+            assert.isBigNumber('tokenId', tokenId);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as OrderValidatorContract;
             const encodedData = self._strictEncodeArguments('getERC721TokenOwner(address,uint256)', [token,
         tokenId
@@ -184,6 +236,16 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<[BigNumber[], BigNumber[]]
         > {
+            assert.isString('target', target);
+            assert.isArray('assetData', assetData);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as OrderValidatorContract;
             const encodedData = self._strictEncodeArguments('getBalancesAndAllowances(address,bytes[])', [target,
         assetData
@@ -214,6 +276,16 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}
         > {
+
+            assert.isString('takerAddress', takerAddress);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as OrderValidatorContract;
             const encodedData = self._strictEncodeArguments('getTraderInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes),address)', [order,
         takerAddress
@@ -243,6 +315,11 @@ export class OrderValidatorContract extends BaseContract {
             _exchange: string,
             _zrxAssetData: string,
     ): Promise<OrderValidatorContract> {
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         if (artifact.compilerOutput === undefined) {
             throw new Error('Compiler output not found in the artifact file');
         }
@@ -261,6 +338,12 @@ _zrxAssetData
             _exchange: string,
             _zrxAssetData: string,
     ): Promise<OrderValidatorContract> {
+        assert.isString('bytecode', bytecode);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
         const constructorAbi = BaseContract._lookupConstructorAbi(abi);
         [_exchange,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/order_validator.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/order_validator.ts
@@ -1,6 +1,6 @@
-// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma whitespace class-name
+// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma
+// tslint:disable:whitespace no-unbound-method no-trailing-whitespace
 // tslint:disable:no-unused-variable
-// tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
 import { schemas } from '@0x/json-schemas';
 import {
@@ -36,7 +36,6 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<[{orderStatus: number;orderHash: string;orderTakerAssetFilledAmount: BigNumber}, {makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}]
         > {
-
             assert.isString('takerAddress', takerAddress);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
@@ -76,8 +75,7 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<[BigNumber, BigNumber]
         > {
-            assert.isString('target', target);
-            assert.isString('assetData', assetData);
+            assert.isString('target', target);assert.isString('assetData', assetData);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -116,8 +114,7 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<[Array<{orderStatus: number;orderHash: string;orderTakerAssetFilledAmount: BigNumber}>, Array<{makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}>]
         > {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAddresses', takerAddresses);
+            assert.isArray('orders', orders);assert.isArray('takerAddresses', takerAddresses);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -156,8 +153,7 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<Array<{makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}>
         > {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAddresses', takerAddresses);
+            assert.isArray('orders', orders);assert.isArray('takerAddresses', takerAddresses);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -196,8 +192,7 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-            assert.isString('token', token);
-            assert.isBigNumber('tokenId', tokenId);
+            assert.isString('token', token);assert.isBigNumber('tokenId', tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -236,8 +231,7 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<[BigNumber[], BigNumber[]]
         > {
-            assert.isString('target', target);
-            assert.isArray('assetData', assetData);
+            assert.isString('target', target);assert.isArray('assetData', assetData);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -276,7 +270,6 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}
         > {
-
             assert.isString('takerAddress', takerAddress);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
@@ -338,7 +331,7 @@ _zrxAssetData
             _exchange: string,
             _zrxAssetData: string,
     ): Promise<OrderValidatorContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,
@@ -381,4 +374,5 @@ _zrxAssetData
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count
-// tslint:enable:no-unbound-method
+// tslint:enable:no-unbound-method no-parameter-reassignment no-consecutive-blank-lines ordered-imports align
+// tslint:enable:trailing-comma whitespace no-trailing-whitespace

--- a/packages/abi-gen-wrappers/src/generated-wrappers/order_validator.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/order_validator.ts
@@ -75,7 +75,8 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<[BigNumber, BigNumber]
         > {
-            assert.isString('target', target);assert.isString('assetData', assetData);
+            assert.isString('target', target);
+            assert.isString('assetData', assetData);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -114,7 +115,8 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<[Array<{orderStatus: number;orderHash: string;orderTakerAssetFilledAmount: BigNumber}>, Array<{makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}>]
         > {
-            assert.isArray('orders', orders);assert.isArray('takerAddresses', takerAddresses);
+            assert.isArray('orders', orders);
+            assert.isArray('takerAddresses', takerAddresses);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -153,7 +155,8 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<Array<{makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}>
         > {
-            assert.isArray('orders', orders);assert.isArray('takerAddresses', takerAddresses);
+            assert.isArray('orders', orders);
+            assert.isArray('takerAddresses', takerAddresses);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -192,7 +195,8 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-            assert.isString('token', token);assert.isBigNumber('tokenId', tokenId);
+            assert.isString('token', token);
+            assert.isBigNumber('tokenId', tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -231,7 +235,8 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<[BigNumber[], BigNumber[]]
         > {
-            assert.isString('target', target);assert.isArray('assetData', assetData);
+            assert.isString('target', target);
+            assert.isArray('assetData', assetData);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -331,7 +336,7 @@ _zrxAssetData
             _exchange: string,
             _zrxAssetData: string,
     ): Promise<OrderValidatorContract> {
-        assert.isHexString('bytecode', bytecode);
+        assert.isString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/order_validator.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/order_validator.ts
@@ -36,6 +36,7 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<[{orderStatus: number;orderHash: string;orderTakerAssetFilledAmount: BigNumber}, {makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}]
         > {
+
             assert.isString('takerAddress', takerAddress);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
@@ -75,7 +76,8 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<[BigNumber, BigNumber]
         > {
-            assert.isString('target', target);assert.isString('assetData', assetData);
+            assert.isString('target', target);
+            assert.isString('assetData', assetData);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -114,7 +116,8 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<[Array<{orderStatus: number;orderHash: string;orderTakerAssetFilledAmount: BigNumber}>, Array<{makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}>]
         > {
-            assert.isArray('orders', orders);assert.isArray('takerAddresses', takerAddresses);
+            assert.isArray('orders', orders);
+            assert.isArray('takerAddresses', takerAddresses);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -153,7 +156,8 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<Array<{makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}>
         > {
-            assert.isArray('orders', orders);assert.isArray('takerAddresses', takerAddresses);
+            assert.isArray('orders', orders);
+            assert.isArray('takerAddresses', takerAddresses);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -192,7 +196,8 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-            assert.isString('token', token);assert.isBigNumber('tokenId', tokenId);
+            assert.isString('token', token);
+            assert.isBigNumber('tokenId', tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -231,7 +236,8 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<[BigNumber[], BigNumber[]]
         > {
-            assert.isString('target', target);assert.isArray('assetData', assetData);
+            assert.isString('target', target);
+            assert.isArray('assetData', assetData);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -270,6 +276,7 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<{makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}
         > {
+
             assert.isString('takerAddress', takerAddress);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/order_validator.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/order_validator.ts
@@ -75,8 +75,7 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<[BigNumber, BigNumber]
         > {
-            assert.isString('target', target);
-            assert.isString('assetData', assetData);
+            assert.isString('target', target);assert.isString('assetData', assetData);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -115,8 +114,7 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<[Array<{orderStatus: number;orderHash: string;orderTakerAssetFilledAmount: BigNumber}>, Array<{makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}>]
         > {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAddresses', takerAddresses);
+            assert.isArray('orders', orders);assert.isArray('takerAddresses', takerAddresses);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -155,8 +153,7 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<Array<{makerBalance: BigNumber;makerAllowance: BigNumber;takerBalance: BigNumber;takerAllowance: BigNumber;makerZrxBalance: BigNumber;makerZrxAllowance: BigNumber;takerZrxBalance: BigNumber;takerZrxAllowance: BigNumber}>
         > {
-            assert.isArray('orders', orders);
-            assert.isArray('takerAddresses', takerAddresses);
+            assert.isArray('orders', orders);assert.isArray('takerAddresses', takerAddresses);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -195,8 +192,7 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-            assert.isString('token', token);
-            assert.isBigNumber('tokenId', tokenId);
+            assert.isString('token', token);assert.isBigNumber('tokenId', tokenId);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -235,8 +231,7 @@ export class OrderValidatorContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<[BigNumber[], BigNumber[]]
         > {
-            assert.isString('target', target);
-            assert.isArray('assetData', assetData);
+            assert.isString('target', target);assert.isArray('assetData', assetData);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -336,7 +331,7 @@ _zrxAssetData
             _exchange: string,
             _zrxAssetData: string,
     ): Promise<OrderValidatorContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/weth9.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/weth9.ts
@@ -1,6 +1,6 @@
-// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma whitespace class-name
+// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma
+// tslint:disable:whitespace no-unbound-method no-trailing-whitespace
 // tslint:disable:no-unused-variable
-// tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
 import { schemas } from '@0x/json-schemas';
 import {
@@ -69,6 +69,7 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -103,17 +104,15 @@ export class WETH9Contract extends BaseContract {
             wad: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('guy', guy);
-            assert.isBigNumber('wad', wad);
+            assert.isString('guy', guy);assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [guy,
     wad
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -133,8 +132,7 @@ export class WETH9Contract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('guy', guy);
-            assert.isBigNumber('wad', wad);
+            assert.isString('guy', guy);assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const txHashPromise = self.approve.sendTransactionAsync(guy,
     wad
@@ -156,17 +154,15 @@ export class WETH9Contract extends BaseContract {
             wad: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('guy', guy);
-            assert.isBigNumber('wad', wad);
+            assert.isString('guy', guy);assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [guy,
     wad
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -178,8 +174,7 @@ export class WETH9Contract extends BaseContract {
             guy: string,
             wad: BigNumber,
         ): string {
-            assert.isString('guy', guy);
-            assert.isBigNumber('wad', wad);
+            assert.isString('guy', guy);assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [guy,
     wad
@@ -193,8 +188,7 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('guy', guy);
-            assert.isBigNumber('wad', wad);
+            assert.isString('guy', guy);assert.isBigNumber('wad', wad);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -231,6 +225,7 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -266,19 +261,16 @@ export class WETH9Contract extends BaseContract {
             wad: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('src', src);
-            assert.isString('dst', dst);
-            assert.isBigNumber('wad', wad);
+            assert.isString('src', src);assert.isString('dst', dst);assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [src,
     dst,
     wad
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -300,9 +292,7 @@ export class WETH9Contract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('src', src);
-            assert.isString('dst', dst);
-            assert.isBigNumber('wad', wad);
+            assert.isString('src', src);assert.isString('dst', dst);assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const txHashPromise = self.transferFrom.sendTransactionAsync(src,
     dst,
@@ -326,19 +316,16 @@ export class WETH9Contract extends BaseContract {
             wad: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('src', src);
-            assert.isString('dst', dst);
-            assert.isBigNumber('wad', wad);
+            assert.isString('src', src);assert.isString('dst', dst);assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [src,
     dst,
     wad
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -351,9 +338,7 @@ export class WETH9Contract extends BaseContract {
             dst: string,
             wad: BigNumber,
         ): string {
-            assert.isString('src', src);
-            assert.isString('dst', dst);
-            assert.isBigNumber('wad', wad);
+            assert.isString('src', src);assert.isString('dst', dst);assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [src,
     dst,
@@ -369,9 +354,7 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('src', src);
-            assert.isString('dst', dst);
-            assert.isBigNumber('wad', wad);
+            assert.isString('src', src);assert.isString('dst', dst);assert.isBigNumber('wad', wad);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -412,11 +395,10 @@ export class WETH9Contract extends BaseContract {
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('withdraw(uint256)', [wad
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -458,11 +440,10 @@ export class WETH9Contract extends BaseContract {
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('withdraw(uint256)', [wad
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -521,6 +502,7 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<number
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -592,6 +574,7 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -626,17 +609,15 @@ export class WETH9Contract extends BaseContract {
             wad: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('dst', dst);
-            assert.isBigNumber('wad', wad);
+            assert.isString('dst', dst);assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [dst,
     wad
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -656,8 +637,7 @@ export class WETH9Contract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('dst', dst);
-            assert.isBigNumber('wad', wad);
+            assert.isString('dst', dst);assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const txHashPromise = self.transfer.sendTransactionAsync(dst,
     wad
@@ -679,17 +659,15 @@ export class WETH9Contract extends BaseContract {
             wad: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('dst', dst);
-            assert.isBigNumber('wad', wad);
+            assert.isString('dst', dst);assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [dst,
     wad
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -701,8 +679,7 @@ export class WETH9Contract extends BaseContract {
             dst: string,
             wad: BigNumber,
         ): string {
-            assert.isString('dst', dst);
-            assert.isBigNumber('wad', wad);
+            assert.isString('dst', dst);assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [dst,
     wad
@@ -716,8 +693,7 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('dst', dst);
-            assert.isBigNumber('wad', wad);
+            assert.isString('dst', dst);assert.isBigNumber('wad', wad);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -752,13 +728,13 @@ export class WETH9Contract extends BaseContract {
         async sendTransactionAsync(
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('deposit()', []);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -774,6 +750,7 @@ export class WETH9Contract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
+
             const self = this as any as WETH9Contract;
             const txHashPromise = self.deposit.sendTransactionAsync(txData);
             return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
@@ -791,13 +768,13 @@ export class WETH9Contract extends BaseContract {
         async estimateGasAsync(
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('deposit()', []);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -807,6 +784,7 @@ export class WETH9Contract extends BaseContract {
         },
         getABIEncodedTransactionData(
         ): string {
+
             const self = this as any as WETH9Contract;
             const abiEncodedTransactionData = self._strictEncodeArguments('deposit()', []);
             return abiEncodedTransactionData;
@@ -816,6 +794,7 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -852,8 +831,7 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-            assert.isString('index_0', index_0);
-            assert.isString('index_1', index_1);
+            assert.isString('index_0', index_0);assert.isString('index_1', index_1);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -908,7 +886,7 @@ export class WETH9Contract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<WETH9Contract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,
@@ -943,4 +921,5 @@ export class WETH9Contract extends BaseContract {
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count
-// tslint:enable:no-unbound-method
+// tslint:enable:no-unbound-method no-parameter-reassignment no-consecutive-blank-lines ordered-imports align
+// tslint:enable:trailing-comma whitespace no-trailing-whitespace

--- a/packages/abi-gen-wrappers/src/generated-wrappers/weth9.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/weth9.ts
@@ -2,6 +2,7 @@
 // tslint:disable:no-unused-variable
 // tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
+import { schemas } from '@0x/json-schemas';
 import {
     BlockParam,
     BlockParamLiteral,
@@ -18,6 +19,7 @@ import {
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
+import { assert } from '@0x/assert';
 import * as ethers from 'ethers';
 // tslint:enable:no-unused-variable
 
@@ -67,6 +69,14 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('name()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -91,16 +101,19 @@ export class WETH9Contract extends BaseContract {
         async sendTransactionAsync(
             guy: string,
             wad: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('guy', guy);
+            assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [guy,
     wad
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -116,17 +129,12 @@ export class WETH9Contract extends BaseContract {
         awaitTransactionSuccessAsync(
             guy: string,
             wad: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('guy', guy);
+            assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const txHashPromise = self.approve.sendTransactionAsync(guy,
     wad
@@ -146,16 +154,19 @@ export class WETH9Contract extends BaseContract {
         async estimateGasAsync(
             guy: string,
             wad: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('guy', guy);
+            assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [guy,
     wad
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -167,6 +178,8 @@ export class WETH9Contract extends BaseContract {
             guy: string,
             wad: BigNumber,
         ): string {
+            assert.isString('guy', guy);
+            assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [guy,
     wad
@@ -180,6 +193,16 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
+            assert.isString('guy', guy);
+            assert.isBigNumber('wad', wad);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [guy,
         wad
@@ -208,6 +231,14 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('totalSupply()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -233,17 +264,21 @@ export class WETH9Contract extends BaseContract {
             src: string,
             dst: string,
             wad: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('src', src);
+            assert.isString('dst', dst);
+            assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [src,
     dst,
     wad
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -261,17 +296,13 @@ export class WETH9Contract extends BaseContract {
             src: string,
             dst: string,
             wad: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('src', src);
+            assert.isString('dst', dst);
+            assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const txHashPromise = self.transferFrom.sendTransactionAsync(src,
     dst,
@@ -293,17 +324,21 @@ export class WETH9Contract extends BaseContract {
             src: string,
             dst: string,
             wad: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('src', src);
+            assert.isString('dst', dst);
+            assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [src,
     dst,
     wad
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -316,6 +351,9 @@ export class WETH9Contract extends BaseContract {
             dst: string,
             wad: BigNumber,
         ): string {
+            assert.isString('src', src);
+            assert.isString('dst', dst);
+            assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [src,
     dst,
@@ -331,6 +369,17 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
+            assert.isString('src', src);
+            assert.isString('dst', dst);
+            assert.isBigNumber('wad', wad);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [src,
         dst,
@@ -357,15 +406,17 @@ export class WETH9Contract extends BaseContract {
     public withdraw = {
         async sendTransactionAsync(
             wad: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('withdraw(uint256)', [wad
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -379,17 +430,11 @@ export class WETH9Contract extends BaseContract {
         },
         awaitTransactionSuccessAsync(
             wad: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const txHashPromise = self.withdraw.sendTransactionAsync(wad
     , txData);
@@ -407,15 +452,17 @@ export class WETH9Contract extends BaseContract {
         },
         async estimateGasAsync(
             wad: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('withdraw(uint256)', [wad
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -426,6 +473,7 @@ export class WETH9Contract extends BaseContract {
         getABIEncodedTransactionData(
             wad: BigNumber,
         ): string {
+            assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const abiEncodedTransactionData = self._strictEncodeArguments('withdraw(uint256)', [wad
     ]);
@@ -437,6 +485,15 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.isBigNumber('wad', wad);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('withdraw(uint256)', [wad
         ]);
@@ -464,6 +521,14 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<number
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('decimals()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -491,6 +556,15 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+            assert.isString('index_0', index_0);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('balanceOf(address)', [index_0
         ]);
@@ -518,6 +592,14 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('symbol()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -542,16 +624,19 @@ export class WETH9Contract extends BaseContract {
         async sendTransactionAsync(
             dst: string,
             wad: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('dst', dst);
+            assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [dst,
     wad
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -567,17 +652,12 @@ export class WETH9Contract extends BaseContract {
         awaitTransactionSuccessAsync(
             dst: string,
             wad: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('dst', dst);
+            assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const txHashPromise = self.transfer.sendTransactionAsync(dst,
     wad
@@ -597,16 +677,19 @@ export class WETH9Contract extends BaseContract {
         async estimateGasAsync(
             dst: string,
             wad: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('dst', dst);
+            assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [dst,
     wad
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -618,6 +701,8 @@ export class WETH9Contract extends BaseContract {
             dst: string,
             wad: BigNumber,
         ): string {
+            assert.isString('dst', dst);
+            assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [dst,
     wad
@@ -631,6 +716,16 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
+            assert.isString('dst', dst);
+            assert.isBigNumber('wad', wad);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [dst,
         wad
@@ -655,14 +750,15 @@ export class WETH9Contract extends BaseContract {
     };
     public deposit = {
         async sendTransactionAsync(
-            txData: Partial<TxDataPayable> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('deposit()', []);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -674,17 +770,10 @@ export class WETH9Contract extends BaseContract {
             return txHash;
         },
         awaitTransactionSuccessAsync(
-            txData?: Partial<TxDataPayable> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
             const self = this as any as WETH9Contract;
             const txHashPromise = self.deposit.sendTransactionAsync(txData);
             return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
@@ -700,14 +789,15 @@ export class WETH9Contract extends BaseContract {
             );
         },
         async estimateGasAsync(
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('deposit()', []);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -726,6 +816,14 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('deposit()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -754,6 +852,16 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+            assert.isString('index_0', index_0);
+            assert.isString('index_1', index_1);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('allowance(address,address)', [index_0,
         index_1
@@ -781,6 +889,11 @@ export class WETH9Contract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<WETH9Contract> {
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         if (artifact.compilerOutput === undefined) {
             throw new Error('Compiler output not found in the artifact file');
         }
@@ -795,6 +908,12 @@ export class WETH9Contract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<WETH9Contract> {
+        assert.isString('bytecode', bytecode);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
         const constructorAbi = BaseContract._lookupConstructorAbi(abi);
         [] = BaseContract._formatABIDataItemList(

--- a/packages/abi-gen-wrappers/src/generated-wrappers/weth9.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/weth9.ts
@@ -69,7 +69,6 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -104,15 +103,17 @@ export class WETH9Contract extends BaseContract {
             wad: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('guy', guy);assert.isBigNumber('wad', wad);
+            assert.isString('guy', guy);
+            assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [guy,
     wad
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -132,7 +133,8 @@ export class WETH9Contract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('guy', guy);assert.isBigNumber('wad', wad);
+            assert.isString('guy', guy);
+            assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const txHashPromise = self.approve.sendTransactionAsync(guy,
     wad
@@ -154,15 +156,17 @@ export class WETH9Contract extends BaseContract {
             wad: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('guy', guy);assert.isBigNumber('wad', wad);
+            assert.isString('guy', guy);
+            assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [guy,
     wad
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -174,7 +178,8 @@ export class WETH9Contract extends BaseContract {
             guy: string,
             wad: BigNumber,
         ): string {
-            assert.isString('guy', guy);assert.isBigNumber('wad', wad);
+            assert.isString('guy', guy);
+            assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [guy,
     wad
@@ -188,7 +193,8 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('guy', guy);assert.isBigNumber('wad', wad);
+            assert.isString('guy', guy);
+            assert.isBigNumber('wad', wad);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -225,7 +231,6 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -261,16 +266,19 @@ export class WETH9Contract extends BaseContract {
             wad: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('src', src);assert.isString('dst', dst);assert.isBigNumber('wad', wad);
+            assert.isString('src', src);
+            assert.isString('dst', dst);
+            assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [src,
     dst,
     wad
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -292,7 +300,9 @@ export class WETH9Contract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('src', src);assert.isString('dst', dst);assert.isBigNumber('wad', wad);
+            assert.isString('src', src);
+            assert.isString('dst', dst);
+            assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const txHashPromise = self.transferFrom.sendTransactionAsync(src,
     dst,
@@ -316,16 +326,19 @@ export class WETH9Contract extends BaseContract {
             wad: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('src', src);assert.isString('dst', dst);assert.isBigNumber('wad', wad);
+            assert.isString('src', src);
+            assert.isString('dst', dst);
+            assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [src,
     dst,
     wad
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -338,7 +351,9 @@ export class WETH9Contract extends BaseContract {
             dst: string,
             wad: BigNumber,
         ): string {
-            assert.isString('src', src);assert.isString('dst', dst);assert.isBigNumber('wad', wad);
+            assert.isString('src', src);
+            assert.isString('dst', dst);
+            assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [src,
     dst,
@@ -354,7 +369,9 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('src', src);assert.isString('dst', dst);assert.isBigNumber('wad', wad);
+            assert.isString('src', src);
+            assert.isString('dst', dst);
+            assert.isBigNumber('wad', wad);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -395,10 +412,11 @@ export class WETH9Contract extends BaseContract {
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('withdraw(uint256)', [wad
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -440,10 +458,11 @@ export class WETH9Contract extends BaseContract {
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('withdraw(uint256)', [wad
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -502,7 +521,6 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<number
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -574,7 +592,6 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -609,15 +626,17 @@ export class WETH9Contract extends BaseContract {
             wad: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('dst', dst);assert.isBigNumber('wad', wad);
+            assert.isString('dst', dst);
+            assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [dst,
     wad
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -637,7 +656,8 @@ export class WETH9Contract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('dst', dst);assert.isBigNumber('wad', wad);
+            assert.isString('dst', dst);
+            assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const txHashPromise = self.transfer.sendTransactionAsync(dst,
     wad
@@ -659,15 +679,17 @@ export class WETH9Contract extends BaseContract {
             wad: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('dst', dst);assert.isBigNumber('wad', wad);
+            assert.isString('dst', dst);
+            assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [dst,
     wad
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -679,7 +701,8 @@ export class WETH9Contract extends BaseContract {
             dst: string,
             wad: BigNumber,
         ): string {
-            assert.isString('dst', dst);assert.isBigNumber('wad', wad);
+            assert.isString('dst', dst);
+            assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [dst,
     wad
@@ -693,7 +716,8 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('dst', dst);assert.isBigNumber('wad', wad);
+            assert.isString('dst', dst);
+            assert.isBigNumber('wad', wad);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -731,10 +755,11 @@ export class WETH9Contract extends BaseContract {
 
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('deposit()', []);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -750,7 +775,6 @@ export class WETH9Contract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-
             const self = this as any as WETH9Contract;
             const txHashPromise = self.deposit.sendTransactionAsync(txData);
             return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
@@ -771,10 +795,11 @@ export class WETH9Contract extends BaseContract {
 
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('deposit()', []);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -794,7 +819,6 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -831,7 +855,8 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-            assert.isString('index_0', index_0);assert.isString('index_1', index_1);
+            assert.isString('index_0', index_0);
+            assert.isString('index_1', index_1);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -886,7 +911,7 @@ export class WETH9Contract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<WETH9Contract> {
-        assert.isHexString('bytecode', bytecode);
+        assert.isString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/weth9.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/weth9.ts
@@ -69,6 +69,7 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -103,17 +104,15 @@ export class WETH9Contract extends BaseContract {
             wad: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('guy', guy);
-            assert.isBigNumber('wad', wad);
+            assert.isString('guy', guy);assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [guy,
     wad
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -133,8 +132,7 @@ export class WETH9Contract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('guy', guy);
-            assert.isBigNumber('wad', wad);
+            assert.isString('guy', guy);assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const txHashPromise = self.approve.sendTransactionAsync(guy,
     wad
@@ -156,17 +154,15 @@ export class WETH9Contract extends BaseContract {
             wad: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('guy', guy);
-            assert.isBigNumber('wad', wad);
+            assert.isString('guy', guy);assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [guy,
     wad
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -178,8 +174,7 @@ export class WETH9Contract extends BaseContract {
             guy: string,
             wad: BigNumber,
         ): string {
-            assert.isString('guy', guy);
-            assert.isBigNumber('wad', wad);
+            assert.isString('guy', guy);assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [guy,
     wad
@@ -193,8 +188,7 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('guy', guy);
-            assert.isBigNumber('wad', wad);
+            assert.isString('guy', guy);assert.isBigNumber('wad', wad);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -231,6 +225,7 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -266,19 +261,16 @@ export class WETH9Contract extends BaseContract {
             wad: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('src', src);
-            assert.isString('dst', dst);
-            assert.isBigNumber('wad', wad);
+            assert.isString('src', src);assert.isString('dst', dst);assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [src,
     dst,
     wad
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -300,9 +292,7 @@ export class WETH9Contract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('src', src);
-            assert.isString('dst', dst);
-            assert.isBigNumber('wad', wad);
+            assert.isString('src', src);assert.isString('dst', dst);assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const txHashPromise = self.transferFrom.sendTransactionAsync(src,
     dst,
@@ -326,19 +316,16 @@ export class WETH9Contract extends BaseContract {
             wad: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('src', src);
-            assert.isString('dst', dst);
-            assert.isBigNumber('wad', wad);
+            assert.isString('src', src);assert.isString('dst', dst);assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [src,
     dst,
     wad
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -351,9 +338,7 @@ export class WETH9Contract extends BaseContract {
             dst: string,
             wad: BigNumber,
         ): string {
-            assert.isString('src', src);
-            assert.isString('dst', dst);
-            assert.isBigNumber('wad', wad);
+            assert.isString('src', src);assert.isString('dst', dst);assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [src,
     dst,
@@ -369,9 +354,7 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('src', src);
-            assert.isString('dst', dst);
-            assert.isBigNumber('wad', wad);
+            assert.isString('src', src);assert.isString('dst', dst);assert.isBigNumber('wad', wad);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -412,11 +395,10 @@ export class WETH9Contract extends BaseContract {
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('withdraw(uint256)', [wad
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -458,11 +440,10 @@ export class WETH9Contract extends BaseContract {
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('withdraw(uint256)', [wad
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -521,6 +502,7 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<number
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -592,6 +574,7 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -626,17 +609,15 @@ export class WETH9Contract extends BaseContract {
             wad: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('dst', dst);
-            assert.isBigNumber('wad', wad);
+            assert.isString('dst', dst);assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [dst,
     wad
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -656,8 +637,7 @@ export class WETH9Contract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('dst', dst);
-            assert.isBigNumber('wad', wad);
+            assert.isString('dst', dst);assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const txHashPromise = self.transfer.sendTransactionAsync(dst,
     wad
@@ -679,17 +659,15 @@ export class WETH9Contract extends BaseContract {
             wad: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('dst', dst);
-            assert.isBigNumber('wad', wad);
+            assert.isString('dst', dst);assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [dst,
     wad
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -701,8 +679,7 @@ export class WETH9Contract extends BaseContract {
             dst: string,
             wad: BigNumber,
         ): string {
-            assert.isString('dst', dst);
-            assert.isBigNumber('wad', wad);
+            assert.isString('dst', dst);assert.isBigNumber('wad', wad);
             const self = this as any as WETH9Contract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [dst,
     wad
@@ -716,8 +693,7 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('dst', dst);
-            assert.isBigNumber('wad', wad);
+            assert.isString('dst', dst);assert.isBigNumber('wad', wad);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -755,11 +731,10 @@ export class WETH9Contract extends BaseContract {
 
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('deposit()', []);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -775,6 +750,7 @@ export class WETH9Contract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
+
             const self = this as any as WETH9Contract;
             const txHashPromise = self.deposit.sendTransactionAsync(txData);
             return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
@@ -795,11 +771,10 @@ export class WETH9Contract extends BaseContract {
 
             const self = this as any as WETH9Contract;
             const encodedData = self._strictEncodeArguments('deposit()', []);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -819,6 +794,7 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -855,8 +831,7 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-            assert.isString('index_0', index_0);
-            assert.isString('index_1', index_1);
+            assert.isString('index_0', index_0);assert.isString('index_1', index_1);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -911,7 +886,7 @@ export class WETH9Contract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<WETH9Contract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/weth9.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/weth9.ts
@@ -69,7 +69,6 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -104,26 +103,27 @@ export class WETH9Contract extends BaseContract {
             wad: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('guy', guy);assert.isBigNumber('wad', wad);
-            const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [guy,
+        assert.isString('guy', guy);
+        assert.isBigNumber('wad', wad);
+        const self = this as any as WETH9Contract;
+        const encodedData = self._strictEncodeArguments('approve(address,uint256)', [guy,
     wad
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.approve.estimateGasAsync.bind(
-                    self,
-                    guy,
-                    wad
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.approve.estimateGasAsync.bind(
+                self,
+                guy,
+                wad
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             guy: string,
@@ -132,54 +132,57 @@ export class WETH9Contract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('guy', guy);assert.isBigNumber('wad', wad);
-            const self = this as any as WETH9Contract;
-            const txHashPromise = self.approve.sendTransactionAsync(guy,
+        assert.isString('guy', guy);
+        assert.isBigNumber('wad', wad);
+        const self = this as any as WETH9Contract;
+        const txHashPromise = self.approve.sendTransactionAsync(guy,
     wad
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             guy: string,
             wad: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('guy', guy);assert.isBigNumber('wad', wad);
-            const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [guy,
+        assert.isString('guy', guy);
+        assert.isBigNumber('wad', wad);
+        const self = this as any as WETH9Contract;
+        const encodedData = self._strictEncodeArguments('approve(address,uint256)', [guy,
     wad
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             guy: string,
             wad: BigNumber,
         ): string {
-            assert.isString('guy', guy);assert.isBigNumber('wad', wad);
-            const self = this as any as WETH9Contract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [guy,
+        assert.isString('guy', guy);
+        assert.isBigNumber('wad', wad);
+        const self = this as any as WETH9Contract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [guy,
     wad
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             guy: string,
@@ -188,7 +191,8 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('guy', guy);assert.isBigNumber('wad', wad);
+            assert.isString('guy', guy);
+            assert.isBigNumber('wad', wad);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -225,7 +229,6 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -261,28 +264,30 @@ export class WETH9Contract extends BaseContract {
             wad: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('src', src);assert.isString('dst', dst);assert.isBigNumber('wad', wad);
-            const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [src,
+        assert.isString('src', src);
+        assert.isString('dst', dst);
+        assert.isBigNumber('wad', wad);
+        const self = this as any as WETH9Contract;
+        const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [src,
     dst,
     wad
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transferFrom.estimateGasAsync.bind(
-                    self,
-                    src,
-                    dst,
-                    wad
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.transferFrom.estimateGasAsync.bind(
+                self,
+                src,
+                dst,
+                wad
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             src: string,
@@ -292,23 +297,25 @@ export class WETH9Contract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('src', src);assert.isString('dst', dst);assert.isBigNumber('wad', wad);
-            const self = this as any as WETH9Contract;
-            const txHashPromise = self.transferFrom.sendTransactionAsync(src,
+        assert.isString('src', src);
+        assert.isString('dst', dst);
+        assert.isBigNumber('wad', wad);
+        const self = this as any as WETH9Contract;
+        const txHashPromise = self.transferFrom.sendTransactionAsync(src,
     dst,
     wad
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             src: string,
@@ -316,35 +323,39 @@ export class WETH9Contract extends BaseContract {
             wad: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('src', src);assert.isString('dst', dst);assert.isBigNumber('wad', wad);
-            const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [src,
+        assert.isString('src', src);
+        assert.isString('dst', dst);
+        assert.isBigNumber('wad', wad);
+        const self = this as any as WETH9Contract;
+        const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [src,
     dst,
     wad
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             src: string,
             dst: string,
             wad: BigNumber,
         ): string {
-            assert.isString('src', src);assert.isString('dst', dst);assert.isBigNumber('wad', wad);
-            const self = this as any as WETH9Contract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [src,
+        assert.isString('src', src);
+        assert.isString('dst', dst);
+        assert.isBigNumber('wad', wad);
+        const self = this as any as WETH9Contract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [src,
     dst,
     wad
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             src: string,
@@ -354,7 +365,9 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('src', src);assert.isString('dst', dst);assert.isBigNumber('wad', wad);
+            assert.isString('src', src);
+            assert.isString('dst', dst);
+            assert.isBigNumber('wad', wad);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -391,24 +404,24 @@ export class WETH9Contract extends BaseContract {
             wad: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isBigNumber('wad', wad);
-            const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('withdraw(uint256)', [wad
+        assert.isBigNumber('wad', wad);
+        const self = this as any as WETH9Contract;
+        const encodedData = self._strictEncodeArguments('withdraw(uint256)', [wad
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.withdraw.estimateGasAsync.bind(
-                    self,
-                    wad
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.withdraw.estimateGasAsync.bind(
+                self,
+                wad
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             wad: BigNumber,
@@ -416,49 +429,49 @@ export class WETH9Contract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isBigNumber('wad', wad);
-            const self = this as any as WETH9Contract;
-            const txHashPromise = self.withdraw.sendTransactionAsync(wad
+        assert.isBigNumber('wad', wad);
+        const self = this as any as WETH9Contract;
+        const txHashPromise = self.withdraw.sendTransactionAsync(wad
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             wad: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isBigNumber('wad', wad);
-            const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('withdraw(uint256)', [wad
+        assert.isBigNumber('wad', wad);
+        const self = this as any as WETH9Contract;
+        const encodedData = self._strictEncodeArguments('withdraw(uint256)', [wad
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             wad: BigNumber,
         ): string {
-            assert.isBigNumber('wad', wad);
-            const self = this as any as WETH9Contract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('withdraw(uint256)', [wad
+        assert.isBigNumber('wad', wad);
+        const self = this as any as WETH9Contract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('withdraw(uint256)', [wad
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             wad: BigNumber,
@@ -502,7 +515,6 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<number
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -574,7 +586,6 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -609,26 +620,27 @@ export class WETH9Contract extends BaseContract {
             wad: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('dst', dst);assert.isBigNumber('wad', wad);
-            const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [dst,
+        assert.isString('dst', dst);
+        assert.isBigNumber('wad', wad);
+        const self = this as any as WETH9Contract;
+        const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [dst,
     wad
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transfer.estimateGasAsync.bind(
-                    self,
-                    dst,
-                    wad
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.transfer.estimateGasAsync.bind(
+                self,
+                dst,
+                wad
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             dst: string,
@@ -637,54 +649,57 @@ export class WETH9Contract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('dst', dst);assert.isBigNumber('wad', wad);
-            const self = this as any as WETH9Contract;
-            const txHashPromise = self.transfer.sendTransactionAsync(dst,
+        assert.isString('dst', dst);
+        assert.isBigNumber('wad', wad);
+        const self = this as any as WETH9Contract;
+        const txHashPromise = self.transfer.sendTransactionAsync(dst,
     wad
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             dst: string,
             wad: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('dst', dst);assert.isBigNumber('wad', wad);
-            const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [dst,
+        assert.isString('dst', dst);
+        assert.isBigNumber('wad', wad);
+        const self = this as any as WETH9Contract;
+        const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [dst,
     wad
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             dst: string,
             wad: BigNumber,
         ): string {
-            assert.isString('dst', dst);assert.isBigNumber('wad', wad);
-            const self = this as any as WETH9Contract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [dst,
+        assert.isString('dst', dst);
+        assert.isBigNumber('wad', wad);
+        const self = this as any as WETH9Contract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [dst,
     wad
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             dst: string,
@@ -693,7 +708,8 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('dst', dst);assert.isBigNumber('wad', wad);
+            assert.isString('dst', dst);
+            assert.isBigNumber('wad', wad);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -728,73 +744,68 @@ export class WETH9Contract extends BaseContract {
         async sendTransactionAsync(
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-
-            const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('deposit()', []);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.deposit.estimateGasAsync.bind(
-                    self,
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const self = this as any as WETH9Contract;
+        const encodedData = self._strictEncodeArguments('deposit()', []);
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.deposit.estimateGasAsync.bind(
+                self,
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-
-            const self = this as any as WETH9Contract;
-            const txHashPromise = self.deposit.sendTransactionAsync(txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        const self = this as any as WETH9Contract;
+        const txHashPromise = self.deposit.sendTransactionAsync(txData);
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-
-            const self = this as any as WETH9Contract;
-            const encodedData = self._strictEncodeArguments('deposit()', []);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const self = this as any as WETH9Contract;
+        const encodedData = self._strictEncodeArguments('deposit()', []);
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
         ): string {
-
-            const self = this as any as WETH9Contract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('deposit()', []);
-            return abiEncodedTransactionData;
+        const self = this as any as WETH9Contract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('deposit()', []);
+        return abiEncodedTransactionData;
         },
         async callAsync(
             callData: Partial<CallData> = {},
             defaultBlock?: BlockParam,
         ): Promise<void
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -831,7 +842,8 @@ export class WETH9Contract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-            assert.isString('index_0', index_0);assert.isString('index_1', index_1);
+            assert.isString('index_0', index_0);
+            assert.isString('index_1', index_1);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/zrx_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/zrx_token.ts
@@ -2,6 +2,7 @@
 // tslint:disable:no-unused-variable
 // tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
+import { schemas } from '@0x/json-schemas';
 import {
     BlockParam,
     BlockParamLiteral,
@@ -18,6 +19,7 @@ import {
 import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
 import { SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
+import { assert } from '@0x/assert';
 import * as ethers from 'ethers';
 // tslint:enable:no-unused-variable
 
@@ -53,6 +55,14 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('name()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -77,16 +87,19 @@ export class ZRXTokenContract extends BaseContract {
         async sendTransactionAsync(
             _spender: string,
             _value: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -102,17 +115,12 @@ export class ZRXTokenContract extends BaseContract {
         awaitTransactionSuccessAsync(
             _spender: string,
             _value: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const txHashPromise = self.approve.sendTransactionAsync(_spender,
     _value
@@ -132,16 +140,19 @@ export class ZRXTokenContract extends BaseContract {
         async estimateGasAsync(
             _spender: string,
             _value: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -153,6 +164,8 @@ export class ZRXTokenContract extends BaseContract {
             _spender: string,
             _value: BigNumber,
         ): string {
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
@@ -166,6 +179,16 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
         _value
@@ -194,6 +217,14 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('totalSupply()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -219,17 +250,21 @@ export class ZRXTokenContract extends BaseContract {
             _from: string,
             _to: string,
             _value: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -247,17 +282,13 @@ export class ZRXTokenContract extends BaseContract {
             _from: string,
             _to: string,
             _value: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const txHashPromise = self.transferFrom.sendTransactionAsync(_from,
     _to,
@@ -279,17 +310,21 @@ export class ZRXTokenContract extends BaseContract {
             _from: string,
             _to: string,
             _value: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -302,6 +337,9 @@ export class ZRXTokenContract extends BaseContract {
             _to: string,
             _value: BigNumber,
         ): string {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
@@ -317,6 +355,17 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
         _to,
@@ -346,6 +395,14 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<number
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('decimals()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -373,6 +430,15 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+            assert.isString('_owner', _owner);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('balanceOf(address)', [_owner
         ]);
@@ -400,6 +466,14 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('symbol()', []);
             const callDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
@@ -424,16 +498,19 @@ export class ZRXTokenContract extends BaseContract {
         async sendTransactionAsync(
             _to: string,
             _value: BigNumber,
-            txData: Partial<TxData> = {},
+        txData?: Partial<TxData> | undefined,
         ): Promise<string> {
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -449,17 +526,12 @@ export class ZRXTokenContract extends BaseContract {
         awaitTransactionSuccessAsync(
             _to: string,
             _value: BigNumber,
-            txData?: Partial<TxData> | number,
+            txData?: Partial<TxData>,
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            // `txData` may be omitted on its own, so it might be set to `pollingIntervalMs`.
-            if (typeof(txData) === 'number') {
-                pollingIntervalMs = txData;
-                timeoutMs = pollingIntervalMs;
-                txData = {};
-            }
-            //
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const txHashPromise = self.transfer.sendTransactionAsync(_to,
     _value
@@ -479,16 +551,19 @@ export class ZRXTokenContract extends BaseContract {
         async estimateGasAsync(
             _to: string,
             _value: BigNumber,
-            txData: Partial<TxData> = {},
+            txData?: Partial<TxData> | undefined,
         ): Promise<number> {
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -500,6 +575,8 @@ export class ZRXTokenContract extends BaseContract {
             _to: string,
             _value: BigNumber,
         ): string {
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
@@ -513,6 +590,16 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
         _value
@@ -543,6 +630,16 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+            assert.isString('_owner', _owner);
+            assert.isString('_spender', _spender);
+            assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
+                schemas.addressSchema,
+                schemas.numberSchema,
+                schemas.jsNumber,
+            ]);
+            if (defaultBlock !== undefined) {
+                assert.isBlockParam('defaultBlock', defaultBlock);
+            }
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('allowance(address,address)', [_owner,
         _spender
@@ -570,6 +667,11 @@ export class ZRXTokenContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<ZRXTokenContract> {
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         if (artifact.compilerOutput === undefined) {
             throw new Error('Compiler output not found in the artifact file');
         }
@@ -584,6 +686,12 @@ export class ZRXTokenContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<ZRXTokenContract> {
+        assert.isString('bytecode', bytecode);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
         const constructorAbi = BaseContract._lookupConstructorAbi(abi);
         [] = BaseContract._formatABIDataItemList(

--- a/packages/abi-gen-wrappers/src/generated-wrappers/zrx_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/zrx_token.ts
@@ -1,6 +1,6 @@
-// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma whitespace class-name
+// tslint:disable:no-consecutive-blank-lines ordered-imports align trailing-comma
+// tslint:disable:whitespace no-unbound-method no-trailing-whitespace
 // tslint:disable:no-unused-variable
-// tslint:disable:no-unbound-method
 import { BaseContract, PromiseWithTransactionHash } from '@0x/base-contract';
 import { schemas } from '@0x/json-schemas';
 import {
@@ -55,6 +55,7 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -89,17 +90,15 @@ export class ZRXTokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_spender', _spender);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -119,8 +118,7 @@ export class ZRXTokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_spender', _spender);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const txHashPromise = self.approve.sendTransactionAsync(_spender,
     _value
@@ -142,17 +140,15 @@ export class ZRXTokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_spender', _spender);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -164,8 +160,7 @@ export class ZRXTokenContract extends BaseContract {
             _spender: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_spender', _spender);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
@@ -179,8 +174,7 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_spender', _spender);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -217,6 +211,7 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -252,19 +247,16 @@ export class ZRXTokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -286,9 +278,7 @@ export class ZRXTokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const txHashPromise = self.transferFrom.sendTransactionAsync(_from,
     _to,
@@ -312,19 +302,16 @@ export class ZRXTokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -337,9 +324,7 @@ export class ZRXTokenContract extends BaseContract {
             _to: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
@@ -355,9 +340,7 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -395,6 +378,7 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<number
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -466,6 +450,7 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -500,17 +485,15 @@ export class ZRXTokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -530,8 +513,7 @@ export class ZRXTokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const txHashPromise = self.transfer.sendTransactionAsync(_to,
     _value
@@ -553,17 +535,15 @@ export class ZRXTokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -575,8 +555,7 @@ export class ZRXTokenContract extends BaseContract {
             _to: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
@@ -590,8 +569,7 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -630,8 +608,7 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-            assert.isString('_owner', _owner);
-            assert.isString('_spender', _spender);
+            assert.isString('_owner', _owner);assert.isString('_spender', _spender);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -686,7 +663,7 @@ export class ZRXTokenContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<ZRXTokenContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,
@@ -721,4 +698,5 @@ export class ZRXTokenContract extends BaseContract {
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', 'abi', '_web3Wrapper']);
     }
 } // tslint:disable:max-file-line-count
-// tslint:enable:no-unbound-method
+// tslint:enable:no-unbound-method no-parameter-reassignment no-consecutive-blank-lines ordered-imports align
+// tslint:enable:trailing-comma whitespace no-trailing-whitespace

--- a/packages/abi-gen-wrappers/src/generated-wrappers/zrx_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/zrx_token.ts
@@ -55,7 +55,6 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -90,15 +89,17 @@ export class ZRXTokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -118,7 +119,8 @@ export class ZRXTokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const txHashPromise = self.approve.sendTransactionAsync(_spender,
     _value
@@ -140,15 +142,17 @@ export class ZRXTokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -160,7 +164,8 @@ export class ZRXTokenContract extends BaseContract {
             _spender: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
@@ -174,7 +179,8 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -211,7 +217,6 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -247,16 +252,19 @@ export class ZRXTokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -278,7 +286,9 @@ export class ZRXTokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const txHashPromise = self.transferFrom.sendTransactionAsync(_from,
     _to,
@@ -302,16 +312,19 @@ export class ZRXTokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -324,7 +337,9 @@ export class ZRXTokenContract extends BaseContract {
             _to: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
@@ -340,7 +355,9 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -378,7 +395,6 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<number
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -450,7 +466,6 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -485,15 +500,17 @@ export class ZRXTokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -513,7 +530,8 @@ export class ZRXTokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const txHashPromise = self.transfer.sendTransactionAsync(_to,
     _value
@@ -535,15 +553,17 @@ export class ZRXTokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
+            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...txData,
+                    ...passedInTxData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -555,7 +575,8 @@ export class ZRXTokenContract extends BaseContract {
             _to: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
@@ -569,7 +590,8 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -608,7 +630,8 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-            assert.isString('_owner', _owner);assert.isString('_spender', _spender);
+            assert.isString('_owner', _owner);
+            assert.isString('_spender', _spender);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -663,7 +686,7 @@ export class ZRXTokenContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<ZRXTokenContract> {
-        assert.isHexString('bytecode', bytecode);
+        assert.isString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/zrx_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/zrx_token.ts
@@ -55,7 +55,6 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -90,26 +89,27 @@ export class ZRXTokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
-            const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
+        assert.isString('_spender', _spender);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as ZRXTokenContract;
+        const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.approve.estimateGasAsync.bind(
-                    self,
-                    _spender,
-                    _value
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.approve.estimateGasAsync.bind(
+                self,
+                _spender,
+                _value
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             _spender: string,
@@ -118,54 +118,57 @@ export class ZRXTokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
-            const self = this as any as ZRXTokenContract;
-            const txHashPromise = self.approve.sendTransactionAsync(_spender,
+        assert.isString('_spender', _spender);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as ZRXTokenContract;
+        const txHashPromise = self.approve.sendTransactionAsync(_spender,
     _value
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             _spender: string,
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
-            const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
+        assert.isString('_spender', _spender);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as ZRXTokenContract;
+        const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             _spender: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
-            const self = this as any as ZRXTokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
+        assert.isString('_spender', _spender);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as ZRXTokenContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             _spender: string,
@@ -174,7 +177,8 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);
+            assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -211,7 +215,6 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -247,28 +250,30 @@ export class ZRXTokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
-            const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as ZRXTokenContract;
+        const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transferFrom.estimateGasAsync.bind(
-                    self,
-                    _from,
-                    _to,
-                    _value
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.transferFrom.estimateGasAsync.bind(
+                self,
+                _from,
+                _to,
+                _value
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             _from: string,
@@ -278,23 +283,25 @@ export class ZRXTokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
-            const self = this as any as ZRXTokenContract;
-            const txHashPromise = self.transferFrom.sendTransactionAsync(_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as ZRXTokenContract;
+        const txHashPromise = self.transferFrom.sendTransactionAsync(_from,
     _to,
     _value
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             _from: string,
@@ -302,35 +309,39 @@ export class ZRXTokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
-            const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as ZRXTokenContract;
+        const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             _from: string,
             _to: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
-            const self = this as any as ZRXTokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
+        assert.isString('_from', _from);
+        assert.isString('_to', _to);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as ZRXTokenContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             _from: string,
@@ -340,7 +351,9 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -378,7 +391,6 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<number
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -450,7 +462,6 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
-
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -485,26 +496,27 @@ export class ZRXTokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
-            const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
+        assert.isString('_to', _to);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as ZRXTokenContract;
+        const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-                self.transfer.estimateGasAsync.bind(
-                    self,
-                    _to,
-                    _value
-                ),
-            );
-            const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
-            return txHash;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+            self.transfer.estimateGasAsync.bind(
+                self,
+                _to,
+                _value
+            ),
+        );
+        const txHash = await self._web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+        return txHash;
         },
         awaitTransactionSuccessAsync(
             _to: string,
@@ -513,54 +525,57 @@ export class ZRXTokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
-            const self = this as any as ZRXTokenContract;
-            const txHashPromise = self.transfer.sendTransactionAsync(_to,
+        assert.isString('_to', _to);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as ZRXTokenContract;
+        const txHashPromise = self.transfer.sendTransactionAsync(_to,
     _value
     , txData);
-            return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
-                txHashPromise,
-                (async (): Promise<TransactionReceiptWithDecodedLogs> => {
-                    // When the transaction hash resolves, wait for it to be mined.
-                    return self._web3Wrapper.awaitTransactionSuccessAsync(
-                        await txHashPromise,
-                        pollingIntervalMs,
-                        timeoutMs,
-                    );
-                })(),
-            );
+        return new PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs>(
+            txHashPromise,
+            (async (): Promise<TransactionReceiptWithDecodedLogs> => {
+                // When the transaction hash resolves, wait for it to be mined.
+                return self._web3Wrapper.awaitTransactionSuccessAsync(
+                    await txHashPromise,
+                    pollingIntervalMs,
+                    timeoutMs,
+                );
+            })(),
+        );
         },
         async estimateGasAsync(
             _to: string,
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
-            const self = this as any as ZRXTokenContract;
-            const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
+        assert.isString('_to', _to);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as ZRXTokenContract;
+        const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
-            const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
-                {
-                    to: self.address,
-                    ...txData,
-                    data: encodedData,
-                },
-                self._web3Wrapper.getContractDefaults(),
-            );
-            const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
-            return gas;
+        const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
+            {
+                to: self.address,
+                ...txData,
+                data: encodedData,
+            },
+            self._web3Wrapper.getContractDefaults(),
+        );
+        const gas = await self._web3Wrapper.estimateGasAsync(txDataWithDefaults);
+        return gas;
         },
         getABIEncodedTransactionData(
             _to: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
-            const self = this as any as ZRXTokenContract;
-            const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
+        assert.isString('_to', _to);
+        assert.isBigNumber('_value', _value);
+        const self = this as any as ZRXTokenContract;
+        const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
-            return abiEncodedTransactionData;
+        return abiEncodedTransactionData;
         },
         async callAsync(
             _to: string,
@@ -569,7 +584,8 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);
+            assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -608,7 +624,8 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-            assert.isString('_owner', _owner);assert.isString('_spender', _spender);
+            assert.isString('_owner', _owner);
+            assert.isString('_spender', _spender);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,

--- a/packages/abi-gen-wrappers/src/generated-wrappers/zrx_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/zrx_token.ts
@@ -55,6 +55,7 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -89,17 +90,15 @@ export class ZRXTokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_spender', _spender);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -119,8 +118,7 @@ export class ZRXTokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_spender', _spender);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const txHashPromise = self.approve.sendTransactionAsync(_spender,
     _value
@@ -142,17 +140,15 @@ export class ZRXTokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_spender', _spender);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -164,8 +160,7 @@ export class ZRXTokenContract extends BaseContract {
             _spender: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_spender', _spender);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('approve(address,uint256)', [_spender,
     _value
@@ -179,8 +174,7 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_spender', _spender);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_spender', _spender);assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -217,6 +211,7 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -252,19 +247,16 @@ export class ZRXTokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -286,9 +278,7 @@ export class ZRXTokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const txHashPromise = self.transferFrom.sendTransactionAsync(_from,
     _to,
@@ -312,19 +302,16 @@ export class ZRXTokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -337,9 +324,7 @@ export class ZRXTokenContract extends BaseContract {
             _to: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transferFrom(address,address,uint256)', [_from,
     _to,
@@ -355,9 +340,7 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_from', _from);
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_from', _from);assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -395,6 +378,7 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<number
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -466,6 +450,7 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<string
         > {
+
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -500,17 +485,15 @@ export class ZRXTokenContract extends BaseContract {
             _value: BigNumber,
         txData?: Partial<TxData> | undefined,
         ): Promise<string> {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -530,8 +513,7 @@ export class ZRXTokenContract extends BaseContract {
             pollingIntervalMs?: number,
             timeoutMs?: number,
         ): PromiseWithTransactionHash<TransactionReceiptWithDecodedLogs> {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const txHashPromise = self.transfer.sendTransactionAsync(_to,
     _value
@@ -553,17 +535,15 @@ export class ZRXTokenContract extends BaseContract {
             _value: BigNumber,
             txData?: Partial<TxData> | undefined,
         ): Promise<number> {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const encodedData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
     ]);
-            const passedInTxData = txData === undefined ? {} : txData;
             const txDataWithDefaults = await BaseContract._applyDefaultsToTxDataAsync(
                 {
                     to: self.address,
-                    ...passedInTxData,
+                    ...txData,
                     data: encodedData,
                 },
                 self._web3Wrapper.getContractDefaults(),
@@ -575,8 +555,7 @@ export class ZRXTokenContract extends BaseContract {
             _to: string,
             _value: BigNumber,
         ): string {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             const self = this as any as ZRXTokenContract;
             const abiEncodedTransactionData = self._strictEncodeArguments('transfer(address,uint256)', [_to,
     _value
@@ -590,8 +569,7 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<boolean
         > {
-            assert.isString('_to', _to);
-            assert.isBigNumber('_value', _value);
+            assert.isString('_to', _to);assert.isBigNumber('_value', _value);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -630,8 +608,7 @@ export class ZRXTokenContract extends BaseContract {
             defaultBlock?: BlockParam,
         ): Promise<BigNumber
         > {
-            assert.isString('_owner', _owner);
-            assert.isString('_spender', _spender);
+            assert.isString('_owner', _owner);assert.isString('_spender', _spender);
             assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
                 schemas.addressSchema,
                 schemas.numberSchema,
@@ -686,7 +663,7 @@ export class ZRXTokenContract extends BaseContract {
         supportedProvider: SupportedProvider,
         txDefaults: Partial<TxData>,
     ): Promise<ZRXTokenContract> {
-        assert.isString('bytecode', bytecode);
+        assert.isHexString('bytecode', bytecode);
         assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
             schemas.addressSchema,
             schemas.numberSchema,

--- a/packages/abi-gen/src/index.ts
+++ b/packages/abi-gen/src/index.ts
@@ -68,6 +68,7 @@ function registerPartials(partialsGlob: string): void {
 }
 
 Handlebars.registerHelper('parameterType', utils.solTypeToTsType.bind(utils, ParamKind.Input, args.backend));
+Handlebars.registerHelper('assertionType', utils.solTypeToAssertion.bind(utils));
 Handlebars.registerHelper('returnType', utils.solTypeToTsType.bind(utils, ParamKind.Output, args.backend));
 if (args.partials) {
     registerPartials(args.partials);

--- a/packages/abi-gen/src/utils.ts
+++ b/packages/abi-gen/src/utils.ts
@@ -32,8 +32,10 @@ export const utils = {
             }
             const TUPLE_TYPE_REGEX = '^tuple$';
             if (solType.match(TUPLE_TYPE_REGEX)) {
-                // NOTE(fabio): Omit assertions for complex types since this would require schema assertions
-                // and we currently do not want to make @0x/abi-gen a 0x-specific tool.
+                // NOTE(fabio): Omit assertions for complex types since this would require taking a type
+                // definition and generating an instance of that type programmatically and checking it
+                // against a list of know json-schemas in order to discover the correct schema assertion
+                // to use. This approach is brittle and error-prone.
                 const assertion = '';
                 return assertion;
             }

--- a/packages/abi-gen/src/utils.ts
+++ b/packages/abi-gen/src/utils.ts
@@ -16,7 +16,7 @@ export const utils = {
             const solTypeRegexToTsType = [
                 {
                     regex: '^u?int(8|16|32)?$',
-                    assertion: '', // TODO(fabio): Create a combined assertion for `number|bigNumber`?
+                    assertion: `assert.isNumberOrBigNumber('${solName}', ${solName});`,
                 },
                 { regex: '^string$', assertion: `assert.isString('${solName}', ${solName});` },
                 { regex: '^address$', assertion: `assert.isString('${solName}', ${solName});` },
@@ -32,9 +32,8 @@ export const utils = {
             }
             const TUPLE_TYPE_REGEX = '^tuple$';
             if (solType.match(TUPLE_TYPE_REGEX)) {
-                // Omit assertions for complex types for now
-                // TODO(fabio): Figure out an elegant way to map complex types to JSON-schemas and
-                // add a schema assertion for that type here.
+                // NOTE(fabio): Omit assertions for complex types since this would require schema assertions
+                // and we currently do not want to make @0x/abi-gen a 0x-specific tool.
                 const assertion = '';
                 return assertion;
             }

--- a/packages/assert/CHANGELOG.json
+++ b/packages/assert/CHANGELOG.json
@@ -3,7 +3,8 @@
         "version": "2.1.0",
         "changes": [
             {
-                "note": "Add new assertions: `isArray`, `isBlockParam`"
+                "note": "Add new assertions: `isArray`, `isBlockParam`",
+                "pr": 1823
             }
         ]
     },

--- a/packages/assert/CHANGELOG.json
+++ b/packages/assert/CHANGELOG.json
@@ -3,7 +3,7 @@
         "version": "2.1.0",
         "changes": [
             {
-                "note": "Add new assertions: `isArray`, `isBlockParam`",
+                "note": "Add new assertions: `isArray`, `isBlockParam` and `isNumberOrBigNumber`",
                 "pr": 1823
             }
         ]

--- a/packages/assert/CHANGELOG.json
+++ b/packages/assert/CHANGELOG.json
@@ -1,5 +1,13 @@
 [
     {
+        "version": "2.1.0",
+        "changes": [
+            {
+                "note": "Add new assertions: `isArray`, `isBlockParam`"
+            }
+        ]
+    },
+    {
         "timestamp": 1557507213,
         "version": "2.0.10",
         "changes": [

--- a/packages/assert/src/index.ts
+++ b/packages/assert/src/index.ts
@@ -87,6 +87,20 @@ Validation errors: ${validationResult.errors.join(', ')}`;
         const isValidUri = validUrl.isUri(value) !== undefined;
         assert.assert(isValidUri, assert.typeAssertionMessage(variableName, 'uri', value));
     },
+    isBlockParam(variableName: string, value: any): void {
+        if (Number.isInteger(value) && value >= 0) {
+            return;
+        }
+        if (value === 'earliest' || value === 'latest' || value === 'pending') {
+            return;
+        }
+        throw new Error(assert.typeAssertionMessage(variableName, 'BlockParam', value));
+    },
+    isArray(variableName: string, value: any): void {
+        if (!Array.isArray(value)) {
+            throw new Error(assert.typeAssertionMessage(variableName, 'Array', value));
+        }
+    },
     assert(condition: boolean, message: string): void {
         if (!condition) {
             throw new Error(message);

--- a/packages/assert/src/index.ts
+++ b/packages/assert/src/index.ts
@@ -56,6 +56,16 @@ export const assert = {
     isNumber(variableName: string, value: number): void {
         assert.assert(_.isFinite(value), assert.typeAssertionMessage(variableName, 'number', value));
     },
+    isNumberOrBigNumber(variableName: string, value: number): void {
+        if (_.isFinite(value)) {
+            return;
+        } else {
+            assert.assert(
+                BigNumber.isBigNumber(value),
+                assert.typeAssertionMessage(variableName, 'number or BigNumber', value),
+            );
+        }
+    },
     isBoolean(variableName: string, value: boolean): void {
         assert.assert(_.isBoolean(value), assert.typeAssertionMessage(variableName, 'boolean', value));
     },

--- a/packages/assert/src/index.ts
+++ b/packages/assert/src/index.ts
@@ -56,7 +56,7 @@ export const assert = {
     isNumber(variableName: string, value: number): void {
         assert.assert(_.isFinite(value), assert.typeAssertionMessage(variableName, 'number', value));
     },
-    isNumberOrBigNumber(variableName: string, value: number): void {
+    isNumberOrBigNumber(variableName: string, value: any): void {
         if (_.isFinite(value)) {
             return;
         } else {

--- a/packages/base-contract/package.json
+++ b/packages/base-contract/package.json
@@ -43,6 +43,8 @@
     "dependencies": {
         "@0x/typescript-typings": "^4.2.2",
         "@0x/utils": "^4.3.3",
+        "@0x/assert": "^2.0.10",
+        "@0x/json-schemas": "^3.0.10",
         "@0x/web3-wrapper": "^6.0.6",
         "ethereum-types": "^2.1.2",
         "ethers": "~4.0.4",

--- a/packages/contract-wrappers/src/contract_wrappers/exchange_wrapper.ts
+++ b/packages/contract-wrappers/src/contract_wrappers/exchange_wrapper.ts
@@ -92,7 +92,7 @@ export class ExchangeWrapper extends ContractWrapper {
         assert.doesConformToSchema('methodOpts', methodOpts, methodOptsSchema);
         const exchangeContract = await this._getExchangeContractAsync();
 
-        const txData = {};
+        const txData = undefined;
         const assetProxy = await exchangeContract.getAssetProxy.callAsync(proxyId, txData, methodOpts.defaultBlock);
         return assetProxy;
     }
@@ -107,7 +107,7 @@ export class ExchangeWrapper extends ContractWrapper {
         assert.doesConformToSchema('methodOpts', methodOpts, methodOptsSchema);
         const exchangeContract = await this._getExchangeContractAsync();
 
-        const txData = {};
+        const txData = undefined;
         const filledTakerAssetAmountInBaseUnits = await exchangeContract.filled.callAsync(
             orderHash,
             txData,
@@ -124,7 +124,7 @@ export class ExchangeWrapper extends ContractWrapper {
         assert.doesConformToSchema('methodOpts', methodOpts, methodOptsSchema);
         const exchangeContract = await this._getExchangeContractAsync();
 
-        const txData = {};
+        const txData = undefined;
         const version = await exchangeContract.VERSION.callAsync(txData, methodOpts.defaultBlock);
         return version;
     }
@@ -146,7 +146,7 @@ export class ExchangeWrapper extends ContractWrapper {
         assert.doesConformToSchema('methodOpts', methodOpts, methodOptsSchema);
         const exchangeContract = await this._getExchangeContractAsync();
 
-        const txData = {};
+        const txData = undefined;
         const orderEpoch = await exchangeContract.orderEpoch.callAsync(
             makerAddress,
             senderAddress,
@@ -166,7 +166,7 @@ export class ExchangeWrapper extends ContractWrapper {
         assert.doesConformToSchema('methodOpts', methodOpts, methodOptsSchema);
         const exchangeContract = await this._getExchangeContractAsync();
 
-        const txData = {};
+        const txData = undefined;
         const isCancelled = await exchangeContract.cancelled.callAsync(orderHash, txData, methodOpts.defaultBlock);
         return isCancelled;
     }
@@ -836,7 +836,7 @@ export class ExchangeWrapper extends ContractWrapper {
         assert.isHexString('signature', signature);
         assert.doesConformToSchema('methodOpts', methodOpts, methodOptsSchema);
         const exchangeInstance = await this._getExchangeContractAsync();
-        const txData = {};
+        const txData = undefined;
         const isValidSignature = await exchangeInstance.isValidSignature.callAsync(
             hash,
             signerAddress,
@@ -867,7 +867,7 @@ export class ExchangeWrapper extends ContractWrapper {
         const normalizedSignerAddress = signerAddress.toLowerCase();
         const normalizedValidatorAddress = validatorAddress.toLowerCase();
         const exchangeInstance = await this._getExchangeContractAsync();
-        const txData = {};
+        const txData = undefined;
         const isValidSignature = await exchangeInstance.allowedValidators.callAsync(
             normalizedSignerAddress,
             normalizedValidatorAddress,
@@ -892,7 +892,7 @@ export class ExchangeWrapper extends ContractWrapper {
         }
         const exchangeInstance = await this._getExchangeContractAsync();
 
-        const txData = {};
+        const txData = undefined;
         const isPreSigned = await exchangeInstance.preSigned.callAsync(
             hash,
             signerAddress,
@@ -915,7 +915,7 @@ export class ExchangeWrapper extends ContractWrapper {
             assert.doesConformToSchema('methodOpts', methodOpts, methodOptsSchema);
         }
         const exchangeInstance = await this._getExchangeContractAsync();
-        const txData = {};
+        const txData = undefined;
         const isExecuted = await exchangeInstance.transactions.callAsync(
             transactionHash,
             txData,
@@ -936,7 +936,7 @@ export class ExchangeWrapper extends ContractWrapper {
             assert.doesConformToSchema('methodOpts', methodOpts, methodOptsSchema);
         }
         const exchangeInstance = await this._getExchangeContractAsync();
-        const txData = {};
+        const txData = undefined;
         const orderInfo = await exchangeInstance.getOrderInfo.callAsync(order, txData, methodOpts.defaultBlock);
         return orderInfo;
     }
@@ -956,7 +956,7 @@ export class ExchangeWrapper extends ContractWrapper {
             assert.doesConformToSchema('methodOpts', methodOpts, methodOptsSchema);
         }
         const exchangeInstance = await this._getExchangeContractAsync();
-        const txData = {};
+        const txData = undefined;
         const ordersInfo = await exchangeInstance.getOrdersInfo.callAsync(orders, txData, methodOpts.defaultBlock);
         return ordersInfo;
     }

--- a/packages/contract-wrappers/src/contract_wrappers/exchange_wrapper.ts
+++ b/packages/contract-wrappers/src/contract_wrappers/exchange_wrapper.ts
@@ -92,8 +92,8 @@ export class ExchangeWrapper extends ContractWrapper {
         assert.doesConformToSchema('methodOpts', methodOpts, methodOptsSchema);
         const exchangeContract = await this._getExchangeContractAsync();
 
-        const txData = undefined;
-        const assetProxy = await exchangeContract.getAssetProxy.callAsync(proxyId, txData, methodOpts.defaultBlock);
+        const callData = {};
+        const assetProxy = await exchangeContract.getAssetProxy.callAsync(proxyId, callData, methodOpts.defaultBlock);
         return assetProxy;
     }
     /**
@@ -107,10 +107,10 @@ export class ExchangeWrapper extends ContractWrapper {
         assert.doesConformToSchema('methodOpts', methodOpts, methodOptsSchema);
         const exchangeContract = await this._getExchangeContractAsync();
 
-        const txData = undefined;
+        const callData = {};
         const filledTakerAssetAmountInBaseUnits = await exchangeContract.filled.callAsync(
             orderHash,
-            txData,
+            callData,
             methodOpts.defaultBlock,
         );
         return filledTakerAssetAmountInBaseUnits;
@@ -124,8 +124,8 @@ export class ExchangeWrapper extends ContractWrapper {
         assert.doesConformToSchema('methodOpts', methodOpts, methodOptsSchema);
         const exchangeContract = await this._getExchangeContractAsync();
 
-        const txData = undefined;
-        const version = await exchangeContract.VERSION.callAsync(txData, methodOpts.defaultBlock);
+        const callData = {};
+        const version = await exchangeContract.VERSION.callAsync(callData, methodOpts.defaultBlock);
         return version;
     }
     /**
@@ -146,11 +146,11 @@ export class ExchangeWrapper extends ContractWrapper {
         assert.doesConformToSchema('methodOpts', methodOpts, methodOptsSchema);
         const exchangeContract = await this._getExchangeContractAsync();
 
-        const txData = undefined;
+        const callData = {};
         const orderEpoch = await exchangeContract.orderEpoch.callAsync(
             makerAddress,
             senderAddress,
-            txData,
+            callData,
             methodOpts.defaultBlock,
         );
         return orderEpoch;
@@ -166,8 +166,8 @@ export class ExchangeWrapper extends ContractWrapper {
         assert.doesConformToSchema('methodOpts', methodOpts, methodOptsSchema);
         const exchangeContract = await this._getExchangeContractAsync();
 
-        const txData = undefined;
-        const isCancelled = await exchangeContract.cancelled.callAsync(orderHash, txData, methodOpts.defaultBlock);
+        const callData = {};
+        const isCancelled = await exchangeContract.cancelled.callAsync(orderHash, callData, methodOpts.defaultBlock);
         return isCancelled;
     }
     /**
@@ -836,12 +836,12 @@ export class ExchangeWrapper extends ContractWrapper {
         assert.isHexString('signature', signature);
         assert.doesConformToSchema('methodOpts', methodOpts, methodOptsSchema);
         const exchangeInstance = await this._getExchangeContractAsync();
-        const txData = undefined;
+        const callData = {};
         const isValidSignature = await exchangeInstance.isValidSignature.callAsync(
             hash,
             signerAddress,
             signature,
-            txData,
+            callData,
             methodOpts.defaultBlock,
         );
         return isValidSignature;
@@ -867,11 +867,11 @@ export class ExchangeWrapper extends ContractWrapper {
         const normalizedSignerAddress = signerAddress.toLowerCase();
         const normalizedValidatorAddress = validatorAddress.toLowerCase();
         const exchangeInstance = await this._getExchangeContractAsync();
-        const txData = undefined;
+        const callData = {};
         const isValidSignature = await exchangeInstance.allowedValidators.callAsync(
             normalizedSignerAddress,
             normalizedValidatorAddress,
-            txData,
+            callData,
             methodOpts.defaultBlock,
         );
         return isValidSignature;
@@ -892,11 +892,11 @@ export class ExchangeWrapper extends ContractWrapper {
         }
         const exchangeInstance = await this._getExchangeContractAsync();
 
-        const txData = undefined;
+        const callData = {};
         const isPreSigned = await exchangeInstance.preSigned.callAsync(
             hash,
             signerAddress,
-            txData,
+            callData,
             methodOpts.defaultBlock,
         );
         return isPreSigned;
@@ -915,10 +915,10 @@ export class ExchangeWrapper extends ContractWrapper {
             assert.doesConformToSchema('methodOpts', methodOpts, methodOptsSchema);
         }
         const exchangeInstance = await this._getExchangeContractAsync();
-        const txData = undefined;
+        const callData = {};
         const isExecuted = await exchangeInstance.transactions.callAsync(
             transactionHash,
-            txData,
+            callData,
             methodOpts.defaultBlock,
         );
         return isExecuted;
@@ -936,8 +936,8 @@ export class ExchangeWrapper extends ContractWrapper {
             assert.doesConformToSchema('methodOpts', methodOpts, methodOptsSchema);
         }
         const exchangeInstance = await this._getExchangeContractAsync();
-        const txData = undefined;
-        const orderInfo = await exchangeInstance.getOrderInfo.callAsync(order, txData, methodOpts.defaultBlock);
+        const callData = {};
+        const orderInfo = await exchangeInstance.getOrderInfo.callAsync(order, callData, methodOpts.defaultBlock);
         return orderInfo;
     }
     /**
@@ -956,8 +956,8 @@ export class ExchangeWrapper extends ContractWrapper {
             assert.doesConformToSchema('methodOpts', methodOpts, methodOptsSchema);
         }
         const exchangeInstance = await this._getExchangeContractAsync();
-        const txData = undefined;
-        const ordersInfo = await exchangeInstance.getOrdersInfo.callAsync(orders, txData, methodOpts.defaultBlock);
+        const callData = {};
+        const ordersInfo = await exchangeInstance.getOrdersInfo.callAsync(orders, callData, methodOpts.defaultBlock);
         return ordersInfo;
     }
     /**

--- a/packages/web3-wrapper/src/web3_wrapper.ts
+++ b/packages/web3-wrapper/src/web3_wrapper.ts
@@ -55,7 +55,7 @@ export class Web3Wrapper {
     private _provider: ZeroExProvider;
     // Raw provider passed in. Do not use. Only here to return the unmodified provider passed in via `getProvider()`
     private readonly _supportedProvider: SupportedProvider;
-    private readonly _txDefaults: Partial<TxData>;
+    private readonly _callAndTxnDefaults: Partial<CallData> | undefined;
     private _jsonRpcRequestId: number;
     /**
      * Check if an address is a valid Ethereum address
@@ -147,22 +147,22 @@ export class Web3Wrapper {
      * Instantiates a new Web3Wrapper.
      * @param   provider    The Web3 provider instance you would like the Web3Wrapper to use for interacting with
      *                      the backing Ethereum node.
-     * @param   txDefaults  Override TxData defaults sent with RPC requests to the backing Ethereum node.
+     * @param   callAndTxnDefaults  Override Call and Txn Data defaults sent with RPC requests to the backing Ethereum node.
      * @return  An instance of the Web3Wrapper class.
      */
-    constructor(supportedProvider: SupportedProvider, txDefaults?: Partial<TxData>) {
+    constructor(supportedProvider: SupportedProvider, callAndTxnDefaults: Partial<CallData> = {}) {
         this.abiDecoder = new AbiDecoder([]);
         this._supportedProvider = supportedProvider;
         this._provider = providerUtils.standardizeOrThrow(supportedProvider);
-        this._txDefaults = txDefaults || {};
+        this._callAndTxnDefaults = callAndTxnDefaults;
         this._jsonRpcRequestId = 1;
     }
     /**
      * Get the contract defaults set to the Web3Wrapper instance
-     * @return  TxData defaults (e.g gas, gasPrice, nonce, etc...)
+     * @return  CallAndTxnData defaults (e.g gas, gasPrice, nonce, etc...)
      */
-    public getContractDefaults(): Partial<TxData> {
-        return this._txDefaults;
+    public getContractDefaults(): Partial<CallData> | undefined {
+        return this._callAndTxnDefaults;
     }
     /**
      * Retrieve the Web3 provider

--- a/yarn.lock
+++ b/yarn.lock
@@ -13941,8 +13941,6 @@ react-highlight@0xproject/react-highlight#react-peer-deps:
   dependencies:
     highlight.js "^9.11.0"
     highlightjs-solidity "^1.0.5"
-    react "^16.4.2"
-    react-dom "^16.4.2"
 
 react-hot-loader@^4.3.3:
   version "4.3.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15066,6 +15066,13 @@ schedule@^0.5.0:
   dependencies:
     object-assign "^4.1.1"
 
+scheduler@^0.13.6:
+  version "0.13.6"
+  resolved "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
 schema-utils@^0.4.4:
   version "0.4.7"
   resolved "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13941,6 +13941,8 @@ react-highlight@0xproject/react-highlight#react-peer-deps:
   dependencies:
     highlight.js "^9.11.0"
     highlightjs-solidity "^1.0.5"
+    react "^16.4.2"
+    react-dom "^16.4.2"
 
 react-hot-loader@^4.3.3:
   version "4.3.4"


### PR DESCRIPTION
## Description

As part of our multi-language support push, we are moving all the additional logic currently residing in the `@0x/contract-wrappers` package into the auto-generated `@0x/abi-gen-wrappers`. This PR is that first step in that direction by adding parameter assertions to the abi-gen templates, so that JS users get helpful error messages when passing in parameters with the incorrect type into the wrappers.

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
