### PR TITLE
Move pool operator logic to vault and allow operators to decrease operatorShare

### DIFF
--- a/contracts/staking/contracts/src/fees/MixinExchangeFees.sol
+++ b/contracts/staking/contracts/src/fees/MixinExchangeFees.sol
@@ -254,7 +254,7 @@ contract MixinExchangeFees is
 
             // compute weighted stake
             uint256 totalStakeDelegatedToPool = getTotalStakeDelegatedToPool(poolId).currentEpochBalance;
-            uint256 stakeHeldByPoolOperator = getStakeDelegatedToPoolByOwner(getStakingPoolOperator(poolId), poolId).currentEpochBalance;
+            uint256 stakeHeldByPoolOperator = getStakeDelegatedToPoolByOwner(rewardVault.operatorOf(poolId), poolId).currentEpochBalance;
             uint256 weightedStake = stakeHeldByPoolOperator.safeAdd(
                 totalStakeDelegatedToPool
                     .safeSub(stakeHeldByPoolOperator)
@@ -300,7 +300,7 @@ contract MixinExchangeFees is
             );
 
             // record reward in vault
-            (, uint256 poolPortion) = rewardVault.recordDepositFor(
+            (, uint256 membersPortion) = rewardVault.recordDepositFor(
                 activePools[i].poolId,
                 reward,
                 activePools[i].delegatedStake == 0 // true -> reward is for operator only
@@ -308,10 +308,10 @@ contract MixinExchangeFees is
             totalRewardsPaid = totalRewardsPaid.safeAdd(reward);
 
             // sync cumulative rewards, if necessary.
-            if (poolPortion > 0) {
+            if (membersPortion > 0) {
                 _recordRewardForDelegators(
                     activePools[i].poolId,
-                    poolPortion,
+                    membersPortion,
                     activePools[i].delegatedStake,
                     currentEpoch
                 );

--- a/contracts/staking/contracts/src/immutable/MixinStorage.sol
+++ b/contracts/staking/contracts/src/immutable/MixinStorage.sol
@@ -90,9 +90,6 @@ contract MixinStorage is
     // tracking Pool Id
     bytes32 internal nextPoolId = INITIAL_POOL_ID;
 
-    // mapping from Pool Id to Pool
-    mapping (bytes32 => IStructs.Pool) internal poolById;
-
     // mapping from Maker Address to a struct representing the pool the maker has joined and
     // whether the operator of that pool has subsequently added the maker.
     mapping (address => IStructs.MakerPoolJoinStatus) internal poolJoinedByMakerAddress;

--- a/contracts/staking/contracts/src/interfaces/IStructs.sol
+++ b/contracts/staking/contracts/src/interfaces/IStructs.sol
@@ -21,24 +21,6 @@ pragma solidity ^0.5.9;
 
 interface IStructs {
 
-    /// @dev Allowed signature types.
-    enum SignatureType {
-        Illegal,            // 0x00, default value
-        Invalid,            // 0x01
-        EIP712,             // 0x02
-        EthSign,            // 0x03
-        Wallet,             // 0x04
-        NSignatureTypes     // 0x05, number of signature types. Always leave at end.
-    }
-
-    /// @dev Status for Staking Pools (see MixinStakingPool).
-    /// @param operatorAddress Address of pool operator.
-    /// @param operatorShare Portion of pool rewards owned by operator, in ppm.
-    struct Pool {
-        address payable operatorAddress;
-        uint32 operatorShare;
-    }
-
     /// @dev Status for a pool that actively traded during the current epoch.
     /// (see MixinExchangeFees).
     /// @param poolId Unique Id of staking pool.

--- a/contracts/staking/contracts/src/libs/LibStakingRichErrors.sol
+++ b/contracts/staking/contracts/src/libs/LibStakingRichErrors.sol
@@ -84,9 +84,9 @@ library LibStakingRichErrors {
     bytes4 internal constant AMOUNT_EXCEEDS_BALANCE_OF_POOL_ERROR_SELECTOR =
         0x4c5c09dd;
 
-    // bytes4(keccak256("InvalidPoolOperatorShareError(bytes32,uint32)"))
-    bytes4 internal constant INVALID_POOL_OPERATOR_SHARE_ERROR_SELECTOR =
-        0x70f55b5a;
+    // bytes4(keccak256("OperatorShareError(uint8,bytes32,uint32)"))
+    bytes4 internal constant OPERATOR_SHARE_ERROR_SELECTOR =
+        0x22df9597;
 
     // bytes4(keccak256("PoolAlreadyExistsError(bytes32)"))
     bytes4 internal constant POOL_ALREADY_EXISTS_ERROR_SELECTOR =
@@ -112,13 +112,6 @@ library LibStakingRichErrors {
     bytes internal constant PROXY_DESTINATION_CANNOT_BE_NIL =
         hex"01ecebea";
 
-    enum MakerPoolAssignmentErrorCodes {
-        MAKER_ADDRESS_ALREADY_REGISTERED,
-        MAKER_ADDRESS_NOT_REGISTERED,
-        MAKER_ADDRESS_NOT_PENDING_ADD,
-        POOL_IS_FULL
-    }
-
     // bytes4(keccak256("InvalidProtocolFeePaymentError(uint8,uint256,uint256)"))
     bytes4 internal constant INVALID_PROTOCOL_FEE_PAYMENT_ERROR_SELECTOR =
         0xefd6cb33;
@@ -126,6 +119,18 @@ library LibStakingRichErrors {
     // bytes4(keccak256("InvalidWethAssetDataError()"))
     bytes internal constant INVALID_WETH_ASSET_DATA_ERROR =
         hex"24bf322c";
+
+    enum MakerPoolAssignmentErrorCodes {
+        MAKER_ADDRESS_ALREADY_REGISTERED,
+        MAKER_ADDRESS_NOT_REGISTERED,
+        MAKER_ADDRESS_NOT_PENDING_ADD,
+        POOL_IS_FULL
+    }
+
+    enum OperatorShareErrorCodes {
+        OPERATOR_SHARE_MUST_BE_BETWEEN_0_AND_100,
+        CAN_ONLY_DECREASE_OPERATOR_SHARE
+    }
 
     // solhint-disable func-name-mixedcase
     function MiscalculatedRewardsError(
@@ -320,18 +325,20 @@ library LibStakingRichErrors {
         );
     }
 
-    function InvalidPoolOperatorShareError(
+    function OperatorShareError(
+        OperatorShareErrorCodes errorCode,
         bytes32 poolId,
-        uint32 poolOperatorShare
+        uint32 operatorShare
     )
         internal
         pure
         returns (bytes memory)
     {
         return abi.encodeWithSelector(
-            INVALID_POOL_OPERATOR_SHARE_ERROR_SELECTOR,
+            OPERATOR_SHARE_ERROR_SELECTOR,
+            errorCode,
             poolId,
-            poolOperatorShare
+            operatorShare
         );
     }
 

--- a/contracts/staking/contracts/src/stake/MixinStake.sol
+++ b/contracts/staking/contracts/src/stake/MixinStake.sol
@@ -24,7 +24,6 @@ import "../immutable/MixinConstants.sol";
 import "../immutable/MixinStorage.sol";
 import "../interfaces/IStakingEvents.sol";
 import "./MixinZrxVault.sol";
-import "../staking_pools/MixinStakingPoolRewardVault.sol";
 import "../staking_pools/MixinStakingPoolRewards.sol";
 import "../sys/MixinScheduler.sol";
 import "../libs/LibStakingRichErrors.sol";

--- a/contracts/staking/contracts/src/vaults/StakingPoolRewardVault.sol
+++ b/contracts/staking/contracts/src/vaults/StakingPoolRewardVault.sol
@@ -96,9 +96,8 @@ contract StakingPoolRewardVault is
         )
     {
         // update balance of pool
-        Pool memory pool = poolById[poolId];
+        Pool storage pool = poolById[poolId];
         (operatorPortion, membersPortion) = _incrementPoolBalances(pool, amount, operatorOnly);
-        poolById[poolId] = pool;
         return (operatorPortion, membersPortion);
     }
 
@@ -193,7 +192,7 @@ contract StakingPoolRewardVault is
         }
 
         // pool must not exist
-        Pool memory pool = poolById[poolId];
+        Pool storage pool = poolById[poolId];
         if (pool.initialized) {
             LibRichErrors.rrevert(LibStakingRichErrors.PoolAlreadyExistsError(
                 poolId
@@ -204,7 +203,6 @@ contract StakingPoolRewardVault is
         pool.initialized = true;
         pool.operatorAddress = operatorAddress;
         pool.operatorShare = operatorShare;
-        poolById[poolId] = pool;
 
         // notify
         emit StakingPoolRegistered(poolId, operatorShare);
@@ -295,9 +293,8 @@ contract StakingPoolRewardVault is
     /// @param amount Amount to add to balance.
     /// @param operatorOnly Only give this balance to the operator.
     /// @return portion of amount given to operator and delegators, respectively.
-    function _incrementPoolBalances(Pool memory pool, uint256 amount, bool operatorOnly)
+    function _incrementPoolBalances(Pool storage pool, uint256 amount, bool operatorOnly)
         private
-        pure
         returns (uint256 operatorPortion, uint256 membersPortion)
     {
         // compute portions. One of the two must round down: the operator always receives the leftover from rounding.

--- a/contracts/staking/contracts/src/vaults/StakingPoolRewardVault.sol
+++ b/contracts/staking/contracts/src/vaults/StakingPoolRewardVault.sol
@@ -96,8 +96,7 @@ contract StakingPoolRewardVault is
         )
     {
         // update balance of pool
-        Pool storage pool = poolById[poolId];
-        (operatorPortion, membersPortion) = _incrementPoolBalances(pool, amount, operatorOnly);
+        (operatorPortion, membersPortion) = _incrementPoolBalances(poolById[poolId], amount, operatorOnly);
         return (operatorPortion, membersPortion);
     }
 

--- a/contracts/staking/contracts/src/vaults/StakingPoolRewardVault.sol
+++ b/contracts/staking/contracts/src/vaults/StakingPoolRewardVault.sol
@@ -17,6 +17,7 @@
 */
 
 pragma solidity ^0.5.9;
+pragma experimental ABIEncoderV2;
 
 import "@0x/contracts-exchange-libs/contracts/src/LibMath.sol";
 import "@0x/contracts-utils/contracts/src/LibRichErrors.sol";
@@ -46,8 +47,8 @@ contract StakingPoolRewardVault is
     using LibSafeMath for uint256;
     using LibSafeDowncast for uint256;
 
-    // mapping from Pool to Reward Balance in ETH
-    mapping (bytes32 => Balance) internal balanceByPoolId;
+    // mapping from poolId to Pool metadata
+    mapping (bytes32 => Pool) internal poolById;
 
     // address of ether vault
     IEthVault internal ethVault;
@@ -81,7 +82,7 @@ contract StakingPoolRewardVault is
     /// @param amount Amount in ETH to record.
     /// @param operatorOnly Only attribute amount to operator.
     /// @return operatorPortion Portion of amount attributed to the operator.
-    /// @return poolPortion Portion of amount attributed to the pool.
+    /// @return membersPortion Portion of amount attributed to the pool.
     function recordDepositFor(
         bytes32 poolId,
         uint256 amount,
@@ -91,14 +92,14 @@ contract StakingPoolRewardVault is
         onlyStakingContract
         returns (
             uint256 operatorPortion,
-            uint256 poolPortion
+            uint256 membersPortion
         )
     {
         // update balance of pool
-        Balance memory balance = balanceByPoolId[poolId];
-        (operatorPortion, poolPortion) = _incrementBalanceStruct(balance, amount, operatorOnly);
-        balanceByPoolId[poolId] = balance;
-        return (operatorPortion, poolPortion);
+        Pool memory pool = poolById[poolId];
+        (operatorPortion, membersPortion) = _incrementPoolBalances(pool, amount, operatorOnly);
+        poolById[poolId] = pool;
+        return (operatorPortion, membersPortion);
     }
 
     /// @dev Withdraw some amount in ETH of an operator's reward.
@@ -118,16 +119,16 @@ contract StakingPoolRewardVault is
         }
 
         // sanity check - sufficient balance?
-        uint256 operatorBalance = uint256(balanceByPoolId[poolId].operatorBalance);
+        uint256 operatorBalance = uint256(poolById[poolId].operatorBalance);
         if (amount > operatorBalance) {
             LibRichErrors.rrevert(LibStakingRichErrors.AmountExceedsBalanceOfPoolError(
                 amount,
-                balanceByPoolId[poolId].operatorBalance
+                poolById[poolId].operatorBalance
             ));
         }
 
         // update balance and transfer `amount` in ETH to staking contract
-        balanceByPoolId[poolId].operatorBalance = operatorBalance.safeSub(amount).downcastToUint96();
+        poolById[poolId].operatorBalance = operatorBalance.safeSub(amount).downcastToUint96();
         _transferToEthVault(operator, amount);
 
         // notify
@@ -152,16 +153,16 @@ contract StakingPoolRewardVault is
         }
 
         // sanity check - sufficient balance?
-        uint256 membersBalance = uint256(balanceByPoolId[poolId].membersBalance);
+        uint256 membersBalance = uint256(poolById[poolId].membersBalance);
         if (amount > membersBalance) {
             LibRichErrors.rrevert(LibStakingRichErrors.AmountExceedsBalanceOfPoolError(
                 amount,
-                balanceByPoolId[poolId].membersBalance
+                poolById[poolId].membersBalance
             ));
         }
 
         // update balance and transfer `amount` in ETH to staking contract
-        balanceByPoolId[poolId].membersBalance = membersBalance.safeSub(amount).downcastToUint96();
+        poolById[poolId].membersBalance = membersBalance.safeSub(amount).downcastToUint96();
         _transferToEthVault(member, amount);
 
         // notify
@@ -172,35 +173,76 @@ contract StakingPoolRewardVault is
     /// Note that this is only callable by the staking contract, and when
     /// not in catastrophic failure mode.
     /// @param poolId Unique Id of pool.
-    /// @param poolOperatorShare Fraction of rewards given to the pool operator, in ppm.
-    function registerStakingPool(bytes32 poolId, uint32 poolOperatorShare)
+    /// @param operatorShare Fraction of rewards given to the pool operator, in ppm.
+    function registerStakingPool(
+        bytes32 poolId,
+        address payable operatorAddress,
+        uint32 operatorShare
+    )
         external
         onlyStakingContract
         onlyNotInCatastrophicFailure
     {
         // operator share must be a valid fraction
-        if (poolOperatorShare > PPM_DENOMINATOR) {
-            LibRichErrors.rrevert(LibStakingRichErrors.InvalidPoolOperatorShareError(
+        if (operatorShare > PPM_DENOMINATOR) {
+            LibRichErrors.rrevert(LibStakingRichErrors.OperatorShareError(
+                LibStakingRichErrors.OperatorShareErrorCodes.OPERATOR_SHARE_MUST_BE_BETWEEN_0_AND_100,
                 poolId,
-                poolOperatorShare
+                operatorShare
             ));
         }
 
         // pool must not exist
-        Balance memory balance = balanceByPoolId[poolId];
-        if (balance.initialized) {
+        Pool memory pool = poolById[poolId];
+        if (pool.initialized) {
             LibRichErrors.rrevert(LibStakingRichErrors.PoolAlreadyExistsError(
                 poolId
             ));
         }
 
-        // set initial balance
-        balance.initialized = true;
-        balance.operatorShare = poolOperatorShare;
-        balanceByPoolId[poolId] = balance;
+        // initialize pool
+        pool.initialized = true;
+        pool.operatorAddress = operatorAddress;
+        pool.operatorShare = operatorShare;
+        poolById[poolId] = pool;
 
         // notify
-        emit StakingPoolRegistered(poolId, poolOperatorShare);
+        emit StakingPoolRegistered(poolId, operatorShare);
+    }
+
+    /// @dev Decreases the operator share for the given pool (i.e. increases pool rewards for members).
+    /// Note that this is only callable by the staking contract, and will revert if the new operator
+    /// share value is greater than the old value.
+    /// @param poolId Unique Id of pool.
+    /// @param newOperatorShare The newly decreased percentage of any rewards owned by the operator.
+    function decreaseOperatorShare(bytes32 poolId, uint32 newOperatorShare)
+        external
+        onlyStakingContract
+        onlyNotInCatastrophicFailure
+    {
+        uint32 oldOperatorShare = poolById[poolId].operatorShare;
+
+        if (newOperatorShare >= oldOperatorShare) {
+            LibRichErrors.rrevert(LibStakingRichErrors.OperatorShareError(
+                LibStakingRichErrors.OperatorShareErrorCodes.CAN_ONLY_DECREASE_OPERATOR_SHARE,
+                poolId,
+                newOperatorShare
+            ));
+        } else {
+            poolById[poolId].operatorShare = newOperatorShare;
+            emit OperatorShareDecreased(poolId, oldOperatorShare, newOperatorShare);
+        }
+    }
+
+    /// @dev Returns the address of the operator of a given pool
+    /// @param poolId Unique id of pool
+    /// @return operatorAddress Operator of the pool
+    function operatorOf(bytes32 poolId)
+        external
+        view
+        returns (address payable)
+    {
+        return poolById[poolId].operatorAddress;
     }
 
     /// @dev Returns the total balance of a pool.
@@ -211,8 +253,7 @@ contract StakingPoolRewardVault is
         view
         returns (uint256)
     {
-        Balance memory balance = balanceByPoolId[poolId];
-        return balance.operatorBalance + balance.membersBalance;
+        return poolById[poolId].operatorBalance + poolById[poolId].membersBalance;
     }
 
     /// @dev Returns the balance of a pool operator.
@@ -223,7 +264,7 @@ contract StakingPoolRewardVault is
         view
         returns (uint256)
     {
-        return balanceByPoolId[poolId].operatorBalance;
+        return poolById[poolId].operatorBalance;
     }
 
     /// @dev Returns the balance co-owned by members of a pool.
@@ -234,7 +275,7 @@ contract StakingPoolRewardVault is
         view
         returns (uint256)
     {
-        return balanceByPoolId[poolId].membersBalance;
+        return poolById[poolId].membersBalance;
     }
 
     /// @dev Returns the operator share of a pool's balance.
@@ -245,42 +286,42 @@ contract StakingPoolRewardVault is
         view
         returns (uint256)
     {
-        return balanceByPoolId[poolId].operatorShare;
+        return poolById[poolId].operatorShare;
     }
 
-    /// @dev Increments a balance struct, splitting the input amount between the
+    /// @dev Increments a balances in a Pool struct, splitting the input amount between the
     /// pool operator and members of the pool based on the pool operator's share.
-    /// @param balance Balance struct to increment.
+    /// @param pool Pool struct with the balances to increment.
     /// @param amount Amount to add to balance.
     /// @param operatorOnly Only give this balance to the operator.
     /// @return portion of amount given to operator and delegators, respectively.
-    function _incrementBalanceStruct(Balance memory balance, uint256 amount, bool operatorOnly)
+    function _incrementPoolBalances(Pool memory pool, uint256 amount, bool operatorOnly)
         private
         pure
-        returns (uint256 operatorPortion, uint256 poolPortion)
+        returns (uint256 operatorPortion, uint256 membersPortion)
     {
         // compute portions. One of the two must round down: the operator always receives the leftover from rounding.
         operatorPortion = operatorOnly
             ? amount
             : LibMath.getPartialAmountCeil(
-                uint256(balance.operatorShare),
+                uint256(pool.operatorShare),
                 PPM_DENOMINATOR,
                 amount
             );
 
-        poolPortion = amount.safeSub(operatorPortion);
+        membersPortion = amount.safeSub(operatorPortion);
 
         // compute new balances
-        uint256 newOperatorBalance = uint256(balance.operatorBalance).safeAdd(operatorPortion);
-        uint256 newMembersBalance = uint256(balance.membersBalance).safeAdd(poolPortion);
+        uint256 newOperatorBalance = uint256(pool.operatorBalance).safeAdd(operatorPortion);
+        uint256 newMembersBalance = uint256(pool.membersBalance).safeAdd(membersPortion);
 
         // save new balances
-        balance.operatorBalance = newOperatorBalance.downcastToUint96();
-        balance.membersBalance = newMembersBalance.downcastToUint96();
+        pool.operatorBalance = newOperatorBalance.downcastToUint96();
+        pool.membersBalance = newMembersBalance.downcastToUint96();
 
         return (
             operatorPortion,
-            poolPortion
+            membersPortion
         );
     }
 

--- a/contracts/staking/contracts/test/TestStorageLayout.sol
+++ b/contracts/staking/contracts/test/TestStorageLayout.sol
@@ -73,9 +73,6 @@ contract TestStorageLayout is
             if sub(nextPoolId_slot, slot) { revertIncorrectStorageSlot() }
             slot := add(slot, 1)
 
-            if sub(poolById_slot, slot) { revertIncorrectStorageSlot() }
-            slot := add(slot, 1)
-
             if sub(poolJoinedByMakerAddress_slot, slot) { revertIncorrectStorageSlot() }
             slot := add(slot, 1)
 

--- a/contracts/staking/test/actors/pool_operator_actor.ts
+++ b/contracts/staking/test/actors/pool_operator_actor.ts
@@ -86,4 +86,26 @@ export class PoolOperatorActor extends BaseActor {
         );
         expect(poolIdOfMakerAfterRemoving, 'pool id of maker').to.be.equal(stakingConstants.NIL_POOL_ID);
     }
+    public async decreaseStakingPoolOperatorShareAsync(
+        poolId: string,
+        newOperatorShare: number,
+        revertError?: RevertError,
+    ): Promise<void> {
+        // decrease operator share
+        const txReceiptPromise = this._stakingApiWrapper.stakingContract.decreaseStakingPoolOperatorShare.awaitTransactionSuccessAsync(
+            poolId,
+            newOperatorShare,
+            { from: this._owner },
+        );
+        if (revertError !== undefined) {
+            await expect(txReceiptPromise).to.revertWith(revertError);
+            return;
+        }
+        await txReceiptPromise;
+        // Check operator share
+        const decreasedOperatorShare = await this._stakingApiWrapper.rewardVaultContract.getOperatorShare.callAsync(
+            poolId,
+        );
+        expect(decreasedOperatorShare, 'updated operator share').to.be.bignumber.equal(newOperatorShare);
+    }
 }

--- a/contracts/staking/test/pools_test.ts
+++ b/contracts/staking/test/pools_test.ts
@@ -381,6 +381,24 @@ blockchainTests('Staking Pool Management', env => {
             // decrease operator share
             await poolOperator.decreaseStakingPoolOperatorShareAsync(poolId, increasedOperatorShare, revertError);
         });
+        it('Should fail if operator calls decreaseStakingPoolOperatorShare but newOperatorShare == oldOperatorShare', async () => {
+            // test parameters
+            const operatorAddress = users[0];
+            const operatorShare = (39 / 100) * PPM_DENOMINATOR;
+            const poolOperator = new PoolOperatorActor(operatorAddress, stakingApiWrapper);
+
+            // create pool
+            const poolId = await poolOperator.createStakingPoolAsync(operatorShare, false);
+            expect(poolId).to.be.equal(stakingConstants.INITIAL_POOL_ID);
+
+            const revertError = new StakingRevertErrors.OperatorShareError(
+                StakingRevertErrors.OperatorShareErrorCodes.CanOnlyDecreaseOperatorShare,
+                poolId,
+                operatorShare,
+            );
+            // decrease operator share
+            await poolOperator.decreaseStakingPoolOperatorShareAsync(poolId, operatorShare, revertError);
+        });
     });
 });
 // tslint:enable:no-unnecessary-type-assertion

--- a/contracts/staking/test/vaults_test.ts
+++ b/contracts/staking/test/vaults_test.ts
@@ -37,6 +37,7 @@ blockchainTests('Staking Vaults', env => {
             let revertError = new StakingRevertErrors.PoolAlreadyExistsError(poolId);
             let tx = stakingApiWrapper.rewardVaultContract.registerStakingPool.awaitTransactionSuccessAsync(
                 poolId,
+                poolOperator,
                 operatorShare,
                 { from: stakingApiWrapper.stakingContractAddress },
             );
@@ -45,6 +46,7 @@ blockchainTests('Staking Vaults', env => {
             revertError = new StakingRevertErrors.OnlyCallableByStakingContractError(notStakingContractAddress);
             tx = stakingApiWrapper.rewardVaultContract.registerStakingPool.awaitTransactionSuccessAsync(
                 poolId,
+                poolOperator,
                 operatorShare,
                 { from: notStakingContractAddress },
             );

--- a/packages/order-utils/src/staking_revert_errors.ts
+++ b/packages/order-utils/src/staking_revert_errors.ts
@@ -9,6 +9,11 @@ export enum MakerPoolAssignmentErrorCodes {
     PoolIsFull,
 }
 
+export enum OperatorShareErrorCodes {
+    OperatorShareMustBeBetween0And100,
+    CanOnlyDecreaseOperatorShare,
+}
+
 export enum ProtocolFeePaymentErrorCodes {
     ZeroProtocolFeePaid,
     MismatchedFeeAndPayment,
@@ -141,13 +146,13 @@ export class AmountExceedsBalanceOfPoolError extends RevertError {
     }
 }
 
-export class InvalidPoolOperatorShareError extends RevertError {
-    constructor(poolId?: string, poolOperatorShare?: BigNumber | number | string) {
-        super(
-            'InvalidPoolOperatorShareError',
-            'InvalidPoolOperatorShareError(bytes32 poolId, uint32 poolOperatorShare)',
-            { poolId, poolOperatorShare },
-        );
+export class OperatorShareError extends RevertError {
+    constructor(error?: OperatorShareErrorCodes, poolId?: string, operatorShare?: BigNumber | number | string) {
+        super('OperatorShareError', 'OperatorShareError(uint8 error, bytes32 poolId, uint32 operatorShare)', {
+            error,
+            poolId,
+            operatorShare,
+        });
     }
 }
 
@@ -213,7 +218,7 @@ const types = [
     OnlyCallableIfInCatastrophicFailureError,
     OnlyCallableIfNotInCatastrophicFailureError,
     AmountExceedsBalanceOfPoolError,
-    InvalidPoolOperatorShareError,
+    OperatorShareError,
     PoolAlreadyExistsError,
     InvalidCobbDouglasAlphaError,
     EthVaultNotSetError,


### PR DESCRIPTION
## Description
Moves the pool operator getter and related modifiers from `MixinStakingPool` to `MixinStakingPoolRewardVault`, moving the state from `MixinStorage` to `StakingPoolRewardVault`. 
This PR also adds the functionality for operators to decrease their share of the rewards in the pool. 
As a byproduct of these changes, `IStructs.Pool` is ded but the `Balance` struct is renamed to `Pool` because it now has a few fields unrelated to balances.

## Testing instructions
Probably want to add some integration tests involving `decreaseStakingPoolOperatorShare` in a future PR, for now I think unit tests will suffice

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

* Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
