### PR TITLE
subproviders: Fix Trezor subprovider inefficiency

### DIFF
--- a/packages/subproviders/CHANGELOG.json
+++ b/packages/subproviders/CHANGELOG.json
@@ -1,5 +1,18 @@
 [
     {
+        "version": "4.1.0",
+        "changes": [
+            {
+                "note": "Improve performance of Trezor subprovider via caching",
+                "pr": 1830
+            },
+            {
+                "note": "Add Trezor handware wallet subprovider",
+                "pr": 1431
+            }
+        ]
+    },
+    {
         "timestamp": 1557507213,
         "version": "4.0.6",
         "changes": [

--- a/packages/subproviders/src/subproviders/trezor.ts
+++ b/packages/subproviders/src/subproviders/trezor.ts
@@ -29,7 +29,7 @@ export class TrezorSubprovider extends BaseWalletSubprovider {
     private readonly _trezorConnectClientApi: any;
     private readonly _networkId: number;
     private readonly _addressSearchLimit: number;
-    private _initialDerivedKeyInfo: any;
+    private _initialDerivedKeyInfo: DerivedHDKeyInfo | undefined;
     /**
      * Instantiates a TrezorSubprovider. Defaults to private key path set to `44'/60'/0'/0/`.
      * Must be initialized with trezor-connect API module https://github.com/trezor/connect.


### PR DESCRIPTION
## Description

Cache the derived key info since it does not change and currently we request it from the Trezor device for each request.

Credit goes to @NoahZinsmeister who suggested this optimization: https://github.com/NoahZinsmeister/0x-monorepo/commit/d77ea80509a365acf941136c9ecc92be7bb2c7d1

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
