### PR TITLE
Ensure pool exists before (un)delegating

### DIFF
--- a/contracts/staking/contracts/src/interfaces/IStakingPoolRewardVault.sol
+++ b/contracts/staking/contracts/src/interfaces/IStakingPoolRewardVault.sol
@@ -28,12 +28,10 @@ pragma solidity ^0.5.9;
 interface IStakingPoolRewardVault {
 
     /// @dev Holds the balances and other data for a staking pool.
-    /// @param initialzed True iff the balance struct is initialized.
     /// @param operatorShare Fraction of the total balance owned by the operator, in ppm.
     /// @param operatorBalance Balance in ETH of the operator.
     /// @param membersBalance Balance in ETH co-owned by the pool members.
     struct Pool {
-        bool initialized;
         uint32 operatorShare;
         uint96 operatorBalance;
         uint96 membersBalance;

--- a/contracts/staking/contracts/src/libs/LibStakingRichErrors.sol
+++ b/contracts/staking/contracts/src/libs/LibStakingRichErrors.sol
@@ -117,9 +117,9 @@ library LibStakingRichErrors {
     bytes4 internal constant OPERATOR_SHARE_ERROR_SELECTOR =
         0x22df9597;
 
-    // bytes4(keccak256("PoolAlreadyExistsError(bytes32)"))
-    bytes4 internal constant POOL_ALREADY_EXISTS_ERROR_SELECTOR =
-        0x2a5e4dcf;
+    // bytes4(keccak256("PoolExistenceError(bytes32,bool)"))
+    bytes4 internal constant POOL_EXISTENCE_ERROR_SELECTOR =
+        0x9ae94f01;
 
     // bytes4(keccak256("EthVaultNotSetError()"))
     bytes4 internal constant ETH_VAULT_NOT_SET_ERROR_SELECTOR =
@@ -367,16 +367,18 @@ library LibStakingRichErrors {
         );
     }
 
-    function PoolAlreadyExistsError(
-        bytes32 poolId
+    function PoolExistenceError(
+        bytes32 poolId,
+        bool alreadyExists
     )
         internal
         pure
         returns (bytes memory)
     {
         return abi.encodeWithSelector(
-            POOL_ALREADY_EXISTS_ERROR_SELECTOR,
-            poolId
+            POOL_EXISTENCE_ERROR_SELECTOR,
+            poolId,
+            alreadyExists
         );
     }
 

--- a/contracts/staking/contracts/src/stake/MixinStake.sol
+++ b/contracts/staking/contracts/src/stake/MixinStake.sol
@@ -181,6 +181,16 @@ contract MixinStake is
     )
         private
     {
+        // revert if pool with given poolId doesn't exist
+        if (rewardVault.operatorOf(poolId) == NIL_ADDRESS) {
+            LibRichErrors.rrevert(
+                LibStakingRichErrors.PoolExistenceError(
+                    poolId,
+                    false
+                )
+            );
+        }
+
         // cache amount delegated to pool by owner
         IStructs.StoredBalance memory initDelegatedStakeToPoolByOwner = _loadUnsyncedBalance(delegatedStakeToPoolByOwner[owner][poolId]);
 
@@ -196,7 +206,7 @@ contract MixinStake is
     }
 
     /// @dev Un-Delegates a owners stake from a staking pool.
-    /// @param poolId Id of pool to un-delegate to.
+    /// @param poolId Id of pool to un-delegate from.
     /// @param owner who wants to un-delegate.
     /// @param amount of stake to un-delegate.
     function _undelegateStake(
@@ -206,6 +216,16 @@ contract MixinStake is
     )
         private
     {
+        // revert if pool with given poolId doesn't exist
+        if (rewardVault.operatorOf(poolId) == NIL_ADDRESS) {
+            LibRichErrors.rrevert(
+                LibStakingRichErrors.PoolExistenceError(
+                    poolId,
+                    false
+                )
+            );
+        }
+
         // cache amount delegated to pool by owner
         IStructs.StoredBalance memory initDelegatedStakeToPoolByOwner = _loadUnsyncedBalance(delegatedStakeToPoolByOwner[owner][poolId]);
 

--- a/contracts/staking/contracts/src/vaults/StakingPoolRewardVault.sol
+++ b/contracts/staking/contracts/src/vaults/StakingPoolRewardVault.sol
@@ -193,16 +193,16 @@ contract StakingPoolRewardVault is
             ));
         }
 
-        // pool must not exist
+        // pool must not already exist
         Pool storage pool = poolById[poolId];
-        if (pool.initialized) {
-            LibRichErrors.rrevert(LibStakingRichErrors.PoolAlreadyExistsError(
-                poolId
+        if (pool.operatorAddress != NIL_ADDRESS) {
+            LibRichErrors.rrevert(LibStakingRichErrors.PoolExistenceError(
+                poolId,
+                true
             ));
         }
 
         // initialize pool
-        pool.initialized = true;
         pool.operatorAddress = operatorAddress;
         pool.operatorShare = operatorShare;
 

--- a/contracts/staking/test/vaults_test.ts
+++ b/contracts/staking/test/vaults_test.ts
@@ -34,7 +34,7 @@ blockchainTests('Staking Vaults', env => {
             const poolId = await stakingApiWrapper.utils.createStakingPoolAsync(poolOperator, operatorShare, true);
             const notStakingContractAddress = poolOperator;
             // should fail to create pool if it already exists
-            let revertError = new StakingRevertErrors.PoolAlreadyExistsError(poolId);
+            let revertError = new StakingRevertErrors.PoolExistenceError(poolId, true);
             let tx = stakingApiWrapper.rewardVaultContract.registerStakingPool.awaitTransactionSuccessAsync(
                 poolId,
                 poolOperator,

--- a/packages/order-utils/src/staking_revert_errors.ts
+++ b/packages/order-utils/src/staking_revert_errors.ts
@@ -173,9 +173,12 @@ export class OperatorShareError extends RevertError {
     }
 }
 
-export class PoolAlreadyExistsError extends RevertError {
-    constructor(poolId?: string) {
-        super('PoolAlreadyExistsError', 'PoolAlreadyExistsError(bytes32 poolId)', { poolId });
+export class PoolExistenceError extends RevertError {
+    constructor(poolId?: string, alreadyExists?: boolean) {
+        super('PoolExistenceError', 'PoolExistenceError(bytes32 poolId, bool alreadyExists)', {
+            poolId,
+            alreadyExists,
+        });
     }
 }
 
@@ -266,7 +269,7 @@ const types = [
     OnlyCallableIfInCatastrophicFailureError,
     OnlyCallableIfNotInCatastrophicFailureError,
     OperatorShareError,
-    PoolAlreadyExistsError,
+    PoolExistenceError,
     RewardVaultNotSetError,
     WithdrawAmountExceedsMemberBalanceError,
     ProxyDestinationCannotBeNilError,


### PR DESCRIPTION
## Description
Check whether a pool with the given `poolId` exists at the beginning of `_delegateStake` and `_undelegateStake`, revert if not. Also removes the `bool initialized` field from `struct Pool` because we can just check whether the operator address is nil.

## Testing instructions
Tests added to `stake_test.ts`

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
