### PR TITLE
ERC1155 Asset Proxy: Store scaled values at end of ERC1155 calldata

### DIFF
--- a/contracts/asset-proxy/package.json
+++ b/contracts/asset-proxy/package.json
@@ -79,6 +79,7 @@
         "@0x/utils": "^4.3.3",
         "@0x/web3-wrapper": "^6.0.6",
         "ethereum-types": "^2.1.2",
+        "ethereumjs-util": "^5.1.1",
         "lodash": "^4.17.11"
     },
     "publishConfig": {

--- a/contracts/asset-proxy/test/utils/erc1155_proxy_wrapper.ts
+++ b/contracts/asset-proxy/test/utils/erc1155_proxy_wrapper.ts
@@ -106,20 +106,20 @@ export class ERC1155ProxyWrapper {
         valueMultiplier: BigNumber,
         receiverCallbackData: string,
         authorizedSender: string,
-        extraData?: string,
+        assetData_?: string,
     ): Promise<string> {
         this._validateProxyContractExistsOrThrow();
-        let encodedAssetData = assetDataUtils.encodeERC1155AssetData(
-            contractAddress,
-            tokensToTransfer,
-            valuesToTransfer,
-            receiverCallbackData,
-        );
-        if (extraData !== undefined) {
-            encodedAssetData = `${encodedAssetData}${extraData}`;
-        }
+        const assetData =
+            assetData_ === undefined
+                ? assetDataUtils.encodeERC1155AssetData(
+                      contractAddress,
+                      tokensToTransfer,
+                      valuesToTransfer,
+                      receiverCallbackData,
+                  )
+                : assetData_;
         const data = this._assetProxyInterface.transferFrom.getABIEncodedTransactionData(
-            encodedAssetData,
+            assetData,
             from,
             to,
             valueMultiplier,
@@ -128,6 +128,7 @@ export class ERC1155ProxyWrapper {
             to: (this._proxyContract as ERC1155ProxyContract).address,
             data,
             from: authorizedSender,
+            gas: 300000,
         });
         return txHash;
     }
@@ -153,7 +154,7 @@ export class ERC1155ProxyWrapper {
         valueMultiplier: BigNumber,
         receiverCallbackData: string,
         authorizedSender: string,
-        extraData?: string,
+        assetData?: string,
     ): Promise<TransactionReceiptWithDecodedLogs> {
         const txReceipt = await this._logDecoder.getTxWithDecodedLogsAsync(
             await this.transferFromAsync(
@@ -165,7 +166,7 @@ export class ERC1155ProxyWrapper {
                 valueMultiplier,
                 receiverCallbackData,
                 authorizedSender,
-                extraData,
+                assetData,
             ),
         );
         return txReceipt;

--- a/contracts/erc1155/contracts/src/ERC1155Mintable.sol
+++ b/contracts/erc1155/contracts/src/ERC1155Mintable.sol
@@ -63,6 +63,32 @@ contract ERC1155Mintable is
         }
     }
 
+    /// @dev creates a new token
+    /// @param type_ of token
+    /// @param uri URI of token
+    function createWithType(
+        uint256 type_,
+        string calldata uri
+    )
+        external
+    {
+        // This will allow restricted access to creators.
+        creators[type_] = msg.sender;
+
+        // emit a Transfer event with Create semantic to help with discovery.
+        emit TransferSingle(
+            msg.sender,
+            address(0x0),
+            address(0x0),
+            type_,
+            0
+        );
+
+        if (bytes(uri).length > 0) {
+            emit URI(uri, type_);
+        }
+    }
+
     /// @dev mints fungible tokens
     /// @param id token type
     /// @param to beneficiaries of minted tokens

--- a/yarn.lock
+++ b/yarn.lock
@@ -13891,7 +13891,6 @@ react-dom@^16.3.2:
 react-dom@^16.4.2:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
-  integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -13955,6 +13954,8 @@ react-highlight@0xproject/react-highlight#react-peer-deps:
   dependencies:
     highlight.js "^9.11.0"
     highlightjs-solidity "^1.0.5"
+    react "^16.4.2"
+    react-dom "^16.4.2"
 
 react-hot-loader@^4.3.3:
   version "4.3.4"
@@ -14202,7 +14203,6 @@ react@^16.3.2:
 react@^16.4.2:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
-  integrity sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -15091,7 +15091,6 @@ schedule@^0.5.0:
 scheduler@^0.13.6:
   version "0.13.6"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
-  integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
## Description

Suppose the `tokensToTransfer` and `valuesToTransfer` are identical; their offsets in the ABI-encoded asset data may be the same. E.g. token IDs [1, 2] and values [1, 2]. Suppose we then scale by a factor of 2, then we expect to trade token IDs [1, 2] and values [2, 4]. This update ensures that scaling the values does not simultaneously scale the token IDs.

In this PR:
1. The ERC1155AssetProxy now stores `scaledValues` at the end of the input ERC1155 calldata.
2. The ERC1155 now has a `createWithType` function to create a token with a specific type identifier.
3. A comprehensive test ensuring the successful transfer of value when token ids and values are abi encoded to same entry in calldata.
4. Added new tests for different lengths of receiver callback data, since we are now appending `scaledValues` after `data`.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
