### PR TITLE
Fix react-highlight dep issue

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -71,7 +71,7 @@
         "react-redux": "^5.0.3",
         "react-responsive": "^6.0.1",
         "react-router-dom": "^4.3.1",
-        "react-scroll": "0xproject/react-scroll#pr-330-and-replace-state",
+        "react-scroll": "https://github.com/0xProject/react-scroll.git#d2afc2729dc09980e4113d8c38a1b012ba180d81",
         "react-scrollable-anchor": "^0.6.1",
         "react-syntax-highlighter": "^10.1.1",
         "react-tooltip": "^3.2.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14224,9 +14224,9 @@ react-helmet@^5.2.0:
     prop-types "^15.5.4"
     react-side-effect "^1.1.0"
 
-react-highlight@0xproject/react-highlight#react-peer-deps:
+"react-highlight@https://github.com/0xProject/react-highlight.git#a70c7631e09508dafc4719cbcc6f121074e1937d":
   version "1.0.0"
-  resolved "https://codeload.github.com/0xproject/react-highlight/tar.gz/a70c7631e09508dafc4719cbcc6f121074e1937d"
+  resolved "https://github.com/0xProject/react-highlight.git#a70c7631e09508dafc4719cbcc6f121074e1937d"
   dependencies:
     highlight.js "^9.11.0"
     highlightjs-solidity "^1.0.5"
@@ -14340,9 +14340,9 @@ react-router@^4.3.1:
     prop-types "^15.6.1"
     warning "^4.0.1"
 
-react-scroll@0xproject/react-scroll#pr-330-and-replace-state:
+"react-scroll@https://github.com/0xProject/react-scroll.git#d2afc2729dc09980e4113d8c38a1b012ba180d81":
   version "1.7.11"
-  resolved "https://codeload.github.com/0xproject/react-scroll/tar.gz/d2afc2729dc09980e4113d8c38a1b012ba180d81"
+  resolved "https://github.com/0xProject/react-scroll.git#d2afc2729dc09980e4113d8c38a1b012ba180d81"
   dependencies:
     lodash.throttle "^4.1.1"
     prop-types "^15.5.8"


### PR DESCRIPTION
## Description

Fixes: #1977

Yarn currently has a caching issue with Github deps specified with the short-hand notation, causing the version installed to be in-determinant. This PR makes us always use the explicit HTTP url to the repository and a specific commit hash.
Source: https://github.com/yarnpkg/yarn/issues/4722

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
