### PR TITLE
ERC1155 Proxy - Manually Copy Dynamic Fields from Calldata to Memory

### DIFF
--- a/contracts/asset-proxy/CHANGELOG.json
+++ b/contracts/asset-proxy/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "2.3.0",
+        "changes": [
+            {
+                "note": "Updated ERC1155 Asset Proxy. Less optimization. More explicit handling of edge cases.",
+                "pr": 1852
+            }
+        ]
+    },
+    {
         "version": "2.2.0",
         "changes": [
             {

--- a/contracts/asset-proxy/contracts/src/ERC1155Proxy.sol
+++ b/contracts/asset-proxy/contracts/src/ERC1155Proxy.sol
@@ -166,7 +166,7 @@ contract ERC1155Proxy is
                 // Assert that the length of asset data:
                 // 1. Must be at least 132 bytes (Table #2)
                 // 2. Must be a multiple of 32 (excluding the 4-byte selector)
-                if or(lt(assetDataLength, 100), mod(sub(assetDataLength, 4), 32)) {
+                if or(lt(assetDataLength, 132), mod(sub(assetDataLength, 4), 32)) {
                     // Revert with `Error("INVALID_ASSET_DATA_LENGTH")`
                     mstore(0, 0x08c379a000000000000000000000000000000000000000000000000000000000)
                     mstore(32, 0x0000002000000000000000000000000000000000000000000000000000000000)

--- a/contracts/asset-proxy/contracts/src/ERC1155Proxy.sol
+++ b/contracts/asset-proxy/contracts/src/ERC1155Proxy.sol
@@ -85,7 +85,7 @@ contract ERC1155Proxy is
         // |          |             |         | values:                             |
         // |          | 196 + a     | 32      |   1. values Length                  |
         // |          | 228 + a     | b       |   2. values Contents                |
-        // |          |             |         | data                                |
+        // |          |             |         | data:                               |
         // |          | 228 + a + b | 32      |   1. data Length                    |
         // |          | 260 + a + b | c       |   2. data Contents                  |
         // |          |             |         | scaledValues: (***)                 |
@@ -156,34 +156,22 @@ contract ERC1155Proxy is
                 // 2. Increment by 32 the offsets to `ids`, `values`, and `data`
 
                 // Load offset to `assetData`
-                let assetDataOffset := calldataload(4)
+                let assetDataOffset := add(calldataload(4), 4)
 
-                // Load length in bytes of `assetData`, computed by:
-                // 4 (function selector)
-                // + assetDataOffset
-                let assetDataLength := calldataload(add(4, assetDataOffset))
+                // Load length in bytes of `assetData`
+                let assetDataLength := calldataload(assetDataOffset)
 
-                // This corresponds to the beginning of the Data Area for Table #3.
-                // Computed by:
-                // 4 (function selector)
-                // + assetDataOffset
-                // + 32 (length of assetData)
+                // Copy the components of asset data (Table #2) that remain the same in Table #3.
                 calldatacopy(
-                    32,                         // aligned such that "offset to ids" is at the correct location for Table #3
-                    add(36, assetDataOffset),   // beginning of asset data contents
-                    assetDataLength             // length of asset data
+                    68,                         // aligned such that "offset to ids" is at the correct location for Table #3
+                    add(assetDataOffset, 68),   // beginning of `ids` in asset data (Table #2)
+                    sub(assetDataLength, 36)    // length of asset data, starting at `ids` (Table #2)
                 )
 
                 // Increment by 32 the offsets to `ids`, `values`, and `data`
                 mstore(68, add(mload(68), 32))
                 mstore(100, add(mload(100), 32))
                 mstore(132, add(mload(132), 32))
-
-                // Record the address of the destination erc1155 asset for later.
-                let assetAddress := and(
-                    mload(36),
-                    0x000000000000000000000000ffffffffffffffffffffffffffffffffffffffff
-                )
 
                 ////////// STEP 2/4 //////////
                 // Setup iterators for `values` array (Table #3)
@@ -256,6 +244,14 @@ contract ERC1155Proxy is
                 )
 
                 ////////// STEP 4/4 //////////
+                // Load the address of the destination erc1155 contract from asset data (Table #2)
+                // +32 bytes for assetData Length
+                // +4 bytes for assetProxyId
+                let assetAddress := and(
+                    calldataload(add(assetDataOffset, 36)),
+                    0x000000000000000000000000ffffffffffffffffffffffffffffffffffffffff
+                )
+
                 // Call into the destination erc1155 contract using as calldata Table #3 (constructed in-memory above)
                 let success := call(
                     gas,                                    // forward all gas

--- a/contracts/asset-proxy/contracts/src/ERC1155Proxy.sol
+++ b/contracts/asset-proxy/contracts/src/ERC1155Proxy.sol
@@ -63,7 +63,7 @@ contract ERC1155Proxy is
         // |          |             |         | values:                             |
         // |          | 164 + a     | 32      |   1. values Length                  |
         // |          | 196 + a     | b       |   2. values Contents                |
-        // |          |             |         | data                                |
+        // |          |             |         | data:                               |
         // |          | 196 + a + b | 32      |   1. data Length                    |
         // |          | 228 + a + b | c       |   2. data Contents                  |
         //
@@ -198,10 +198,10 @@ contract ERC1155Proxy is
                 let amount := calldataload(100)
 
                 // Store pointer to `ids` (Table #3)
-                // Subtract 4 for `safeBatchTrasferFrom` selector
+                // Subtract 4 for `safeBatchTransferFrom` selector
                 mstore(68, sub(dataAreaEndOffset, 4))
 
-                // Copy `ids` from `assetData` (Table #2) to memory (Table #3)
+                // Ensure length of `ids` does not overflow
                 let idsOffset := add(paramsInAssetDataOffset, calldataload(add(assetDataOffset, 68)))
                 let idsLength := calldataload(idsOffset)
                 let idsLengthInBytes := mul(idsLength, 32)
@@ -213,6 +213,8 @@ contract ERC1155Proxy is
                     mstore(96, 0)
                     revert(0, 100)
                 }
+
+                // Ensure `ids` does not resolve to outside of `assetData`
                 let idsBegin := add(idsOffset, 32)
                 let idsEnd := add(idsBegin, idsLengthInBytes)
                 if gt(idsEnd, assetDataEnd) {
@@ -223,6 +225,8 @@ contract ERC1155Proxy is
                     mstore(96, 0)
                     revert(0, 100)
                 }
+
+                // Copy `ids` from `assetData` (Table #2) to memory (Table #3)
                 calldatacopy(
                     dataAreaEndOffset,
                     idsOffset,
@@ -234,7 +238,7 @@ contract ERC1155Proxy is
                 // Subtract 4 for `safeBatchTrasferFrom` selector
                 mstore(100, sub(dataAreaEndOffset, 4))
 
-                // Copy `values` from `assetData` (Table #2) to memory (Table #3)
+                // Ensure length of `values` does not overflow
                 let valuesOffset := add(paramsInAssetDataOffset, calldataload(add(assetDataOffset, 100)))
                 let valuesLength := calldataload(valuesOffset)
                 let valuesLengthInBytes := mul(valuesLength, 32)
@@ -246,6 +250,8 @@ contract ERC1155Proxy is
                     mstore(96, 0)
                     revert(0, 100)
                 }
+
+                // Ensure `values` does not resolve to outside of `assetData`
                 let valuesBegin := add(valuesOffset, 32)
                 let valuesEnd := add(valuesBegin, valuesLengthInBytes)
                 if gt(valuesEnd, assetDataEnd) {
@@ -292,7 +298,7 @@ contract ERC1155Proxy is
                 // Subtract 4 for `safeBatchTrasferFrom` selector
                 mstore(132, sub(dataAreaEndOffset, 4))
 
-                // Copy `data` from `assetData` (Table #2) to memory (Table #3)
+                // Ensure `data` does not resolve to outside of `assetData`
                 let dataOffset := add(paramsInAssetDataOffset, calldataload(add(assetDataOffset, 132)))
                 let dataLengthInBytes := calldataload(dataOffset)
                 let dataBegin := add(dataOffset, 32)
@@ -305,6 +311,8 @@ contract ERC1155Proxy is
                     mstore(96, 0)
                     revert(0, 100)
                 }
+
+                // Copy `data` from `assetData` (Table #2) to memory (Table #3)
                 calldatacopy(
                     dataAreaEndOffset,
                     dataOffset,

--- a/contracts/asset-proxy/contracts/src/ERC1155Proxy.sol
+++ b/contracts/asset-proxy/contracts/src/ERC1155Proxy.sol
@@ -205,6 +205,14 @@ contract ERC1155Proxy is
                 let idsOffset := add(paramsInAssetDataOffset, calldataload(add(assetDataOffset, 68)))
                 let idsLength := calldataload(idsOffset)
                 let idsLengthInBytes := mul(idsLength, 32)
+                if sub(div(idsLengthInBytes, 32), idsLength) {
+                    // Revert with `Error("UINT256_OVERFLOW")`
+                    mstore(0, 0x08c379a000000000000000000000000000000000000000000000000000000000)
+                    mstore(32, 0x0000002000000000000000000000000000000000000000000000000000000000)
+                    mstore(64, 0x0000001055494e543235365f4f564552464c4f57000000000000000000000000)
+                    mstore(96, 0)
+                    revert(0, 100)
+                }
                 let idsBegin := add(idsOffset, 32)
                 let idsEnd := add(idsBegin, idsLengthInBytes)
                 if gt(idsEnd, assetDataEnd) {
@@ -230,6 +238,14 @@ contract ERC1155Proxy is
                 let valuesOffset := add(paramsInAssetDataOffset, calldataload(add(assetDataOffset, 100)))
                 let valuesLength := calldataload(valuesOffset)
                 let valuesLengthInBytes := mul(valuesLength, 32)
+                if sub(div(valuesLengthInBytes, 32), valuesLength) {
+                    // Revert with `Error("UINT256_OVERFLOW")`
+                    mstore(0, 0x08c379a000000000000000000000000000000000000000000000000000000000)
+                    mstore(32, 0x0000002000000000000000000000000000000000000000000000000000000000)
+                    mstore(64, 0x0000001055494e543235365f4f564552464c4f57000000000000000000000000)
+                    mstore(96, 0)
+                    revert(0, 100)
+                }
                 let valuesBegin := add(valuesOffset, 32)
                 let valuesEnd := add(valuesBegin, valuesLengthInBytes)
                 if gt(valuesEnd, assetDataEnd) {

--- a/contracts/asset-proxy/contracts/src/ERC1155Proxy.sol
+++ b/contracts/asset-proxy/contracts/src/ERC1155Proxy.sol
@@ -59,7 +59,7 @@ contract ERC1155Proxy is
         // |          | 100         |         |   4. offset to data (*)             |
         // | Data     |             |         | ids:                                |
         // |          | 132         | 32      |   1. ids Length                     |
-        // |          | 164         | a       |   2. ids Contents                   | 
+        // |          | 164         | a       |   2. ids Contents                   |
         // |          |             |         | values:                             |
         // |          | 164 + a     | 32      |   1. values Length                  |
         // |          | 196 + a     | b       |   2. values Contents                |
@@ -77,31 +77,40 @@ contract ERC1155Proxy is
         // |          | 4           |         |   1. from address                   |
         // |          | 36          |         |   2. to address                     |
         // |          | 68          |         |   3. offset to ids (*)              |
-        // |          | 100         |         |   4. offset to values (*)           |
+        // |          | 100         |         |   4. offset to scaledValues (*)     |
         // |          | 132         |         |   5. offset to data (*)             |
         // | Data     |             |         | ids:                                |
         // |          | 164         | 32      |   1. ids Length                     |
-        // |          | 196         | a       |   2. ids Contents                   | 
+        // |          | 196         | a       |   2. ids Contents                   |
         // |          |             |         | values:                             |
         // |          | 196 + a     | 32      |   1. values Length                  |
         // |          | 228 + a     | b       |   2. values Contents                |
         // |          |             |         | data                                |
         // |          | 228 + a + b | 32      |   1. data Length                    |
         // |          | 260 + a + b | c       |   2. data Contents                  |
+        // |          |             |         | scaledValues: (***)                 |
+        // |          | 260 + a+b+c | 32      |   1. scaledValues Length            |
+        // |          | 292 + a+b+c | b       |   2. scaledValues Contents          |
         //
         //
         // (*): offset is computed from start of function parameters, so offset
         //      by an additional 4 bytes in the calldata.
-        // 
+        //
         // (**): the `Offset` column is computed assuming no calldata compression;
         //       offsets in the Data Area are dynamic and should be evaluated in
         //       real-time.
+        //
+        // (***): The contents of `values` are modified and stored separately, as `scaledValues`.
+        //        The `values` array cannot be overwritten, as other dynamically allocated fields
+        //        (`ids` and `data`) may resolve to the same array contents. For example, if
+        //        `ids` = [1,2] and `values` = [1,2], the asset data may be optimized
+        //        such that both arrays resolve to same entry of [1,2].
         //
         // WARNING: The ABIv2 specification allows additional padding between
         //          the Params and Data section. This will result in a larger
         //          offset to assetData.
         //
-        // Note: Table #1 and Table #2 exists in Calldata. We construct Table #3 in memory. 
+        // Note: Table #1 and Table #2 exist in Calldata. We construct Table #3 in memory.
         //
         //
         assembly {
@@ -134,7 +143,7 @@ contract ERC1155Proxy is
                 // Construct Table #3 in memory, starting at memory offset 0.
                 // The algorithm below maps asset data from Table #1 and Table #2 to Table #3, while
                 // scaling the `values` (Table #2) by `amount` (Table #1). Once Table #3 has
-                // been constructed in memory, the destination erc1155 contract is called using this 
+                // been constructed in memory, the destination erc1155 contract is called using this
                 // as its calldata. This process is divided into four steps, below.
 
                 ////////// STEP 1/4 //////////
@@ -177,17 +186,31 @@ contract ERC1155Proxy is
                 )
 
                 ////////// STEP 2/4 //////////
-                let amount := calldataload(100)
+                // Setup iterators for `values` array (Table #3)
                 let valuesOffset := add(mload(100), 4) // add 4 for calldata offset
-                let valuesLengthInBytes := mul(
-                    mload(valuesOffset),
-                    32
-                )
+                let valuesLength := mload(valuesOffset)
+                let valuesLengthInBytes := mul(valuesLength, 32)
                 let valuesBegin := add(valuesOffset, 32)
                 let valuesEnd := add(valuesBegin, valuesLengthInBytes)
-                for { let tokenValueOffset := valuesBegin }
+
+                // Setup iterators for `scaledValues` array (Table #3).
+                // This array is placed at the end of the regular ERC1155 calldata,
+                // which is 32 bytes longer than `assetData` (Table #2).
+                let scaledValuesOffset := add(assetDataLength, 32)
+                let scaledValuesBegin := add(scaledValuesOffset, 32)
+                let scaledValuesEnd := add(scaledValuesBegin, valuesLengthInBytes)
+
+                // Scale `values` by `amount` and store the output in `scaledValues`
+                let amount := calldataload(100)
+                for {
+                        let tokenValueOffset := valuesBegin
+                        let scaledTokenValueOffset := scaledValuesBegin
+                    }
                     lt(tokenValueOffset, valuesEnd)
-                    { tokenValueOffset := add(tokenValueOffset, 32) }
+                    {
+                        tokenValueOffset := add(tokenValueOffset, 32)
+                        scaledTokenValueOffset := add(scaledTokenValueOffset, 32)
+                    }
                 {
                     // Load token value and generate scaled value
                     let tokenValue := mload(tokenValueOffset)
@@ -206,9 +229,16 @@ contract ERC1155Proxy is
                         revert(0, 100)
                     }
 
-                    // There was no overflow, update `tokenValue` with its scaled counterpart
-                    mstore(tokenValueOffset, scaledTokenValue)
+                    // There was no overflow, store the scaled token value
+                    mstore(scaledTokenValueOffset, scaledTokenValue)
                 }
+
+                // Store length of `scaledValues` (which is the same as `values`)
+                mstore(scaledValuesOffset, valuesLength)
+
+                // Point `values` to `scaledValues` (see Table #3);
+                // subtract 4 from memory location to account for selector
+                mstore(100, sub(scaledValuesOffset, 4))
 
                 ////////// STEP 3/4 //////////
                 // Store the safeBatchTransferFrom function selector,
@@ -232,7 +262,7 @@ contract ERC1155Proxy is
                     assetAddress,                           // call address of erc1155 asset
                     0,                                      // don't send any ETH
                     0,                                      // pointer to start of input
-                    add(assetDataLength, 32),               // length of input (Table #3) is 32 bytes longer than `assetData` (Table #2)
+                    scaledValuesEnd,                        // length of input (Table #3) is the end of the `scaledValues`
                     0,                                      // write output over memory that won't be reused
                     0                                       // don't copy output to memory
                 )
@@ -246,7 +276,7 @@ contract ERC1155Proxy is
                     )
                     revert(0, returndatasize())
                 }
-                
+
                 // Return if call was successful
                 return(0, 0)
             }

--- a/contracts/asset-proxy/contracts/src/ERC1155Proxy.sol
+++ b/contracts/asset-proxy/contracts/src/ERC1155Proxy.sol
@@ -163,6 +163,18 @@ contract ERC1155Proxy is
                 // Load length in bytes of `assetData`
                 let assetDataLength := calldataload(assetDataOffset)
 
+                // Assert that the length of asset data:
+                // 1. Must be at least 132 bytes (Table #2)
+                // 2. Must be a multiple of 32 (excluding the 4-byte selector)
+                if or(lt(assetDataLength, 100), mod(sub(assetDataLength, 4), 32)) {
+                    // Revert with `Error("INVALID_ASSET_DATA_LENGTH")`
+                    mstore(0, 0x08c379a000000000000000000000000000000000000000000000000000000000)
+                    mstore(32, 0x0000002000000000000000000000000000000000000000000000000000000000)
+                    mstore(64, 0x00000019494e56414c49445f41535345545f444154415f4c454e475448000000)
+                    mstore(96, 0)
+                    revert(0, 100)
+                }
+
                 // End of asset data in calldata
                 // +32 for length field
                 let assetDataEnd := add(assetDataOffset, add(assetDataLength, 32))

--- a/contracts/asset-proxy/contracts/src/ERC1155Proxy.sol
+++ b/contracts/asset-proxy/contracts/src/ERC1155Proxy.sol
@@ -178,6 +178,14 @@ contract ERC1155Proxy is
                 // End of asset data in calldata
                 // +32 for length field
                 let assetDataEnd := add(assetDataOffset, add(assetDataLength, 32))
+                if gt(assetDataEnd, calldatasize()) {
+                    // Revert with `Error("INVALID_ASSET_DATA")`
+                    mstore(0, 0x08c379a000000000000000000000000000000000000000000000000000000000)
+                    mstore(32, 0x0000002000000000000000000000000000000000000000000000000000000000)
+                    mstore(64, 0x00000012494e56414c49445f41535345545f4441544100000000000000000000)
+                    mstore(96, 0)
+                    revert(0, 100)
+                }
 
                 // Load offset to parameters section in asset data
                 let paramsInAssetDataOffset := add(assetDataOffset, 36)

--- a/contracts/asset-proxy/package.json
+++ b/contracts/asset-proxy/package.json
@@ -79,6 +79,7 @@
         "@0x/utils": "^4.3.3",
         "@0x/web3-wrapper": "^6.0.6",
         "ethereum-types": "^2.1.2",
+        "ethereumjs-util": "^5.1.1",
         "lodash": "^4.17.11"
     },
     "publishConfig": {

--- a/contracts/asset-proxy/test/erc1155_proxy.ts
+++ b/contracts/asset-proxy/test/erc1155_proxy.ts
@@ -30,7 +30,7 @@ const expect = chai.expect;
 const blockchainLifecycle = new BlockchainLifecycle(web3Wrapper);
 
 // tslint:disable:no-unnecessary-type-assertion
-describe('ERC1155Proxy', () => {
+describe.only('ERC1155Proxy', () => {
     // constant values used in transfer tests
     const nftOwnerBalance = new BigNumber(1);
     const nftNotOwnerBalance = new BigNumber(0);

--- a/contracts/asset-proxy/test/erc1155_proxy.ts
+++ b/contracts/asset-proxy/test/erc1155_proxy.ts
@@ -30,7 +30,7 @@ const expect = chai.expect;
 const blockchainLifecycle = new BlockchainLifecycle(web3Wrapper);
 
 // tslint:disable:no-unnecessary-type-assertion
-describe.only('ERC1155Proxy', () => {
+describe('ERC1155Proxy', () => {
     // constant values used in transfer tests
     const nftOwnerBalance = new BigNumber(1);
     const nftNotOwnerBalance = new BigNumber(0);

--- a/contracts/asset-proxy/test/erc1155_proxy.ts
+++ b/contracts/asset-proxy/test/erc1155_proxy.ts
@@ -1152,6 +1152,163 @@ describe('ERC1155Proxy', () => {
                 RevertReason.InvalidIdsOffset,
             );
         });
+        it('should revert token ids length overflows', async () => {
+            // setup test parameters
+            const tokensToTransfer = fungibleTokens.slice(0, 1);
+            const valuesToTransfer = [fungibleValueToTransferLarge];
+            const valueMultiplier = valueMultiplierSmall;
+            const erc1155ContractAddress = erc1155Wrapper.getContract().address;
+            const assetData = assetDataUtils.encodeERC1155AssetData(
+                erc1155ContractAddress,
+                tokensToTransfer,
+                valuesToTransfer,
+                receiverCallbackData,
+            );
+            // The asset data we just generated will look like this:
+            // a7cb5fb7
+            // 0x         0000000000000000000000000b1ba0af832d7c05fd64161e0db78e85978e8082
+            // 0x20       0000000000000000000000000000000000000000000000000000000000000080 // offset to token ids
+            // 0x40       00000000000000000000000000000000000000000000000000000000000000c0
+            // 0x60       0000000000000000000000000000000000000000000000000000000000000100
+            // 0x80       0000000000000000000000000000000000000000000000000000000000000001
+            // 0xA0       0000000000000000000000000000000100000000000000000000000000000000
+            // 0xC0       0000000000000000000000000000000000000000000000000000000000000001
+            // 0xE0       0000000000000000000000000000000000000000000000878678326eac900000
+            // 0x100      0000000000000000000000000000000000000000000000000000000000000004
+            // 0x120      0102030400000000000000000000000000000000000000000000000000000000
+            //
+            // We want to chan ge the offset to token ids to point to the end of calldata
+            const encodedOffsetToTokenIds = '0000000000000000000000000000000000000000000000000000000000000080';
+            const badEncodedOffsetToTokenIds = '0000000000000000000000000000000000000000000000000000000000000140';
+            const assetDataWithBadTokenIdsOffset = assetData.replace(
+                encodedOffsetToTokenIds,
+                badEncodedOffsetToTokenIds,
+            );
+            // We want a length that will overflow when converted to bytes - ie, multiplied by 32.
+            const encodedIdsLengthOverflow = '0800000000000000000000000000000000000000000000000000000000000001';
+            const buffer = '0'.repeat(64 * 10);
+            const assetDataWithOverflow = `${assetDataWithBadTokenIdsOffset}${encodedIdsLengthOverflow}${buffer}`;
+            // execute transfer
+            await expectTransactionFailedAsync(
+                erc1155ProxyWrapper.transferFromAsync(
+                    spender,
+                    receiverContract,
+                    erc1155Contract.address,
+                    tokensToTransfer,
+                    valuesToTransfer,
+                    valueMultiplier,
+                    receiverCallbackData,
+                    authorized,
+                    assetDataWithOverflow,
+                ),
+                RevertReason.Uint256Overflow,
+            );
+        });
+        it('should revert token values length overflows', async () => {
+            // setup test parameters
+            const tokensToTransfer = fungibleTokens.slice(0, 1);
+            const valuesToTransfer = [fungibleValueToTransferLarge];
+            const valueMultiplier = valueMultiplierSmall;
+            const erc1155ContractAddress = erc1155Wrapper.getContract().address;
+            const assetData = assetDataUtils.encodeERC1155AssetData(
+                erc1155ContractAddress,
+                tokensToTransfer,
+                valuesToTransfer,
+                receiverCallbackData,
+            );
+            // The asset data we just generated will look like this:
+            // a7cb5fb7
+            // 0x         0000000000000000000000000b1ba0af832d7c05fd64161e0db78e85978e8082
+            // 0x20       0000000000000000000000000000000000000000000000000000000000000080
+            // 0x40       00000000000000000000000000000000000000000000000000000000000000c0 // offset to token values
+            // 0x60       0000000000000000000000000000000000000000000000000000000000000100
+            // 0x80       0000000000000000000000000000000000000000000000000000000000000001
+            // 0xA0       0000000000000000000000000000000100000000000000000000000000000000
+            // 0xC0       0000000000000000000000000000000000000000000000000000000000000001
+            // 0xE0       0000000000000000000000000000000000000000000000878678326eac900000
+            // 0x100      0000000000000000000000000000000000000000000000000000000000000004
+            // 0x120      0102030400000000000000000000000000000000000000000000000000000000
+            //
+            // We want to chan ge the offset to token values to point to the end of calldata
+            const encodedOffsetToTokenIds = '00000000000000000000000000000000000000000000000000000000000000c0';
+            const badEncodedOffsetToTokenIds = '0000000000000000000000000000000000000000000000000000000000000140';
+            const assetDataWithBadTokenIdsOffset = assetData.replace(
+                encodedOffsetToTokenIds,
+                badEncodedOffsetToTokenIds,
+            );
+            // We want a length that will overflow when converted to bytes - ie, multiplied by 32.
+            const encodedIdsLengthOverflow = '0800000000000000000000000000000000000000000000000000000000000001';
+            const buffer = '0'.repeat(64 * 10);
+            const assetDataWithOverflow = `${assetDataWithBadTokenIdsOffset}${encodedIdsLengthOverflow}${buffer}`;
+            // execute transfer
+            await expectTransactionFailedAsync(
+                erc1155ProxyWrapper.transferFromAsync(
+                    spender,
+                    receiverContract,
+                    erc1155Contract.address,
+                    tokensToTransfer,
+                    valuesToTransfer,
+                    valueMultiplier,
+                    receiverCallbackData,
+                    authorized,
+                    assetDataWithOverflow,
+                ),
+                RevertReason.Uint256Overflow,
+            );
+        });
+        it('should revert token data length overflows', async () => {
+            // setup test parameters
+            const tokensToTransfer = fungibleTokens.slice(0, 1);
+            const valuesToTransfer = [fungibleValueToTransferLarge];
+            const valueMultiplier = valueMultiplierSmall;
+            const erc1155ContractAddress = erc1155Wrapper.getContract().address;
+            const assetData = assetDataUtils.encodeERC1155AssetData(
+                erc1155ContractAddress,
+                tokensToTransfer,
+                valuesToTransfer,
+                receiverCallbackData,
+            );
+            // The asset data we just generated will look like this:
+            // a7cb5fb7
+            // 0x         0000000000000000000000000b1ba0af832d7c05fd64161e0db78e85978e8082
+            // 0x20       0000000000000000000000000000000000000000000000000000000000000080
+            // 0x40       00000000000000000000000000000000000000000000000000000000000000c0
+            // 0x60       0000000000000000000000000000000000000000000000000000000000000100 // offset to token data
+            // 0x80       0000000000000000000000000000000000000000000000000000000000000001
+            // 0xA0       0000000000000000000000000000000100000000000000000000000000000000
+            // 0xC0       0000000000000000000000000000000000000000000000000000000000000001
+            // 0xE0       0000000000000000000000000000000000000000000000878678326eac900000
+            // 0x100      0000000000000000000000000000000000000000000000000000000000000004
+            // 0x120      0102030400000000000000000000000000000000000000000000000000000000
+            //
+            // We want to chan ge the offset to token ids to point to the end of calldata,
+            // which we'll extend with a bad length.
+            const encodedOffsetToTokenIds = '0000000000000000000000000000000000000000000000000000000000000100';
+            const badEncodedOffsetToTokenIds = '0000000000000000000000000000000000000000000000000000000000000140';
+            const assetDataWithBadTokenIdsOffset = assetData.replace(
+                encodedOffsetToTokenIds,
+                badEncodedOffsetToTokenIds,
+            );
+            // We want a length that will overflow when converted to bytes - ie, multiplied by 32.
+            const encodedIdsLengthOverflow = '0800000000000000000000000000000000000000000000000000000000000001';
+            const buffer = '0'.repeat(64 * 10);
+            const assetDataWithOverflow = `${assetDataWithBadTokenIdsOffset}${encodedIdsLengthOverflow}${buffer}`;
+            // execute transfer
+            await expectTransactionFailedAsync(
+                erc1155ProxyWrapper.transferFromAsync(
+                    spender,
+                    receiverContract,
+                    erc1155Contract.address,
+                    tokensToTransfer,
+                    valuesToTransfer,
+                    valueMultiplier,
+                    receiverCallbackData,
+                    authorized,
+                    assetDataWithOverflow,
+                ),
+                RevertReason.InvalidDataOffset,
+            );
+        });
         it('should revert if token values resolves to outside the bounds of calldata', async () => {
             // setup test parameters
             const tokensToTransfer = fungibleTokens.slice(0, 1);

--- a/contracts/asset-proxy/test/erc1155_proxy.ts
+++ b/contracts/asset-proxy/test/erc1155_proxy.ts
@@ -643,7 +643,7 @@ describe('ERC1155Proxy', () => {
                 valuesToTransfer,
                 receiverCallbackData,
             );
-            const extraData = '0102030405060708';
+            const extraData = '0102030405060708091001020304050607080910010203040506070809100102';
             const assetDataWithExtraData = `${assetData}${extraData}`;
             // check balances before transfer
             const expectedInitialBalances = [spenderInitialFungibleBalance, receiverContractInitialFungibleBalance];
@@ -1350,6 +1350,36 @@ describe('ERC1155Proxy', () => {
                     assetDataWithBadTokenData,
                 ),
                 RevertReason.InvalidDataOffset,
+            );
+        });
+        it('should revert if length of assetData, excluding the selector, is not a multiple of 32', async () => {
+            // setup test parameters
+            const tokensToTransfer = fungibleTokens.slice(0, 1);
+            const valuesToTransfer = [fungibleValueToTransferLarge];
+            const valueMultiplier = valueMultiplierSmall;
+            const erc1155ContractAddress = erc1155Wrapper.getContract().address;
+            const assetData = assetDataUtils.encodeERC1155AssetData(
+                erc1155ContractAddress,
+                tokensToTransfer,
+                valuesToTransfer,
+                receiverCallbackData,
+            );
+            const extraData = '01';
+            const assetDataWithExtraData = `${assetData}${extraData}`;
+            // execute transfer
+            await expectTransactionFailedAsync(
+                erc1155ProxyWrapper.transferFromWithLogsAsync(
+                    spender,
+                    receiverContract,
+                    erc1155Contract.address,
+                    tokensToTransfer,
+                    valuesToTransfer,
+                    valueMultiplier,
+                    receiverCallbackData,
+                    authorized,
+                    assetDataWithExtraData,
+                ),
+                RevertReason.InvalidAssetDataLength
             );
         });
         it('should transfer nothing if value is zero', async () => {

--- a/contracts/asset-proxy/test/erc1155_proxy.ts
+++ b/contracts/asset-proxy/test/erc1155_proxy.ts
@@ -1532,17 +1532,12 @@ describe('ERC1155Proxy', () => {
                 authorized,
                 assetData,
             );
-            const offsetToAssetData = "0000000000000000000000000000000000000000000000000000000000000080";
-            const invalidOffsetToAssetData = "0000000000000000000000000000000000000000000000000000000000000180";
+            const offsetToAssetData = '0000000000000000000000000000000000000000000000000000000000000080';
+            const invalidOffsetToAssetData = '0000000000000000000000000000000000000000000000000000000000000180';
             const badTxData = txData.replace(offsetToAssetData, invalidOffsetToAssetData);
-
-            console.log(JSON.stringify(RevertReason.InvalidAssetData));
             // execute transfer
             await expectTransactionFailedAsync(
-                erc1155ProxyWrapper.transferFromRawAsync(
-                    badTxData,
-                    authorized,
-                ),
+                erc1155ProxyWrapper.transferFromRawAsync(badTxData, authorized),
                 RevertReason.InvalidAssetDataLength,
             );
         });
@@ -1570,16 +1565,13 @@ describe('ERC1155Proxy', () => {
                 assetData,
             );
             // append asset data to end of tx data with a length of 0x300 bytes, which will extend past actual calldata.
-            const offsetToAssetData = "0000000000000000000000000000000000000000000000000000000000000080";
-            const invalidOffsetToAssetData = "0000000000000000000000000000000000000000000000000000000000000200";
-            const newAssetData = "0000000000000000000000000000000000000000000000000000000000000304"; 
+            const offsetToAssetData = '0000000000000000000000000000000000000000000000000000000000000080';
+            const invalidOffsetToAssetData = '0000000000000000000000000000000000000000000000000000000000000200';
+            const newAssetData = '0000000000000000000000000000000000000000000000000000000000000304';
             const badTxData = `${txData.replace(offsetToAssetData, invalidOffsetToAssetData)}${newAssetData}`;
             // execute transfer
             await expectTransactionFailedAsync(
-                erc1155ProxyWrapper.transferFromRawAsync(
-                    badTxData,
-                    authorized,
-                ),
+                erc1155ProxyWrapper.transferFromRawAsync(badTxData, authorized),
                 RevertReason.InvalidAssetData,
             );
         });
@@ -1610,7 +1602,7 @@ describe('ERC1155Proxy', () => {
                     authorized,
                     assetDataWithExtraData,
                 ),
-                RevertReason.InvalidAssetDataLength
+                RevertReason.InvalidAssetDataLength,
             );
         });
         it('should revert if length of assetData is less than 132 bytes', async () => {
@@ -1618,12 +1610,12 @@ describe('ERC1155Proxy', () => {
             const tokensToTransfer = fungibleTokens.slice(0, 1);
             const valuesToTransfer = [fungibleValueToTransferLarge];
             const valueMultiplier = valueMultiplierSmall;
-            // we'll construct asset data that has a 4 byte selector plus 
+            // we'll construct asset data that has a 4 byte selector plus
             // 96 byte payload. This results in asset data that is 100 bytes
             // long and will trigger the `invalid length` error.
             // we must be sure to use a # of bytes that is still %32
             // so that we know the error is not triggered by another check in the code.
-            const zeros96Bytes = "0".repeat(188);
+            const zeros96Bytes = '0'.repeat(188);
             const assetData131Bytes = `${AssetProxyId.ERC1155}${zeros96Bytes}`;
             // execute transfer
             await expectTransactionFailedAsync(
@@ -1638,7 +1630,7 @@ describe('ERC1155Proxy', () => {
                     authorized,
                     assetData131Bytes,
                 ),
-                RevertReason.InvalidAssetDataLength
+                RevertReason.InvalidAssetDataLength,
             );
         });
         it('should transfer nothing if value is zero', async () => {

--- a/contracts/asset-proxy/test/erc1155_proxy.ts
+++ b/contracts/asset-proxy/test/erc1155_proxy.ts
@@ -1382,6 +1382,34 @@ describe('ERC1155Proxy', () => {
                 RevertReason.InvalidAssetDataLength
             );
         });
+        it('should revert if length of assetData is less than 132 bytes', async () => {
+            // setup test parameters
+            const tokensToTransfer = fungibleTokens.slice(0, 1);
+            const valuesToTransfer = [fungibleValueToTransferLarge];
+            const valueMultiplier = valueMultiplierSmall;
+            // we'll construct asset data that has a 4 byte selector plus 
+            // 96 byte payload. This results in asset data that is 100 bytes
+            // long and will trigger the `invalid length` error.
+            // we must be sure to use a # of bytes that is still %32
+            // so that we know the error is not triggered by another check in the code.
+            const zeros96Bytes = "0".repeat(188);
+            const assetData131Bytes = `${AssetProxyId.ERC1155}${zeros96Bytes}`;
+            // execute transfer
+            await expectTransactionFailedAsync(
+                erc1155ProxyWrapper.transferFromWithLogsAsync(
+                    spender,
+                    receiverContract,
+                    erc1155Contract.address,
+                    tokensToTransfer,
+                    valuesToTransfer,
+                    valueMultiplier,
+                    receiverCallbackData,
+                    authorized,
+                    assetData131Bytes,
+                ),
+                RevertReason.InvalidAssetDataLength
+            );
+        });
         it('should transfer nothing if value is zero', async () => {
             // setup test parameters
             const tokenHolders = [spender, receiver];

--- a/contracts/asset-proxy/test/utils/erc1155_proxy_wrapper.ts
+++ b/contracts/asset-proxy/test/utils/erc1155_proxy_wrapper.ts
@@ -106,20 +106,20 @@ export class ERC1155ProxyWrapper {
         valueMultiplier: BigNumber,
         receiverCallbackData: string,
         authorizedSender: string,
-        extraData?: string,
+        assetData_?: string,
     ): Promise<string> {
         this._validateProxyContractExistsOrThrow();
-        let encodedAssetData = assetDataUtils.encodeERC1155AssetData(
-            contractAddress,
-            tokensToTransfer,
-            valuesToTransfer,
-            receiverCallbackData,
-        );
-        if (extraData !== undefined) {
-            encodedAssetData = `${encodedAssetData}${extraData}`;
-        }
+        const assetData =
+            assetData_ === undefined
+                ? assetDataUtils.encodeERC1155AssetData(
+                      contractAddress,
+                      tokensToTransfer,
+                      valuesToTransfer,
+                      receiverCallbackData,
+                  )
+                : assetData_;
         const data = this._assetProxyInterface.transferFrom.getABIEncodedTransactionData(
-            encodedAssetData,
+            assetData,
             from,
             to,
             valueMultiplier,
@@ -128,6 +128,7 @@ export class ERC1155ProxyWrapper {
             to: (this._proxyContract as ERC1155ProxyContract).address,
             data,
             from: authorizedSender,
+            gas: 300000,
         });
         return txHash;
     }
@@ -153,7 +154,7 @@ export class ERC1155ProxyWrapper {
         valueMultiplier: BigNumber,
         receiverCallbackData: string,
         authorizedSender: string,
-        extraData?: string,
+        assetData?: string,
     ): Promise<TransactionReceiptWithDecodedLogs> {
         const txReceipt = await this._logDecoder.getTxWithDecodedLogsAsync(
             await this.transferFromAsync(
@@ -165,7 +166,7 @@ export class ERC1155ProxyWrapper {
                 valueMultiplier,
                 receiverCallbackData,
                 authorizedSender,
-                extraData,
+                assetData,
             ),
         );
         return txReceipt;

--- a/contracts/erc1155/contracts/src/ERC1155Mintable.sol
+++ b/contracts/erc1155/contracts/src/ERC1155Mintable.sol
@@ -63,6 +63,32 @@ contract ERC1155Mintable is
         }
     }
 
+    /// @dev creates a new token
+    /// @param type_ of token
+    /// @param uri URI of token
+    function createWithType(
+        uint256 type_,
+        string calldata uri
+    )
+        external
+    {
+        // This will allow restricted access to creators.
+        creators[type_] = msg.sender;
+
+        // emit a Transfer event with Create semantic to help with discovery.
+        emit TransferSingle(
+            msg.sender,
+            address(0x0),
+            address(0x0),
+            type_,
+            0
+        );
+
+        if (bytes(uri).length > 0) {
+            emit URI(uri, type_);
+        }
+    }
+
     /// @dev mints fungible tokens
     /// @param id token type
     /// @param to beneficiaries of minted tokens

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -315,6 +315,7 @@ export enum RevertReason {
     InvalidIdsOffset = 'INVALID_IDS_OFFSET',
     InvalidValuesOffset = 'INVALID_VALUES_OFFSET',
     InvalidDataOffset = 'INVALID_DATA_OFFSET',
+    InvalidAssetDataLength = 'INVALID_ASSET_DATA_LENGTH',
 }
 
 export enum StatusCodes {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -312,6 +312,9 @@ export enum RevertReason {
     TriedToMintNonFungibleForFungibleToken = 'TRIED_TO_MINT_NON_FUNGIBLE_FOR_FUNGIBLE_TOKEN',
     TransferRejected = 'TRANSFER_REJECTED',
     Uint256Underflow = 'UINT256_UNDERFLOW',
+    InvalidIdsOffset = 'INVALID_IDS_OFFSET',
+    InvalidValuesOffset = 'INVALID_VALUES_OFFSET',
+    InvalidDataOffset = 'INVALID_DATA_OFFSET',
 }
 
 export enum StatusCodes {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13274,7 +13274,7 @@ prebuild-install@^2.2.2:
     pump "^2.0.1"
     rc "^1.1.6"
     simple-get "^2.7.0"
-    tar-fs "~1.16.3"
+    tar-fs "^1.13.0"
     tunnel-agent "^0.6.0"
     which-pm-runs "^1.0.0"
 
@@ -13854,7 +13854,7 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.6.tgz#eb18989c6d4f4f162c399f79ddd29f3835568092"
   dependencies:
-    deep-extend "^0.6.0"
+    deep-extend "~0.4.0"
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
@@ -13883,6 +13883,15 @@ react-dom@^16.3.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
+
+react-dom@^16.4.2:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.13.6"
 
 react-dom@^16.5.2:
   version "16.5.2"
@@ -13941,6 +13950,8 @@ react-highlight@0xproject/react-highlight#react-peer-deps:
   dependencies:
     highlight.js "^9.11.0"
     highlightjs-solidity "^1.0.5"
+    react "^16.4.2"
+    react-dom "^16.4.2"
 
 react-hot-loader@^4.3.3:
   version "4.3.4"
@@ -14184,6 +14195,15 @@ react@^16.3.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
+
+react@^16.4.2:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.13.6"
 
 react@^16.5.2:
   version "16.5.2"
@@ -15066,7 +15086,7 @@ schedule@^0.5.0:
 
 scheduler@^0.13.6:
   version "0.13.6"
-  resolved "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
## Description

The original implementation of the ERC1155 Proxy copied asset data in bulk from calldata to memory. This introduced edge cases if dynamic values overlapped one another. This PR removes any overlap by individually copying each dynamic field (`ids`, `values`, and `data`). This will undo any optimization made by a client-side ABI encoder, but is both more secure and aligned with the implementations of other proxies.

This PR supersedes #1825 and #1826.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
