### PR TITLE
Copy validation methods from ExchangeWrapper to order-utils

### DIFF
--- a/packages/contract-wrappers/src/contract_wrappers/exchange_wrapper.ts
+++ b/packages/contract-wrappers/src/contract_wrappers/exchange_wrapper.ts
@@ -1207,17 +1207,9 @@ export class ExchangeWrapper extends ContractWrapper {
         makerAssetAmount: BigNumber,
         takerAddress?: string,
     ): Promise<void> {
-        const balanceAllowanceFetcher = new AssetBalanceAndProxyAllowanceFetcher(
-            this._erc20TokenWrapper,
-            this._erc721TokenWrapper,
-            BlockParamLiteral.Latest,
-        );
-        const balanceAllowanceStore = new BalanceAndProxyAllowanceLazyStore(balanceAllowanceFetcher);
-        const exchangeTradeSimulator = new ExchangeTransferSimulator(balanceAllowanceStore);
-        const exchangeContract = await this._getExchangeContractAsync();
+        const networkId = await this._web3Wrapper.getNetworkIdAsync();
         await OrderValidationUtils.validateMakerTransferThrowIfInvalidAsync(
-            exchangeTradeSimulator,
-            exchangeContract,
+            networkId,
             this._web3Wrapper.getProvider(),
             signedOrder,
             makerAssetAmount,

--- a/packages/order-utils/CHANGELOG.json
+++ b/packages/order-utils/CHANGELOG.json
@@ -14,6 +14,10 @@
             {
                 "note": "Add support for encoding/decoding StaticCallProxy assetData",
                 "pr": 1863
+            },
+            {
+                "note": "Added `validateMakerTransferThrowIfInvalidAsync` to OrderValidationUtils",
+                "pr": "1937"
             }
         ]
     },

--- a/packages/order-utils/src/index.ts
+++ b/packages/order-utils/src/index.ts
@@ -79,4 +79,4 @@ export {
     OrdersAndRemainingMakerFillAmount,
 } from './types';
 
-export { ExchangeContract } from '@0x/abi-gen-wrappers';
+export { ExchangeContract, NetworkId } from '@0x/abi-gen-wrappers';

--- a/packages/order-utils/src/index.ts
+++ b/packages/order-utils/src/index.ts
@@ -78,3 +78,5 @@ export {
     OrdersAndRemainingTakerFillAmount,
     OrdersAndRemainingMakerFillAmount,
 } from './types';
+
+export { ExchangeContract } from '@0x/abi-gen-wrappers';


### PR DESCRIPTION
## Description

Validation methods currently in `@0x/contract-wrappers` ExchangeWrapper will not be automatically generated in `@0x/abi-gen-wrappers`. This PR copies the validation behaviour into `@0x/order-utils`. This is a temporary fix and we intend to remove the validation methods after V3 contracts are deployed and provide better revert reasons.

This also changes `ExchangeWrapper.validateMakerTransferThrowIfInvalidAsync ` to call the method defined in `@0x/order-utils`. I kept the existing unit test to ensure functionality did not change, but did not add a unit test to `order-utils` since it would be a more significant change and we have a plan to deprecate the validation methods. 
 
Resolves #1873 

Will need to update dependency in `@0x/contract-wrappers` after the `@0x/order-utils` changes are published. From `"@0x/order-utils": "^8.1.1"` -> `"@0x/order-utils": "^8.2.0"`

## Testing instructions

Unit tests should pass.



## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature (non-breaking change which adds functionality)

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Prefix PR title with `[WIP]` if necessary.
-   [x] Add tests to cover changes as needed.
-   [x] Update documentation as needed.
-   [x] Add new entries to the relevant CHANGELOG.jsons.
