### PR TITLE
Remove @albrow as code owner for contract tests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -36,5 +36,4 @@ python-packages/ @feuGeneA
 packages/utils/ @hysz
 
 # Protocol/smart contracts
-contracts/core/test/ @albrow
 contracts/ @abandeali1 @hysz


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

I already spoke to the Protocol Team about this on Slack. It doesn't make sense for me to remain a code owner for the contracts tests since it's not something I'm focusing on these days. Still happy to answer any questions that have to do with the work I did if they happen to come up.
