### PR TITLE
abi-gen: skip run_mocha on OSX

### DIFF
--- a/packages/abi-gen/package.json
+++ b/packages/abi-gen/package.json
@@ -16,7 +16,7 @@
         "build:ci": "yarn build",
         "test": "yarn run_mocha && yarn test_cli",
         "test:circleci": "yarn test:coverage && yarn test_cli",
-        "run_mocha": "mocha --require source-map-support/register --require make-promises-safe lib/test/*_test.js --timeout 100000 --bail --exit",
+        "run_mocha": "(uname -s | grep -q Darwin && echo 'HACK! skipping mocha run due to https://github.com/0xProject/0x-monorepo/issues/2000') || mocha --require source-map-support/register --require make-promises-safe lib/test/*_test.js --timeout 100000 --bail --exit",
         "test:coverage": "nyc npm run test --all && yarn coverage:report:lcov",
         "coverage:report:lcov": "nyc report --reporter=text-lcov > coverage/lcov.info",
         "test_cli": "yarn test_cli:run_mocha && yarn diff_contract_wrappers",


### PR DESCRIPTION
## Description

Workaround for #2000 so that developers can just run `abi-gen$ yarn test` on their local (OSX) machine and not have to say "wtf?"

## Testing instructions

Watch CI to verify that it still runs fine on Linux.  To verify for Mac, check out the branch, build and test abi-gen, and look for the "HACK! ..." message in the output.