### PR TITLE
publishing: prompt user for OTP

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
         "graceful-fs": "4.1.15"
     },
     "devDependencies": {
-        "@0x-lerna-fork/lerna": "3.16.7",
+        "@0x-lerna-fork/lerna": "3.16.8",
         "@0xproject/npm-cli-login": "^0.0.11",
         "async-child-process": "^1.1.1",
         "bundlewatch": "^0.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -56,16 +56,16 @@
     read-package-tree "^5.1.6"
     semver "^6.2.0"
 
-"@0x-lerna-fork/changed@3.16.7":
-  version "3.16.7"
-  resolved "https://registry.yarnpkg.com/@0x-lerna-fork/changed/-/changed-3.16.7.tgz#20529ddb56b951a75d10ed9ebfbc6b4ec9214e7e"
-  integrity sha512-26F9E0bitgoEYjb9yfJJAkb1ViMmJLTAYypxLatPuvNMFb90y3pq9YSrLXkGTxg8s6pB2uDdRD/JnnDjFge3XQ==
+"@0x-lerna-fork/changed@3.16.8":
+  version "3.16.8"
+  resolved "https://registry.yarnpkg.com/@0x-lerna-fork/changed/-/changed-3.16.8.tgz#f99767c08c1070506fcca066b829f9b20506c821"
+  integrity sha512-aQb6NoOrjHZbp+vccVpnIjMlot2oqiFUb+dJB5gH0c+Iw7MGb5KSKkF1lODt76U54VCqT3IsBdHB+U1O7bCWrg==
   dependencies:
     "@0x-lerna-fork/collect-updates" "3.16.3"
     "@0x-lerna-fork/command" "3.16.3"
     "@0x-lerna-fork/listable" "3.16.3"
     "@0x-lerna-fork/output" "3.16.3"
-    "@0x-lerna-fork/version" "3.16.7"
+    "@0x-lerna-fork/version" "3.16.8"
 
 "@0x-lerna-fork/check-working-tree@3.16.3":
   version "3.16.3"
@@ -318,14 +318,14 @@
     p-map "^2.1.0"
     write-json-file "^3.2.0"
 
-"@0x-lerna-fork/lerna@3.16.7":
-  version "3.16.7"
-  resolved "https://registry.yarnpkg.com/@0x-lerna-fork/lerna/-/lerna-3.16.7.tgz#0c36ccc46b4dd217f476f9e70a568432cdbc4130"
-  integrity sha512-wajiUnqJnyU6gQV69isVfaLoRzueMWKzYayMHqzVfXGFNlUH8qc19YLQtD14ec8PQpDIMUlKmhEsQv4KNo9j3Q==
+"@0x-lerna-fork/lerna@3.16.8":
+  version "3.16.8"
+  resolved "https://registry.yarnpkg.com/@0x-lerna-fork/lerna/-/lerna-3.16.8.tgz#d8c697db74d598f5ee4e18621ee6c353e9151068"
+  integrity sha512-gkBFBmigBClHQE5JwEP+yE5iuLnY+xEsfUXvSWvpkDN0IOS/kh/74FVbhOzHfrotooA6x+oTOZE5l3cOMOCyuA==
   dependencies:
     "@0x-lerna-fork/add" "3.16.3"
     "@0x-lerna-fork/bootstrap" "3.16.3"
-    "@0x-lerna-fork/changed" "3.16.7"
+    "@0x-lerna-fork/changed" "3.16.8"
     "@0x-lerna-fork/clean" "3.16.3"
     "@0x-lerna-fork/cli" "3.16.3"
     "@0x-lerna-fork/create" "3.16.3"
@@ -335,9 +335,9 @@
     "@0x-lerna-fork/init" "3.16.3"
     "@0x-lerna-fork/link" "3.16.3"
     "@0x-lerna-fork/list" "3.16.3"
-    "@0x-lerna-fork/publish" "3.16.7"
+    "@0x-lerna-fork/publish" "3.16.8"
     "@0x-lerna-fork/run" "3.16.3"
-    "@0x-lerna-fork/version" "3.16.7"
+    "@0x-lerna-fork/version" "3.16.8"
     import-local "^2.0.0"
     npmlog "^4.1.2"
 
@@ -519,10 +519,10 @@
     inquirer "^6.2.0"
     npmlog "^4.1.2"
 
-"@0x-lerna-fork/publish@3.16.7":
-  version "3.16.7"
-  resolved "https://registry.yarnpkg.com/@0x-lerna-fork/publish/-/publish-3.16.7.tgz#5f23fbd106eb5dffb5fc15980e03c9edff901519"
-  integrity sha512-1TLcFi7yOn7FqXoEZf62ND62pPR0OfnBWhRoq3d+b6IUpUl+srkjaznncf0KflJU0ccXMA/2z6uh72IpkvRGCw==
+"@0x-lerna-fork/publish@3.16.8":
+  version "3.16.8"
+  resolved "https://registry.yarnpkg.com/@0x-lerna-fork/publish/-/publish-3.16.8.tgz#9f2bdf8a6085b33af67dc67c700d48b29ddd032f"
+  integrity sha512-II9XEvc7nskBTxWwWnim+T+V+IAUSMO3+ffMUd5U9crhSASuWS1tNdBGjNJPMMaqSGzswUEUxI8PjlfcfVEOIw==
   dependencies:
     "@0x-lerna-fork/check-working-tree" "3.16.3"
     "@0x-lerna-fork/child-process" "3.16.3"
@@ -542,7 +542,7 @@
     "@0x-lerna-fork/run-lifecycle" "3.16.3"
     "@0x-lerna-fork/run-topologically" "3.16.3"
     "@0x-lerna-fork/validation-error" "3.16.3"
-    "@0x-lerna-fork/version" "3.16.7"
+    "@0x-lerna-fork/version" "3.16.8"
     "@evocateur/libnpmaccess" "^3.1.2"
     "@evocateur/npm-registry-fetch" "^4.0.0"
     "@evocateur/pacote" "^9.6.3"
@@ -665,10 +665,10 @@
   dependencies:
     npmlog "^4.1.2"
 
-"@0x-lerna-fork/version@3.16.7":
-  version "3.16.7"
-  resolved "https://registry.yarnpkg.com/@0x-lerna-fork/version/-/version-3.16.7.tgz#f223d1ea27716f6b47a87cfd856c95c14f7edb3c"
-  integrity sha512-WIHT/SnXk49+LzSm65niFm78AyMq+DilDsJ3aGc4eSBEu3ADpMufRNy6ksmI6NB3uk1+KHq/o6at/9vq6bCRMQ==
+"@0x-lerna-fork/version@3.16.8":
+  version "3.16.8"
+  resolved "https://registry.yarnpkg.com/@0x-lerna-fork/version/-/version-3.16.8.tgz#7e08c81149c82507e50e5c1458b748ba84b1c207"
+  integrity sha512-g/oPaNUPw0guxhg6J+3mO7R+RjKlCIZY7vX52pgD7ddnW9znmUepClnEoY92CSDnCqXt3YmZEZsDxeSK0gyycQ==
   dependencies:
     "@0x-lerna-fork/check-working-tree" "3.16.3"
     "@0x-lerna-fork/child-process" "3.16.3"
@@ -714,6 +714,26 @@
   resolved "https://registry.yarnpkg.com/@0x/abi-gen-wrappers/-/abi-gen-wrappers-4.3.0.tgz#b36616b129f44072474a7d5739299e4b1068e3d4"
   dependencies:
     "@0x/base-contract" "^5.1.0"
+
+"@0x/abi-gen@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@0x/abi-gen/-/abi-gen-2.1.1.tgz#2ca9072e64a2a46b6149aaea434f09d5dbf0866f"
+  integrity sha512-QLigDvQEGe248MjafJ58nWfwMbz+Va6KTlCsrADTuQd711XY10c95poDPevOfAXNHFZYpgS6rEzIau0WmY+Kbw==
+  dependencies:
+    "@0x/types" "^2.4.0"
+    "@0x/typescript-typings" "^4.2.3"
+    "@0x/utils" "^4.4.0"
+    chalk "^2.3.0"
+    change-case "^3.0.2"
+    cli-format "^3.0.9"
+    ethereum-types "^2.1.3"
+    glob "^7.1.2"
+    handlebars "^4.0.11"
+    lodash "^4.17.11"
+    mkdirp "^0.5.1"
+    tmp "^0.0.33"
+    to-snake-case "^1.0.0"
+    yargs "^10.0.3"
 
 "@0x/asset-buyer@6.1.4":
   version "6.1.4"


### PR DESCRIPTION
## Description

Our publishing script currently calls `lerna publish` via `exec`, not allowing for any interactivity with the command. Now that we want to enable 2FA however, we need to be able to support OTPs during the commands execution.

This PR switches our use of `exec` for `spawn`, allowing us to intercept the OTP prompt and bubble it up to the publisher running our script. 

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
