### PR TITLE
order-utils: Default Taker Simulation Address to non null address

### DIFF
--- a/packages/order-utils/CHANGELOG.json
+++ b/packages/order-utils/CHANGELOG.json
@@ -3,7 +3,8 @@
         "version": "8.2.4",
         "changes": [
             {
-                "note": "Taker Transfer Simulation now uses a default non null address"
+                "note": "Taker Transfer Simulation now uses a default non null address",
+                "pr": 1969
             }
         ]
     },

--- a/packages/order-utils/CHANGELOG.json
+++ b/packages/order-utils/CHANGELOG.json
@@ -1,5 +1,13 @@
 [
     {
+        "version": "8.2.4",
+        "changes": [
+            {
+                "note": "Taker Transfer Simulation now uses a default non null address"
+            }
+        ]
+    },
+    {
         "version": "8.2.3",
         "changes": [
             {

--- a/packages/order-utils/src/constants.ts
+++ b/packages/order-utils/src/constants.ts
@@ -85,6 +85,7 @@ const STATIC_CALL_METHOD_ABI: MethodAbi = {
 
 export const constants = {
     NULL_ADDRESS: '0x0000000000000000000000000000000000000000',
+    DEFAULT_TAKER_SIMULATION_ADDRESS: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
     NULL_BYTES: '0x',
     NULL_ERC20_ASSET_DATA: '0xf47261b00000000000000000000000000000000000000000000000000000000000000000',
     // tslint:disable-next-line:custom-no-magic-numbers

--- a/packages/order-utils/src/order_validation_utils.ts
+++ b/packages/order-utils/src/order_validation_utils.ts
@@ -123,6 +123,7 @@ export class OrderValidationUtils {
      * @param signedOrder SignedOrder of interest
      * @param makerAssetAmount Amount to transfer from the maker
      * @param takerAddress The address to transfer to, defaults to signedOrder.takerAddress
+     * unless it is address(0). If the takerAddress is address(0) a
      */
     public static async validateMakerTransferThrowIfInvalidAsync(
         networkId: NetworkId,
@@ -131,7 +132,12 @@ export class OrderValidationUtils {
         makerAssetAmount: BigNumber,
         takerAddress?: string,
     ): Promise<void> {
-        const toAddress = takerAddress === undefined ? signedOrder.takerAddress : takerAddress;
+        // Prevent sending to address(0) as a number of tokens in the wild have this restriction
+        const defaultToAddress =
+            signedOrder.takerAddress === constants.NULL_ADDRESS
+                ? constants.DEFAULT_TAKER_SIMULATION_ADDRESS
+                : signedOrder.takerAddress;
+        const toAddress = takerAddress === undefined ? defaultToAddress : takerAddress;
         const contractAddresses = getContractAddressesForNetworkOrThrow(networkId);
         const makerAssetDataProxyId = assetDataUtils.decodeAssetProxyId(signedOrder.makerAssetData);
         const exchangeContract = new ExchangeContract(contractAddresses.exchange, supportedProvider);


### PR DESCRIPTION
## Description

We perform a Transfer simulation to ensure that orders created by makers with specific transfer restrictions are invalidated and removed from orderbooks.

This appears in the wild for tokens like FOAM, and many USD pegs which implement blacklists. If a maker is blacklisted the order appears to be valid. Only transferring the asset results in a revert.

We defaulted to `takerAddress` which in the case of OOO is `address(0)`. This is fine in theory as the [ERC20 spec](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md#transferfrom) does not have a restriction on transferring to `address(0)`. In the wild we see a number of tokens preventing this as a "best practice", and it is the default behaviour in [OpenZeppelin contracts](https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/token/ERC20/ERC20.sol#L155).

The issue bites people currently when validating orders without explicitly overriding the default.

This PR relaxes the default, so when the `takerAddress` is `address(0)` we use a known non 0 address.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Update documentation as needed.
-   [x] Add new entries to the relevant CHANGELOG.jsons.
