### PR TITLE
Added optimization utils for asset-swapper exchange consumer

### DIFF
--- a/packages/asset-swapper/src/constants.ts
+++ b/packages/asset-swapper/src/constants.ts
@@ -10,6 +10,7 @@ import {
     SwapQuoterOpts,
 } from './types';
 
+const NULL_BYTES = '0x';
 const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
 const MAINNET_NETWORK_ID = 1;
 const ONE_SECOND_MS = 1000;
@@ -44,6 +45,7 @@ const DEFAULT_LIQUIDITY_REQUEST_OPTS: LiquidityRequestOpts = {
 };
 
 export const constants = {
+    NULL_BYTES,
     ZERO_AMOUNT: new BigNumber(0),
     NULL_ADDRESS,
     MAINNET_NETWORK_ID,

--- a/packages/asset-swapper/src/quote_consumers/exchange_swap_quote_consumer.ts
+++ b/packages/asset-swapper/src/quote_consumers/exchange_swap_quote_consumer.ts
@@ -77,6 +77,8 @@ export class ExchangeSwapQuoteConsumer implements SwapQuoteConsumerBase<Exchange
 
         const signatures = _.map(orders, o => o.signature);
 
+        const optimizedOrders = swapQuoteConsumerUtils.optimizeOrdersForMarketExchangeOperation(orders, quote.type);
+
         let params: ExchangeSmartContractParams;
         let methodName: string;
 
@@ -84,7 +86,7 @@ export class ExchangeSwapQuoteConsumer implements SwapQuoteConsumerBase<Exchange
             const { makerAssetFillAmount } = quote;
 
             params = {
-                orders,
+                orders: optimizedOrders,
                 signatures,
                 makerAssetFillAmount,
                 type: MarketOperation.Buy,
@@ -95,7 +97,7 @@ export class ExchangeSwapQuoteConsumer implements SwapQuoteConsumerBase<Exchange
             const { takerAssetFillAmount } = quote;
 
             params = {
-                orders,
+                orders: optimizedOrders,
                 signatures,
                 takerAssetFillAmount,
                 type: MarketOperation.Sell,

--- a/packages/asset-swapper/src/utils/assert.ts
+++ b/packages/asset-swapper/src/utils/assert.ts
@@ -12,6 +12,7 @@ export const assert = {
         sharedAssert.isHexString(`${variableName}.makerAssetData`, swapQuote.makerAssetData);
         sharedAssert.doesConformToSchema(`${variableName}.orders`, swapQuote.orders, schemas.signedOrdersSchema);
         sharedAssert.doesConformToSchema(`${variableName}.feeOrders`, swapQuote.feeOrders, schemas.signedOrdersSchema);
+        assert.isValidOrdersForSwapQuote(`${variableName}.orders`, swapQuote.orders, swapQuote.makerAssetData, swapQuote.takerAssetData);
         assert.isValidSwapQuoteInfo(`${variableName}.bestCaseQuoteInfo`, swapQuote.bestCaseQuoteInfo);
         assert.isValidSwapQuoteInfo(`${variableName}.worstCaseQuoteInfo`, swapQuote.worstCaseQuoteInfo);
         if (swapQuote.type === MarketOperation.Buy) {
@@ -19,6 +20,12 @@ export const assert = {
         } else {
             sharedAssert.isBigNumber(`${variableName}.takerAssetFillAmount`, swapQuote.takerAssetFillAmount);
         }
+    },
+    isValidOrdersForSwapQuote(variableName: string, orders: SignedOrder[], makerAssetData: string, takerAssetData: string): void {
+        _.every(orders, (order: SignedOrder, index: number) => {
+            assert.assert(order.takerAssetData === takerAssetData, `Expected ${variableName}[${index}].takerAssetData to be ${takerAssetData}`);
+            assert.assert(order.makerAssetData === makerAssetData, `Expected ${variableName}[${index}].makerAssetData to be ${makerAssetData}`);
+        });
     },
     isValidForwarderSwapQuote(variableName: string, swapQuote: SwapQuote, wethAssetData: string): void {
         assert.isValidSwapQuote(variableName, swapQuote);

--- a/packages/asset-swapper/src/utils/assert.ts
+++ b/packages/asset-swapper/src/utils/assert.ts
@@ -12,7 +12,12 @@ export const assert = {
         sharedAssert.isHexString(`${variableName}.makerAssetData`, swapQuote.makerAssetData);
         sharedAssert.doesConformToSchema(`${variableName}.orders`, swapQuote.orders, schemas.signedOrdersSchema);
         sharedAssert.doesConformToSchema(`${variableName}.feeOrders`, swapQuote.feeOrders, schemas.signedOrdersSchema);
-        assert.isValidOrdersForSwapQuote(`${variableName}.orders`, swapQuote.orders, swapQuote.makerAssetData, swapQuote.takerAssetData);
+        assert.isValidOrdersForSwapQuote(
+            `${variableName}.orders`,
+            swapQuote.orders,
+            swapQuote.makerAssetData,
+            swapQuote.takerAssetData,
+        );
         assert.isValidSwapQuoteInfo(`${variableName}.bestCaseQuoteInfo`, swapQuote.bestCaseQuoteInfo);
         assert.isValidSwapQuoteInfo(`${variableName}.worstCaseQuoteInfo`, swapQuote.worstCaseQuoteInfo);
         if (swapQuote.type === MarketOperation.Buy) {
@@ -21,10 +26,21 @@ export const assert = {
             sharedAssert.isBigNumber(`${variableName}.takerAssetFillAmount`, swapQuote.takerAssetFillAmount);
         }
     },
-    isValidOrdersForSwapQuote(variableName: string, orders: SignedOrder[], makerAssetData: string, takerAssetData: string): void {
+    isValidOrdersForSwapQuote(
+        variableName: string,
+        orders: SignedOrder[],
+        makerAssetData: string,
+        takerAssetData: string,
+    ): void {
         _.every(orders, (order: SignedOrder, index: number) => {
-            assert.assert(order.takerAssetData === takerAssetData, `Expected ${variableName}[${index}].takerAssetData to be ${takerAssetData}`);
-            assert.assert(order.makerAssetData === makerAssetData, `Expected ${variableName}[${index}].makerAssetData to be ${makerAssetData}`);
+            assert.assert(
+                order.takerAssetData === takerAssetData,
+                `Expected ${variableName}[${index}].takerAssetData to be ${takerAssetData}`,
+            );
+            assert.assert(
+                order.makerAssetData === makerAssetData,
+                `Expected ${variableName}[${index}].makerAssetData to be ${makerAssetData}`,
+            );
         });
     },
     isValidForwarderSwapQuote(variableName: string, swapQuote: SwapQuote, wethAssetData: string): void {

--- a/packages/asset-swapper/src/utils/swap_quote_consumer_utils.ts
+++ b/packages/asset-swapper/src/utils/swap_quote_consumer_utils.ts
@@ -1,5 +1,5 @@
 import { ContractWrappers } from '@0x/contract-wrappers';
-import { SignedOrder } from '@0x/types';
+import { SignedOrder, MarketOperation } from '@0x/types';
 import { BigNumber } from '@0x/utils';
 import { SupportedProvider, Web3Wrapper } from '@0x/web3-wrapper';
 import { Provider } from 'ethereum-types';
@@ -71,6 +71,17 @@ export const swapQuoteConsumerUtils = {
     },
     isValidForwarderSignedOrder(order: SignedOrder, wethAssetData: string): boolean {
         return order.takerAssetData === wethAssetData;
+    },
+    optimizeOrdersForMarketExchangeOperation(orders: SignedOrder[], operation: MarketOperation): SignedOrder[] {
+        return _.map(orders, (order: SignedOrder, index: number) => {
+            const optimizedOrder = _.clone(order);
+            if (operation === MarketOperation.Sell && index !== 0) {
+                optimizedOrder.takerAssetData = constants.NULL_ADDRESS;
+            } else if (index !== 0) {
+                optimizedOrder.makerAssetData = constants.NULL_ADDRESS;
+            }
+            return optimizedOrder;
+        });
     },
     async getConsumerForSwapQuoteAsync(
         quote: SwapQuote,

--- a/packages/asset-swapper/src/utils/swap_quote_consumer_utils.ts
+++ b/packages/asset-swapper/src/utils/swap_quote_consumer_utils.ts
@@ -1,5 +1,5 @@
 import { ContractWrappers } from '@0x/contract-wrappers';
-import { SignedOrder, MarketOperation } from '@0x/types';
+import { MarketOperation, SignedOrder } from '@0x/types';
 import { BigNumber } from '@0x/utils';
 import { SupportedProvider, Web3Wrapper } from '@0x/web3-wrapper';
 import { Provider } from 'ethereum-types';

--- a/packages/asset-swapper/src/utils/swap_quote_consumer_utils.ts
+++ b/packages/asset-swapper/src/utils/swap_quote_consumer_utils.ts
@@ -76,9 +76,9 @@ export const swapQuoteConsumerUtils = {
         return _.map(orders, (order: SignedOrder, index: number) => {
             const optimizedOrder = _.clone(order);
             if (operation === MarketOperation.Sell && index !== 0) {
-                optimizedOrder.takerAssetData = constants.NULL_ADDRESS;
+                optimizedOrder.takerAssetData = constants.NULL_BYTES;
             } else if (index !== 0) {
-                optimizedOrder.makerAssetData = constants.NULL_ADDRESS;
+                optimizedOrder.makerAssetData = constants.NULL_BYTES;
             }
             return optimizedOrder;
         });


### PR DESCRIPTION
## Description

Per spec: 

> Note that `marketSellOrdersNoThrow` assumes that the `takerAssetData` is equal for each order. For any order passed in after the first, the `takerAssetData` byte array will be ignored (allowing null byte arrays to be passed in). If an order was intended to use a different `takerAssetData` field, the fill will fail at signature validation.

Added optimization to the output provided by `ExchangeSwapQuoteConsumer`.

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
