### PR TITLE
Remove reference counting for cumulative rewards

### DIFF
--- a/contracts/staking/CHANGELOG.json
+++ b/contracts/staking/CHANGELOG.json
@@ -61,6 +61,14 @@
             {
                 "note": "Introduce multi-block finalization.",
                 "pr": 2155
+            },
+            {
+                "note": "Removed reference counting for cumulative rewards.",
+                "pr": 2188
+            },
+            {
+                "note": "Removed explicit dependency on epoch+1 when delegating.",
+                "pr": 2188
             }
         ]
     }

--- a/contracts/staking/contracts/src/Staking.sol
+++ b/contracts/staking/contracts/src/Staking.sol
@@ -262,14 +262,6 @@ contract Staking is
             slot := add(slot, 0x1)
 
             assertSlotAndOffset(
-                _cumulativeRewardsByPoolReferenceCounter_slot,
-                _cumulativeRewardsByPoolReferenceCounter_offset,
-                slot,
-                offset
-            )
-            slot := add(slot, 0x1)
-
-            assertSlotAndOffset(
                 _cumulativeRewardsByPoolLastStored_slot,
                 _cumulativeRewardsByPoolLastStored_offset,
                 slot,

--- a/contracts/staking/contracts/src/immutable/MixinStorage.sol
+++ b/contracts/staking/contracts/src/immutable/MixinStorage.sol
@@ -94,9 +94,6 @@ contract MixinStorage is
     // mapping from Pool Id to Epoch to Reward Ratio
     mapping (bytes32 => mapping (uint256 => IStructs.Fraction)) internal _cumulativeRewardsByPool;
 
-    // mapping from Pool Id to Epoch to Cumulative Rewards Reference Counter
-    mapping (bytes32 => mapping (uint256 => uint256)) internal _cumulativeRewardsByPoolReferenceCounter;
-
     // mapping from Pool Id to Epoch
     mapping (bytes32 => uint256) internal _cumulativeRewardsByPoolLastStored;
 

--- a/contracts/staking/contracts/test/TestCumulativeRewardTracking.sol
+++ b/contracts/staking/contracts/test/TestCumulativeRewardTracking.sol
@@ -30,11 +30,6 @@ contract TestCumulativeRewardTracking is
         uint256 epoch
     );
 
-    event UnsetCumulativeReward(
-        bytes32 poolId,
-        uint256 epoch
-    );
-
     event SetMostRecentCumulativeReward(
         bytes32 poolId,
         uint256 epoch
@@ -57,13 +52,6 @@ contract TestCumulativeRewardTracking is
             epoch,
             value
         );
-    }
-
-    function _forceUnsetCumulativeReward(bytes32 poolId, uint256 epoch)
-        internal
-    {
-        emit UnsetCumulativeReward(poolId, epoch);
-        MixinCumulativeRewards._forceUnsetCumulativeReward(poolId, epoch);
     }
 
     function _forceSetMostRecentCumulativeRewardEpoch(

--- a/contracts/staking/test/cumulative_reward_tracking_test.ts
+++ b/contracts/staking/test/cumulative_reward_tracking_test.ts
@@ -53,7 +53,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Creates CR for epoch 1
                     TestAction.Delegate,
                 ],
-                [{ event: 'SetCumulativeReward', epoch: 0 }, { event: 'SetCumulativeReward', epoch: 1 }],
+                [{ event: 'SetCumulativeReward', epoch: 0 }],
             );
         });
         it('re-delegating in the same epoch', async () => {
@@ -64,17 +64,13 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                 ],
                 [
                     // Updates CR for epoch 0
-                    // Creates CR for epoch 1
                     TestAction.Delegate,
                     // Updates CR for epoch 0
-                    // Updates CR for epoch 1
                     TestAction.Delegate,
                 ],
                 [
                     { event: 'SetCumulativeReward', epoch: 0 },
-                    { event: 'SetCumulativeReward', epoch: 1 },
                     { event: 'SetCumulativeReward', epoch: 0 },
-                    { event: 'SetCumulativeReward', epoch: 1 },
                 ],
             );
         });
@@ -91,13 +87,11 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Creates a CR for epoch 1
                     // Sets MRCR to epoch 1
                     // Unsets the CR for epoch 0
-                    // Creates a CR for epoch 2
                     TestAction.Delegate,
                 ],
                 [
                     { event: 'SetCumulativeReward', epoch: 1 },
                     { event: 'SetMostRecentCumulativeReward', epoch: 1 },
-                    { event: 'SetCumulativeReward', epoch: 2 },
                 ],
             );
         });
@@ -115,14 +109,11 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                 [
                     // Updates CR for epoch 1
                     // Sets MRCR to epoch 1
-                    // Creates CR for epoch 2
-                    // Clears CR for epoch 0
                     TestAction.Delegate,
                 ],
                 [
                     { event: 'SetCumulativeReward', epoch: 1 },
                     { event: 'SetMostRecentCumulativeReward', epoch: 1 },
-                    { event: 'SetCumulativeReward', epoch: 2 },
                 ],
             );
         });
@@ -135,8 +126,6 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     TestAction.Finalize,
                     // Creates CR for epoch 1
                     // Sets MRCR to epoch 1
-                    // Clears CR for epoch 0
-                    // Creates CR for epoch 2
                     TestAction.Delegate,
                     // Move to epoch 2
                     TestAction.Finalize,
@@ -151,7 +140,6 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                 [
                     { event: 'SetCumulativeReward', epoch: 2 },
                     { event: 'SetMostRecentCumulativeReward', epoch: 2 },
-                    { event: 'SetCumulativeReward', epoch: 3 },
                 ],
             );
         });
@@ -208,7 +196,6 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                 [
                     { event: 'SetCumulativeReward', epoch: 2 },
                     { event: 'SetMostRecentCumulativeReward', epoch: 2 },
-                    { event: 'SetCumulativeReward', epoch: 3 },
                 ],
             );
         });
@@ -241,7 +228,6 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                 [
                     { event: 'SetCumulativeReward', epoch: 2 },
                     { event: 'SetMostRecentCumulativeReward', epoch: 2 },
-                    { event: 'SetCumulativeReward', epoch: 3 },
                 ],
             );
         });
@@ -300,7 +286,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Clears CR for epoch 2
                     TestAction.Delegate,
                 ],
-                [{ event: 'SetCumulativeReward', epoch: 3 }, { event: 'SetCumulativeReward', epoch: 4 }],
+                [{ event: 'SetCumulativeReward', epoch: 3 }],
             );
         });
         it('delegate in epoch 0 and 1, earn reward in epoch 3, then undelegate half', async () => {
@@ -335,7 +321,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Clears CR for epoch 2
                     TestAction.Undelegate,
                 ],
-                [{ event: 'SetCumulativeReward', epoch: 3 }, { event: 'SetCumulativeReward', epoch: 4 }],
+                [{ event: 'SetCumulativeReward', epoch: 3 }],
             );
         });
         it('delegate in epoch 1, 2, earn rewards in epoch 3, skip to epoch 4, then delegate', async () => {
@@ -376,7 +362,6 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                 [
                     { event: 'SetCumulativeReward', epoch: 4 },
                     { event: 'SetMostRecentCumulativeReward', epoch: 4 },
-                    { event: 'SetCumulativeReward', epoch: 5 },
                 ],
             );
         });
@@ -401,7 +386,6 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                 [
                     { event: 'SetCumulativeReward', epoch: 1 },
                     { event: 'SetMostRecentCumulativeReward', epoch: 1 },
-                    { event: 'SetCumulativeReward', epoch: 2 },
                 ],
             );
         });
@@ -440,7 +424,6 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                 [
                     { event: 'SetCumulativeReward', epoch: 4 },
                     { event: 'SetMostRecentCumulativeReward', epoch: 4 },
-                    { event: 'SetCumulativeReward', epoch: 5 },
                 ],
             );
         });
@@ -472,7 +455,6 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                 [
                     { event: 'SetCumulativeReward', epoch: 3 },
                     { event: 'SetMostRecentCumulativeReward', epoch: 3 },
-                    { event: 'SetCumulativeReward', epoch: 4 },
                 ],
             );
         });

--- a/contracts/staking/test/cumulative_reward_tracking_test.ts
+++ b/contracts/staking/test/cumulative_reward_tracking_test.ts
@@ -78,22 +78,6 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                 ],
             );
         });
-        it('delegating then undelegating in the same epoch', async () => {
-            await simulation.runTestAsync(
-                [
-                    // Creates CR for epoch 0
-                    TestAction.CreatePool,
-                    // Updates CR for epoch 0
-                    // Creates CR for epoch 1
-                    TestAction.Delegate,
-                ],
-                [
-                    // Unsets the CR for epoch 1
-                    TestAction.Undelegate,
-                ],
-                [{ event: 'UnsetCumulativeReward', epoch: 1 }],
-            );
-        });
         it('delegating in new epoch', async () => {
             // since there was no delegation in epoch 0 there is no longer a dependency on the CR for epoch 0
             await simulation.runTestAsync(
@@ -113,7 +97,6 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                 [
                     { event: 'SetCumulativeReward', epoch: 1 },
                     { event: 'SetMostRecentCumulativeReward', epoch: 1 },
-                    { event: 'UnsetCumulativeReward', epoch: 0 },
                     { event: 'SetCumulativeReward', epoch: 2 },
                 ],
             );
@@ -140,30 +123,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     { event: 'SetCumulativeReward', epoch: 1 },
                     { event: 'SetMostRecentCumulativeReward', epoch: 1 },
                     { event: 'SetCumulativeReward', epoch: 2 },
-                    { event: 'UnsetCumulativeReward', epoch: 0 },
                 ],
-            );
-        });
-        it('delegate then undelegate to remove all dependencies', async () => {
-            await simulation.runTestAsync(
-                [
-                    // Creates CR for epoch 0
-                    TestAction.CreatePool,
-                    // Moves to epoch 1
-                    TestAction.Finalize,
-                    // Creates CR for epoch 1
-                    // Sets MRCR to epoch 1
-                    // Clears CR for epoch 0
-                    // Creates CR for epoch 2
-                    TestAction.Delegate,
-                ],
-                [
-                    // Clears CR from epoch 2
-                    // Does NOT clear CR from epoch 1 because it is the current
-                    // epoch.
-                    TestAction.Undelegate,
-                ],
-                [{ event: 'UnsetCumulativeReward', epoch: 2 }],
             );
         });
         it('delegating in epoch 1 then again in epoch 2', async () => {
@@ -192,7 +152,6 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     { event: 'SetCumulativeReward', epoch: 2 },
                     { event: 'SetMostRecentCumulativeReward', epoch: 2 },
                     { event: 'SetCumulativeReward', epoch: 3 },
-                    { event: 'UnsetCumulativeReward', epoch: 1 },
                 ],
             );
         });
@@ -217,11 +176,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Clear CR for epoch 1
                     TestAction.Undelegate,
                 ],
-                [
-                    { event: 'SetCumulativeReward', epoch: 2 },
-                    { event: 'SetMostRecentCumulativeReward', epoch: 2 },
-                    { event: 'UnsetCumulativeReward', epoch: 1 },
-                ],
+                [{ event: 'SetCumulativeReward', epoch: 2 }, { event: 'SetMostRecentCumulativeReward', epoch: 2 }],
             );
         });
         it('delegate in epoch 0 and epoch 1, then undelegate half in epoch 2', async () => {
@@ -254,7 +209,6 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     { event: 'SetCumulativeReward', epoch: 2 },
                     { event: 'SetMostRecentCumulativeReward', epoch: 2 },
                     { event: 'SetCumulativeReward', epoch: 3 },
-                    { event: 'UnsetCumulativeReward', epoch: 1 },
                 ],
             );
         });
@@ -288,7 +242,6 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     { event: 'SetCumulativeReward', epoch: 2 },
                     { event: 'SetMostRecentCumulativeReward', epoch: 2 },
                     { event: 'SetCumulativeReward', epoch: 3 },
-                    { event: 'UnsetCumulativeReward', epoch: 1 },
                 ],
             );
         });
@@ -347,12 +300,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Clears CR for epoch 2
                     TestAction.Delegate,
                 ],
-                [
-                    { event: 'SetCumulativeReward', epoch: 3 },
-                    { event: 'SetCumulativeReward', epoch: 4 },
-                    { event: 'UnsetCumulativeReward', epoch: 1 },
-                    { event: 'UnsetCumulativeReward', epoch: 2 },
-                ],
+                [{ event: 'SetCumulativeReward', epoch: 3 }, { event: 'SetCumulativeReward', epoch: 4 }],
             );
         });
         it('delegate in epoch 0 and 1, earn reward in epoch 3, then undelegate half', async () => {
@@ -387,12 +335,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Clears CR for epoch 2
                     TestAction.Undelegate,
                 ],
-                [
-                    { event: 'SetCumulativeReward', epoch: 3 },
-                    { event: 'SetCumulativeReward', epoch: 4 },
-                    { event: 'UnsetCumulativeReward', epoch: 1 },
-                    { event: 'UnsetCumulativeReward', epoch: 2 },
-                ],
+                [{ event: 'SetCumulativeReward', epoch: 3 }, { event: 'SetCumulativeReward', epoch: 4 }],
             );
         });
         it('delegate in epoch 1, 2, earn rewards in epoch 3, skip to epoch 4, then delegate', async () => {
@@ -433,10 +376,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                 [
                     { event: 'SetCumulativeReward', epoch: 4 },
                     { event: 'SetMostRecentCumulativeReward', epoch: 4 },
-                    { event: 'UnsetCumulativeReward', epoch: 3 },
                     { event: 'SetCumulativeReward', epoch: 5 },
-                    { event: 'UnsetCumulativeReward', epoch: 1 },
-                    { event: 'UnsetCumulativeReward', epoch: 2 },
                 ],
             );
         });
@@ -461,7 +401,6 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                 [
                     { event: 'SetCumulativeReward', epoch: 1 },
                     { event: 'SetMostRecentCumulativeReward', epoch: 1 },
-                    { event: 'UnsetCumulativeReward', epoch: 0 },
                     { event: 'SetCumulativeReward', epoch: 2 },
                 ],
             );
@@ -502,7 +441,6 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     { event: 'SetCumulativeReward', epoch: 4 },
                     { event: 'SetMostRecentCumulativeReward', epoch: 4 },
                     { event: 'SetCumulativeReward', epoch: 5 },
-                    { event: 'UnsetCumulativeReward', epoch: 3 },
                 ],
             );
         });
@@ -535,8 +473,6 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     { event: 'SetCumulativeReward', epoch: 3 },
                     { event: 'SetMostRecentCumulativeReward', epoch: 3 },
                     { event: 'SetCumulativeReward', epoch: 4 },
-                    { event: 'UnsetCumulativeReward', epoch: 1 },
-                    { event: 'UnsetCumulativeReward', epoch: 2 },
                 ],
             );
         });

--- a/contracts/staking/test/cumulative_reward_tracking_test.ts
+++ b/contracts/staking/test/cumulative_reward_tracking_test.ts
@@ -68,10 +68,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Updates CR for epoch 0
                     TestAction.Delegate,
                 ],
-                [
-                    { event: 'SetCumulativeReward', epoch: 0 },
-                    { event: 'SetCumulativeReward', epoch: 0 },
-                ],
+                [{ event: 'SetCumulativeReward', epoch: 0 }, { event: 'SetCumulativeReward', epoch: 0 }],
             );
         });
         it('delegating in new epoch', async () => {
@@ -89,10 +86,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Unsets the CR for epoch 0
                     TestAction.Delegate,
                 ],
-                [
-                    { event: 'SetCumulativeReward', epoch: 1 },
-                    { event: 'SetMostRecentCumulativeReward', epoch: 1 },
-                ],
+                [{ event: 'SetCumulativeReward', epoch: 1 }, { event: 'SetMostRecentCumulativeReward', epoch: 1 }],
             );
         });
         it('re-delegating in a new epoch', async () => {
@@ -111,10 +105,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Sets MRCR to epoch 1
                     TestAction.Delegate,
                 ],
-                [
-                    { event: 'SetCumulativeReward', epoch: 1 },
-                    { event: 'SetMostRecentCumulativeReward', epoch: 1 },
-                ],
+                [{ event: 'SetCumulativeReward', epoch: 1 }, { event: 'SetMostRecentCumulativeReward', epoch: 1 }],
             );
         });
         it('delegating in epoch 1 then again in epoch 2', async () => {
@@ -137,10 +128,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Clears CR for epoch 1
                     TestAction.Delegate,
                 ],
-                [
-                    { event: 'SetCumulativeReward', epoch: 2 },
-                    { event: 'SetMostRecentCumulativeReward', epoch: 2 },
-                ],
+                [{ event: 'SetCumulativeReward', epoch: 2 }, { event: 'SetMostRecentCumulativeReward', epoch: 2 }],
             );
         });
         it('delegate in epoch 1 then undelegate in epoch 2', async () => {
@@ -193,10 +181,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Clears CR for epoch 1
                     TestAction.Undelegate,
                 ],
-                [
-                    { event: 'SetCumulativeReward', epoch: 2 },
-                    { event: 'SetMostRecentCumulativeReward', epoch: 2 },
-                ],
+                [{ event: 'SetCumulativeReward', epoch: 2 }, { event: 'SetMostRecentCumulativeReward', epoch: 2 }],
             );
         });
         it('delegate in epoch 1 and 2 then again in 3', async () => {
@@ -225,10 +210,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Clears CR for epoch 1
                     TestAction.Delegate,
                 ],
-                [
-                    { event: 'SetCumulativeReward', epoch: 2 },
-                    { event: 'SetMostRecentCumulativeReward', epoch: 2 },
-                ],
+                [{ event: 'SetCumulativeReward', epoch: 2 }, { event: 'SetMostRecentCumulativeReward', epoch: 2 }],
             );
         });
         it('delegate in epoch 0, earn reward in epoch 1', async () => {
@@ -359,10 +341,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Clears CR for epoch 1
                     TestAction.Delegate,
                 ],
-                [
-                    { event: 'SetCumulativeReward', epoch: 4 },
-                    { event: 'SetMostRecentCumulativeReward', epoch: 4 },
-                ],
+                [{ event: 'SetCumulativeReward', epoch: 4 }, { event: 'SetMostRecentCumulativeReward', epoch: 4 }],
             );
         });
         it('earn reward in epoch 1 with no stake, then delegate', async () => {
@@ -383,10 +362,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Creates CR for epoch 2
                     TestAction.Delegate,
                 ],
-                [
-                    { event: 'SetCumulativeReward', epoch: 1 },
-                    { event: 'SetMostRecentCumulativeReward', epoch: 1 },
-                ],
+                [{ event: 'SetCumulativeReward', epoch: 1 }, { event: 'SetMostRecentCumulativeReward', epoch: 1 }],
             );
         });
         it('delegate in epoch 1, 3, then delegate in epoch 4', async () => {
@@ -421,10 +397,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Creates CR for epoch 5
                     TestAction.Delegate,
                 ],
-                [
-                    { event: 'SetCumulativeReward', epoch: 4 },
-                    { event: 'SetMostRecentCumulativeReward', epoch: 4 },
-                ],
+                [{ event: 'SetCumulativeReward', epoch: 4 }, { event: 'SetMostRecentCumulativeReward', epoch: 4 }],
             );
         });
         it('delegate in epoch 1, then epoch 3', async () => {
@@ -452,10 +425,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Clears CR for epoch 2
                     TestAction.Delegate,
                 ],
-                [
-                    { event: 'SetCumulativeReward', epoch: 3 },
-                    { event: 'SetMostRecentCumulativeReward', epoch: 3 },
-                ],
+                [{ event: 'SetCumulativeReward', epoch: 3 }, { event: 'SetMostRecentCumulativeReward', epoch: 3 }],
             );
         });
     });

--- a/contracts/staking/test/utils/cumulative_reward_tracking_simulation.ts
+++ b/contracts/staking/test/utils/cumulative_reward_tracking_simulation.ts
@@ -46,11 +46,6 @@ export class CumulativeRewardTrackingSimulation {
                     event: log.event,
                     epoch: log.args.epoch.toNumber(),
                 });
-            } else if (log.event === TestCumulativeRewardTrackingEvents.UnsetCumulativeReward) {
-                logs.push({
-                    event: log.event,
-                    epoch: log.args.epoch.toNumber(),
-                });
             }
         }
         return logs;


### PR DESCRIPTION
## Description

This removes reference counting for cumulative rewards.

Reference counting allowed us to clear old state that was no longer needed by the staking contract. After reviewing the tradeoffs with the protocologists, it was decided that we would remove this feature in favor of simplicity.

See #2154 for full context.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
