### PR TITLE
Don't use python path when copying contract artifacts

### DIFF
--- a/packages/contract-artifacts/src/copy.ts
+++ b/packages/contract-artifacts/src/copy.ts
@@ -48,13 +48,7 @@ if (allArtifactPaths.length < pkgNames.length) {
 for (const _path of allArtifactPaths) {
     const fileName = _path.split('/').slice(-1)[0];
     const targetPath = path.join(__dirname, '../../artifacts', fileName);
-    const targetPathPython = path.join(
-        MONOREPO_ROOT,
-        'python-packages/contract_artifacts/src/zero_ex/contract_artifacts/artifacts',
-        fileName,
-    );
     fs.copyFileSync(_path, targetPath);
-    fs.copyFileSync(_path, targetPathPython);
     logUtils.log(`Copied ${_path}`);
 }
 logUtils.log(`Finished copying contract-artifacts. Remember to transform artifacts before publishing or using abi-gen`);


### PR DESCRIPTION
## Description

We stopped checking contract artifacts for python packages into github. This PR removes the python_packages path when copying artifacts, which was causing it to fail before.

Fixes #2063
## Testing instructions

Run `yarn artifacts_update` and verify it works.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue) 
<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
