### PR TITLE
Add compiler settings to published artifacts

### DIFF
--- a/packages/contract-artifacts/src/transform.ts
+++ b/packages/contract-artifacts/src/transform.ts
@@ -7,6 +7,7 @@ export const REQUIRED_PROPERTIES: string[] = [
     'compilerOutput.evm.bytecode.object',
     'compilerOutput.abi',
     'compilerOutput.devdoc',
+    'compiler',
 ];
 
 export const FORBIDDEN_PROPERTIES: string[] = [

--- a/packages/contract-artifacts/test/contract_artifacts_test.ts
+++ b/packages/contract-artifacts/test/contract_artifacts_test.ts
@@ -29,6 +29,10 @@ describe('Contract Artifacts', () => {
         const missingRequiredPropertiesByArtifact: ObjectMap<string[]> = {};
         for (const [artifactName, artifact] of Object.entries(artifacts)) {
             for (const requiredProperty of REQUIRED_PROPERTIES) {
+                // HACK (xianny): Remove after `compiler` field is added in v3.
+                if (requiredProperty === 'compiler' && artifact.schemaVersion === '2.0.0') {
+                    continue;
+                }
                 const requiredValue = get(artifact, requiredProperty);
                 if (requiredValue === undefined || requiredValue === '') {
                     const previousMissing = missingRequiredPropertiesByArtifact[artifactName];


### PR DESCRIPTION
## Description

Resolves #1960

Upon looking closer, the scripts in `development` preserves the `compiler` field already. If we run `yarn artifacts_update` in `@0x/contract-artifacts`, we get the same artifacts currently published but **with the compiler field added**.  It was not included in the initial commit of `@0x/contract-artifacts`. 

This PR updates a test to ensure that publishing v3 artifacts will require the `compiler` field to pass CI. These are the fields that will be required:

<img width="1366" alt="Screen Shot 2019-07-15 at 5 57 58 PM" src="https://user-images.githubusercontent.com/8582774/61258526-12104800-a72b-11e9-89f6-66eb41f5a52f.png">

## Testing instructions

Try running `yarn artifacts_update` in `packages/contract-artifacts` and see that the `compiler` field is preserved. 

@fabioberger can you confirm these are the fields we need?

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

 * Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Prefix PR title with `[WIP]` if necessary.
-   [x] Add tests to cover changes as needed.
-   [x] Update documentation as needed.
-   [x] Add new entries to the relevant CHANGELOG.jsons.
