### PR TITLE
Quick fixes

### DIFF
--- a/packages/asset-swapper/webpack.config.js
+++ b/packages/asset-swapper/webpack.config.js
@@ -39,6 +39,9 @@ module.exports = {
             }),
         ],
     },
+    externals: {
+        fs: true,
+    },
     module: {
         rules: [
             {

--- a/packages/migrations/package.json
+++ b/packages/migrations/package.json
@@ -30,7 +30,7 @@
     "config": {
         "s3_snapshot_bucket": "s3://ganache-snapshots.0x.org",
         "docker_snapshot_name": "0xorg/ganache-cli",
-        "snapshot_name": "0x_ganache_snapshot",
+        "snapshot_name": "0x_ganache_snapshot-v3-beta",
         "postpublish": {
             "assets": []
         }

--- a/packages/migrations/src/migration.ts
+++ b/packages/migrations/src/migration.ts
@@ -260,6 +260,13 @@ export async function runMigrationsAsync(
     //     await multiAssetProxy.transferOwnership.sendTransactionAsync(assetProxyOwner.address, txDefaults),
     // );
 
+    // Fake the above transactions so our nonce increases and we result with the same addresses
+    // while AssetProxyOwner is disabled (TODO: @dekz remove)
+    const dummyTransactionCount = 5;
+    for (let index = 0; index < dummyTransactionCount; index++) {
+        await web3Wrapper.sendTransactionAsync({ to: txDefaults.from, from: txDefaults.from, value: new BigNumber(0) });
+    }
+
     // Fund the Forwarder with ZRX
     const zrxDecimals = await zrxToken.decimals.callAsync();
     const zrxForwarderAmount = Web3Wrapper.toBaseUnitAmount(new BigNumber(5000), zrxDecimals);

--- a/packages/orderbook/package.json
+++ b/packages/orderbook/package.json
@@ -12,6 +12,9 @@
         "type": "git",
         "url": "https://github.com/0xProject/0x-monorepo.git"
     },
+    "publishConfig": {
+        "access": "public"
+    },
     "scripts": {
         "clean": "shx rm -rf lib generated_docs",
         "test": "jest",


### PR DESCRIPTION
## Description

* Fixed the webpack publish for asset swapper to be in line with 0x.js
* Modified the migration snapshot name to not clobber v2 until we're ready to overwrite
* Added filler transactions to keep contract addresses consistent whilst asset proxy is disabled
* Non-private package publish for orderbook

### Ganache Snapshot
```
docker run -it --rm -p 8545:8545 -e SNAPSHOT_NAME=0x_ganache_snapshot-v3-beta -e VERSION=4.3.2 0xorg/ganache-cli:latest
```
http://ganache-snapshots.0x.org.s3.amazonaws.com/0x_ganache_snapshot-v3-beta-4.3.2.zip
