### PR TITLE
This one weird trick cuts contract test runtime by over 50% in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,18 +51,7 @@ jobs:
             - restore_cache:
                   keys:
                       - repo-{{ .Environment.CIRCLE_SHA1 }}
-            - run: yarn wsrun test:circleci @0x/contracts-multisig
-            - run: yarn wsrun test:circleci @0x/contracts-utils
-            - run: yarn wsrun test:circleci @0x/contracts-exchange-libs
-            - run: yarn wsrun test:circleci @0x/contracts-erc20
-            - run: yarn wsrun test:circleci @0x/contracts-erc721
-            - run: yarn wsrun test:circleci @0x/contracts-erc1155
-            - run: yarn wsrun test:circleci @0x/contracts-extensions
-            - run: yarn wsrun test:circleci @0x/contracts-asset-proxy
-            - run: yarn wsrun test:circleci @0x/contracts-exchange
-            - run: yarn wsrun test:circleci @0x/contracts-exchange-forwarder
-            - run: yarn wsrun test:circleci @0x/contracts-coordinator
-            - run: yarn wsrun test:circleci @0x/contracts-dev-utils
+            - run: yarn wsrun test:circleci @0x/contracts-multisig @0x/contracts-utils @0x/contracts-exchange-libs @0x/contracts-erc20 @0x/contracts-erc721 @0x/contracts-erc1155 @0x/contracts-extensions @0x/contracts-asset-proxy @0x/contracts-exchange @0x/contracts-exchange-forwarder @0x/contracts-coordinator @0x/contracts-dev-utils
     test-contracts-geth:
         docker:
             - image: circleci/node:9-browsers
@@ -74,18 +63,7 @@ jobs:
                       - repo-{{ .Environment.CIRCLE_SHA1 }}
             # HACK(albrow): we need to sleep 10 seconds to ensure the devnet is
             # initialized
-            - run: sleep 10 && TEST_PROVIDER=geth yarn wsrun test @0x/contracts-multisig
-            - run: TEST_PROVIDER=geth yarn wsrun test:circleci @0x/contracts-utils
-            - run: TEST_PROVIDER=geth yarn wsrun test:circleci @0x/contracts-exchange-libs
-            - run: TEST_PROVIDER=geth yarn wsrun test:circleci @0x/contracts-erc20
-            - run: TEST_PROVIDER=geth yarn wsrun test:circleci @0x/contracts-erc721
-            - run: TEST_PROVIDER=geth yarn wsrun test:circleci @0x/contracts-erc1155
-            - run: TEST_PROVIDER=geth yarn wsrun test:circleci @0x/contracts-extensions
-            - run: TEST_PROVIDER=geth yarn wsrun test:circleci @0x/contracts-asset-proxy
-            - run: TEST_PROVIDER=geth yarn wsrun test:circleci @0x/contracts-exchange
-            - run: TEST_PROVIDER=geth yarn wsrun test:circleci @0x/contracts-exchange-forwarder
-            - run: TEST_PROVIDER=geth yarn wsrun test:circleci @0x/contracts-coordinator
-            - run: TEST_PROVIDER=geth yarn wsrun test:circleci @0x/contracts-dev-utils
+            - run: sleep 10 && TEST_PROVIDER=geth yarn wsrun test:circleci @0x/contracts-multisig @0x/contracts-utils @0x/contracts-exchange-libs @0x/contracts-erc20 @0x/contracts-erc721 @0x/contracts-erc1155 @0x/contracts-extensions @0x/contracts-asset-proxy @0x/contracts-exchange @0x/contracts-exchange-forwarder @0x/contracts-coordinator @0x/contracts-dev-utils
     test-publish:
         resource_class: medium+
         docker:
@@ -114,26 +92,7 @@ jobs:
             - restore_cache:
                   keys:
                       - repo-{{ .Environment.CIRCLE_SHA1 }}
-            - run: yarn wsrun test:circleci @0x/contracts-test-utils
-            - run: yarn wsrun test:circleci @0x/abi-gen
-            - run: yarn wsrun test:circleci @0x/asset-buyer
-            - run: yarn wsrun test:circleci @0x/contract-artifacts
-            - run: yarn wsrun test:circleci @0x/assert
-            - run: yarn wsrun test:circleci @0x/base-contract
-            - run: yarn wsrun test:circleci @0x/connect
-            - run: yarn wsrun test:circleci @0x/contract-wrappers
-            - run: yarn wsrun test:circleci @0x/dev-utils
-            - run: yarn wsrun test:circleci @0x/json-schemas
-            - run: yarn wsrun test:circleci @0x/metacoin
-            - run: yarn wsrun test:circleci @0x/order-utils
-            - run: yarn wsrun test:circleci @0x/order-watcher
-            - run: yarn wsrun test:circleci @0x/sol-compiler
-            - run: yarn wsrun test:circleci @0x/sol-tracing-utils
-            - run: yarn wsrun test:circleci @0x/sol-doc
-            - run: yarn wsrun test:circleci @0x/subproviders
-            - run: yarn wsrun test:circleci @0x/web3-wrapper
-            - run: yarn wsrun test:circleci @0x/utils
-            - run: yarn wsrun test:circleci @0x/instant
+            - run: yarn wsrun test:circleci @0x/contracts-test-utils @0x/abi-gen @0x/asset-buyer @0x/contract-artifacts @0x/assert @0x/base-contract @0x/connect @0x/contract-wrappers @0x/dev-utils @0x/json-schemas @0x/metacoin @0x/order-utils @0x/order-watcher @0x/sol-compiler @0x/sol-tracing-utils @0x/sol-doc @0x/subproviders @0x/web3-wrapper @0x/utils @0x/instant
             - save_cache:
                   key: coverage-abi-gen-{{ .Environment.CIRCLE_SHA1 }}
                   paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,26 @@ jobs:
             - restore_cache:
                   keys:
                       - repo-{{ .Environment.CIRCLE_SHA1 }}
-            - run: yarn wsrun test:circleci @0x/contracts-test-utils @0x/abi-gen @0x/asset-buyer @0x/contract-artifacts @0x/assert @0x/base-contract @0x/connect @0x/contract-wrappers @0x/dev-utils @0x/json-schemas @0x/metacoin @0x/order-utils @0x/order-watcher @0x/sol-compiler @0x/sol-tracing-utils @0x/sol-doc @0x/subproviders @0x/web3-wrapper @0x/utils @0x/instant
+            - run: yarn wsrun test:circleci @0x/contracts-test-utils
+            - run: yarn wsrun test:circleci @0x/abi-gen
+            - run: yarn wsrun test:circleci @0x/asset-buyer
+            - run: yarn wsrun test:circleci @0x/contract-artifacts
+            - run: yarn wsrun test:circleci @0x/assert
+            - run: yarn wsrun test:circleci @0x/base-contract
+            - run: yarn wsrun test:circleci @0x/connect
+            - run: yarn wsrun test:circleci @0x/contract-wrappers
+            - run: yarn wsrun test:circleci @0x/dev-utils
+            - run: yarn wsrun test:circleci @0x/json-schemas
+            - run: yarn wsrun test:circleci @0x/metacoin
+            - run: yarn wsrun test:circleci @0x/order-utils
+            - run: yarn wsrun test:circleci @0x/order-watcher
+            - run: yarn wsrun test:circleci @0x/sol-compiler
+            - run: yarn wsrun test:circleci @0x/sol-tracing-utils
+            - run: yarn wsrun test:circleci @0x/sol-doc
+            - run: yarn wsrun test:circleci @0x/subproviders
+            - run: yarn wsrun test:circleci @0x/web3-wrapper
+            - run: yarn wsrun test:circleci @0x/utils
+            - run: yarn wsrun test:circleci @0x/instant
             - save_cache:
                   key: coverage-abi-gen-{{ .Environment.CIRCLE_SHA1 }}
                   paths:


### PR DESCRIPTION
## Description

On a recent CI run for the development branch, `test-contracts-ganache` took 9 minutes and 40 seconds to run ([see here](https://circleci.com/workflow-run/51c2cd00-8799-472f-9b94-d3ef63f1c412)).  The CI runs for this PR have clocked the same `test-contracts-ganache` task at 4:22 ([see here](https://circleci.com/workflow-run/f7235f03-f0e4-439c-88bf-e47165446139)) and 5:29 ([see here](https://circleci.com/workflow-run/3510d6e1-d1b0-4c7f-ae78-f1c5b9a35926)).

Ignoring cache load/save times, the actual contract test run times were also reduced by over 50%.  I semi-manually compiled a total of 8 minutes and 39 seconds from the CI view of the run times for each of the individual packages.  The cache-ignored contract test run time from the commits in this PR were 3:58 and 3:55.

Unfortunately, the same trick can't readily be applied to `test-rest`.  There were test failures, which can be seen in the CI run for the first commit in this PR.  These should be investigated, because there are big savings to be had if we can circumvent them.  With `test-contracts-ganache`, the parallelization effectively reduced the total run time to the longest individual run time of the lot.  If that same pattern holds up with `test-rest`, the total task run time would be reduced from 5 minutes to 1 minute.

The changes to `test-contracts-geth` are untested, since they're disabled in CI.

## Testing instructions

Watch CI :smile: 

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes the issue of long test run times)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Prove the concept
-   [x] Restore `test-rest` to the old way, since it's failing.
-   [ ] Discuss whether we should commit the `test-contract-geth` changes.