### PR TITLE
[WIP] Feature/exposing receipt to generated wrappers

### DIFF
--- a/packages/abi-gen-templates/CHANGELOG.json
+++ b/packages/abi-gen-templates/CHANGELOG.json
@@ -9,6 +9,10 @@
             {
                 "note": "Updated interface to `deployAsync` to include log decode dependencies.",
                 "pr": 1995
+            },
+            {
+                "note": "Updated template to set the `txReceipt` to the contract instance after successful deployment.",
+                "pr": 2024
             }
         ]
     },

--- a/packages/abi-gen-templates/contract.handlebars
+++ b/packages/abi-gen-templates/contract.handlebars
@@ -119,6 +119,7 @@ export class {{contractName}}Contract extends BaseContract {
         logUtils.log(`{{contractName}} successfully deployed at ${txReceipt.contractAddress}`);
         const contractInstance = new {{contractName}}Contract(txReceipt.contractAddress as string, provider, txDefaults, logDecodeDependencies);
         contractInstance.constructorArgs = [{{> params inputs=ctor.inputs}}];
+        contractInstance.txReceipt = txReceipt;
         return contractInstance;
     }
 

--- a/packages/abi-gen-wrappers/CHANGELOG.json
+++ b/packages/abi-gen-wrappers/CHANGELOG.json
@@ -5,6 +5,10 @@
             {
                 "note": "Add subscribe/unsubscribe methods for events",
                 "pr": 1970
+            },
+            {
+                "note": "Exposing `txReceipt` to newly deployed contract instances.",
+                "pr": 2024
             }
         ]
     },

--- a/packages/abi-gen-wrappers/src/generated-wrappers/asset_proxy_owner.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/asset_proxy_owner.ts
@@ -2173,6 +2173,7 @@ export class AssetProxyOwnerContract extends BaseContract {
             logDecodeDependencies,
         );
         contractInstance.constructorArgs = [_owners, _assetProxyContracts, _required, _secondsTimeLocked];
+        contractInstance.txReceipt = txReceipt;
         return contractInstance;
     }
 

--- a/packages/abi-gen-wrappers/src/generated-wrappers/coordinator.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/coordinator.ts
@@ -683,6 +683,7 @@ export class CoordinatorContract extends BaseContract {
             logDecodeDependencies,
         );
         contractInstance.constructorArgs = [_exchange];
+        contractInstance.txReceipt = txReceipt;
         return contractInstance;
     }
 

--- a/packages/abi-gen-wrappers/src/generated-wrappers/coordinator_registry.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/coordinator_registry.ts
@@ -266,6 +266,7 @@ export class CoordinatorRegistryContract extends BaseContract {
             logDecodeDependencies,
         );
         contractInstance.constructorArgs = [];
+        contractInstance.txReceipt = txReceipt;
         return contractInstance;
     }
 

--- a/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc20_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc20_token.ts
@@ -1192,6 +1192,7 @@ export class DummyERC20TokenContract extends BaseContract {
             logDecodeDependencies,
         );
         contractInstance.constructorArgs = [_name, _symbol, _decimals, _totalSupply];
+        contractInstance.txReceipt = txReceipt;
         return contractInstance;
     }
 

--- a/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc721_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/dummy_erc721_token.ts
@@ -1516,6 +1516,7 @@ export class DummyERC721TokenContract extends BaseContract {
             logDecodeDependencies,
         );
         contractInstance.constructorArgs = [_name, _symbol];
+        contractInstance.txReceipt = txReceipt;
         return contractInstance;
     }
 

--- a/packages/abi-gen-wrappers/src/generated-wrappers/dutch_auction.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/dutch_auction.ts
@@ -607,6 +607,7 @@ export class DutchAuctionContract extends BaseContract {
             logDecodeDependencies,
         );
         contractInstance.constructorArgs = [_exchange];
+        contractInstance.txReceipt = txReceipt;
         return contractInstance;
     }
 

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc20_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc20_proxy.ts
@@ -759,6 +759,7 @@ export class ERC20ProxyContract extends BaseContract {
             logDecodeDependencies,
         );
         contractInstance.constructorArgs = [];
+        contractInstance.txReceipt = txReceipt;
         return contractInstance;
     }
 

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc20_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc20_token.ts
@@ -647,6 +647,7 @@ export class ERC20TokenContract extends BaseContract {
             logDecodeDependencies,
         );
         contractInstance.constructorArgs = [];
+        contractInstance.txReceipt = txReceipt;
         return contractInstance;
     }
 

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc721_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc721_proxy.ts
@@ -759,6 +759,7 @@ export class ERC721ProxyContract extends BaseContract {
             logDecodeDependencies,
         );
         contractInstance.constructorArgs = [];
+        contractInstance.txReceipt = txReceipt;
         return contractInstance;
     }
 

--- a/packages/abi-gen-wrappers/src/generated-wrappers/erc721_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/erc721_token.ts
@@ -1040,6 +1040,7 @@ export class ERC721TokenContract extends BaseContract {
             logDecodeDependencies,
         );
         contractInstance.constructorArgs = [];
+        contractInstance.txReceipt = txReceipt;
         return contractInstance;
     }
 

--- a/packages/abi-gen-wrappers/src/generated-wrappers/eth_balance_checker.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/eth_balance_checker.ts
@@ -130,6 +130,7 @@ export class EthBalanceCheckerContract extends BaseContract {
             logDecodeDependencies,
         );
         contractInstance.constructorArgs = [];
+        contractInstance.txReceipt = txReceipt;
         return contractInstance;
     }
 

--- a/packages/abi-gen-wrappers/src/generated-wrappers/exchange.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/exchange.ts
@@ -4636,6 +4636,7 @@ export class ExchangeContract extends BaseContract {
             logDecodeDependencies,
         );
         contractInstance.constructorArgs = [_zrxAssetData];
+        contractInstance.txReceipt = txReceipt;
         return contractInstance;
     }
 

--- a/packages/abi-gen-wrappers/src/generated-wrappers/forwarder.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/forwarder.ts
@@ -1115,6 +1115,7 @@ export class ForwarderContract extends BaseContract {
             logDecodeDependencies,
         );
         contractInstance.constructorArgs = [_exchange, _zrxAssetData, _wethAssetData];
+        contractInstance.txReceipt = txReceipt;
         return contractInstance;
     }
 

--- a/packages/abi-gen-wrappers/src/generated-wrappers/i_asset_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/i_asset_proxy.ts
@@ -764,6 +764,7 @@ export class IAssetProxyContract extends BaseContract {
             logDecodeDependencies,
         );
         contractInstance.constructorArgs = [];
+        contractInstance.txReceipt = txReceipt;
         return contractInstance;
     }
 

--- a/packages/abi-gen-wrappers/src/generated-wrappers/i_validator.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/i_validator.ts
@@ -144,6 +144,7 @@ export class IValidatorContract extends BaseContract {
             logDecodeDependencies,
         );
         contractInstance.constructorArgs = [];
+        contractInstance.txReceipt = txReceipt;
         return contractInstance;
     }
 

--- a/packages/abi-gen-wrappers/src/generated-wrappers/i_wallet.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/i_wallet.ts
@@ -136,6 +136,7 @@ export class IWalletContract extends BaseContract {
             logDecodeDependencies,
         );
         contractInstance.constructorArgs = [];
+        contractInstance.txReceipt = txReceipt;
         return contractInstance;
     }
 

--- a/packages/abi-gen-wrappers/src/generated-wrappers/multi_asset_proxy.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/multi_asset_proxy.ts
@@ -956,6 +956,7 @@ export class MultiAssetProxyContract extends BaseContract {
             logDecodeDependencies,
         );
         contractInstance.constructorArgs = [];
+        contractInstance.txReceipt = txReceipt;
         return contractInstance;
     }
 

--- a/packages/abi-gen-wrappers/src/generated-wrappers/order_validator.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/order_validator.ts
@@ -689,6 +689,7 @@ export class OrderValidatorContract extends BaseContract {
             logDecodeDependencies,
         );
         contractInstance.constructorArgs = [_exchange, _zrxAssetData];
+        contractInstance.txReceipt = txReceipt;
         return contractInstance;
     }
 

--- a/packages/abi-gen-wrappers/src/generated-wrappers/weth9.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/weth9.ts
@@ -952,6 +952,7 @@ export class WETH9Contract extends BaseContract {
             logDecodeDependencies,
         );
         contractInstance.constructorArgs = [];
+        contractInstance.txReceipt = txReceipt;
         return contractInstance;
     }
 

--- a/packages/abi-gen-wrappers/src/generated-wrappers/zrx_token.ts
+++ b/packages/abi-gen-wrappers/src/generated-wrappers/zrx_token.ts
@@ -761,6 +761,7 @@ export class ZRXTokenContract extends BaseContract {
             logDecodeDependencies,
         );
         contractInstance.constructorArgs = [];
+        contractInstance.txReceipt = txReceipt;
         return contractInstance;
     }
 

--- a/packages/abi-gen/test-cli/expected-output/typescript/abi_gen_dummy.ts
+++ b/packages/abi-gen/test-cli/expected-output/typescript/abi_gen_dummy.ts
@@ -1077,6 +1077,7 @@ export class AbiGenDummyContract extends BaseContract {
             logDecodeDependencies,
         );
         contractInstance.constructorArgs = [];
+        contractInstance.txReceipt = txReceipt;
         return contractInstance;
     }
 

--- a/packages/abi-gen/test-cli/expected-output/typescript/lib_dummy.ts
+++ b/packages/abi-gen/test-cli/expected-output/typescript/lib_dummy.ts
@@ -86,6 +86,7 @@ export class LibDummyContract extends BaseContract {
             logDecodeDependencies,
         );
         contractInstance.constructorArgs = [];
+        contractInstance.txReceipt = txReceipt;
         return contractInstance;
     }
 

--- a/packages/abi-gen/test-cli/expected-output/typescript/test_lib_dummy.ts
+++ b/packages/abi-gen/test-cli/expected-output/typescript/test_lib_dummy.ts
@@ -166,6 +166,7 @@ export class TestLibDummyContract extends BaseContract {
             logDecodeDependencies,
         );
         contractInstance.constructorArgs = [];
+        contractInstance.txReceipt = txReceipt;
         return contractInstance;
     }
 

--- a/packages/base-contract/CHANGELOG.json
+++ b/packages/base-contract/CHANGELOG.json
@@ -9,6 +9,10 @@
             {
                 "note": "Updated interface to `deployAsync` to include log decode dependencies.",
                 "pr": 1995
+            },
+            {
+                "note": "Updated BaseContract to have an optional field for the `txReceipt` of successful deployment transaction.",
+                "pr": 2024
             }
         ]
     },

--- a/packages/base-contract/src/index.ts
+++ b/packages/base-contract/src/index.ts
@@ -11,6 +11,7 @@ import {
     DataItem,
     MethodAbi,
     SupportedProvider,
+    TransactionReceiptWithDecodedLogs,
     TxData,
     TxDataPayable,
 } from 'ethereum-types';
@@ -61,6 +62,7 @@ export class BaseContract {
     public address: string;
     public contractName: string;
     public constructorArgs: any[] = [];
+    public txReceipt?: TransactionReceiptWithDecodedLogs;
     protected static _formatABIDataItemList(
         abis: DataItem[],
         values: any[],


### PR DESCRIPTION
## Description

Adding code to the template and base class to expose the transaction receipt from contract deployment when using the generated contract wrappers.  This is primarily a change to support usage of 0x tooling rather than the 0x contract assets.

<!--- Describe your changes in detail -->

## Testing instructions

A freshly deployed contract wrapper instance should now have the `txReceipt` to obtain any useful information.
<!--- Please describe how reviewers can test your changes -->

## Types of changes

 * New feature (non-breaking change which adds functionality) 

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Prefix PR title with `[WIP]` if necessary.
-   [x] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
