### PR TITLE
Make wethAssetProxy and zrxVault deployment constants

### DIFF
--- a/contracts/staking/contracts/src/Staking.sol
+++ b/contracts/staking/contracts/src/Staking.sol
@@ -108,14 +108,6 @@ contract Staking is
             /// MixinStorage
 
             assertSlotAndOffset(
-                wethAssetProxy_slot,
-                wethAssetProxy_offset,
-                slot,
-                offset
-            )
-            slot := add(slot, 0x1)
-
-            assertSlotAndOffset(
                 stakingContract_slot,
                 stakingContract_offset,
                 slot,
@@ -262,14 +254,6 @@ contract Staking is
             assertSlotAndOffset(
                 validExchanges_slot,
                 validExchanges_offset,
-                slot,
-                offset
-            )
-            slot := add(slot, 0x1)
-
-            assertSlotAndOffset(
-                zrxVault_slot,
-                zrxVault_offset,
                 slot,
                 offset
             )

--- a/contracts/staking/contracts/src/Staking.sol
+++ b/contracts/staking/contracts/src/Staking.sol
@@ -56,22 +56,14 @@ contract Staking is
     /// @dev Initialize storage owned by this contract.
     ///      This function should not be called directly.
     ///      The StakingProxy contract will call it in `attachStakingContract()`.
-    /// @param _wethProxyAddress The address that can transfer WETH for fees.
-    /// @param _zrxVaultAddress Address of the ZrxVault contract.
-    function init(
-        address _wethProxyAddress,
-        address _zrxVaultAddress
-    )
+    function init()
         public
         onlyAuthorized
     {
         // DANGER! When performing upgrades, take care to modify this logic
         // to prevent accidentally clearing prior state.
         _initMixinScheduler();
-        _initMixinParams(
-            _wethProxyAddress,
-            _zrxVaultAddress
-        );
+        _initMixinParams();
     }
 
     /// @dev This function will fail if the storage layout of this contract deviates from

--- a/contracts/staking/contracts/src/fees/MixinExchangeFees.sol
+++ b/contracts/staking/contracts/src/fees/MixinExchangeFees.sol
@@ -69,7 +69,7 @@ contract MixinExchangeFees is
         // Transfer the protocol fee to this address if it should be paid in
         // WETH.
         if (msg.value == 0) {
-            wethAssetProxy.transferFrom(
+            _getWethAssetProxy().transferFrom(
                 _getWethAssetData(),
                 payerAddress,
                 address(this),

--- a/contracts/staking/contracts/src/fees/MixinExchangeFees.sol
+++ b/contracts/staking/contracts/src/fees/MixinExchangeFees.sol
@@ -69,8 +69,8 @@ contract MixinExchangeFees is
         // Transfer the protocol fee to this address if it should be paid in
         // WETH.
         if (msg.value == 0) {
-            _getWethAssetProxy().transferFrom(
-                _getWethAssetData(),
+            getWethAssetProxy().transferFrom(
+                getWethAssetData(),
                 payerAddress,
                 address(this),
                 protocolFeePaid

--- a/contracts/staking/contracts/src/immutable/MixinDeploymentConstants.sol
+++ b/contracts/staking/contracts/src/immutable/MixinDeploymentConstants.sol
@@ -82,8 +82,8 @@ contract MixinDeploymentConstants {
     /// @dev An overridable way to access the deployed WETH contract.
     ///      Must be view to allow overrides to access state.
     /// @return wethContract The WETH contract instance.
-    function _getWethContract()
-        internal
+    function getWethContract()
+        public
         view
         returns (IEtherToken wethContract)
     {
@@ -94,8 +94,8 @@ contract MixinDeploymentConstants {
     /// @dev An overridable way to access the deployed WETH assetData.
     ///      Must be view to allow overrides to access state.
     /// @return wethAssetData The assetData of the configured WETH contract.
-    function _getWethAssetData()
-        internal
+    function getWethAssetData()
+        public
         view
         returns (bytes memory wethAssetData)
     {
@@ -106,8 +106,8 @@ contract MixinDeploymentConstants {
     /// @dev An overridable way to access the deployed WETH assetProxy.
     ///      Must be view to allow overrides to access state.
     /// @return wethAssetProxy The assetProxy used to transfer WETH.
-    function _getWethAssetProxy()
-        internal
+    function getWethAssetProxy()
+        public
         view
         returns (IAssetProxy wethAssetProxy)
     {
@@ -118,8 +118,8 @@ contract MixinDeploymentConstants {
     /// @dev An overridable way to access the deployed zrxVault.
     ///      Must be view to allow overrides to access state.
     /// @return zrxVault The zrxVault contract.
-    function _getZrxVault()
-        internal
+    function getZrxVault()
+        public
         view
         returns (IZrxVault zrxVault)
     {

--- a/contracts/staking/contracts/src/immutable/MixinDeploymentConstants.sol
+++ b/contracts/staking/contracts/src/immutable/MixinDeploymentConstants.sol
@@ -18,11 +18,13 @@
 
 pragma solidity ^0.5.9;
 
+import "@0x/contracts-asset-proxy/contracts/src/interfaces/IAssetProxy.sol";
 import "@0x/contracts-erc20/contracts/src/interfaces/IEtherToken.sol";
 import "@0x/contracts-asset-proxy/contracts/src/interfaces/IAssetData.sol";
 import "@0x/contracts-utils/contracts/src/LibRichErrors.sol";
 import "@0x/contracts-utils/contracts/src/LibBytes.sol";
 import "../libs/LibStakingRichErrors.sol";
+import "../interfaces/IZrxVault.sol";
 
 
 // solhint-disable separate-by-one-line-in-contract
@@ -49,6 +51,10 @@ contract MixinDeploymentConstants {
 
     // Ropsten & Rinkeby Weth Asset Data
     // bytes constant internal WETH_ASSET_DATA = hex"f47261b0000000000000000000000000c778417e063141139fce010982780140aa0cd5ab";
+
+    // @TODO SET THESE VALUES FOR DEPLOYMENT
+    address constant public WETH_ASSET_PROXY_ADDRESS = address(1);
+    address constant public ZRX_VAULT_ADDRESS = address(1);
 
     /// @dev Ensures that the WETH_ASSET_DATA is correct.
     constructor()
@@ -87,5 +93,23 @@ contract MixinDeploymentConstants {
     {
         wethAssetData = WETH_ASSET_DATA;
         return wethAssetData;
+    }
+
+    function _getWethAssetProxy()
+        internal
+        view
+        returns (IAssetProxy wethAssetProxy)
+    {
+        wethAssetProxy = IAssetProxy(WETH_ASSET_PROXY_ADDRESS);
+        return wethAssetProxy;
+    }
+
+    function _getZrxVault()
+        internal
+        view
+        returns (IZrxVault zrxVault)
+    {
+        zrxVault = IZrxVault(ZRX_VAULT_ADDRESS);
+        return zrxVault;
     }
 }

--- a/contracts/staking/contracts/src/immutable/MixinDeploymentConstants.sol
+++ b/contracts/staking/contracts/src/immutable/MixinDeploymentConstants.sol
@@ -35,40 +35,48 @@ contract MixinDeploymentConstants {
     // @TODO SET THESE VALUES FOR DEPLOYMENT
 
     // Mainnet WETH9 Address
-    address constant internal WETH_ADDRESS = address(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+    address constant private WETH_ADDRESS = address(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
 
     // Kovan WETH9 Address
-    // address constant internal WETH_ADDRESS = address(0xd0a1e359811322d97991e03f863a0c30c2cf029c);
+    // address constant private WETH_ADDRESS = address(0xd0a1e359811322d97991e03f863a0c30c2cf029c);
 
     // Ropsten & Rinkeby WETH9 Address
-    // address constant internal WETH_ADDRESS = address(0xc778417e063141139fce010982780140aa0cd5ab);
+    // address constant private WETH_ADDRESS = address(0xc778417e063141139fce010982780140aa0cd5ab);
 
     // Mainnet Weth Asset Data
-    bytes constant internal WETH_ASSET_DATA = hex"f47261b0000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
+    bytes constant private WETH_ASSET_DATA = hex"f47261b0000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
 
     // Kovan Weth Asset Data
-    // bytes constant internal WETH_ASSET_DATA = hex"f47261b0000000000000000000000000d0a1e359811322d97991e03f863a0c30c2cf029c";
+    // bytes constant private WETH_ASSET_DATA = hex"f47261b0000000000000000000000000d0a1e359811322d97991e03f863a0c30c2cf029c";
 
     // Ropsten & Rinkeby Weth Asset Data
-    // bytes constant internal WETH_ASSET_DATA = hex"f47261b0000000000000000000000000c778417e063141139fce010982780140aa0cd5ab";
+    // bytes constant private WETH_ASSET_DATA = hex"f47261b0000000000000000000000000c778417e063141139fce010982780140aa0cd5ab";
 
     // @TODO SET THESE VALUES FOR DEPLOYMENT
-    address constant public WETH_ASSET_PROXY_ADDRESS = address(1);
-    address constant public ZRX_VAULT_ADDRESS = address(1);
+    address constant private WETH_ASSET_PROXY_ADDRESS = address(1);
+    address constant private ZRX_VAULT_ADDRESS = address(1);
 
     /// @dev Ensures that the WETH_ASSET_DATA is correct.
     constructor()
         public
     {
-        // Ensure that the WETH_ASSET_DATA is correct.
-        if (!WETH_ASSET_DATA.equals(
-            abi.encodeWithSelector(
+        require(
+            WETH_ASSET_DATA.equals(abi.encodeWithSelector(
                 IAssetData(address(0)).ERC20Token.selector,
                 WETH_ADDRESS
-            )
-        )) {
-            LibRichErrors.rrevert(LibStakingRichErrors.InvalidWethAssetDataError());
-        }
+            )),
+            "INVALID_WETH_ASSET_DATA"
+        );
+
+        require(
+            WETH_ASSET_PROXY_ADDRESS != address(0),
+            "WETH_ASSET_PROXY_MUST_BE_SET"
+        );
+
+        require(
+            ZRX_VAULT_ADDRESS != address(0),
+            "ZRX_VAULT_MUST_BE_SET"
+        );
     }
 
     /// @dev An overridable way to access the deployed WETH contract.
@@ -95,6 +103,9 @@ contract MixinDeploymentConstants {
         return wethAssetData;
     }
 
+    /// @dev An overridable way to access the deployed WETH assetProxy.
+    ///      Must be view to allow overrides to access state.
+    /// @return wethAssetProxy The assetProxy used to transfer WETH.
     function _getWethAssetProxy()
         internal
         view
@@ -104,6 +115,9 @@ contract MixinDeploymentConstants {
         return wethAssetProxy;
     }
 
+    /// @dev An overridable way to access the deployed zrxVault.
+    ///      Must be view to allow overrides to access state.
+    /// @return zrxVault The zrxVault contract.
     function _getZrxVault()
         internal
         view

--- a/contracts/staking/contracts/src/immutable/MixinStorage.sol
+++ b/contracts/staking/contracts/src/immutable/MixinStorage.sol
@@ -33,9 +33,6 @@ contract MixinStorage is
     MixinConstants,
     Authorizable
 {
-    // WETH Asset Proxy
-    IAssetProxy public wethAssetProxy;
-
     // address of staking contract
     address public stakingContract;
 
@@ -100,9 +97,6 @@ contract MixinStorage is
 
     // registered 0x Exchange contracts
     mapping (address => bool) public validExchanges;
-
-    // ZRX vault (stores staked ZRX)
-    IZrxVault public zrxVault;
 
     /* Tweakable parameters */
 

--- a/contracts/staking/contracts/src/interfaces/IStakingEvents.sol
+++ b/contracts/staking/contracts/src/interfaces/IStakingEvents.sol
@@ -95,17 +95,13 @@ interface IStakingEvents {
     /// @param maximumMakersInPool Maximum number of maker addresses allowed to be registered to a pool.
     /// @param cobbDouglasAlphaNumerator Numerator for cobb douglas alpha factor.
     /// @param cobbDouglasAlphaDenominator Denominator for cobb douglas alpha factor.
-    /// @param wethProxyAddress The address that can transfer WETH for fees.
-    /// @param zrxVaultAddress Address of the ZrxVault contract.
     event ParamsSet(
         uint256 epochDurationInSeconds,
         uint32 rewardDelegatedStakeWeight,
         uint256 minimumPoolStake,
         uint256 maximumMakersInPool,
         uint256 cobbDouglasAlphaNumerator,
-        uint256 cobbDouglasAlphaDenominator,
-        address wethProxyAddress,
-        address zrxVaultAddress
+        uint256 cobbDouglasAlphaDenominator
     );
 
     /// @dev Emitted by MixinStakingPool when a new pool is created.

--- a/contracts/staking/contracts/src/interfaces/IStakingProxy.sol
+++ b/contracts/staking/contracts/src/interfaces/IStakingProxy.sol
@@ -45,15 +45,7 @@ interface IStakingProxy /* is IStaking */
     /// @dev Attach a staking contract; future calls will be delegated to the staking contract.
     /// Note that this is callable only by this contract's owner.
     /// @param _stakingContract Address of staking contract.
-    /// @param _wethProxyAddress The address that can transfer WETH for fees.
-    ///        Use address in storage if NIL_ADDRESS is passed in.
-    /// @param _zrxVaultAddress Address of the ZrxVault contract.
-    ///        Use address in storage if NIL_ADDRESS is passed in.
-    function attachStakingContract(
-        address _stakingContract,
-        address _wethProxyAddress,
-        address _zrxVaultAddress
-    )
+    function attachStakingContract(address _stakingContract)
         external;
 
     /// @dev Detach the current staking contract.

--- a/contracts/staking/contracts/src/interfaces/IStorage.sol
+++ b/contracts/staking/contracts/src/interfaces/IStorage.sol
@@ -26,11 +26,6 @@ import "../interfaces/IStructs.sol";
 
 interface IStorage {
 
-    function wethAssetProxy()
-        external
-        view
-        returns (IAssetProxy);
-
     function stakingContract()
         external
         view
@@ -80,11 +75,6 @@ interface IStorage {
         external
         view
         returns (bool);
-
-    function zrxVault()
-        external
-        view
-        returns (IZrxVault);
 
     function epochDurationInSeconds()
         external

--- a/contracts/staking/contracts/src/interfaces/IStorageInit.sol
+++ b/contracts/staking/contracts/src/interfaces/IStorageInit.sol
@@ -22,11 +22,6 @@ pragma solidity ^0.5.9;
 interface IStorageInit {
 
     /// @dev Initialize storage owned by this contract.
-    /// @param _wethProxyAddress The address that can transfer WETH for fees.
-    /// @param _zrxVaultAddress Address of the ZrxVault contract.
-    function init(
-        address _wethProxyAddress,
-        address _zrxVaultAddress
-    )
+    function init()
         external;
 }

--- a/contracts/staking/contracts/src/libs/LibStakingRichErrors.sol
+++ b/contracts/staking/contracts/src/libs/LibStakingRichErrors.sol
@@ -43,8 +43,6 @@ library LibStakingRichErrors {
         InvalidRewardDelegatedStakeWeight,
         InvalidMaximumMakersInPool,
         InvalidMinimumPoolStake,
-        InvalidWethProxyAddress,
-        InvalidZrxVaultAddress,
         InvalidEpochDuration
     }
 

--- a/contracts/staking/contracts/src/libs/LibStakingRichErrors.sol
+++ b/contracts/staking/contracts/src/libs/LibStakingRichErrors.sol
@@ -133,10 +133,6 @@ library LibStakingRichErrors {
     bytes4 internal constant INVALID_PROTOCOL_FEE_PAYMENT_ERROR_SELECTOR =
         0xefd6cb33;
 
-    // bytes4(keccak256("InvalidWethAssetDataError()"))
-    bytes internal constant INVALID_WETH_ASSET_DATA_ERROR =
-        hex"24bf322c";
-
     // bytes4(keccak256("PreviousEpochNotFinalizedError(uint256,uint256)"))
     bytes4 internal constant PREVIOUS_EPOCH_NOT_FINALIZED_ERROR_SELECTOR =
         0x614b800a;
@@ -405,14 +401,6 @@ library LibStakingRichErrors {
         returns (bytes memory)
     {
         return PROXY_DESTINATION_CANNOT_BE_NIL_ERROR;
-    }
-
-    function InvalidWethAssetDataError()
-        internal
-        pure
-        returns (bytes memory)
-    {
-        return INVALID_WETH_ASSET_DATA_ERROR;
     }
 
     function PreviousEpochNotFinalizedError(

--- a/contracts/staking/contracts/src/stake/MixinStake.sol
+++ b/contracts/staking/contracts/src/stake/MixinStake.sol
@@ -50,7 +50,7 @@ contract MixinStake is
         address payable owner = msg.sender;
 
         // deposit equivalent amount of ZRX into vault
-        zrxVault.depositFrom(owner, amount);
+        _getZrxVault().depositFrom(owner, amount);
 
         // mint stake
         _incrementCurrentAndNextBalance(_activeStakeByOwner[owner], amount);
@@ -96,7 +96,7 @@ contract MixinStake is
             currentWithdrawableStake.safeSub(amount);
 
         // withdraw equivalent amount of ZRX from vault
-        zrxVault.withdrawFrom(owner, amount);
+        _getZrxVault().withdrawFrom(owner, amount);
 
         // emit stake event
         emit Unstake(

--- a/contracts/staking/contracts/src/stake/MixinStake.sol
+++ b/contracts/staking/contracts/src/stake/MixinStake.sol
@@ -50,7 +50,7 @@ contract MixinStake is
         address payable owner = msg.sender;
 
         // deposit equivalent amount of ZRX into vault
-        _getZrxVault().depositFrom(owner, amount);
+        getZrxVault().depositFrom(owner, amount);
 
         // mint stake
         _incrementCurrentAndNextBalance(_activeStakeByOwner[owner], amount);
@@ -96,7 +96,7 @@ contract MixinStake is
             currentWithdrawableStake.safeSub(amount);
 
         // withdraw equivalent amount of ZRX from vault
-        _getZrxVault().withdrawFrom(owner, amount);
+        getZrxVault().withdrawFrom(owner, amount);
 
         // emit stake event
         emit Unstake(
@@ -211,7 +211,7 @@ contract MixinStake is
         // Increment how much stake has been delegated to pool.
         _incrementNextBalance(_delegatedStakeByPoolId[poolId], amount);
 
-        // Synchronizes reward state in the pool that the staker is delegating
+        // Synchronizes reward state in the pool that the owner is delegating
         // to.
         IStructs.StoredBalance memory finalDelegatedStakeToPoolByOwner =
             _loadSyncedBalance(_delegatedStakeToPoolByOwner[owner][poolId]);
@@ -251,7 +251,7 @@ contract MixinStake is
         // decrement how much stake has been delegated to pool
         _decrementNextBalance(_delegatedStakeByPoolId[poolId], amount);
 
-        // synchronizes reward state in the pool that the staker is undelegating
+        // synchronizes reward state in the pool that the owner is undelegating
         // from
         IStructs.StoredBalance memory finalDelegatedStakeToPoolByOwner =
             _loadSyncedBalance(_delegatedStakeToPoolByOwner[owner][poolId]);

--- a/contracts/staking/contracts/src/stake/MixinStakeBalances.sol
+++ b/contracts/staking/contracts/src/stake/MixinStakeBalances.sol
@@ -92,7 +92,7 @@ contract MixinStakeBalances is
         view
         returns (uint256)
     {
-        return zrxVault.balanceOf(owner);
+        return _getZrxVault().balanceOf(owner);
     }
 
     /// @dev Returns the active stake for a given owner.

--- a/contracts/staking/contracts/src/stake/MixinStakeBalances.sol
+++ b/contracts/staking/contracts/src/stake/MixinStakeBalances.sol
@@ -92,7 +92,7 @@ contract MixinStakeBalances is
         view
         returns (uint256)
     {
-        return _getZrxVault().balanceOf(owner);
+        return getZrxVault().balanceOf(owner);
     }
 
     /// @dev Returns the active stake for a given owner.

--- a/contracts/staking/contracts/src/staking_pools/MixinStakingPoolRewards.sol
+++ b/contracts/staking/contracts/src/staking_pools/MixinStakingPoolRewards.sol
@@ -184,7 +184,7 @@ contract MixinStakingPoolRewards is
 
         if (operatorReward > 0) {
             // Transfer the operator's weth reward to the operator
-            _getWethContract().transfer(pool.operator, operatorReward);
+            getWethContract().transfer(pool.operator, operatorReward);
         }
 
         if (membersReward > 0) {
@@ -283,7 +283,7 @@ contract MixinStakingPoolRewards is
         _decreasePoolRewards(poolId, balance);
 
         // Withdraw the member's WETH balance
-        _getWethContract().transfer(member, balance);
+        getWethContract().transfer(member, balance);
     }
 
     /// @dev Computes the reward balance in ETH of a specific member of a pool.

--- a/contracts/staking/contracts/src/sys/MixinFinalizer.sol
+++ b/contracts/staking/contracts/src/sys/MixinFinalizer.sol
@@ -245,7 +245,7 @@ contract MixinFinalizer is
     {
         uint256 ethBalance = address(this).balance;
         if (ethBalance != 0) {
-            _getWethContract().deposit.value(ethBalance)();
+            getWethContract().deposit.value(ethBalance)();
         }
     }
 
@@ -256,7 +256,7 @@ contract MixinFinalizer is
         view
         returns (uint256 wethBalance)
     {
-        wethBalance = _getWethContract().balanceOf(address(this))
+        wethBalance = getWethContract().balanceOf(address(this))
             .safeSub(wethReservedForPoolRewards);
 
         return wethBalance;

--- a/contracts/staking/contracts/src/sys/MixinParams.sol
+++ b/contracts/staking/contracts/src/sys/MixinParams.sol
@@ -18,12 +18,9 @@
 
 pragma solidity ^0.5.9;
 
-import "@0x/contracts-erc20/contracts/src/interfaces/IEtherToken.sol";
 import "@0x/contracts-utils/contracts/src/LibRichErrors.sol";
-import "@0x/contracts-asset-proxy/contracts/src/interfaces/IAssetProxy.sol";
 import "../immutable/MixinStorage.sol";
 import "../interfaces/IStakingEvents.sol";
-import "../interfaces/IZrxVault.sol";
 import "../libs/LibStakingRichErrors.sol";
 
 
@@ -40,17 +37,13 @@ contract MixinParams is
     /// @param _maximumMakersInPool Maximum number of maker addresses allowed to be registered to a pool.
     /// @param _cobbDouglasAlphaNumerator Numerator for cobb douglas alpha factor.
     /// @param _cobbDouglasAlphaDenominator Denominator for cobb douglas alpha factor.
-    /// @param _wethProxyAddress The address that can transfer WETH for fees.
-    /// @param _zrxVaultAddress Address of the ZrxVault contract.
     function setParams(
         uint256 _epochDurationInSeconds,
         uint32 _rewardDelegatedStakeWeight,
         uint256 _minimumPoolStake,
         uint256 _maximumMakersInPool,
         uint32 _cobbDouglasAlphaNumerator,
-        uint32 _cobbDouglasAlphaDenominator,
-        address _wethProxyAddress,
-        address _zrxVaultAddress
+        uint32 _cobbDouglasAlphaDenominator
     )
         external
         onlyAuthorized
@@ -61,9 +54,7 @@ contract MixinParams is
             _minimumPoolStake,
             _maximumMakersInPool,
             _cobbDouglasAlphaNumerator,
-            _cobbDouglasAlphaDenominator,
-            _wethProxyAddress,
-            _zrxVaultAddress
+            _cobbDouglasAlphaDenominator
         );
     }
 
@@ -74,8 +65,6 @@ contract MixinParams is
     /// @return _maximumMakersInPool Maximum number of maker addresses allowed to be registered to a pool.
     /// @return _cobbDouglasAlphaNumerator Numerator for cobb douglas alpha factor.
     /// @return _cobbDouglasAlphaDenominator Denominator for cobb douglas alpha factor.
-    /// @return _wethProxyAddress The address that can transfer WETH for fees.
-    /// @return _zrxVaultAddress Address of the ZrxVault contract.
     function getParams()
         external
         view
@@ -85,9 +74,7 @@ contract MixinParams is
             uint256 _minimumPoolStake,
             uint256 _maximumMakersInPool,
             uint32 _cobbDouglasAlphaNumerator,
-            uint32 _cobbDouglasAlphaDenominator,
-            address _wethProxyAddress,
-            address _zrxVaultAddress
+            uint32 _cobbDouglasAlphaDenominator
         )
     {
         _epochDurationInSeconds = epochDurationInSeconds;
@@ -96,17 +83,10 @@ contract MixinParams is
         _maximumMakersInPool = maximumMakersInPool;
         _cobbDouglasAlphaNumerator = cobbDouglasAlphaNumerator;
         _cobbDouglasAlphaDenominator = cobbDouglasAlphaDenominator;
-        _wethProxyAddress = address(wethAssetProxy);
-        _zrxVaultAddress = address(zrxVault);
     }
 
     /// @dev Initialize storage belonging to this mixin.
-    /// @param _wethProxyAddress The address that can transfer WETH for fees.
-    /// @param _zrxVaultAddress Address of the ZrxVault contract.
-    function _initMixinParams(
-        address _wethProxyAddress,
-        address _zrxVaultAddress
-    )
+    function _initMixinParams()
         internal
     {
         // Ensure state is uninitialized.
@@ -120,9 +100,7 @@ contract MixinParams is
             100 * MIN_TOKEN_VALUE,         // minimumPoolStake
             10,                            // maximumMakersInPool
             1,                             // cobbDouglasAlphaNumerator
-            2,                             // cobbDouglasAlphaDenominator
-            _wethProxyAddress,
-            _zrxVaultAddress
+            2                              // cobbDouglasAlphaDenominator
         );
     }
 
@@ -136,9 +114,7 @@ contract MixinParams is
             minimumPoolStake != 0 &&
             maximumMakersInPool != 0 &&
             cobbDouglasAlphaNumerator != 0 &&
-            cobbDouglasAlphaDenominator != 0 &&
-            address(wethAssetProxy) != NIL_ADDRESS &&
-            address(zrxVault) != NIL_ADDRESS
+            cobbDouglasAlphaDenominator != 0
         ) {
             LibRichErrors.rrevert(
                 LibStakingRichErrors.InitializationError(
@@ -155,17 +131,13 @@ contract MixinParams is
     /// @param _maximumMakersInPool Maximum number of maker addresses allowed to be registered to a pool.
     /// @param _cobbDouglasAlphaNumerator Numerator for cobb douglas alpha factor.
     /// @param _cobbDouglasAlphaDenominator Denominator for cobb douglas alpha factor.
-    /// @param _wethProxyAddress The address that can transfer WETH for fees.
-    /// @param _zrxVaultAddress Address of the ZrxVault contract.
     function _setParams(
         uint256 _epochDurationInSeconds,
         uint32 _rewardDelegatedStakeWeight,
         uint256 _minimumPoolStake,
         uint256 _maximumMakersInPool,
         uint32 _cobbDouglasAlphaNumerator,
-        uint32 _cobbDouglasAlphaDenominator,
-        address _wethProxyAddress,
-        address _zrxVaultAddress
+        uint32 _cobbDouglasAlphaDenominator
     )
         private
     {
@@ -175,8 +147,6 @@ contract MixinParams is
         maximumMakersInPool = _maximumMakersInPool;
         cobbDouglasAlphaNumerator = _cobbDouglasAlphaNumerator;
         cobbDouglasAlphaDenominator = _cobbDouglasAlphaDenominator;
-        wethAssetProxy = IAssetProxy(_wethProxyAddress);
-        zrxVault = IZrxVault(_zrxVaultAddress);
 
         emit ParamsSet(
             _epochDurationInSeconds,
@@ -184,9 +154,7 @@ contract MixinParams is
             _minimumPoolStake,
             _maximumMakersInPool,
             _cobbDouglasAlphaNumerator,
-            _cobbDouglasAlphaDenominator,
-            _wethProxyAddress,
-            _zrxVaultAddress
+            _cobbDouglasAlphaDenominator
         );
     }
 }

--- a/contracts/staking/contracts/test/TestAssertStorageParams.sol
+++ b/contracts/staking/contracts/test/TestAssertStorageParams.sol
@@ -32,15 +32,11 @@ contract TestAssertStorageParams is
         uint256 maximumMakersInPool;
         uint32 cobbDouglasAlphaNumerator;
         uint32 cobbDouglasAlphaDenominator;
-        address wethProxyAddress;
-        address zrxVaultAddress;
     }
 
     constructor()
         public
         StakingProxy(
-            NIL_ADDRESS,
-            NIL_ADDRESS,
             NIL_ADDRESS,
             NIL_ADDRESS
         )
@@ -55,12 +51,10 @@ contract TestAssertStorageParams is
         maximumMakersInPool = params.maximumMakersInPool;
         cobbDouglasAlphaNumerator = params.cobbDouglasAlphaNumerator;
         cobbDouglasAlphaDenominator = params.cobbDouglasAlphaDenominator;
-        wethAssetProxy = IAssetProxy(params.wethProxyAddress);
-        zrxVault = IZrxVault(params.zrxVaultAddress);
         _assertValidStorageParams();
     }
 
-    function _attachStakingContract(address, address, address)
+    function _attachStakingContract(address)
         internal
     {}
 }

--- a/contracts/staking/contracts/test/TestCumulativeRewardTracking.sol
+++ b/contracts/staking/contracts/test/TestCumulativeRewardTracking.sol
@@ -35,9 +35,19 @@ contract TestCumulativeRewardTracking is
         uint256 epoch
     );
 
-    constructor(address wethAddress) public TestStaking(wethAddress) {}
+    constructor(
+        address wethAddress,
+        address zrxVaultAddress
+    )
+        public
+        TestStaking(
+            wethAddress,
+            address(0),
+            zrxVaultAddress
+        )
+    {}
 
-    function init(address, address) public {}
+    function init() public {}
 
     function _forceSetCumulativeReward(
         bytes32 poolId,

--- a/contracts/staking/contracts/test/TestDelegatorRewards.sol
+++ b/contracts/staking/contracts/test/TestDelegatorRewards.sol
@@ -39,13 +39,8 @@ contract TestDelegatorRewards is
         uint256 membersStake;
     }
 
-    constructor()
-        public
-    {
-        init(
-            address(1),
-            address(1)
-        );
+    constructor() public {
+        init();
     }
 
     mapping (uint256 => mapping (bytes32 => UnfinalizedPoolReward)) private

--- a/contracts/staking/contracts/test/TestFinalizer.sol
+++ b/contracts/staking/contracts/test/TestFinalizer.sol
@@ -56,10 +56,7 @@ contract TestFinalizer is
     )
         public
     {
-        init(
-            address(1),
-            address(1)
-        );
+        init();
         _operatorRewardsReceiver = operatorRewardsReceiver;
         _membersRewardsReceiver = membersRewardsReceiver;
     }

--- a/contracts/staking/contracts/test/TestInitTarget.sol
+++ b/contracts/staking/contracts/test/TestInitTarget.sol
@@ -35,15 +35,7 @@ contract TestInitTarget is
     // `address(this)` of the last `init()` call.
     address private _initThisAddress = address(0);
 
-    event InitAddresses(
-        address wethProxyAddress,
-        address zrxVaultAddress          
-    );
-
-    function init(
-        address wethProxyAddress,
-        address zrxVaultAddress           
-    )
+    function init()
         external
     {
         if (SHOULD_REVERT_ADDRESS.balance != 0) {
@@ -52,10 +44,6 @@ contract TestInitTarget is
         _initCounter += 1;
         _initSender = msg.sender;
         _initThisAddress = address(this);
-        emit InitAddresses(
-            wethProxyAddress,
-            zrxVaultAddress
-        );
     }
 
     function getInitState()

--- a/contracts/staking/contracts/test/TestProtocolFees.sol
+++ b/contracts/staking/contracts/test/TestProtocolFees.sol
@@ -91,10 +91,6 @@ contract TestProtocolFees is
         emit ERC20ProxyTransferFrom(assetData, from, to, amount);
     }
 
-    function getWethAssetData() external view returns (bytes memory) {
-        return _getWethAssetData();
-    }
-
     /// @dev Overridden to use test pools.
     function getStakingPoolIdOfMaker(address makerAddress)
         public
@@ -131,8 +127,8 @@ contract TestProtocolFees is
         });
     }
 
-    function _getWethAssetProxy()
-        internal
+    function getWethAssetProxy()
+        public
         view
         returns (IAssetProxy wethAssetProxy)
     {

--- a/contracts/staking/contracts/test/TestProtocolFees.sol
+++ b/contracts/staking/contracts/test/TestProtocolFees.sol
@@ -44,12 +44,7 @@ contract TestProtocolFees is
     mapping(address => bytes32) private _makersToTestPoolIds;
 
     constructor(address exchangeAddress) public {
-        init(
-            // Use this contract as the ERC20Proxy.
-            address(this),
-            // vault addresses must be non-zero
-            address(1)
-        );
+        init();
         validExchanges[exchangeAddress] = true;
     }
 
@@ -134,5 +129,14 @@ contract TestProtocolFees is
             currentEpochBalance: pool.operatorStake,
             nextEpochBalance: pool.operatorStake
         });
+    }
+
+    function _getWethAssetProxy()
+        internal
+        view
+        returns (IAssetProxy wethAssetProxy)
+    {
+        wethAssetProxy = IAssetProxy(address(this));
+        return wethAssetProxy;
     }
 }

--- a/contracts/staking/contracts/test/TestStaking.sol
+++ b/contracts/staking/contracts/test/TestStaking.sol
@@ -43,8 +43,8 @@ contract TestStaking is
     }
 
     /// @dev Overridden to use testWethAddress;
-    function _getWethContract()
-        internal
+    function getWethContract()
+        public
         view
         returns (IEtherToken)
     {
@@ -55,8 +55,8 @@ contract TestStaking is
         return IEtherToken(wethAddress);
     }
 
-    function _getWethAssetData()
-        internal
+    function getWethAssetData()
+        public
         view
         returns (bytes memory)
     {
@@ -67,8 +67,8 @@ contract TestStaking is
         ); 
     }
 
-    function _getWethAssetProxy()
-        internal
+    function getWethAssetProxy()
+        public
         view
         returns (IAssetProxy wethAssetProxy)
     {
@@ -77,8 +77,8 @@ contract TestStaking is
         return wethAssetProxy;
     }
 
-    function _getZrxVault()
-        internal
+    function getZrxVault()
+        public
         view
         returns (IZrxVault zrxVault)
     {

--- a/contracts/staking/contracts/test/TestStaking.sol
+++ b/contracts/staking/contracts/test/TestStaking.sol
@@ -27,9 +27,19 @@ contract TestStaking is
     Staking
 {
     address public testWethAddress;
+    address public testWethAssetProxyAddress;
+    address public testZrxVaultAddress;
 
-    constructor(address wethAddress) public {
+    constructor(
+        address wethAddress,
+        address wethAssetProxyAddress,
+        address zrxVaultAddress
+    )
+        public
+    {
         testWethAddress = wethAddress;
+        testWethAssetProxyAddress = wethAssetProxyAddress;
+        testZrxVaultAddress = zrxVaultAddress;
     }
 
     /// @dev Overridden to use testWethAddress;
@@ -55,5 +65,25 @@ contract TestStaking is
             IAssetData(address(0)).ERC20Token.selector,
             wethAddress
         ); 
+    }
+
+    function _getWethAssetProxy()
+        internal
+        view
+        returns (IAssetProxy wethAssetProxy)
+    {
+        address wethAssetProxyAddress = TestStaking(address(uint160(stakingContract))).testWethAssetProxyAddress();
+        wethAssetProxy = IAssetProxy(wethAssetProxyAddress);
+        return wethAssetProxy;
+    }
+
+    function _getZrxVault()
+        internal
+        view
+        returns (IZrxVault zrxVault)
+    {
+        address zrxVaultAddress = TestStaking(address(uint160(stakingContract))).testZrxVaultAddress();
+        zrxVault = IZrxVault(zrxVaultAddress);
+        return zrxVault;
     }
 }

--- a/contracts/staking/contracts/test/TestStakingNoWETH.sol
+++ b/contracts/staking/contracts/test/TestStakingNoWETH.sol
@@ -42,6 +42,14 @@ contract TestStakingNoWETH is
         return true;
     }
 
+    function getWethContract()
+        public
+        view
+        returns (IEtherToken)
+    {
+        return IEtherToken(address(this));
+    }
+
     function _wrapEth()
         internal
     {}
@@ -52,13 +60,5 @@ contract TestStakingNoWETH is
         returns (uint256)
     {
         return address(this).balance;
-    }
-
-    function _getWethContract()
-        internal
-        view
-        returns (IEtherToken)
-    {
-        return IEtherToken(address(this));
     }
 }

--- a/contracts/staking/contracts/test/TestStakingProxy.sol
+++ b/contracts/staking/contracts/test/TestStakingProxy.sol
@@ -31,21 +31,9 @@ contract TestStakingProxy is
         public
         StakingProxy(
             _stakingContract,
-            NIL_ADDRESS,
-            NIL_ADDRESS,
             NIL_ADDRESS
         )
     {}
-
-    function setAddressParams(
-        address _wethProxyAddress,
-        address _zrxVaultAddress        
-    )
-        external
-    {
-        wethAssetProxy = IAssetProxy(_wethProxyAddress);
-        zrxVault = IZrxVault(_zrxVaultAddress);
-    }
 
     function _assertValidStorageParams()
         internal

--- a/contracts/staking/test/params.ts
+++ b/contracts/staking/test/params.ts
@@ -39,8 +39,6 @@ blockchainTests('Configurable Parameters unit tests', env => {
                 new BigNumber(_params.maximumMakersInPool),
                 new BigNumber(_params.cobbDouglasAlphaNumerator),
                 new BigNumber(_params.cobbDouglasAlphaDenominator),
-                _params.wethProxyAddress,
-                _params.zrxVaultAddress,
                 { from },
             );
             // Assert event.
@@ -53,8 +51,6 @@ blockchainTests('Configurable Parameters unit tests', env => {
             expect(event.maximumMakersInPool).to.bignumber.eq(_params.maximumMakersInPool);
             expect(event.cobbDouglasAlphaNumerator).to.bignumber.eq(_params.cobbDouglasAlphaNumerator);
             expect(event.cobbDouglasAlphaDenominator).to.bignumber.eq(_params.cobbDouglasAlphaDenominator);
-            expect(event.wethProxyAddress).to.eq(_params.wethProxyAddress);
-            expect(event.zrxVaultAddress).to.eq(_params.zrxVaultAddress);
             // Assert `getParams()`.
             const actual = await testContract.getParams.callAsync();
             expect(actual[0]).to.bignumber.eq(_params.epochDurationInSeconds);
@@ -63,8 +59,6 @@ blockchainTests('Configurable Parameters unit tests', env => {
             expect(actual[3]).to.bignumber.eq(_params.maximumMakersInPool);
             expect(actual[4]).to.bignumber.eq(_params.cobbDouglasAlphaNumerator);
             expect(actual[5]).to.bignumber.eq(_params.cobbDouglasAlphaDenominator);
-            expect(actual[6]).to.eq(_params.wethProxyAddress);
-            expect(actual[7]).to.eq(_params.zrxVaultAddress);
             return receipt;
         }
 

--- a/contracts/staking/test/rewards_test.ts
+++ b/contracts/staking/test/rewards_test.ts
@@ -46,7 +46,6 @@ blockchainTests.resets('Testing Rewards', env => {
             minimumPoolStake: new BigNumber(2),
             cobbDouglasAlphaNumerator: new BigNumber(1),
             cobbDouglasAlphaDenominator: new BigNumber(6),
-            zrxVaultAddress: stakingApiWrapper.zrxVaultContract.address,
         });
         // setup stakers
         stakers = actors.slice(0, 2).map(a => new StakerActor(a, stakingApiWrapper));

--- a/contracts/staking/test/utils/api_wrapper.ts
+++ b/contracts/staking/test/utils/api_wrapper.ts
@@ -117,8 +117,6 @@ export class StakingApiWrapper {
                 new BigNumber(_params.maximumMakersInPool),
                 new BigNumber(_params.cobbDouglasAlphaNumerator),
                 new BigNumber(_params.cobbDouglasAlphaDenominator),
-                _params.wethProxyAddress,
-                _params.zrxVaultAddress,
             );
         },
 
@@ -228,22 +226,6 @@ export async function deployAndConfigureContractsAsync(
         artifacts,
     );
 
-    // deploy staking contract
-    const stakingContract = await TestStakingContract.deployFrom0xArtifactAsync(
-        customStakingArtifact !== undefined ? customStakingArtifact : artifacts.TestStaking,
-        env.provider,
-        env.txDefaults,
-        artifacts,
-        wethContract.address,
-    );
-
-    // deploy read-only proxy
-    const readOnlyProxyContract = await ReadOnlyProxyContract.deployFrom0xArtifactAsync(
-        artifacts.ReadOnlyProxy,
-        env.provider,
-        env.txDefaults,
-        artifacts,
-    );
     // deploy zrx vault
     const zrxVaultContract = await ZrxVaultContract.deployFrom0xArtifactAsync(
         artifacts.ZrxVault,
@@ -253,6 +235,26 @@ export async function deployAndConfigureContractsAsync(
         erc20ProxyContract.address,
         zrxTokenContract.address,
     );
+
+    // deploy staking contract
+    const stakingContract = await TestStakingContract.deployFrom0xArtifactAsync(
+        customStakingArtifact !== undefined ? customStakingArtifact : artifacts.TestStaking,
+        env.provider,
+        env.txDefaults,
+        artifacts,
+        wethContract.address,
+        erc20ProxyContract.address,
+        zrxVaultContract.address,
+    );
+
+    // deploy read-only proxy
+    const readOnlyProxyContract = await ReadOnlyProxyContract.deployFrom0xArtifactAsync(
+        artifacts.ReadOnlyProxy,
+        env.provider,
+        env.txDefaults,
+        artifacts,
+    );
+
     // deploy staking proxy
     const stakingProxyContract = await StakingProxyContract.deployFrom0xArtifactAsync(
         artifacts.StakingProxy,
@@ -261,8 +263,6 @@ export async function deployAndConfigureContractsAsync(
         artifacts,
         stakingContract.address,
         readOnlyProxyContract.address,
-        erc20ProxyContract.address,
-        zrxVaultContract.address,
     );
     // deploy cobb douglas contract
     const cobbDouglasContract = await TestCobbDouglasContract.deployFrom0xArtifactAsync(

--- a/contracts/staking/test/utils/constants.ts
+++ b/contracts/staking/test/utils/constants.ts
@@ -1,4 +1,4 @@
-import { constants as testConstants, randomAddress } from '@0x/contracts-test-utils';
+import { constants as testConstants } from '@0x/contracts-test-utils';
 import { BigNumber } from '@0x/utils';
 
 const TEN_DAYS = 10 * 24 * 60 * 60;
@@ -17,8 +17,6 @@ export const constants = {
         maximumMakersInPool: new BigNumber(10),
         cobbDouglasAlphaNumerator: new BigNumber(1),
         cobbDouglasAlphaDenominator: new BigNumber(2),
-        wethProxyAddress: randomAddress(),
-        zrxVaultAddress: randomAddress(),
     },
     PPM,
 };

--- a/contracts/staking/test/utils/cumulative_reward_tracking_simulation.ts
+++ b/contracts/staking/test/utils/cumulative_reward_tracking_simulation.ts
@@ -1,4 +1,4 @@
-import { BlockchainTestsEnvironment, constants, expect, txDefaults } from '@0x/contracts-test-utils';
+import { BlockchainTestsEnvironment, expect, txDefaults } from '@0x/contracts-test-utils';
 import { BigNumber } from '@0x/utils';
 import { DecodedLogEntry, TransactionReceiptWithDecodedLogs } from 'ethereum-types';
 import * as _ from 'lodash';
@@ -86,6 +86,7 @@ export class CumulativeRewardTrackingSimulation {
             txDefaults,
             artifacts,
             this._stakingApiWrapper.wethContract.address,
+            this._stakingApiWrapper.zrxVaultContract.address,
         );
     }
 
@@ -104,8 +105,6 @@ export class CumulativeRewardTrackingSimulation {
         await this._executeActionsAsync(initActions);
         await this._stakingApiWrapper.stakingProxyContract.attachStakingContract.awaitTransactionSuccessAsync(
             this.getTestCumulativeRewardTrackingContract().address,
-            constants.NULL_ADDRESS,
-            constants.NULL_ADDRESS,
         );
         const testLogs = await this._executeActionsAsync(testActions);
         CumulativeRewardTrackingSimulation._assertTestLogs(expectedTestLogs, testLogs);

--- a/contracts/staking/test/utils/types.ts
+++ b/contracts/staking/test/utils/types.ts
@@ -11,8 +11,6 @@ export interface StakingParams {
     maximumMakersInPool: Numberish;
     cobbDouglasAlphaNumerator: Numberish;
     cobbDouglasAlphaDenominator: Numberish;
-    wethProxyAddress: string;
-    zrxVaultAddress: string;
 }
 
 export interface StakerBalances {

--- a/packages/order-utils/src/staking_revert_errors.ts
+++ b/packages/order-utils/src/staking_revert_errors.ts
@@ -24,8 +24,6 @@ export enum InvalidParamValueErrorCode {
     InvalidRewardDelegatedStakeWeight,
     InvalidMaximumMakersInPool,
     InvalidMinimumPoolStake,
-    InvalidWethProxyAddress,
-    InvalidZrxVaultAddress,
     InvalidEpochDuration,
 }
 


### PR DESCRIPTION
## Description

This PR makes `wethAssetProxy` and `zrxVault` deployment constants instead of individually upgradable params. The original purpose of this change was to test how much is would reduce the codesize of the staking contract (only ~500 bytes, it turns out). I'm open to merging it or closing it. The benefit is that it would save a bunch of gas by reducing `sloads`. The downside is that upgrading these params becomes a bit less flexible, as the entire staking logic contract would need to be swapped out.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
