### PR TITLE
Implement ERC1155Proxy and StaticCallProxy in Solidity

### DIFF
--- a/contracts/asset-proxy/contracts/src/ERC1155Proxy.sol
+++ b/contracts/asset-proxy/contracts/src/ERC1155Proxy.sol
@@ -18,349 +18,71 @@
 
 pragma solidity ^0.5.9;
 
+import "@0x/contracts-utils/contracts/src/LibBytes.sol";
+import "@0x/contracts-utils/contracts/src/SafeMath.sol";
+import "@0x/contracts-erc1155/contracts/src/interfaces/IERC1155.sol";
 import "./MixinAuthorizable.sol";
+import "./interfaces/IAssetProxy.sol";
 
 
 contract ERC1155Proxy is
-    MixinAuthorizable
+    MixinAuthorizable,
+    SafeMath,
+    IAssetProxy
 {
+    using LibBytes for bytes;
 
     // Id of this proxy.
     bytes4 constant internal PROXY_ID = bytes4(keccak256("ERC1155Assets(address,uint256[],uint256[],bytes)"));
 
-    // solhint-disable-next-line payable-fallback
-    function () 
+    /// @dev Transfers batch of ERC1155 assets. Either succeeds or throws.
+    /// @param assetData Byte array encoded with ERC1155 token address, array of ids, array of values, and callback data.
+    /// @param from Address to transfer assets from.
+    /// @param to Address to transfer assets to.
+    /// @param amount Amount that will be multiplied with each element of `assetData.values` to scale the
+    ///        values that will be transferred.
+    function transferFrom(
+        bytes calldata assetData,
+        address from,
+        address to,
+        uint256 amount
+    )
         external
+        onlyAuthorized
     {
-        // Input calldata to this function is encoded as follows:
-        //                      -- TABLE #1 --
-        // | Area     | Offset (**) | Length      | Contents                        |
-        // |----------|-------------|-------------|---------------------------------|
-        // | Header   | 0           | 4           | function selector               |
-        // | Params   |             | 4 * 32      | function parameters:            |
-        // |          | 4           |             |   1. offset to assetData (*)    |
-        // |          | 36          |             |   2. from                       |
-        // |          | 68          |             |   3. to                         |
-        // |          | 100         |             |   4. amount                     |
-        // | Data     |             |             | assetData:                      |
-        // |          | 132         | 32          | assetData Length                |
-        // |          | 164         | (see below) | assetData Contents              |
-        //
-        //
-        // Asset data is encoded as follows:
-        //                      -- TABLE #2 --
-        // | Area     | Offset      | Length  | Contents                            |
-        // |----------|-------------|---------|-------------------------------------|
-        // | Header   | 0           | 4       | assetProxyId                        |
-        // | Params   |             | 4 * 32  | function parameters:                |
-        // |          | 4           |         |   1. address of ERC1155 contract    |
-        // |          | 36          |         |   2. offset to ids (*)              |
-        // |          | 68          |         |   3. offset to values (*)           |
-        // |          | 100         |         |   4. offset to data (*)             |
-        // | Data     |             |         | ids:                                |
-        // |          | 132         | 32      |   1. ids Length                     |
-        // |          | 164         | a       |   2. ids Contents                   |
-        // |          |             |         | values:                             |
-        // |          | 164 + a     | 32      |   1. values Length                  |
-        // |          | 196 + a     | b       |   2. values Contents                |
-        // |          |             |         | data:                               |
-        // |          | 196 + a + b | 32      |   1. data Length                    |
-        // |          | 228 + a + b | c       |   2. data Contents                  |
-        //
-        //
-        // Calldata for target ERC155 asset is encoded for safeBatchTransferFrom:
-        //                      -- TABLE #3 --
-        // | Area     | Offset (**) | Length  | Contents                            |
-        // |----------|-------------|---------|-------------------------------------|
-        // | Header   | 0           | 4       | safeBatchTransferFrom selector      |
-        // | Params   |             | 5 * 32  | function parameters:                |
-        // |          | 4           |         |   1. from address                   |
-        // |          | 36          |         |   2. to address                     |
-        // |          | 68          |         |   3. offset to ids (*)              |
-        // |          | 100         |         |   4. offset to values (*)           |
-        // |          | 132         |         |   5. offset to data (*)             |
-        // | Data     |             |         | ids:                                |
-        // |          | 164         | 32      |   1. ids Length                     |
-        // |          | 196         | a       |   2. ids Contents                   |
-        // |          |             |         | values:                             |
-        // |          | 196 + a     | 32      |   1. values Length                  |
-        // |          | 228 + a     | b       |   2. values Contents                |
-        // |          |             |         | data:                               |
-        // |          | 228 + a + b | 32      |   1. data Length                    |
-        // |          | 260 + a + b | c       |   2. data Contents                  |
-        //
-        //
-        // (*): offset is computed from start of function parameters, so offset
-        //      by an additional 4 bytes in the calldata.
-        //
-        // (**): the `Offset` column is computed assuming no calldata compression;
-        //       offsets in the Data Area are dynamic and should be evaluated in
-        //       real-time.
-        //
-        // WARNING: The ABIv2 specification allows additional padding between
-        //          the Params and Data section. This will result in a larger
-        //          offset to assetData.
-        //
-        // Note: Table #1 and Table #2 exist in Calldata. We construct Table #3 in memory.
-        //
-        //
-        assembly {
-            // The first 4 bytes of calldata holds the function selector
-            let selector := and(calldataload(0), 0xffffffff00000000000000000000000000000000000000000000000000000000)
+        // Decode params from `assetData`
+        // solhint-disable indent
+        (
+            address erc1155TokenAddress,
+            uint256[] memory ids,
+            uint256[] memory values,
+            bytes memory data
+        ) = abi.decode(
+            assetData.sliceDestructive(4, assetData.length),
+            (address, uint256[], uint256[], bytes)
+        );
+        // solhint-enable indent
 
-            // `transferFrom` will be called with the following parameters:
-            // assetData Encoded byte array.
-            // from Address to transfer asset from.
-            // to Address to transfer asset to.
-            // amount Amount of asset to transfer.
-            // bytes4(keccak256("transferFrom(bytes,address,address,uint256)")) = 0xa85e59e4
-            if eq(selector, 0xa85e59e400000000000000000000000000000000000000000000000000000000) {
-
-                // To lookup a value in a mapping, we load from the storage location keccak256(k, p),
-                // where k is the key left padded to 32 bytes and p is the storage slot
-                mstore(0, caller)
-                mstore(32, authorized_slot)
-
-                 // Revert if authorized[msg.sender] == false
-                if iszero(sload(keccak256(0, 64))) {
-                    // Revert with `Error("SENDER_NOT_AUTHORIZED")`
-                    mstore(0, 0x08c379a000000000000000000000000000000000000000000000000000000000)
-                    mstore(32, 0x0000002000000000000000000000000000000000000000000000000000000000)
-                    mstore(64, 0x0000001553454e4445525f4e4f545f415554484f52495a454400000000000000)
-                    mstore(96, 0)
-                    revert(0, 100)
-                }
-
-                // Construct Table #3 in memory, starting at memory offset 0.
-                // The algorithm below maps calldata (Table #1) and assetData (Table #2) to memory (Table #3).
-                // Once Table #3 ha been constructed in memory, the destination erc1155 contract is called using this
-                // as its calldata. This process is divided into three steps, below.
-
-                ////////// STEP 1/3 - Map calldata to memory (Table #1 -> Table #3) //////////
-
-                // Store the safeBatchTransferFrom function selector, which is computed using:
-                // bytes4(keccak256("safeBatchTransferFrom(address,address,uint256[],uint256[],bytes)"))
-                mstore(0, 0x2eb2c2d600000000000000000000000000000000000000000000000000000000)
-
-                // Copy `from` and `to` fields from calldata (Table #1) into memory (Table #3)
-                calldatacopy(
-                    4,          // aligned such that `from` and `to` are at the correct location for Table #3
-                    36,         // beginning of `from` field from Table #1
-                    64          // 32 bytes for `from` + 32 bytes for `to` field
-                )
-
-                ////////// STEP 2/3 - Map assetData to memory (Table #2 -> Table #3) //////////
-
-                // Map relevant fields from assetData (Table #2) into memory (Table #3)
-                // The Contents column of Table #2 is the same as Table #3,
-                // beginning from parameter 3 - `offset to ids (*)`
-                // The `values` from assetData (Table #2) are multiplied by `amount` (Table #1)
-                // when they are copied into memory.
-
-                // Load offset to `assetData`
-                let assetDataOffset := add(calldataload(4), 4)
-
-                // Load length in bytes of `assetData`
-                let assetDataLength := calldataload(assetDataOffset)
-
-                // Assert that the length of asset data:
-                // 1. Must be at least 132 bytes (Table #2)
-                // 2. Must be a multiple of 32 (excluding the 4-byte selector)
-                if or(lt(assetDataLength, 132), mod(sub(assetDataLength, 4), 32)) {
-                    // Revert with `Error("INVALID_ASSET_DATA_LENGTH")`
-                    mstore(0, 0x08c379a000000000000000000000000000000000000000000000000000000000)
-                    mstore(32, 0x0000002000000000000000000000000000000000000000000000000000000000)
-                    mstore(64, 0x00000019494e56414c49445f41535345545f444154415f4c454e475448000000)
-                    mstore(96, 0)
-                    revert(0, 100)
-                }
-
-                // End of asset data in calldata
-                // +32 for length field
-                let assetDataEnd := add(assetDataOffset, add(assetDataLength, 32))
-                if gt(assetDataEnd, calldatasize()) {
-                    // Revert with `Error("INVALID_ASSET_DATA_END")`
-                    mstore(0, 0x08c379a000000000000000000000000000000000000000000000000000000000)
-                    mstore(32, 0x0000002000000000000000000000000000000000000000000000000000000000)
-                    mstore(64, 0x00000016494e56414c49445f41535345545f444154415f454e44000000000000)
-                    mstore(96, 0)
-                    revert(0, 100)
-                }
-
-                // Load offset to parameters section in asset data
-                let paramsInAssetDataOffset := add(assetDataOffset, 36)
-
-                // Offset of end of Data Area in memory.
-                // This value will grow as we construct Table #3.
-                let dataAreaEndOffset := 164
-
-                // Load amount by which to scale values
-                let amount := calldataload(100)
-
-                // Store pointer to `ids` (Table #3)
-                // Subtract 4 for `safeBatchTransferFrom` selector
-                mstore(68, sub(dataAreaEndOffset, 4))
-
-                // Ensure length of `ids` does not overflow
-                let idsOffset := add(paramsInAssetDataOffset, calldataload(add(assetDataOffset, 68)))
-                let idsLength := calldataload(idsOffset)
-                let idsLengthInBytes := mul(idsLength, 32)
-                if sub(div(idsLengthInBytes, 32), idsLength) {
-                    // Revert with `Error("UINT256_OVERFLOW")`
-                    mstore(0, 0x08c379a000000000000000000000000000000000000000000000000000000000)
-                    mstore(32, 0x0000002000000000000000000000000000000000000000000000000000000000)
-                    mstore(64, 0x0000001055494e543235365f4f564552464c4f57000000000000000000000000)
-                    mstore(96, 0)
-                    revert(0, 100)
-                }
-
-                // Ensure `ids` does not resolve to outside of `assetData`
-                let idsBegin := add(idsOffset, 32)
-                let idsEnd := add(idsBegin, idsLengthInBytes)
-                if gt(idsEnd, assetDataEnd) {
-                    // Revert with `Error("INVALID_IDS_OFFSET")`
-                    mstore(0, 0x08c379a000000000000000000000000000000000000000000000000000000000)
-                    mstore(32, 0x0000002000000000000000000000000000000000000000000000000000000000)
-                    mstore(64, 0x00000012494e56414c49445f4944535f4f464653455400000000000000000000)
-                    mstore(96, 0)
-                    revert(0, 100)
-                }
-
-                // Copy `ids` from `assetData` (Table #2) to memory (Table #3)
-                calldatacopy(
-                    dataAreaEndOffset,
-                    idsOffset,
-                    add(idsLengthInBytes, 32)
-                )
-                dataAreaEndOffset := add(dataAreaEndOffset, add(idsLengthInBytes, 32))
-
-                // Store pointer to `values` (Table #3)
-                // Subtract 4 for `safeBatchTrasferFrom` selector
-                mstore(100, sub(dataAreaEndOffset, 4))
-
-                // Ensure length of `values` does not overflow
-                let valuesOffset := add(paramsInAssetDataOffset, calldataload(add(assetDataOffset, 100)))
-                let valuesLength := calldataload(valuesOffset)
-                let valuesLengthInBytes := mul(valuesLength, 32)
-                if sub(div(valuesLengthInBytes, 32), valuesLength) {
-                    // Revert with `Error("UINT256_OVERFLOW")`
-                    mstore(0, 0x08c379a000000000000000000000000000000000000000000000000000000000)
-                    mstore(32, 0x0000002000000000000000000000000000000000000000000000000000000000)
-                    mstore(64, 0x0000001055494e543235365f4f564552464c4f57000000000000000000000000)
-                    mstore(96, 0)
-                    revert(0, 100)
-                }
-
-                // Ensure `values` does not resolve to outside of `assetData`
-                let valuesBegin := add(valuesOffset, 32)
-                let valuesEnd := add(valuesBegin, valuesLengthInBytes)
-                if gt(valuesEnd, assetDataEnd) {
-                    // Revert with `Error("INVALID_VALUES_OFFSET")`
-                    mstore(0, 0x08c379a000000000000000000000000000000000000000000000000000000000)
-                    mstore(32, 0x0000002000000000000000000000000000000000000000000000000000000000)
-                    mstore(64, 0x00000015494e56414c49445f56414c5545535f4f464653455400000000000000)
-                    mstore(96, 0)
-                    revert(0, 100)
-                }
-
-                // Store length of `values`
-                mstore(dataAreaEndOffset, valuesLength)
-                dataAreaEndOffset := add(dataAreaEndOffset, 32)
-
-                // Scale and store elements of `values`
-                for { let currentValueOffset := valuesBegin }
-                    lt(currentValueOffset, valuesEnd)
-                    { currentValueOffset := add(currentValueOffset, 32) }
-                {
-                    // Load value and generate scaled value
-                    let currentValue := calldataload(currentValueOffset)
-                    let currentValueScaled := mul(currentValue, amount)
-
-                    // Revert if `amount` != 0 and multiplication resulted in an overflow
-                    if iszero(or(
-                        iszero(amount),
-                        eq(div(currentValueScaled, amount), currentValue)
-                    )) {
-                        // Revert with `Error("UINT256_OVERFLOW")`
-                        mstore(0, 0x08c379a000000000000000000000000000000000000000000000000000000000)
-                        mstore(32, 0x0000002000000000000000000000000000000000000000000000000000000000)
-                        mstore(64, 0x0000001055494e543235365f4f564552464c4f57000000000000000000000000)
-                        mstore(96, 0)
-                        revert(0, 100)
-                    }
-
-                    // There was no overflow, store the scaled token value
-                    mstore(dataAreaEndOffset, currentValueScaled)
-                    dataAreaEndOffset := add(dataAreaEndOffset, 32)
-                }
-
-                // Store pointer to `data` (Table #3)
-                // Subtract 4 for `safeBatchTrasferFrom` selector
-                mstore(132, sub(dataAreaEndOffset, 4))
-
-                // Ensure `data` does not resolve to outside of `assetData`
-                let dataOffset := add(paramsInAssetDataOffset, calldataload(add(assetDataOffset, 132)))
-                let dataLengthInBytes := calldataload(dataOffset)
-                let dataBegin := add(dataOffset, 32)
-                let dataEnd := add(dataBegin, dataLengthInBytes)
-                if gt(dataEnd, assetDataEnd) {
-                    // Revert with `Error("INVALID_DATA_OFFSET")`
-                    mstore(0, 0x08c379a000000000000000000000000000000000000000000000000000000000)
-                    mstore(32, 0x0000002000000000000000000000000000000000000000000000000000000000)
-                    mstore(64, 0x00000013494e56414c49445f444154415f4f4646534554000000000000000000)
-                    mstore(96, 0)
-                    revert(0, 100)
-                }
-
-                // Copy `data` from `assetData` (Table #2) to memory (Table #3)
-                calldatacopy(
-                    dataAreaEndOffset,
-                    dataOffset,
-                    add(dataLengthInBytes, 32)
-                )
-
-                // Update the end of data offset to be word-aligned
-                let dataLengthInWords := div(add(dataLengthInBytes, 31), 32)
-                let dataLengthInBytesWordAligned := mul(dataLengthInWords, 32)
-                dataAreaEndOffset := add(dataAreaEndOffset, add(dataLengthInBytesWordAligned, 32))
-
-                ////////// STEP 3/3 - Execute Transfer //////////
-                // Load the address of the destination erc1155 contract from asset data (Table #2)
-                // +32 bytes for assetData Length
-                // +4 bytes for assetProxyId
-                let assetAddress := and(
-                    calldataload(add(assetDataOffset, 36)),
-                    0x000000000000000000000000ffffffffffffffffffffffffffffffffffffffff
-                )
-
-                // Call into the destination erc1155 contract using as calldata Table #3 (constructed in-memory above)
-                let success := call(
-                    gas,                                    // forward all gas
-                    assetAddress,                           // call address of erc1155 asset
-                    0,                                      // don't send any ETH
-                    0,                                      // pointer to start of input
-                    dataAreaEndOffset,                      // length of input is the end of the Data Area (Table #3)
-                    0,                                      // write output over memory that won't be reused
-                    0                                       // don't copy output to memory
-                )
-
-                // Revert with reason given by AssetProxy if `transferFrom` call failed
-                if iszero(success) {
-                    returndatacopy(
-                        0,                // copy to memory at 0
-                        0,                // copy from return data at 0
-                        returndatasize()  // copy all return data
-                    )
-                    revert(0, returndatasize())
-                }
-
-                // Return if call was successful
-                return(0, 0)
-            }
-
-            // Revert if undefined function is called
-            revert(0, 0)
+        // Scale values up by `amount`
+        uint256 length = values.length;
+        uint256[] memory scaledValues = new uint256[](length);
+        for (uint256 i = 0; i != length; i++) {
+            // We write the scaled values to an unused location in memory in order
+            // to avoid copying over `ids` or `data`. This is possible if they are
+            // identical to `values` and the offsets for each are pointing to the 
+            // same location in the ABI encoded calldata.
+            scaledValues[i] = safeMul(values[i], amount);
         }
+
+        // Execute `safeBatchTransferFrom` call
+        // Either succeeds or throws
+        IERC1155(erc1155TokenAddress).safeBatchTransferFrom(
+            from,
+            to,
+            ids,
+            scaledValues,
+            data
+        );
     }
 
     /// @dev Gets the proxy id associated with the proxy address.

--- a/contracts/asset-proxy/contracts/src/StaticCallProxy.sol
+++ b/contracts/asset-proxy/contracts/src/StaticCallProxy.sol
@@ -18,181 +18,57 @@
 
 pragma solidity ^0.5.9;
 
+import "@0x/contracts-utils/contracts/src/LibBytes.sol";
 
+
+// solhint-disable no-unused-vars
 contract StaticCallProxy {
+
+    using LibBytes for bytes;
 
     // Id of this proxy.
     bytes4 constant internal PROXY_ID = bytes4(keccak256("StaticCall(address,bytes,bytes32)"));
 
-    // solhint-disable-next-line payable-fallback
-    function ()
+    /// @dev Makes a staticcall to a target address and verifies that the data returned matches the expected return data.
+    /// @param assetData Byte array encoded with staticCallTarget, staticCallData, and expectedCallResultHash
+    /// @param from This value is ignored.
+    /// @param to This value is ignored.
+    /// @param amount This value is ignored.
+    function transferFrom(
+        bytes calldata assetData,
+        address from,
+        address to,
+        uint256 amount
+    )
         external
+        view
     {
-        assembly {
-            // The first 4 bytes of calldata holds the function selector
-            let selector := and(calldataload(0), 0xffffffff00000000000000000000000000000000000000000000000000000000)
+        // Decode params from `assetData`
+        (
+            address staticCallTarget,
+            bytes memory staticCallData,
+            bytes32 expectedReturnDataHash
+        ) = abi.decode(
+            assetData.sliceDestructive(4, assetData.length),
+            (address, bytes, bytes32)
+        );
 
-            // `transferFrom` will be called with the following parameters:
-            // assetData Encoded byte array.
-            // from Address to transfer asset from.
-            // to Address to transfer asset to.
-            // amount Amount of asset to transfer.
-            // bytes4(keccak256("transferFrom(bytes,address,address,uint256)")) = 0xa85e59e4
-            if eq(selector, 0xa85e59e400000000000000000000000000000000000000000000000000000000) {
+        // Execute staticcall
+        (bool success, bytes memory returnData) = staticCallTarget.staticcall(staticCallData);
 
-                // `transferFrom`.
-                // The function is marked `external`, so no abi decoding is done for
-                // us. Instead, we expect the `calldata` memory to contain the
-                // following:
-                //
-                // | Area     | Offset | Length  | Contents                            |
-                // |----------|--------|---------|-------------------------------------|
-                // | Header   | 0      | 4       | function selector                   |
-                // | Params   |        | 4 * 32  | function parameters:                |
-                // |          | 4      |         |   1. offset to assetData (*)        |
-                // |          | 36     |         |   2. from                           |
-                // |          | 68     |         |   3. to                             |
-                // |          | 100    |         |   4. amount                         |
-                // | Data     |        |         | assetData:                          |
-                // |          | 132    | 32      | assetData Length                    |
-                // |          | 164    | **      | assetData Contents                  |
-                //
-                // (*): offset is computed from start of function parameters, so offset
-                //      by an additional 4 bytes in the calldata.
-                //
-                // (**): see table below to compute length of assetData Contents
-                // (***): Note that the `from`, `to`, and `amount` params in calldata are ignored in this function.
-                //
-                // WARNING: The ABIv2 specification allows additional padding between
-                //          the Params and Data section. This will result in a larger
-                //          offset to assetData.
-
-                // Load offset to `assetData`
-                let assetDataOffset := add(calldataload(4), 4)
-
-                // Validate length of `assetData`
-                let assetDataLen := calldataload(assetDataOffset)
-                if or(lt(assetDataLen, 100), mod(sub(assetDataLen, 4), 32)) {
-                    // Revert with `Error("INVALID_ASSET_DATA_LENGTH")`
-                    mstore(0, 0x08c379a000000000000000000000000000000000000000000000000000000000)
-                    mstore(32, 0x0000002000000000000000000000000000000000000000000000000000000000)
-                    mstore(64, 0x00000019494e56414c49445f41535345545f444154415f4c454e475448000000)
-                    mstore(96, 0)
-                    revert(0, 100)
-                }
-
-                // Ensure that `assetData` ends inside of calldata
-                let assetDataEnd := add(assetDataOffset, add(assetDataLen, 32))
-                if gt(assetDataEnd, calldatasize()) {
-                    // Revert with `Error("INVALID_ASSET_DATA_END")`
-                    mstore(0, 0x08c379a000000000000000000000000000000000000000000000000000000000)
-                    mstore(32, 0x0000002000000000000000000000000000000000000000000000000000000000)
-                    mstore(64, 0x00000016494e56414c49445f41535345545f444154415f454e44000000000000)
-                    mstore(96, 0)
-                    revert(0, 100)
-                }
-
-                // Asset data is encoded as follows:
-                // | Area     | Offset      | Length  | Contents                             |
-                // |----------|-------------|---------|--------------------------------------|
-                // | Header   | 0           | 4       | assetProxyId                         |
-                // | Params   |             | 4 * 32  | function parameters:                 |
-                // |          | 4           |         |   1. address of callTarget           |
-                // |          | 36          |         |   2. offset to staticCallData (*)    |
-                // |          | 68          |         |   3. expected 32 byte hash of output |
-                // | Data     |             |         | staticCallData:                      |
-                // |          | 100         | 32      |   1. staticCallData Length           |
-                // |          | 132         | a       |   2. staticCallData Contents         | 
-
-                // In order to find the offset to `staticCallData`, we must add:
-                // assetDataOffset
-                // + 32 (assetData len)
-                // + 4 (proxyId)
-                // + 32 (callTarget)
-                let paramsInAssetDataOffset := add(assetDataOffset, 36)
-                let staticCallDataOffset := add(paramsInAssetDataOffset, calldataload(add(assetDataOffset, 68)))
-
-                // Load length of `staticCallData`
-                let staticCallDataLen := calldataload(staticCallDataOffset)
-
-                // Ensure `staticCallData` does not begin to outside of `assetData`
-                let staticCallDataBegin := add(staticCallDataOffset, 32)
-                let staticCallDataEnd := add(staticCallDataBegin, staticCallDataLen)
-                if gt(staticCallDataEnd, assetDataEnd) {
-                    // Revert with `Error("INVALID_STATIC_CALL_DATA_OFFSET")`
-                    mstore(0, 0x08c379a000000000000000000000000000000000000000000000000000000000)
-                    mstore(32, 0x0000002000000000000000000000000000000000000000000000000000000000)
-                    mstore(64, 0x0000001f494e56414c49445f5354415449435f43414c4c5f444154415f4f4646)
-                    mstore(96, 0x5345540000000000000000000000000000000000000000000000000000000000)
-                    revert(0, 100)
-                }
-
-                // Copy `staticCallData` into memory
-                calldatacopy(
-                    0,                              // memory can be safely overwritten from beginning
-                    staticCallDataBegin,            // start of `staticCallData`
-                    staticCallDataLen               // copy the entire `staticCallData`
-                )
-
-                // In order to find the offset to `callTarget`, we must add:
-                // assetDataOffset
-                // + 32 (assetData len)
-                // + 4 (proxyId)
-                let callTarget := and(
-                    calldataload(add(assetDataOffset, 36)),
-                    0x000000000000000000000000ffffffffffffffffffffffffffffffffffffffff
-                )
-
-                // Perform `callTarget.staticcall(staticCallData)`
-                let success := staticcall(
-                    gas,                         // forward all gas
-                    callTarget,                  // call address `callTarget`
-                    0,                           // pointer to start of input
-                    staticCallDataLen,           // length of input
-                    0,                           // start of memory can be safely overwritten
-                    0                            // don't copy output to memory
-                )
-
-                // Copy entire output to start of memory
-                let outputLen := returndatasize()
-                returndatacopy(
-                    0,                // copy to memory at 0
-                    0,                // copy from return data at 0
-                    outputLen         // copy all return data
-                )
-
-                // Revert with reason given by `callTarget` if staticcall is unsuccessful
-                if iszero(success) {
-                    revert(0, outputLen)
-                }
-
-                // Calculate hash of output
-                let callResultHash := keccak256(0, outputLen)
-
-                // In order to find the offset to `expectedCallResultHash`, we must add:
-                // assetDataOffset
-                // + 32 (assetData len)
-                // + 4 (proxyId)
-                // + 32 (callTarget)
-                // + 32 (staticCallDataOffset)
-                let expectedResultHash := calldataload(add(assetDataOffset, 100))
-
-                if sub(callResultHash, expectedResultHash) {
-                    // Revert with `Error("UNEXPECTED_STATIC_CALL_RESULT")`
-                    mstore(0, 0x08c379a000000000000000000000000000000000000000000000000000000000)
-                    mstore(32, 0x0000002000000000000000000000000000000000000000000000000000000000)
-                    mstore(64, 0x0000001d554e45585045435445445f5354415449435f43414c4c5f524553554c)
-                    mstore(96, 0x5400000000000000000000000000000000000000000000000000000000000000)
-                    revert(0, 100)
-                }
-
-                // Return if output matched expected output
-                return(0, 0)
+        // Revert with returned data if staticcall is unsuccessful
+        if (!success) {
+            assembly {
+                revert(add(returnData, 32), mload(returnData))
             }
-
-            // Revert if undefined function is called
-            revert(0, 0)
         }
+
+        // Revert if hash of return data is not as expected
+        bytes32 returnDataHash = keccak256(returnData);
+        require(
+            expectedReturnDataHash == returnDataHash,
+            "UNEXPECTED_STATIC_CALL_RESULT"
+        );
     }
 
     /// @dev Gets the proxy id associated with the proxy address.

--- a/contracts/asset-proxy/contracts/src/interfaces/IAssetProxy.sol
+++ b/contracts/asset-proxy/contracts/src/interfaces/IAssetProxy.sol
@@ -21,9 +21,8 @@ pragma solidity ^0.5.5;
 import "./IAuthorizable.sol";
 
 
-contract IAssetProxy is
-    IAuthorizable
-{
+contract IAssetProxy {
+
     /// @dev Transfers assets. Either succeeds or throws.
     /// @param assetData Byte array encoded for the respective asset proxy.
     /// @param from Address to transfer asset from.

--- a/contracts/asset-proxy/test/erc1155_proxy.ts
+++ b/contracts/asset-proxy/test/erc1155_proxy.ts
@@ -1077,7 +1077,7 @@ describe('ERC1155Proxy', () => {
             // 0x100      0000000000000000000000000000000000000000000000000000000000000004
             // 0x120      0102030400000000000000000000000000000000000000000000000000000000
             //
-            // We want to chan ge the offset to token ids to point outside the calldata.
+            // We want to change the offset to token ids to point outside the calldata.
             const encodedOffsetToTokenIds = '0000000000000000000000000000000000000000000000000000000000000080';
             const badEncodedOffsetToTokenIds = '0000000000000000000000000000000000000000000000000000000000000180';
             const assetDataWithBadTokenIdsOffset = assetData.replace(
@@ -1085,7 +1085,7 @@ describe('ERC1155Proxy', () => {
                 badEncodedOffsetToTokenIds,
             );
             // execute transfer
-            await expectTransactionFailedAsync(
+            await expectTransactionFailedWithoutReasonAsync(
                 erc1155ProxyWrapper.transferFromAsync(
                     spender,
                     receiverContract,
@@ -1097,7 +1097,6 @@ describe('ERC1155Proxy', () => {
                     authorized,
                     assetDataWithBadTokenIdsOffset,
                 ),
-                RevertReason.InvalidIdsOffset,
             );
         });
         it('should revert if an element of token ids lies to outside the bounds of calldata', async () => {
@@ -1125,7 +1124,7 @@ describe('ERC1155Proxy', () => {
             // 0x100      0000000000000000000000000000000000000000000000000000000000000004
             // 0x120      0102030400000000000000000000000000000000000000000000000000000000
             //
-            // We want to chan ge the offset to token ids to the end of calldata.
+            // We want to change the offset to token ids to the end of calldata.
             // Then we'll add an invalid length: we encode length of 2 but only add 1 element.
             const encodedOffsetToTokenIds = '0000000000000000000000000000000000000000000000000000000000000080';
             const newEcodedOffsetToTokenIds = '0000000000000000000000000000000000000000000000000000000000000140';
@@ -1137,7 +1136,7 @@ describe('ERC1155Proxy', () => {
             const encodedTokenIdValues = '0000000000000000000000000000000000000000000000000000000000000001';
             const assetDataWithBadTokenIds = `${assetDataWithNewTokenIdsOffset}${encodedTokenIdsLength}${encodedTokenIdValues}`;
             // execute transfer
-            await expectTransactionFailedAsync(
+            await expectTransactionFailedWithoutReasonAsync(
                 erc1155ProxyWrapper.transferFromAsync(
                     spender,
                     receiverContract,
@@ -1149,7 +1148,6 @@ describe('ERC1155Proxy', () => {
                     authorized,
                     assetDataWithBadTokenIds,
                 ),
-                RevertReason.InvalidIdsOffset,
             );
         });
         it('should revert token ids length overflows', async () => {
@@ -1177,7 +1175,7 @@ describe('ERC1155Proxy', () => {
             // 0x100      0000000000000000000000000000000000000000000000000000000000000004
             // 0x120      0102030400000000000000000000000000000000000000000000000000000000
             //
-            // We want to chan ge the offset to token ids to point to the end of calldata
+            // We want to change the offset to token ids to point to the end of calldata
             const encodedOffsetToTokenIds = '0000000000000000000000000000000000000000000000000000000000000080';
             const badEncodedOffsetToTokenIds = '0000000000000000000000000000000000000000000000000000000000000140';
             const assetDataWithBadTokenIdsOffset = assetData.replace(
@@ -1189,7 +1187,7 @@ describe('ERC1155Proxy', () => {
             const buffer = '0'.repeat(64 * 10);
             const assetDataWithOverflow = `${assetDataWithBadTokenIdsOffset}${encodedIdsLengthOverflow}${buffer}`;
             // execute transfer
-            await expectTransactionFailedAsync(
+            await expectTransactionFailedWithoutReasonAsync(
                 erc1155ProxyWrapper.transferFromAsync(
                     spender,
                     receiverContract,
@@ -1201,7 +1199,6 @@ describe('ERC1155Proxy', () => {
                     authorized,
                     assetDataWithOverflow,
                 ),
-                RevertReason.Uint256Overflow,
             );
         });
         it('should revert token values length overflows', async () => {
@@ -1229,7 +1226,7 @@ describe('ERC1155Proxy', () => {
             // 0x100      0000000000000000000000000000000000000000000000000000000000000004
             // 0x120      0102030400000000000000000000000000000000000000000000000000000000
             //
-            // We want to chan ge the offset to token values to point to the end of calldata
+            // We want to change the offset to token values to point to the end of calldata
             const encodedOffsetToTokenIds = '00000000000000000000000000000000000000000000000000000000000000c0';
             const badEncodedOffsetToTokenIds = '0000000000000000000000000000000000000000000000000000000000000140';
             const assetDataWithBadTokenIdsOffset = assetData.replace(
@@ -1241,7 +1238,7 @@ describe('ERC1155Proxy', () => {
             const buffer = '0'.repeat(64 * 10);
             const assetDataWithOverflow = `${assetDataWithBadTokenIdsOffset}${encodedIdsLengthOverflow}${buffer}`;
             // execute transfer
-            await expectTransactionFailedAsync(
+            await expectTransactionFailedWithoutReasonAsync(
                 erc1155ProxyWrapper.transferFromAsync(
                     spender,
                     receiverContract,
@@ -1253,7 +1250,6 @@ describe('ERC1155Proxy', () => {
                     authorized,
                     assetDataWithOverflow,
                 ),
-                RevertReason.Uint256Overflow,
             );
         });
         it('should revert token data length overflows', async () => {
@@ -1281,7 +1277,7 @@ describe('ERC1155Proxy', () => {
             // 0x100      0000000000000000000000000000000000000000000000000000000000000004
             // 0x120      0102030400000000000000000000000000000000000000000000000000000000
             //
-            // We want to chan ge the offset to token ids to point to the end of calldata,
+            // We want to change the offset to token ids to point to the end of calldata,
             // which we'll extend with a bad length.
             const encodedOffsetToTokenIds = '0000000000000000000000000000000000000000000000000000000000000100';
             const badEncodedOffsetToTokenIds = '0000000000000000000000000000000000000000000000000000000000000140';
@@ -1294,7 +1290,7 @@ describe('ERC1155Proxy', () => {
             const buffer = '0'.repeat(64 * 10);
             const assetDataWithOverflow = `${assetDataWithBadTokenIdsOffset}${encodedIdsLengthOverflow}${buffer}`;
             // execute transfer
-            await expectTransactionFailedAsync(
+            await expectTransactionFailedWithoutReasonAsync(
                 erc1155ProxyWrapper.transferFromAsync(
                     spender,
                     receiverContract,
@@ -1306,7 +1302,6 @@ describe('ERC1155Proxy', () => {
                     authorized,
                     assetDataWithOverflow,
                 ),
-                RevertReason.InvalidDataOffset,
             );
         });
         it('should revert if token values resolves to outside the bounds of calldata', async () => {
@@ -1334,7 +1329,7 @@ describe('ERC1155Proxy', () => {
             // 0x100      0000000000000000000000000000000000000000000000000000000000000004
             // 0x120      0102030400000000000000000000000000000000000000000000000000000000
             //
-            // We want to chan ge the offset to token values to point outside the calldata.
+            // We want to change the offset to token values to point outside the calldata.
             const encodedOffsetToTokenValues = '00000000000000000000000000000000000000000000000000000000000000c0';
             const badEncodedOffsetToTokenValues = '00000000000000000000000000000000000000000000000000000000000001c0';
             const assetDataWithBadTokenIdsOffset = assetData.replace(
@@ -1342,7 +1337,7 @@ describe('ERC1155Proxy', () => {
                 badEncodedOffsetToTokenValues,
             );
             // execute transfer
-            await expectTransactionFailedAsync(
+            await expectTransactionFailedWithoutReasonAsync(
                 erc1155ProxyWrapper.transferFromAsync(
                     spender,
                     receiverContract,
@@ -1354,7 +1349,6 @@ describe('ERC1155Proxy', () => {
                     authorized,
                     assetDataWithBadTokenIdsOffset,
                 ),
-                RevertReason.InvalidValuesOffset,
             );
         });
         it('should revert if an element of token values lies to outside the bounds of calldata', async () => {
@@ -1382,7 +1376,7 @@ describe('ERC1155Proxy', () => {
             // 0x100      0000000000000000000000000000000000000000000000000000000000000004
             // 0x120      0102030400000000000000000000000000000000000000000000000000000000
             //
-            // We want to chan ge the offset to token values to the end of calldata.
+            // We want to change the offset to token values to the end of calldata.
             // Then we'll add an invalid length: we encode length of 2 but only add 1 element.
             const encodedOffsetToTokenValues = '00000000000000000000000000000000000000000000000000000000000000c0';
             const newEcodedOffsetToTokenValues = '0000000000000000000000000000000000000000000000000000000000000140';
@@ -1394,7 +1388,7 @@ describe('ERC1155Proxy', () => {
             const encodedTokenValuesElements = '0000000000000000000000000000000000000000000000000000000000000001';
             const assetDataWithBadTokenIds = `${assetDataWithNewTokenValuesOffset}${encodedTokenValuesLength}${encodedTokenValuesElements}`;
             // execute transfer
-            await expectTransactionFailedAsync(
+            await expectTransactionFailedWithoutReasonAsync(
                 erc1155ProxyWrapper.transferFromAsync(
                     spender,
                     receiverContract,
@@ -1406,7 +1400,6 @@ describe('ERC1155Proxy', () => {
                     authorized,
                     assetDataWithBadTokenIds,
                 ),
-                RevertReason.InvalidValuesOffset,
             );
         });
         it('should revert if token data resolves to outside the bounds of calldata', async () => {
@@ -1434,7 +1427,7 @@ describe('ERC1155Proxy', () => {
             // 0x100      0000000000000000000000000000000000000000000000000000000000000004
             // 0x120      0102030400000000000000000000000000000000000000000000000000000000
             //
-            // We want to chan ge the offset to token data to point outside the calldata.
+            // We want to change the offset to token data to point outside the calldata.
             const encodedOffsetToTokenData = '0000000000000000000000000000000000000000000000000000000000000100';
             const badEncodedOffsetToTokenData = '00000000000000000000000000000000000000000000000000000000000001c0';
             const assetDataWithBadTokenDataOffset = assetData.replace(
@@ -1442,7 +1435,7 @@ describe('ERC1155Proxy', () => {
                 badEncodedOffsetToTokenData,
             );
             // execute transfer
-            await expectTransactionFailedAsync(
+            await expectTransactionFailedWithoutReasonAsync(
                 erc1155ProxyWrapper.transferFromAsync(
                     spender,
                     receiverContract,
@@ -1454,7 +1447,6 @@ describe('ERC1155Proxy', () => {
                     authorized,
                     assetDataWithBadTokenDataOffset,
                 ),
-                RevertReason.InvalidDataOffset,
             );
         });
         it('should revert if an element of token data lies to outside the bounds of calldata', async () => {
@@ -1482,7 +1474,7 @@ describe('ERC1155Proxy', () => {
             // 0x100      0000000000000000000000000000000000000000000000000000000000000004
             // 0x120      0102030400000000000000000000000000000000000000000000000000000000
             //
-            // We want to chan ge the offset to token data to the end of calldata.
+            // We want to change the offset to token data to the end of calldata.
             // Then we'll add an invalid length: we encode length of 33 but only add 32 elements.
             const encodedOffsetToTokenData = '0000000000000000000000000000000000000000000000000000000000000100';
             const newEcodedOffsetToTokenData = '0000000000000000000000000000000000000000000000000000000000000140';
@@ -1494,7 +1486,7 @@ describe('ERC1155Proxy', () => {
             const encodedTokenDataElements = '0000000000000000000000000000000000000000000000000000000000000001';
             const assetDataWithBadTokenData = `${assetDataWithNewTokenDataOffset}${encodedTokenDataLength}${encodedTokenDataElements}`;
             // execute transfer
-            await expectTransactionFailedAsync(
+            await expectTransactionFailedWithoutReasonAsync(
                 erc1155ProxyWrapper.transferFromAsync(
                     spender,
                     receiverContract,
@@ -1506,7 +1498,6 @@ describe('ERC1155Proxy', () => {
                     authorized,
                     assetDataWithBadTokenData,
                 ),
-                RevertReason.InvalidDataOffset,
             );
         });
         it('should revert if asset data lies outside the bounds of calldata', async () => {
@@ -1536,9 +1527,8 @@ describe('ERC1155Proxy', () => {
             const invalidOffsetToAssetData = '0000000000000000000000000000000000000000000000000000000000000180';
             const badTxData = txData.replace(offsetToAssetData, invalidOffsetToAssetData);
             // execute transfer
-            await expectTransactionFailedAsync(
+            await expectTransactionFailedWithoutReasonAsync(
                 erc1155ProxyWrapper.transferFromRawAsync(badTxData, authorized),
-                RevertReason.InvalidAssetDataLength,
             );
         });
         it('should revert if asset data lies outside the bounds of calldata', async () => {
@@ -1570,39 +1560,8 @@ describe('ERC1155Proxy', () => {
             const newAssetData = '0000000000000000000000000000000000000000000000000000000000000304';
             const badTxData = `${txData.replace(offsetToAssetData, invalidOffsetToAssetData)}${newAssetData}`;
             // execute transfer
-            await expectTransactionFailedAsync(
+            await expectTransactionFailedWithoutReasonAsync(
                 erc1155ProxyWrapper.transferFromRawAsync(badTxData, authorized),
-                RevertReason.InvalidAssetDataEnd,
-            );
-        });
-        it('should revert if length of assetData, excluding the selector, is not a multiple of 32', async () => {
-            // setup test parameters
-            const tokensToTransfer = fungibleTokens.slice(0, 1);
-            const valuesToTransfer = [fungibleValueToTransferLarge];
-            const valueMultiplier = valueMultiplierSmall;
-            const erc1155ContractAddress = erc1155Wrapper.getContract().address;
-            const assetData = assetDataUtils.encodeERC1155AssetData(
-                erc1155ContractAddress,
-                tokensToTransfer,
-                valuesToTransfer,
-                receiverCallbackData,
-            );
-            const extraData = '01';
-            const assetDataWithExtraData = `${assetData}${extraData}`;
-            // execute transfer
-            await expectTransactionFailedAsync(
-                erc1155ProxyWrapper.transferFromAsync(
-                    spender,
-                    receiverContract,
-                    erc1155Contract.address,
-                    tokensToTransfer,
-                    valuesToTransfer,
-                    valueMultiplier,
-                    receiverCallbackData,
-                    authorized,
-                    assetDataWithExtraData,
-                ),
-                RevertReason.InvalidAssetDataLength,
             );
         });
         it('should revert if length of assetData is less than 132 bytes', async () => {
@@ -1618,7 +1577,7 @@ describe('ERC1155Proxy', () => {
             const zeros96Bytes = '0'.repeat(188);
             const assetData131Bytes = `${AssetProxyId.ERC1155}${zeros96Bytes}`;
             // execute transfer
-            await expectTransactionFailedAsync(
+            await expectTransactionFailedWithoutReasonAsync(
                 erc1155ProxyWrapper.transferFromAsync(
                     spender,
                     receiverContract,
@@ -1630,7 +1589,6 @@ describe('ERC1155Proxy', () => {
                     authorized,
                     assetData131Bytes,
                 ),
-                RevertReason.InvalidAssetDataLength,
             );
         });
         it('should transfer nothing if value is zero', async () => {

--- a/contracts/asset-proxy/test/static_call_proxy.ts
+++ b/contracts/asset-proxy/test/static_call_proxy.ts
@@ -175,7 +175,7 @@ describe('StaticCallProxy', () => {
                 RevertReason.UnexpectedStaticCallResult,
             );
         });
-        it('should be successful if a function call with no inputs is successful', async () => {
+        it('should be successful if a function call with no inputs and no outputs is successful', async () => {
             const staticCallData = staticCallTarget.noInputFunction.getABIEncodedTransactionData();
             const expectedResultHash = constants.KECCAK256_NULL;
             const assetData = assetDataUtils.encodeStaticCallAssetData(
@@ -183,6 +183,12 @@ describe('StaticCallProxy', () => {
                 staticCallData,
                 expectedResultHash,
             );
+            await staticCallProxy.transferFrom.awaitTransactionSuccessAsync(assetData, fromAddress, toAddress, amount);
+        });
+        it('should be successful if the staticCallTarget is not a contract and no return value is expected', async () => {
+            const staticCallData = '0x0102030405060708';
+            const expectedResultHash = constants.KECCAK256_NULL;
+            const assetData = assetDataUtils.encodeStaticCallAssetData(toAddress, staticCallData, expectedResultHash);
             await staticCallProxy.transferFrom.awaitTransactionSuccessAsync(assetData, fromAddress, toAddress, amount);
         });
         it('should be successful if a function call with one static input returns the correct value', async () => {

--- a/contracts/asset-proxy/test/static_call_proxy.ts
+++ b/contracts/asset-proxy/test/static_call_proxy.ts
@@ -95,26 +95,12 @@ describe('StaticCallProxy', () => {
             const invalidOffsetToAssetData = ethUtil.bufferToHex(paddedTxDataEndBuffer).slice(2);
             const newAssetData = '0000000000000000000000000000000000000000000000000000000000000304';
             const badTxData = `${txData.replace(offsetToAssetData, invalidOffsetToAssetData)}${newAssetData}`;
-            await expectTransactionFailedAsync(
+            await expectTransactionFailedWithoutReasonAsync(
                 web3Wrapper.sendTransactionAsync({
                     to: staticCallProxy.address,
                     from: fromAddress,
                     data: badTxData,
                 }),
-                RevertReason.InvalidAssetDataEnd,
-            );
-        });
-        it('should revert if the length of assetData, excluding the proxyId, is not a multiple of 32', async () => {
-            const staticCallData = staticCallTarget.noInputFunction.getABIEncodedTransactionData();
-            const expectedResultHash = constants.KECCAK256_NULL;
-            const assetData = `${assetDataUtils.encodeStaticCallAssetData(
-                staticCallTarget.address,
-                staticCallData,
-                expectedResultHash,
-            )}01`;
-            await expectTransactionFailedAsync(
-                staticCallProxy.transferFrom.sendTransactionAsync(assetData, fromAddress, toAddress, amount),
-                RevertReason.InvalidAssetDataLength,
             );
         });
         it('should revert if the length of assetData is less than 100 bytes', async () => {
@@ -125,9 +111,8 @@ describe('StaticCallProxy', () => {
                 .slice(0, -128);
             const assetDataByteLen = (assetData.length - 2) / 2;
             expect((assetDataByteLen - 4) % 32).to.equal(0);
-            await expectTransactionFailedAsync(
+            await expectTransactionFailedWithoutReasonAsync(
                 staticCallProxy.transferFrom.sendTransactionAsync(assetData, fromAddress, toAddress, amount),
-                RevertReason.InvalidAssetDataLength,
             );
         });
         it('should revert if the offset to `staticCallData` points to outside of assetData', async () => {
@@ -147,9 +132,8 @@ describe('StaticCallProxy', () => {
                 offsetToStaticCallData,
                 invalidOffsetToStaticCallData,
             )}${newStaticCallData}`;
-            await expectTransactionFailedAsync(
+            await expectTransactionFailedWithoutReasonAsync(
                 staticCallProxy.transferFrom.sendTransactionAsync(badAssetData, fromAddress, toAddress, amount),
-                RevertReason.InvalidStaticCallDataOffset,
             );
         });
         it('should revert if the callTarget attempts to write to state', async () => {


### PR DESCRIPTION
## Description

- Implements the `ERC1155Proxy` and `StaticCallProxy` in Solidity
- Note: `StaticCallProxy` cannot inherit `IAssetProxy` because its `transferFrom` function is marked as `view`.
- Many revert conditions no longer contain reasons, as they are handled within Solidity
- There are no longer any checks for if the length of `assetData` is a multiple of 32. However, any lengths less than required should fail (TODO: add tests for this)
- Found some pretty bizarre behavior is Solidity's `abi.decode`. When multiple offsets point to the same location in calldata (i.e if `values` == `ids`) then the decoded output is also copied to the same location in memory. This means we cannot modify `values` directly, or we may end up modifying `ids` or `data` as well.
- Thoughts on using `slice` vs `sliceDestructive` here? I opted for `sliceDestructive` because `assetData` is not reused, it is cheaper, and the implementation is arguably simpler.

TODO: gas benchmarking

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
