### PR TITLE
Fixes false positives in `expectTransactionFailedAsync`

### DIFF
--- a/contracts/test-utils/CHANGELOG.json
+++ b/contracts/test-utils/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "3.1.8",
+        "changes": [
+            {
+                "note": "Fixed false positives in `expectTransactionFailedAsync` and `expectContractCallFailedAsync`",
+                "pr": 1852
+            }
+        ]
+    },
+    {
         "timestamp": 1558712885,
         "version": "3.1.7",
         "changes": [

--- a/contracts/test-utils/src/assertions.ts
+++ b/contracts/test-utils/src/assertions.ts
@@ -104,7 +104,8 @@ export async function expectTransactionFailedAsync(p: sendTransactionResult, rea
     }
     switch (nodeType) {
         case NodeType.Ganache:
-            return expect(p).to.be.rejectedWith(reason);
+            const rejectionMessageRegex = new RegExp(`^VM Exception while processing transaction: revert ${reason}$`);
+            return expect(p).to.be.rejectedWith(rejectionMessageRegex);
         case NodeType.Geth:
             logUtils.warn(
                 'WARNING: Geth does not support revert reasons for sendTransaction. This test will pass if the transaction fails for any reason.',
@@ -160,7 +161,8 @@ export async function expectTransactionFailedWithoutReasonAsync(p: sendTransacti
  * otherwise resolve with no value.
  */
 export async function expectContractCallFailedAsync<T>(p: Promise<T>, reason: RevertReason): Promise<void> {
-    return expect(p).to.be.rejectedWith(reason);
+    const rejectionMessageRegex = new RegExp(`^VM Exception while processing transaction: revert ${reason}$`);
+    return expect(p).to.be.rejectedWith(rejectionMessageRegex);
 }
 
 /**


### PR DESCRIPTION
## Description

The function `expectTransactionFailedAsync(transactionReceipt, expectedRevertReason)` returns a false positive when the expected revert reason is a substring of the exception message. 

For example, if the expected revert reason is `INVALID_DATA` and the actual reason is `INVALID_DATA_OFFSET` then there will be a false positive.

To go one step further, the full exception message is `VM Exception while processing transaction: revert INVALID_DATA_OFFSET`. Any substring within that message will also return a false positive, for example, `processing trans`.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
