### PR TITLE
Use less strict validation in `cancelOrder`, remove `cancelOrderNoThrow`

### DIFF
--- a/contracts/exchange/contracts/src/MixinExchangeCore.sol
+++ b/contracts/exchange/contracts/src/MixinExchangeCore.sol
@@ -256,6 +256,11 @@ contract MixinExchangeCore is
         // Validate context
         _assertValidCancel(order, orderInfo);
 
+        // Noop if order is already unfillable
+        if (orderInfo.orderStatus != OrderStatus.FILLABLE) {
+            return;
+        }
+
         // Perform cancel
         _updateCancelledState(order, orderInfo.orderHash);
     }
@@ -466,15 +471,6 @@ contract MixinExchangeCore is
         internal
         view
     {
-        // Ensure order is valid
-        // An order can only be cancelled if its status is FILLABLE.
-        if (orderInfo.orderStatus != uint8(OrderStatus.FILLABLE)) {
-            LibRichErrors._rrevert(LibExchangeRichErrors.OrderStatusError(
-                orderInfo.orderHash,
-                OrderStatus(orderInfo.orderStatus)
-            ));
-        }
-
         // Validate sender is allowed to cancel this order
         if (order.senderAddress != address(0)) {
             if (order.senderAddress != msg.sender) {

--- a/contracts/exchange/contracts/src/MixinExchangeCore.sol
+++ b/contracts/exchange/contracts/src/MixinExchangeCore.sol
@@ -257,7 +257,7 @@ contract MixinExchangeCore is
         _assertValidCancel(order, orderInfo);
 
         // Noop if order is already unfillable
-        if (orderInfo.orderStatus != OrderStatus.FILLABLE) {
+        if (orderInfo.orderStatus != uint8(OrderStatus.FILLABLE)) {
             return;
         }
 

--- a/contracts/exchange/contracts/src/MixinWrapperFunctions.sol
+++ b/contracts/exchange/contracts/src/MixinWrapperFunctions.sol
@@ -371,19 +371,6 @@ contract MixinWrapperFunctions is
         return fillResults;
     }
 
-    /// @dev After calling, the order can not be filled anymore.
-    //       Returns false if the cancelOrder call would otherwise revert.
-    /// @param order Order to cancel. Order must be OrderStatus.FILLABLE.
-    /// @return True if the order was cancelled successfully.
-    function cancelOrderNoThrow(LibOrder.Order memory order)
-        public
-        returns (bool didCancel)
-    {
-        bytes memory cancelOrderCallData = abi.encodeWithSelector(CANCEL_ORDER_SELECTOR, order);
-        (didCancel,) = address(this).delegatecall(cancelOrderCallData);
-        return didCancel;
-    }
-
     /// @dev Executes multiple calls of cancelOrder.
     /// @param orders Array of order specifications.
     function batchCancelOrders(LibOrder.Order[] memory orders)
@@ -394,21 +381,6 @@ contract MixinWrapperFunctions is
         for (uint256 i = 0; i != ordersLength; i++) {
             _cancelOrder(orders[i]);
         }
-    }
-
-    /// @dev Executes multiple calls of canccelOrderNoThrow.
-    /// @param orders Array of order specifications.
-    /// @return Bool array containing results of each individual cancellation.
-    function batchCancelOrdersNoThrow(LibOrder.Order[] memory orders)
-        public
-        returns (bool[] memory)
-    {
-        uint256 ordersLength = orders.length;
-        bool[] memory didCancel = new bool[](ordersLength);
-        for (uint256 i = 0; i != ordersLength; i++) {
-            didCancel[i] = cancelOrderNoThrow(orders[i]);
-        }
-        return didCancel;
     }
 
     /// @dev Fetches information for all passed in orders.

--- a/contracts/exchange/test/core.ts
+++ b/contracts/exchange/test/core.ts
@@ -433,6 +433,29 @@ describe('Exchange core', () => {
             const tx = exchangeWrapper.fillOrderAsync(signedOrder, takerAddress);
             return expect(tx).to.revertWith(expectedError);
         });
+
+        it('should throw if rounding error is greater than 0.1%', async () => {
+            signedOrder = await orderFactory.newSignedOrderAsync({
+                makerAssetAmount: new BigNumber(1001),
+                takerAssetAmount: new BigNumber(3),
+            });
+
+            const fillTakerAssetAmount1 = new BigNumber(2);
+            await exchangeWrapper.fillOrderAsync(signedOrder, takerAddress, {
+                takerAssetFillAmount: fillTakerAssetAmount1,
+            });
+
+            const fillTakerAssetAmount2 = new BigNumber(1);
+            const expectedError = new LibMathRevertErrors.RoundingError(
+                fillTakerAssetAmount2,
+                new BigNumber(3),
+                new BigNumber(1001),
+            );
+            const tx = exchangeWrapper.fillOrderAsync(signedOrder, takerAddress, {
+                takerAssetFillAmount: fillTakerAssetAmount2,
+            });
+            return expect(tx).to.revertWith(expectedError);
+        });
     });
 
     describe('Fill transfer ordering', () => {
@@ -749,30 +772,20 @@ describe('Exchange core', () => {
             return expect(tx).to.revertWith(expectedError);
         });
 
-        it('should revert if makerAssetAmount is 0', async () => {
+        it('should noop if makerAssetAmount is 0', async () => {
             signedOrder = await orderFactory.newSignedOrderAsync({
                 makerAssetAmount: new BigNumber(0),
             });
-            const orderHash = orderHashUtils.getOrderHashHex(signedOrder);
-            const expectedError = new ExchangeRevertErrors.OrderStatusError(
-                orderHash,
-                OrderStatus.InvalidMakerAssetAmount,
-            );
-            const tx = exchangeWrapper.cancelOrderAsync(signedOrder, makerAddress);
-            return expect(tx).to.revertWith(expectedError);
+            const tx = await exchangeWrapper.cancelOrderAsync(signedOrder, makerAddress);
+            expect(tx.logs.length).to.equal(0);
         });
 
-        it('should revert if takerAssetAmount is 0', async () => {
+        it('should noop if takerAssetAmount is 0', async () => {
             signedOrder = await orderFactory.newSignedOrderAsync({
                 takerAssetAmount: new BigNumber(0),
             });
-            const orderHash = orderHashUtils.getOrderHashHex(signedOrder);
-            const expectedError = new ExchangeRevertErrors.OrderStatusError(
-                orderHash,
-                OrderStatus.InvalidTakerAssetAmount,
-            );
-            const tx = exchangeWrapper.cancelOrderAsync(signedOrder, makerAddress);
-            return expect(tx).to.revertWith(expectedError);
+            const tx = await exchangeWrapper.cancelOrderAsync(signedOrder, makerAddress);
+            expect(tx.logs.length).to.equal(0);
         });
 
         it('should be able to cancel an order', async () => {
@@ -785,7 +798,7 @@ describe('Exchange core', () => {
             return expect(tx).to.revertWith(expectedError);
         });
 
-        it('should log 1 event with correct arguments', async () => {
+        it('should log 1 event with correct arguments if cancelled successfully', async () => {
             const res = await exchangeWrapper.cancelOrderAsync(signedOrder, makerAddress);
             expect(res.logs).to.have.length(1);
 
@@ -800,46 +813,19 @@ describe('Exchange core', () => {
             expect(orderHashUtils.getOrderHashHex(signedOrder)).to.be.equal(logArgs.orderHash);
         });
 
-        it('should revert if already cancelled', async () => {
+        it('should noop if already cancelled', async () => {
             await exchangeWrapper.cancelOrderAsync(signedOrder, makerAddress);
-            const orderHash = orderHashUtils.getOrderHashHex(signedOrder);
-            const expectedError = new ExchangeRevertErrors.OrderStatusError(orderHash, OrderStatus.Cancelled);
-            const tx = exchangeWrapper.cancelOrderAsync(signedOrder, makerAddress);
-            return expect(tx).to.revertWith(expectedError);
+            const tx = await exchangeWrapper.cancelOrderAsync(signedOrder, makerAddress);
+            expect(tx.logs.length).to.equal(0);
         });
 
-        it('should revert if order is expired', async () => {
+        it('should noop if order is expired', async () => {
             const currentTimestamp = await getLatestBlockTimestampAsync();
             signedOrder = await orderFactory.newSignedOrderAsync({
                 expirationTimeSeconds: new BigNumber(currentTimestamp).minus(10),
             });
-            const orderHash = orderHashUtils.getOrderHashHex(signedOrder);
-            const expectedError = new ExchangeRevertErrors.OrderStatusError(orderHash, OrderStatus.Expired);
-            const tx = exchangeWrapper.cancelOrderAsync(signedOrder, makerAddress);
-            return expect(tx).to.revertWith(expectedError);
-        });
-
-        it('should revert if rounding error is greater than 0.1%', async () => {
-            signedOrder = await orderFactory.newSignedOrderAsync({
-                makerAssetAmount: new BigNumber(1001),
-                takerAssetAmount: new BigNumber(3),
-            });
-
-            const fillTakerAssetAmount1 = new BigNumber(2);
-            await exchangeWrapper.fillOrderAsync(signedOrder, takerAddress, {
-                takerAssetFillAmount: fillTakerAssetAmount1,
-            });
-
-            const fillTakerAssetAmount2 = new BigNumber(1);
-            const expectedError = new LibMathRevertErrors.RoundingError(
-                fillTakerAssetAmount2,
-                new BigNumber(3),
-                new BigNumber(1001),
-            );
-            const tx = exchangeWrapper.fillOrderAsync(signedOrder, takerAddress, {
-                takerAssetFillAmount: fillTakerAssetAmount2,
-            });
-            return expect(tx).to.revertWith(expectedError);
+            const tx = await exchangeWrapper.cancelOrderAsync(signedOrder, makerAddress);
+            expect(tx.logs.length).to.equal(0);
         });
     });
 

--- a/contracts/exchange/test/utils/exchange_wrapper.ts
+++ b/contracts/exchange/test/utils/exchange_wrapper.ts
@@ -56,15 +56,6 @@ export class ExchangeWrapper {
         const tx = await this._logDecoder.getTxWithDecodedLogsAsync(txHash);
         return tx;
     }
-    public async cancelOrderNoThrowAsync(
-        signedOrder: SignedOrder,
-        from: string,
-    ): Promise<TransactionReceiptWithDecodedLogs> {
-        const params = orderUtils.createCancel(signedOrder);
-        const txHash = await this._exchange.cancelOrderNoThrow.sendTransactionAsync(params.order, { from });
-        const tx = await this._logDecoder.getTxWithDecodedLogsAsync(txHash);
-        return tx;
-    }
     public async fillOrKillOrderAsync(
         signedOrder: SignedOrder,
         from: string,
@@ -204,14 +195,6 @@ export class ExchangeWrapper {
         from: string,
     ): Promise<TransactionReceiptWithDecodedLogs> {
         const txHash = await this._exchange.batchCancelOrders.sendTransactionAsync(orders, { from });
-        const tx = await this._logDecoder.getTxWithDecodedLogsAsync(txHash);
-        return tx;
-    }
-    public async batchCancelOrdersNoThrowAsync(
-        orders: SignedOrder[],
-        from: string,
-    ): Promise<TransactionReceiptWithDecodedLogs> {
-        const txHash = await this._exchange.batchCancelOrdersNoThrow.sendTransactionAsync(orders, { from });
         const tx = await this._logDecoder.getTxWithDecodedLogsAsync(txHash);
         return tx;
     }

--- a/contracts/exchange/test/wrapper.ts
+++ b/contracts/exchange/test/wrapper.ts
@@ -19,13 +19,11 @@ import { OrderStatus, SignedOrder } from '@0x/types';
 import { BigNumber, providerUtils, ReentrancyGuardRevertErrors } from '@0x/utils';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 import * as chai from 'chai';
-import { LogWithDecodedArgs } from 'ethereum-types';
 import * as _ from 'lodash';
 
 import {
     artifacts,
     constants as exchangeConstants,
-    ExchangeCancelEventArgs,
     ExchangeContract,
     ExchangeWrapper,
     ReentrantERC20TokenContract,
@@ -548,88 +546,6 @@ describe('Exchange wrappers', () => {
             expect(newOwnerMakerAsset).to.be.bignumber.equal(takerAddress);
             const newOwnerTakerAsset = await erc721Token.ownerOf.callAsync(takerAssetId);
             expect(newOwnerTakerAsset).to.be.bignumber.equal(makerAddress);
-        });
-    });
-
-    describe('cancelOrderNoThrow', () => {
-        it('should return false if not sent by maker', async () => {
-            const signedOrder = await orderFactory.newSignedOrderAsync();
-            const orderHash = orderHashUtils.getOrderHashHex(signedOrder);
-            const didCancel = await exchange.cancelOrderNoThrow.callAsync(signedOrder, { from: takerAddress });
-            const isCancelled = await exchange.cancelled.callAsync(orderHash);
-            expect(didCancel).to.equal(false);
-            expect(isCancelled).to.equal(false);
-        });
-
-        it('should return false if makerAssetAmount is 0', async () => {
-            const signedOrder = await orderFactory.newSignedOrderAsync({
-                makerAssetAmount: new BigNumber(0),
-            });
-            const orderHash = orderHashUtils.getOrderHashHex(signedOrder);
-            const didCancel = await exchange.cancelOrderNoThrow.callAsync(signedOrder, { from: makerAddress });
-            const isCancelled = await exchange.cancelled.callAsync(orderHash);
-            expect(didCancel).to.equal(false);
-            expect(isCancelled).to.equal(false);
-        });
-
-        it('should return false if takerAssetAmount is 0', async () => {
-            const signedOrder = await orderFactory.newSignedOrderAsync({
-                takerAssetAmount: new BigNumber(0),
-            });
-            const orderHash = orderHashUtils.getOrderHashHex(signedOrder);
-            const didCancel = await exchange.cancelOrderNoThrow.callAsync(signedOrder, { from: makerAddress });
-            const isCancelled = await exchange.cancelled.callAsync(orderHash);
-            expect(didCancel).to.equal(false);
-            expect(isCancelled).to.equal(false);
-        });
-
-        it('should be able to cancel an order', async () => {
-            const signedOrder = await orderFactory.newSignedOrderAsync();
-            await exchangeWrapper.cancelOrderNoThrowAsync(signedOrder, makerAddress);
-            const orderHash = orderHashUtils.getOrderHashHex(signedOrder);
-            const expectedError = new ExchangeRevertErrors.OrderStatusError(orderHash, OrderStatus.Cancelled);
-            const tx = exchangeWrapper.fillOrderAsync(signedOrder, takerAddress, {
-                takerAssetFillAmount: signedOrder.takerAssetAmount.div(2),
-            });
-            return expect(tx).to.revertWith(expectedError);
-        });
-
-        it('should log 1 event with correct arguments if successful', async () => {
-            const signedOrder = await orderFactory.newSignedOrderAsync();
-            const res = await exchangeWrapper.cancelOrderNoThrowAsync(signedOrder, makerAddress);
-            expect(res.logs).to.have.length(1);
-
-            const log = res.logs[0] as LogWithDecodedArgs<ExchangeCancelEventArgs>;
-            const logArgs = log.args;
-
-            expect(signedOrder.makerAddress).to.be.equal(logArgs.makerAddress);
-            expect(signedOrder.makerAddress).to.be.equal(logArgs.senderAddress);
-            expect(signedOrder.feeRecipientAddress).to.be.equal(logArgs.feeRecipientAddress);
-            expect(signedOrder.makerAssetData).to.be.equal(logArgs.makerAssetData);
-            expect(signedOrder.takerAssetData).to.be.equal(logArgs.takerAssetData);
-            expect(orderHashUtils.getOrderHashHex(signedOrder)).to.be.equal(logArgs.orderHash);
-        });
-
-        it('should return false if already cancelled', async () => {
-            const signedOrder = await orderFactory.newSignedOrderAsync();
-            const orderHash = orderHashUtils.getOrderHashHex(signedOrder);
-            await exchangeWrapper.cancelOrderAsync(signedOrder, makerAddress);
-            const isCancelled = await exchange.cancelled.callAsync(orderHash);
-            expect(isCancelled).to.equal(true);
-            const didCancel = await exchange.cancelOrderNoThrow.callAsync(signedOrder, { from: makerAddress });
-            expect(didCancel).to.equal(false);
-        });
-
-        it('should return false if order is expired', async () => {
-            const currentTimestamp = await getLatestBlockTimestampAsync();
-            const signedOrder = await orderFactory.newSignedOrderAsync({
-                expirationTimeSeconds: new BigNumber(currentTimestamp).minus(10),
-            });
-            const orderHash = orderHashUtils.getOrderHashHex(signedOrder);
-            const didCancel = await exchange.cancelOrderNoThrow.callAsync(signedOrder, { from: makerAddress });
-            const isCancelled = await exchange.cancelled.callAsync(orderHash);
-            expect(didCancel).to.equal(false);
-            expect(isCancelled).to.equal(false);
         });
     });
 
@@ -1772,27 +1688,6 @@ describe('Exchange wrappers', () => {
                 const expectedError = new ExchangeRevertErrors.OrderStatusError(orderHash, OrderStatus.Cancelled);
                 const tx = exchangeWrapper.batchCancelOrdersAsync(signedOrders, makerAddress);
                 return expect(tx).to.revertWith(expectedError);
-            });
-        });
-
-        describe('batchCancelOrdersNoThrow', () => {
-            it('should be able to cancel multiple signedOrders', async () => {
-                const takerAssetCancelAmounts = _.map(signedOrders, signedOrder => signedOrder.takerAssetAmount);
-                await exchangeWrapper.batchCancelOrdersNoThrowAsync(signedOrders, makerAddress);
-
-                await exchangeWrapper.batchFillOrdersNoThrowAsync(signedOrders, takerAddress, {
-                    takerAssetFillAmounts: takerAssetCancelAmounts,
-                });
-                const newBalances = await erc20Wrapper.getBalancesAsync();
-                expect(erc20Balances).to.be.deep.equal(newBalances);
-            });
-            it('should return false for cancelled orders', async () => {
-                await exchangeWrapper.cancelOrderAsync(signedOrders[1], makerAddress);
-                const didCancelArray = await exchange.batchCancelOrdersNoThrow.callAsync(signedOrders, {
-                    from: makerAddress,
-                });
-                expect(didCancelArray[0]).to.equal(true);
-                expect(didCancelArray[1]).to.equal(false);
             });
         });
 


### PR DESCRIPTION
## Description

In the interest of simplifying the Exchange contract interface, this PR uses less strict validation in `cancelOrder` and removes `cancelOrderNoThrow`. `cancelOrder` now returns early if the order is not `FILLABLE`, rather than reverting.

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
