### PR TITLE
[WIP] Support arrays in EIP712

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -708,7 +708,7 @@ export interface EIP712Types {
     [key: string]: EIP712Parameter[];
 }
 
-export type EIP712ObjectValue = string | number | EIP712Object;
+export type EIP712ObjectValue = string | number | EIP712Object | (string | number | EIP712Object)[];
 
 export interface EIP712Object {
     [key: string]: EIP712ObjectValue;

--- a/packages/utils/test/sign_typed_data_utils_test.ts
+++ b/packages/utils/test/sign_typed_data_utils_test.ts
@@ -159,5 +159,133 @@ describe('signTypedDataUtils', () => {
             const hashHex = `0x${hash}`;
             expect(hashHex).to.be.eq('0xfaa49b35faeb9197e9c3ba7a52075e6dad19739549f153b77dfcf59408a4b422');
         });
+        it('creates a hash of an object with an array of ints', () => {
+            const intArrayData = {
+                types: {
+                    EIP712Domain: [
+                        {
+                            name: 'name',
+                            type: 'string',
+                        },
+                        {
+                            name: 'version',
+                            type: 'string',
+                        },
+                        {
+                            name: 'verifyingContract',
+                            type: 'address',
+                        },
+                    ],
+                    MyStruct: [
+                        {
+                            name: 'myInts',
+                            type: 'uint256[]',
+                        },
+                    ],
+                },
+                domain: {
+                    name: 'TestDomain',
+                    version: '4.5',
+                    verifyingContract: '0x0000000000000000000000000000000000000000',
+                },
+                message: {
+                    myInts: ['0', '1', '2'],
+                },
+                primaryType: 'MyStruct',
+            };
+            const hash = signTypedDataUtils.generateTypedDataHash(intArrayData).toString('hex');
+            const hashHex = `0x${hash}`;
+            expect(hashHex).to.be.eq('0x0000000000000000000000000000000000000000000000000000000000000000');
+        });
+        it('creates a hash of an object with an array of addresses', () => {
+            const addressArrayData = {
+                types: {
+                    EIP712Domain: [
+                        {
+                            name: 'name',
+                            type: 'string',
+                        },
+                        {
+                            name: 'version',
+                            type: 'string',
+                        },
+                        {
+                            name: 'verifyingContract',
+                            type: 'address',
+                        },
+                    ],
+                    MyStruct: [
+                        {
+                            name: 'myAddresses',
+                            type: 'address[]',
+                        },
+                    ],
+                },
+                domain: {
+                    name: 'TestDomain',
+                    version: '4.5',
+                    verifyingContract: '0x0000000000000000000000000000000000000000',
+                },
+                message: {
+                    myAddresses: [
+                      '0x0123456789012345678901234567890123456789',
+                      '0x1234567890123456789012345678901234567890',
+                      '0x2345678901234567890123456789012345678901',
+                    ],
+                },
+                primaryType: 'MyStruct',
+            };
+            const hash = signTypedDataUtils.generateTypedDataHash(addressArrayData).toString('hex');
+            const hashHex = `0x${hash}`;
+            expect(hashHex).to.be.eq('0x0000000000000000000000000000000000000000000000000000000000000000');
+        });
+        it('creates a hash of an object with an array of structs', () => {
+            const structArrayData = {
+                types: {
+                    EIP712Domain: [
+                        {
+                            name: 'name',
+                            type: 'string',
+                        },
+                        {
+                            name: 'version',
+                            type: 'string',
+                        },
+                        {
+                            name: 'verifyingContract',
+                            type: 'address',
+                        },
+                    ],
+                    MyStruct: [
+                        {
+                            name: 'mySmallStructs',
+                            type: 'MySmallStruct[]',
+                        },
+                    ],
+                    MySmallStruct: [
+                        {
+                            name: 'myData',
+                            type: 'uint256',
+                        },
+                    ],
+                },
+                domain: {
+                    name: 'TestDomain',
+                    version: '4.5',
+                    verifyingContract: '0x0000000000000000000000000000000000000000',
+                },
+                message: {
+                    mySmallStructs: [
+                      { myData: '1' },
+                      { myData: '2' },
+                      { myData: '3' },
+                    ],
+                },
+                primaryType: 'MyStruct',
+            };
+            const hash = signTypedDataUtils.generateTypedDataHash(structArrayData).toString('hex');
+            const hashHex = `0x${hash}`;
+            expect(hashHex).to.be.eq('0x0000000000000000000000000000000000000000000000000000000000000000');
+        });
     });
 });


### PR DESCRIPTION
## Description

In _encodeData, supports Arrays for EIP712
https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md

Adds _encodeValue method which ABI encodes the hashable bytes32 value of a single variable.
(string and bytes types are hashed, primitive types are padded to 32 bytes, struct types are EIP712 hashed, arrays are hashed)

## Testing instructions

TODO

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (EIP712 was previously not properly supported)

* New feature (EIP712 is now fully supported)

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
