### PR TITLE
Fix case in pre-publish write access checks

### DIFF
--- a/packages/monorepo-scripts/src/prepublish_checks.ts
+++ b/packages/monorepo-scripts/src/prepublish_checks.ts
@@ -148,7 +148,14 @@ async function checkPublishRequiredSetupAsync(updatedPublicPackages: Package[]):
     const writePermissions = Object.keys(pkgPermissions).filter(pkgName => {
         return pkgPermissions[pkgName] === 'read-write';
     });
-    const unwriteablePkgs = updatedPublicPackages.filter(pkg => !writePermissions.includes(pkg.packageJson.name));
+    const unwriteablePkgs = [];
+    for (const pkg of updatedPublicPackages) {
+        const isPackagePublished = (await npmUtils.getPackageRegistryJsonIfExistsAsync(pkg.packageJson.name)) !== undefined;
+        const isPackageWritePermissionsGranted = writePermissions.includes(pkg.packageJson.name);
+        if (!isPackageWritePermissionsGranted && isPackagePublished) {
+            unwriteablePkgs.push(pkg);
+        }
+    }
     if (unwriteablePkgs.length > 0) {
         utils.log(`Missing write permissions for the following packages:`);
         unwriteablePkgs.forEach(pkg => {

--- a/packages/monorepo-scripts/src/prepublish_checks.ts
+++ b/packages/monorepo-scripts/src/prepublish_checks.ts
@@ -153,7 +153,7 @@ async function checkPublishRequiredSetupAsync(updatedPublicPackages: Package[]):
         const isPackagePublished =
             (await npmUtils.getPackageRegistryJsonIfExistsAsync(pkg.packageJson.name)) !== undefined;
         const isPackageWritePermissionsGranted = writePermissions.includes(pkg.packageJson.name);
-        if (!isPackageWritePermissionsGranted && isPackagePublished) {
+        if (isPackagePublished && !isPackageWritePermissionsGranted) {
             unwriteablePkgs.push(pkg);
         }
     }

--- a/packages/monorepo-scripts/src/prepublish_checks.ts
+++ b/packages/monorepo-scripts/src/prepublish_checks.ts
@@ -150,7 +150,8 @@ async function checkPublishRequiredSetupAsync(updatedPublicPackages: Package[]):
     });
     const unwriteablePkgs = [];
     for (const pkg of updatedPublicPackages) {
-        const isPackagePublished = (await npmUtils.getPackageRegistryJsonIfExistsAsync(pkg.packageJson.name)) !== undefined;
+        const isPackagePublished =
+            (await npmUtils.getPackageRegistryJsonIfExistsAsync(pkg.packageJson.name)) !== undefined;
         const isPackageWritePermissionsGranted = writePermissions.includes(pkg.packageJson.name);
         if (!isPackageWritePermissionsGranted && isPackagePublished) {
             unwriteablePkgs.push(pkg);


### PR DESCRIPTION
## Description

New packages do not exist in registry and therefore would be caught by `checkPublishRequiredSetupAsync` as packages that don't have write access. Added changes for code to not throw an error if packages are not published yet. 