### PR TITLE
DevUtils.sol: Upgrade for v3

### DIFF
--- a/contracts/dev-utils/compiler.json
+++ b/contracts/dev-utils/compiler.json
@@ -7,7 +7,7 @@
         "evmVersion": "constantinople",
         "optimizer": {
             "enabled": true,
-            "runs": 1000000,
+            "runs": 10000,
             "details": { "yul": true, "deduplicate": true, "cse": true, "constantOptimizer": true }
         },
         "outputSelection": {

--- a/contracts/dev-utils/package.json
+++ b/contracts/dev-utils/package.json
@@ -12,7 +12,7 @@
     "scripts": {
         "build": "yarn pre_build && tsc -b",
         "build:ci": "yarn build",
-        "pre_build": "run-s compile contracts:gen generate_contract_wrappers",
+        "pre_build": "run-s compile quantify_bytecode contracts:gen generate_contract_wrappers",
         "test": "yarn run_mocha",
         "rebuild_and_test": "run-s build test",
         "test:coverage": "SOLIDITY_COVERAGE=true run-s build run_mocha coverage:report:text coverage:report:lcov",
@@ -32,6 +32,7 @@
         "test:circleci": "yarn test",
         "contracts:gen": "contracts-gen",
         "lint-contracts": "solhint -c ../.solhint.json contracts/**/**/**/**/*.sol",
+        "quantify_bytecode": "echo EVM bytecode object lengths:;for i in ./generated-artifacts/*.json; do node -e \"console.log('$i\t' + (require('$i').compilerOutput.evm.bytecode.object.length - 2) / 2)\"; done",
         "compile:truffle": "truffle compile"
     },
     "config": {

--- a/contracts/dev-utils/test/order_validation_utils.ts
+++ b/contracts/dev-utils/test/order_validation_utils.ts
@@ -551,6 +551,42 @@ describe('OrderValidationUtils/OrderTransferSimulatorUtils', () => {
             );
             expect(orderTransferResults).to.equal(OrderTransferResults.TransfersSuccessful);
         });
+        it('should return TransfersSuccessful for a partial fill when taker has ample assets for the fill but not for the whole order', async () => {
+            await erc20Token2.setBalance.awaitTransactionSuccessAsync(
+                takerAddress,
+                signedOrder.takerAssetAmount.dividedBy(2),
+                {
+                    from: owner,
+                },
+            );
+            await erc20Token2.approve.awaitTransactionSuccessAsync(erc20Proxy.address, signedOrder.takerAssetAmount, {
+                from: takerAddress,
+            });
+            await erc20Token.setBalance.awaitTransactionSuccessAsync(makerAddress, signedOrder.makerAssetAmount, {
+                from: owner,
+            });
+            await erc20Token.approve.awaitTransactionSuccessAsync(erc20Proxy.address, signedOrder.makerAssetAmount, {
+                from: makerAddress,
+            });
+            await feeErc20Token.setBalance.awaitTransactionSuccessAsync(takerAddress, signedOrder.takerFee, {
+                from: owner,
+            });
+            await feeErc20Token.approve.awaitTransactionSuccessAsync(erc20Proxy.address, signedOrder.takerFee, {
+                from: takerAddress,
+            });
+            await feeErc20Token.setBalance.awaitTransactionSuccessAsync(makerAddress, signedOrder.makerFee, {
+                from: owner,
+            });
+            await feeErc20Token.approve.awaitTransactionSuccessAsync(erc20Proxy.address, signedOrder.makerFee, {
+                from: makerAddress,
+            });
+            const orderTransferResults = await devUtils.getSimulatedOrderTransferResults.callAsync(
+                signedOrder,
+                takerAddress,
+                signedOrder.takerAssetAmount.dividedBy(2),
+            );
+            expect(orderTransferResults).to.equal(OrderTransferResults.TransfersSuccessful);
+        });
     });
     describe('getSimulatedOrdersTransferResults', async () => {
         it('should simulate the transfers of each order independently from one another', async () => {

--- a/contracts/exchange/contracts/src/interfaces/IProtocolFees.sol
+++ b/contracts/exchange/contracts/src/interfaces/IProtocolFees.sol
@@ -36,4 +36,16 @@ contract IProtocolFees {
     /// @param updatedProtocolFeeCollector The updated protocolFeeCollector contract address.
     function setProtocolFeeCollectorAddress(address updatedProtocolFeeCollector)
         external;
+
+    /// @dev Returns the protocolFeeMultiplier
+    function protocolFeeMultiplier()
+        external
+        view
+        returns (uint256);
+
+    /// @dev Returns the protocolFeeCollector address
+    function protocolFeeCollector()
+        external
+        view
+        returns (address);
 }

--- a/packages/contract-artifacts/src/copy.ts
+++ b/packages/contract-artifacts/src/copy.ts
@@ -41,7 +41,7 @@ if (allArtifactPaths.length < pkgNames.length) {
     throw new Error(
         `Expected ${pkgNames.length} artifacts, found ${
             allArtifactPaths.length
-        }. Please ensure artifacts are present in ${contractsPath}/**/generated_artifacts`,
+        }. Please ensure artifacts are present in ${contractsPath}/**/generated-artifacts`,
     );
 }
 


### PR DESCRIPTION
## Description

This contract needs to be upgraded to work with v3 and deployed for use by Mesh.

## Testing instructions

Run tests for `0x-monorepo/contracts/dev-utils` (or just watch CI).

## Types of changes

* Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Make DevUtils deployable.  The `DevUtils` contract can’t currently be deployed because the contract size is too large. We can experiment with turning off compiler optimizations, which might lower the codesize. Otherwise we’ll have to break up the deployments into multiple contracts (@abandeali1 thinks the `OrderValidationUtils` and `OrderTransferSimulationUtils` contracts are most important).
-   [x] More tests for `OrderTransferSimulationUtils` (there was previously a fairly large bug that wasn’t caught in tests, which you can see by looking at the diff)
