### PR TITLE
Fix circleci workflow failing on 3.0 branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,7 +225,8 @@ jobs:
                   keys:
                       - repo-{{ .Environment.CIRCLE_SHA1 }}
             - run: yarn wsrun test:circleci @0x/contracts-test-utils
-            - run: yarn wsrun test:circleci @0x/abi-gen
+            # TODO(dorothy-zbornak): Re-enable after updating this package for 3.0.
+            # - run: yarn wsrun test:circleci-3.0 @0x/abi-gen
             - run: yarn wsrun test:circleci @0x/assert
             - run: yarn wsrun test:circleci @0x/base-contract
             # TODO(dorothy-zbornak): Re-enable after updating this package for 3.0.
@@ -238,10 +239,11 @@ jobs:
             - run: yarn wsrun test:circleci @0x/subproviders
             - run: yarn wsrun test:circleci @0x/web3-wrapper
             - run: yarn wsrun test:circleci @0x/utils
-            - save_cache:
-                  key: coverage-abi-gen-{{ .Environment.CIRCLE_SHA1 }}
-                  paths:
-                      - ~/repo/packages/abi-gen/coverage/lcov.info
+            # TODO(dorothy-zbornak): Re-enable after updating this package for 3.0.
+            # - save_cache:
+            #       key: coverage-abi-gen-{{ .Environment.CIRCLE_SHA1 }}
+            #       paths:
+            #           - ~/repo/packages/abi-gen/coverage/lcov.info
             - save_cache:
                   key: coverage-assert-{{ .Environment.CIRCLE_SHA1 }}
                   paths:
@@ -514,9 +516,10 @@ jobs:
             - restore_cache:
                   keys:
                       - repo-{{ .Environment.CIRCLE_SHA1 }}
-            - restore_cache:
-                  keys:
-                      - coverage-abi-gen-{{ .Environment.CIRCLE_SHA1 }}
+            # TODO(dorothy-zbornak): Re-enable after updating this package for 3.0.
+            # - restore_cache:
+            #       keys:
+            #           - coverage-abi-gen-{{ .Environment.CIRCLE_SHA1 }}
             - restore_cache:
                   keys:
                       - coverage-assert-{{ .Environment.CIRCLE_SHA1 }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -591,7 +591,9 @@ workflows:
             #           - build-3.0
             - submit-coverage-3.0:
                   requires:
-                      - test-python
+                      - test-contracts-ganache-3.0
+                      - test-rest-3.0
+                      - static-tests-3.0
             # Disabled for 3.0
             # - test-python:
             #       requires:

--- a/contracts/asset-proxy/.solhintignore
+++ b/contracts/asset-proxy/.solhintignore
@@ -1,0 +1,2 @@
+# solhint can't parse `abi.decode` syntax.
+contracts/src/ERC1155Proxy.sol

--- a/contracts/asset-proxy/test/erc1155_proxy.ts
+++ b/contracts/asset-proxy/test/erc1155_proxy.ts
@@ -1747,9 +1747,14 @@ describe('ERC1155Proxy', () => {
                 nftNotOwnerBalance,
             ];
             await erc1155Wrapper.assertBalancesAsync(tokenHolders, tokensToTransfer, expectedInitialBalances);
+            const expectedError = new SafeMathRevertErrors.SafeMathError(
+                SafeMathRevertErrors.SafeMathErrorCodes.Uint256MultiplicationOverflow,
+                maxUintValue,
+                valueMultiplier,
+            );
             // execute transfer
             // note - this will overflow because we are trying to transfer `maxUintValue * 2` of the 2nd token
-            await expectTransactionFailedAsync(
+            await expect(
                 erc1155ProxyWrapper.transferFromAsync(
                     spender,
                     receiver,
@@ -1760,8 +1765,7 @@ describe('ERC1155Proxy', () => {
                     receiverCallbackData,
                     authorized,
                 ),
-                RevertReason.Uint256Overflow,
-            );
+            ).to.revertWith(expectedError);
         });
         it('should revert if transferring > 1 instances of a non-fungible token (valueMultiplier field >1)', async () => {
             // setup test parameters


### PR DESCRIPTION
## Description
Also, tests were broken.

- Removed `test-python` (which we don't run) as a workflow dependency in the circleci config. Looks like the rebase snuck this in.
- Disabled `abi-gen` tests in circleci. The new tests use reference contracts from the `development` branch, which obviously break on `3.0`. We could just update them, but it might get annoying having to keep doing that.
- Add a `.solhintignore` file to `/contracts/asset-proxy` to ignore `ERC1155Proxy.sol`.
  - Solhint can't parse this file at all because of the `abi.decode()` in it. I tried upgrading solhint to latest and still no dice. Time to switch?
- Fix a broken test in `/contracts/asset-proxy/test/erc1155_proxy.ts`. Not sure how this one got in.

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
