### PR TITLE
sra_client.py: don't test against Python 2.7

### DIFF
--- a/python-packages/sra_client/tox.ini
+++ b/python-packages/sra_client/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py3
+envlist = py3
 
 [testenv]
 deps=-r{toxinidir}/requirements.txt


### PR DESCRIPTION
We don't support 2.7 for any of our other packages, so no need to do it for this one.  And, I was running `tox` locally, and I don't even have Python 2.7 installed, so this was failing for me, so I thought I'd just remove it.