### PR TITLE
Maintain global stake

### DIFF
--- a/contracts/staking/contracts/src/immutable/MixinStorage.sol
+++ b/contracts/staking/contracts/src/immutable/MixinStorage.sol
@@ -47,6 +47,10 @@ contract MixinStorage is
     // address for read-only proxy to call
     address public readOnlyProxyCallee;
 
+    // mapping from StakeStatus to the total amount of stake in that status for the entire
+    // staking system.
+    mapping (uint8 => IStructs.StoredBalance) public globalStakeByStatus;
+
     // mapping from Owner to Amount of Active Stake
     // (access using _loadAndSyncBalance or _loadUnsyncedBalance)
     mapping (address => IStructs.StoredBalance) internal _activeStakeByOwner;

--- a/contracts/staking/contracts/src/stake/MixinStake.sol
+++ b/contracts/staking/contracts/src/stake/MixinStake.sol
@@ -49,6 +49,9 @@ contract MixinStake is
         // mint stake
         _incrementCurrentAndNextBalance(_activeStakeByOwner[owner], amount);
 
+        // update global total of active stake
+        _incrementCurrentAndNextBalance(globalStakeByStatus[uint8(IStructs.StakeStatus.ACTIVE)], amount);
+
         // notify
         emit Stake(
             owner,
@@ -77,6 +80,9 @@ contract MixinStake is
 
         // burn inactive stake
         _decrementCurrentAndNextBalance(_inactiveStakeByOwner[owner], amount);
+
+        // update global total of inactive stake
+        _decrementCurrentAndNextBalance(globalStakeByStatus[uint8(IStructs.StakeStatus.INACTIVE)], amount);
 
         // update withdrawable field
         _withdrawableStakeByOwner[owner] = currentWithdrawableStake.safeSub(amount);
@@ -139,6 +145,13 @@ contract MixinStake is
         IStructs.StoredBalance storage fromPtr = _getBalancePtrFromStatus(owner, from.status);
         IStructs.StoredBalance storage toPtr = _getBalancePtrFromStatus(owner, to.status);
         _moveStake(fromPtr, toPtr, amount);
+
+        // update global total of stake in the statuses being moved between
+        _moveStake(
+            globalStakeByStatus[uint8(from.status)],
+            globalStakeByStatus[uint8(to.status)],
+            amount
+        );
 
         // update withdrawable field, if necessary
         if (from.status == IStructs.StakeStatus.INACTIVE) {

--- a/contracts/staking/contracts/src/stake/MixinStakeBalances.sol
+++ b/contracts/staking/contracts/src/stake/MixinStakeBalances.sol
@@ -31,6 +31,54 @@ contract MixinStakeBalances is
 {
     using LibSafeMath for uint256;
 
+    /// @dev Returns the total active stake across the entire staking system.
+    /// @return Global active stake.
+    function getGlobalActiveStake()
+        external
+        view
+        returns (IStructs.StakeBalance memory balance)
+    {
+        IStructs.StoredBalance memory storedBalance = _loadAndSyncBalance(
+            globalStakeByStatus[uint8(IStructs.StakeStatus.ACTIVE)]
+        );
+        return IStructs.StakeBalance({
+            currentEpochBalance: storedBalance.currentEpochBalance,
+            nextEpochBalance: storedBalance.nextEpochBalance
+        });
+    }
+
+    /// @dev Returns the total inactive stake across the entire staking system.
+    /// @return Global inactive stake.
+    function getGlobalInactiveStake()
+        external
+        view
+        returns (IStructs.StakeBalance memory balance)
+    {
+        IStructs.StoredBalance memory storedBalance = _loadAndSyncBalance(
+            globalStakeByStatus[uint8(IStructs.StakeStatus.INACTIVE)]
+        );
+        return IStructs.StakeBalance({
+            currentEpochBalance: storedBalance.currentEpochBalance,
+            nextEpochBalance: storedBalance.nextEpochBalance
+        });
+    }
+
+    /// @dev Returns the total stake delegated across the entire staking system.
+    /// @return Global delegated stake.
+    function getGlobalDelegatedStake()
+        external
+        view
+        returns (IStructs.StakeBalance memory balance)
+    {
+        IStructs.StoredBalance memory storedBalance = _loadAndSyncBalance(
+            globalStakeByStatus[uint8(IStructs.StakeStatus.DELEGATED)]
+        );
+        return IStructs.StakeBalance({
+            currentEpochBalance: storedBalance.currentEpochBalance,
+            nextEpochBalance: storedBalance.nextEpochBalance
+        });
+    }
+
     /// @dev Returns the total stake for a given owner.
     /// @param owner of stake.
     /// @return Total active stake for owner.

--- a/contracts/staking/test/utils/types.ts
+++ b/contracts/staking/test/utils/types.ts
@@ -86,6 +86,9 @@ export interface StakeBalances {
     activeStakeBalance: StakeBalance;
     inactiveStakeBalance: StakeBalance;
     delegatedStakeBalance: StakeBalance;
+    globalActiveStakeBalance: StakeBalance;
+    globalInactiveStakeBalance: StakeBalance;
+    globalDelegatedStakeBalance: StakeBalance;
     delegatedStakeByPool: StakeBalanceByPool;
     totalDelegatedStakeByPool: StakeBalanceByPool;
 }


### PR DESCRIPTION
## Description
Adds a state variable to keep track of total stake in the system (by status), which gets updated every time `stake`, `unstake`, or `moveStake` is called. Intended for use in future features. 
Also makes some functions in `staker_actor` private
## Testing instructions
Updated `staker_actor.ts` to check global stake

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature (non-breaking change which adds functionality)

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
