### PR TITLE
Remove solc-bin from npm publish

### DIFF
--- a/packages/sol-compiler/.npmignore
+++ b/packages/sol-compiler/.npmignore
@@ -9,3 +9,5 @@
 # Package specific ignore
 !bin/**/*
 !solc_bin/.gitkeep
+lib/solc_bin/*
+!lib/solc_bin/.gitkeep


### PR DESCRIPTION
3.1.11 was published with 
https://unpkg.com/browse/@0x/sol-compiler@3.1.11/lib/solc_bin/

## Description

Prevent multiple versions of sol compiler being published in the package. These are downloaded on demand.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
