### PR TITLE
order_utils.py: pin eth-abi version

### DIFF
--- a/python-packages/order_utils/setup.py
+++ b/python-packages/order_utils/setup.py
@@ -172,7 +172,7 @@ setup(
         "0x-contract-artifacts",
         "0x-json-schemas",
         "0x-web3",
-        "eth-abi",
+        "eth-abi<2.0.0",
         "eth_utils",
         "hypothesis>=3.31.2",  # HACK! this is web3's dependency!
         # above works around https://github.com/ethereum/web3.py/issues/1179


### PR DESCRIPTION
Fixes broken builds due to new release of eth-abi.