### PR TITLE
Optimize batchMatchOrders, consolidate TransactionSignatureError rich revert

### DIFF
--- a/contracts/exchange-libs/contracts/src/LibExchangeRichErrors.sol
+++ b/contracts/exchange-libs/contracts/src/LibExchangeRichErrors.sol
@@ -50,7 +50,8 @@ library LibExchangeRichErrors {
     }
 
     enum SignatureErrorCodes {
-        BAD_SIGNATURE,
+        BAD_ORDER_SIGNATURE,
+        BAD_TRANSACTION_SIGNATURE,
         INVALID_LENGTH,
         UNSUPPORTED,
         ILLEGAL,
@@ -120,10 +121,6 @@ library LibExchangeRichErrors {
     // bytes4(keccak256("TransactionError(uint8,bytes32)"))
     bytes4 internal constant TRANSACTION_ERROR_SELECTOR =
         0xf5985184;
-
-    // bytes4(keccak256("TransactionSignatureError(bytes32,address,bytes)"))
-    bytes4 internal constant TRANSACTION_SIGNATURE_ERROR_SELECTOR =
-        0xbfd56ef6;
 
     // bytes4(keccak256("TransactionExecutionError(bytes32,bytes)"))
     bytes4 internal constant TRANSACTION_EXECUTION_ERROR_SELECTOR =
@@ -252,14 +249,6 @@ library LibExchangeRichErrors {
         returns (bytes4)
     {
         return TRANSACTION_ERROR_SELECTOR;
-    }
-
-    function TransactionSignatureErrorSelector()
-        internal
-        pure
-        returns (bytes4)
-    {
-        return TRANSACTION_SIGNATURE_ERROR_SELECTOR;
     }
 
     function TransactionExecutionErrorSelector()
@@ -535,23 +524,6 @@ library LibExchangeRichErrors {
             TRANSACTION_ERROR_SELECTOR,
             errorCode,
             transactionHash
-        );
-    }
-
-    function TransactionSignatureError(
-        bytes32 transactionHash,
-        address signerAddress,
-        bytes memory signature
-    )
-        internal
-        pure
-        returns (bytes memory)
-    {
-        return abi.encodeWithSelector(
-            TRANSACTION_SIGNATURE_ERROR_SELECTOR,
-            transactionHash,
-            signerAddress,
-            signature
         );
     }
 

--- a/contracts/exchange/contracts/src/MixinExchangeCore.sol
+++ b/contracts/exchange/contracts/src/MixinExchangeCore.sol
@@ -116,8 +116,7 @@ contract MixinExchangeCore is
     }
 
     /// @dev After calling, the order can not be filled anymore.
-    ///      Throws if order is invalid or sender does not have permission to cancel.
-    /// @param order Order to cancel. Order must be OrderStatus.FILLABLE.
+    /// @param order Order struct containing order specifications.
     function cancelOrder(LibOrder.Order memory order)
         public
         payable
@@ -217,7 +216,12 @@ contract MixinExchangeCore is
         uint256 takerAssetFilledAmount = LibSafeMath.min256(takerAssetFillAmount, remainingTakerAssetAmount);
 
         // Compute proportional fill amounts
-        fillResults = LibFillResults.calculateFillResults(order, takerAssetFilledAmount, protocolFeeMultiplier, tx.gasprice);
+        fillResults = LibFillResults.calculateFillResults(
+            order,
+            takerAssetFilledAmount,
+            protocolFeeMultiplier,
+            tx.gasprice
+        );
 
         bytes32 orderHash = orderInfo.orderHash;
 
@@ -382,7 +386,7 @@ contract MixinExchangeCore is
                 )
             ) {
                 LibRichErrors.rrevert(LibExchangeRichErrors.SignatureError(
-                    LibExchangeRichErrors.SignatureErrorCodes.BAD_SIGNATURE,
+                    LibExchangeRichErrors.SignatureErrorCodes.BAD_ORDER_SIGNATURE,
                     orderInfo.orderHash,
                     makerAddress,
                     signature

--- a/contracts/exchange/contracts/src/MixinExchangeCore.sol
+++ b/contracts/exchange/contracts/src/MixinExchangeCore.sol
@@ -136,11 +136,8 @@ contract MixinExchangeCore is
         view
         returns (LibOrder.OrderInfo memory orderInfo)
     {
-        // Compute the order hash
-        orderInfo.orderHash = order.getTypedDataHash(EIP712_EXCHANGE_DOMAIN_HASH);
-
-        // Fetch filled amount
-        orderInfo.orderTakerAssetFilledAmount = filled[orderInfo.orderHash];
+        // Compute the order hash and fetch the amount of takerAsset that has already been filled
+        (orderInfo.orderHash, orderInfo.orderTakerAssetFilledAmount) = _getOrderHashAndFilledAmount(order);
 
         // If order.makerAssetAmount is zero, we also reject the order.
         // While the Exchange contract handles them correctly, they create
@@ -487,5 +484,18 @@ contract MixinExchangeCore is
         if (!didPayProtocolFee) {
             fillResults.protocolFeePaid = 0;
         }
+    }
+
+    /// @dev Gets the order's hash and amount of takerAsset that has already been filled.
+    /// @param order Order struct containing order specifications.
+    /// @return The typed data hash and amount filled of the order.
+    function _getOrderHashAndFilledAmount(LibOrder.Order memory order)
+        internal
+        view
+        returns (bytes32 orderHash, uint256 orderTakerAssetFilledAmount)
+    {
+        orderHash = order.getTypedDataHash(EIP712_EXCHANGE_DOMAIN_HASH);
+        orderTakerAssetFilledAmount = filled[orderHash];
+        return (orderHash, orderTakerAssetFilledAmount);
     }
 }

--- a/contracts/exchange/contracts/src/MixinSignatureValidator.sol
+++ b/contracts/exchange/contracts/src/MixinSignatureValidator.sol
@@ -422,7 +422,7 @@ contract MixinSignatureValidator is
         returns (SignatureType signatureType)
     {
         // Read the signatureType from the signature
-        SignatureType signatureType = _readSignatureType(
+        signatureType = _readSignatureType(
             hash,
             signerAddress,
             signature

--- a/contracts/exchange/contracts/src/MixinTransactions.sol
+++ b/contracts/exchange/contracts/src/MixinTransactions.sol
@@ -117,7 +117,7 @@ contract MixinTransactions is
         _setCurrentContextAddressIfRequired(signerAddress, address(0));
 
         emit TransactionExecution(transactionHash);
-
+        
         return returnData;
     }
 
@@ -178,7 +178,8 @@ contract MixinTransactions is
                 signature
             )
         ) {
-            LibRichErrors.rrevert(LibExchangeRichErrors.TransactionSignatureError(
+            LibRichErrors.rrevert(LibExchangeRichErrors.SignatureError(
+                LibExchangeRichErrors.SignatureErrorCodes.BAD_TRANSACTION_SIGNATURE,
                 transactionHash,
                 signerAddress,
                 signature

--- a/contracts/exchange/contracts/src/libs/LibExchangeRichErrorDecoder.sol
+++ b/contracts/exchange/contracts/src/libs/LibExchangeRichErrorDecoder.sol
@@ -302,27 +302,6 @@ contract LibExchangeRichErrorDecoder {
         errorCode = LibExchangeRichErrors.TransactionErrorCodes(_errorCode);
     }
 
-    /// @dev Decompose an ABI-encoded TransactionSignatureError.
-    /// @param encoded ABI-encoded revert error.
-    /// @return transactionHash Hash of the transaction.
-    /// @return signerAddress Signer of the transaction.
-    /// @return signature Full signature for the transaction.
-    function decodeTransactionSignatureError(bytes memory encoded)
-        public
-        pure
-        returns (
-            bytes32 transactionHash,
-            address signerAddress,
-            bytes memory signature
-        )
-    {
-        _assertSelectorBytes(encoded, LibExchangeRichErrors.TransactionSignatureErrorSelector());
-        (transactionHash, signerAddress, signature) = abi.decode(
-            encoded.sliceDestructive(4, encoded.length),
-            (bytes32, address, bytes)
-        );
-    }
-
     /// @dev Decompose an ABI-encoded TransactionExecutionError.
     /// @param encoded ABI-encoded revert error.
     /// @return transactionHash Hash of the transaction.

--- a/contracts/exchange/contracts/test/IsolatedExchange.sol
+++ b/contracts/exchange/contracts/test/IsolatedExchange.sol
@@ -72,8 +72,8 @@ contract IsolatedExchange is
     /// @dev Overridden to simplify signature validation.
     ///      Unfortunately, this is `view`, so it can't log arguments.
     function _isValidOrderWithHashSignature(
-        LibOrder.Order memory order,
-        bytes32 orderHash,
+        LibOrder.Order memory,
+        bytes32,
         bytes memory signature
     )
         internal

--- a/contracts/exchange/contracts/test/ReentrancyTester.sol
+++ b/contracts/exchange/contracts/test/ReentrancyTester.sol
@@ -50,16 +50,16 @@ contract ReentrancyTester is
     function isReentrant(bytes calldata fnCallData)
         external
         nonReentrant
-        returns (bool isReentrant)
+        returns (bool allowsReentrancy)
     {
         (bool didSucceed, bytes memory resultData) = address(this).delegatecall(fnCallData);
         if (didSucceed) {
-            isReentrant = true;
+            allowsReentrancy = true;
         } else {
             if (resultData.equals(LibReentrancyGuardRichErrors.IllegalReentrancyError())) {
-                isReentrant = false;
+                allowsReentrancy = false;
             } else {
-                isReentrant = true;
+                allowsReentrancy = true;
             }
         }
     }
@@ -96,8 +96,8 @@ contract ReentrancyTester is
     /// @dev Overridden to always succeed.
     function _fillOrder(
         LibOrder.Order memory order,
-        uint256 takerAssetFillAmount,
-        bytes memory signature
+        uint256,
+        bytes memory
     )
         internal
         returns (LibFillResults.FillResults memory fillResults)
@@ -111,8 +111,8 @@ contract ReentrancyTester is
     /// @dev Overridden to always succeed.
     function _fillOrKillOrder(
         LibOrder.Order memory order,
-        uint256 takerAssetFillAmount,
-        bytes memory signature
+        uint256,
+        bytes memory
     )
         internal
         returns (LibFillResults.FillResults memory fillResults)
@@ -125,8 +125,8 @@ contract ReentrancyTester is
 
     /// @dev Overridden to always succeed.
     function _executeTransaction(
-        LibZeroExTransaction.ZeroExTransaction memory transaction,
-        bytes memory signature
+        LibZeroExTransaction.ZeroExTransaction memory,
+        bytes memory
     )
         internal
         returns (bytes memory resultData)
@@ -139,9 +139,9 @@ contract ReentrancyTester is
     function _batchMatchOrders(
         LibOrder.Order[] memory leftOrders,
         LibOrder.Order[] memory rightOrders,
-        bytes[] memory leftSignatures,
-        bytes[] memory rightSignatures,
-        bool shouldMaximallyFillOrders
+        bytes[] memory,
+        bytes[] memory,
+        bool
     )
         internal
         returns (LibFillResults.BatchMatchedFillResults memory batchMatchedFillResults)
@@ -171,9 +171,9 @@ contract ReentrancyTester is
     function _matchOrders(
         LibOrder.Order memory leftOrder,
         LibOrder.Order memory rightOrder,
-        bytes memory leftSignature,
-        bytes memory rightSignature,
-        bool shouldMaximallyFillOrders
+        bytes memory,
+        bytes memory,
+        bool
     )
         internal
         returns (LibFillResults.MatchedFillResults memory matchedFillResults)

--- a/contracts/exchange/contracts/test/TestProtocolFeesReceiver.sol
+++ b/contracts/exchange/contracts/test/TestProtocolFeesReceiver.sol
@@ -253,6 +253,7 @@ contract TestProtocolFeesReceiver {
         uint256 expectedProtocolFeePaid
     )
         internal
+        pure
     {
         // If the expected available balance was sufficient to pay the protocol fee, the protocol fee
         // should have been paid in ether. Otherwise, no ether should be sent to pay the protocol fee.

--- a/contracts/exchange/test/core.ts
+++ b/contracts/exchange/test/core.ts
@@ -281,7 +281,7 @@ blockchainTests.resets('Exchange core', () => {
                     takerAssetFillAmount: fillAmount,
                 });
                 const expectedError = new ExchangeRevertErrors.SignatureError(
-                    ExchangeRevertErrors.SignatureErrorCode.BadSignature,
+                    ExchangeRevertErrors.SignatureErrorCode.BadOrderSignature,
                     orderHashHex,
                     signedOrder.makerAddress,
                     signedOrder.signature,
@@ -312,7 +312,7 @@ blockchainTests.resets('Exchange core', () => {
                     takerAssetFillAmount: fillAmount,
                 });
                 const expectedError = new ExchangeRevertErrors.SignatureError(
-                    ExchangeRevertErrors.SignatureErrorCode.BadSignature,
+                    ExchangeRevertErrors.SignatureErrorCode.BadOrderSignature,
                     orderHashHex,
                     signedOrder.makerAddress,
                     signedOrder.signature,
@@ -343,7 +343,7 @@ blockchainTests.resets('Exchange core', () => {
                     takerAssetFillAmount: fillAmount,
                 });
                 const expectedError = new ExchangeRevertErrors.SignatureError(
-                    ExchangeRevertErrors.SignatureErrorCode.BadSignature,
+                    ExchangeRevertErrors.SignatureErrorCode.BadOrderSignature,
                     orderHashHex,
                     signedOrder.makerAddress,
                     signedOrder.signature,

--- a/contracts/exchange/test/isolated_fill_order.ts
+++ b/contracts/exchange/test/isolated_fill_order.ts
@@ -507,7 +507,7 @@ blockchainTests('Isolated fillOrder() tests', env => {
             const order = createOrder();
             const signature = createBadSignature();
             const expectedError = new ExchangeRevertErrors.SignatureError(
-                ExchangeRevertErrors.SignatureErrorCode.BadSignature,
+                ExchangeRevertErrors.SignatureErrorCode.BadOrderSignature,
                 exchange.getOrderHash(order),
                 order.makerAddress,
                 signature,
@@ -523,7 +523,7 @@ blockchainTests('Isolated fillOrder() tests', env => {
             const goodSignature = createGoodSignature(SignatureType.Wallet);
             const badSignature = createBadSignature(SignatureType.Wallet);
             const expectedError = new ExchangeRevertErrors.SignatureError(
-                ExchangeRevertErrors.SignatureErrorCode.BadSignature,
+                ExchangeRevertErrors.SignatureErrorCode.BadOrderSignature,
                 exchange.getOrderHash(order),
                 order.makerAddress,
                 badSignature,

--- a/contracts/exchange/test/lib_exchange_rich_error_decoder.ts
+++ b/contracts/exchange/test/lib_exchange_rich_error_decoder.ts
@@ -145,13 +145,6 @@ blockchainTests.resets('LibExchangeRichErrorDecoder', ({ provider, txDefaults })
 
     (() => {
         const transactionHash = orderUtils.generatePseudoRandomOrderHash();
-        const signer = addressUtils.generatePseudoRandomAddress();
-        const signature = hexRandom(SIGNATURE_LENGTH);
-        createDecodeTest(ExchangeRevertErrors.TransactionSignatureError, [transactionHash, signer, signature]);
-    })();
-
-    (() => {
-        const transactionHash = orderUtils.generatePseudoRandomOrderHash();
         const errorData = hexRandom(ERROR_DATA_LENGTH);
         createDecodeTest(ExchangeRevertErrors.TransactionExecutionError, [transactionHash, errorData]);
     })();

--- a/contracts/exchange/test/match_orders.ts
+++ b/contracts/exchange/test/match_orders.ts
@@ -1300,7 +1300,7 @@ describe('matchOrders', () => {
             };
             const orderHashHex = orderHashUtils.getOrderHashHex(reconstructedOrderRight);
             const expectedError = new ExchangeRevertErrors.SignatureError(
-                ExchangeRevertErrors.SignatureErrorCode.BadSignature,
+                ExchangeRevertErrors.SignatureErrorCode.BadOrderSignature,
                 orderHashHex,
                 signedOrderRight.makerAddress,
                 signedOrderRight.signature,
@@ -1327,7 +1327,7 @@ describe('matchOrders', () => {
             };
             const orderHashHex = orderHashUtils.getOrderHashHex(reconstructedOrderRight);
             const expectedError = new ExchangeRevertErrors.SignatureError(
-                ExchangeRevertErrors.SignatureErrorCode.BadSignature,
+                ExchangeRevertErrors.SignatureErrorCode.BadOrderSignature,
                 orderHashHex,
                 signedOrderRight.makerAddress,
                 signedOrderRight.signature,
@@ -2381,7 +2381,7 @@ describe('matchOrders', () => {
             };
             const orderHashHex = orderHashUtils.getOrderHashHex(reconstructedOrderRight);
             const expectedError = new ExchangeRevertErrors.SignatureError(
-                ExchangeRevertErrors.SignatureErrorCode.BadSignature,
+                ExchangeRevertErrors.SignatureErrorCode.BadOrderSignature,
                 orderHashHex,
                 signedOrderRight.makerAddress,
                 signedOrderRight.signature,
@@ -2408,7 +2408,7 @@ describe('matchOrders', () => {
             };
             const orderHashHex = orderHashUtils.getOrderHashHex(reconstructedOrderRight);
             const expectedError = new ExchangeRevertErrors.SignatureError(
-                ExchangeRevertErrors.SignatureErrorCode.BadSignature,
+                ExchangeRevertErrors.SignatureErrorCode.BadOrderSignature,
                 orderHashHex,
                 signedOrderRight.makerAddress,
                 signedOrderRight.signature,

--- a/contracts/exchange/test/transactions.ts
+++ b/contracts/exchange/test/transactions.ts
@@ -229,7 +229,8 @@ blockchainTests.resets('Exchange transactions', env => {
                     const invalidSigHex = `0x${invalidSigBuff.toString('hex')}`;
                     transaction.signature = invalidSigHex;
                     const transactionHashHex = transactionHashUtils.getTransactionHashHex(transaction);
-                    const expectedError = new ExchangeRevertErrors.TransactionSignatureError(
+                    const expectedError = new ExchangeRevertErrors.SignatureError(
+                        ExchangeRevertErrors.SignatureErrorCode.BadTransactionSignature,
                         transactionHashHex,
                         transaction.signerAddress,
                         transaction.signature,

--- a/contracts/exchange/test/transactions_unit_tests.ts
+++ b/contracts/exchange/test/transactions_unit_tests.ts
@@ -466,7 +466,8 @@ blockchainTests.resets('Transaction Unit Tests', ({ provider, web3Wrapper, txDef
         it('should revert if the signer != msg.sender and the signature is not valid', async () => {
             const transaction = await generateZeroExTransactionAsync({ signerAddress: accounts[1] });
             const transactionHash = transactionHashUtils.getTransactionHashHex(transaction);
-            const expectedError = new ExchangeRevertErrors.TransactionSignatureError(
+            const expectedError = new ExchangeRevertErrors.SignatureError(
+                ExchangeRevertErrors.SignatureErrorCode.BadTransactionSignature,
                 transactionHash,
                 accounts[1],
                 INVALID_SIGNATURE,
@@ -655,7 +656,8 @@ blockchainTests.resets('Transaction Unit Tests', ({ provider, web3Wrapper, txDef
         it('should revert if signer != msg.sender and the signature is invalid', async () => {
             const transaction = await generateZeroExTransactionAsync({ signerAddress: accounts[0] });
             const transactionHash = transactionHashUtils.getTransactionHashHex(transaction);
-            const expectedError = new ExchangeRevertErrors.TransactionSignatureError(
+            const expectedError = new ExchangeRevertErrors.SignatureError(
+                ExchangeRevertErrors.SignatureErrorCode.BadTransactionSignature,
                 transactionHash,
                 accounts[0],
                 INVALID_SIGNATURE,

--- a/contracts/utils/contracts/test/TestOwnable.sol
+++ b/contracts/utils/contracts/test/TestOwnable.sol
@@ -9,6 +9,7 @@ contract TestOwnable is
     function externalOnlyOwner()
         external
         onlyOwner
+        view
         returns (bool)
     {
         return true;

--- a/packages/order-utils/src/exchange_revert_errors.ts
+++ b/packages/order-utils/src/exchange_revert_errors.ts
@@ -25,7 +25,8 @@ export enum FillErrorCode {
 }
 
 export enum SignatureErrorCode {
-    BadSignature,
+    BadOrderSignature,
+    BadTransactionSignature,
     InvalidLength,
     Unsupported,
     Illegal,
@@ -179,20 +180,6 @@ export class TransactionError extends RevertError {
     }
 }
 
-export class TransactionSignatureError extends RevertError {
-    constructor(transactionHash?: string, signer?: string, signature?: string) {
-        super(
-            'TransactionSignatureError',
-            'TransactionSignatureError(bytes32 transactionHash, address signer, bytes signature)',
-            {
-                transactionHash,
-                signer,
-                signature,
-            },
-        );
-    }
-}
-
 export class TransactionExecutionError extends RevertError {
     constructor(transactionHash?: string, errorData?: string) {
         super('TransactionExecutionError', 'TransactionExecutionError(bytes32 transactionHash, bytes errorData)', {
@@ -292,7 +279,6 @@ const types = [
     TransactionExecutionError,
     TransactionGasPriceError,
     TransactionInvalidContextError,
-    TransactionSignatureError,
 ];
 
 // Register the types we've defined.


### PR DESCRIPTION
## Description

- `batchMatchOrders` makes many `getOrderInfo` calls when all we really want is the `orderTakerAssetFilledAmount`. By creating a `_getOrderHashAndFilledAmount` function, we drastically reduce the amount of sloads used (-2 per `getOrderInfo`, plus we remove many useless checks). This change adds about 30 gas to a `fillOrder` call, but saves ~3500 gas for a `batchMatchOrders` call with 1x `leftOrder` and 2x `rightOrder`. The savings will go up by a lot post Istanbul.
- This PR also clears most compiler warnings throughout the packages.
- The `TransactionSignatureError` is consolidated with the regular `SignatureError` using a new error code.

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
