### PR TITLE
Feature/staking/storage layout assertion

### DIFF
--- a/contracts/staking/contracts/src/Staking.sol
+++ b/contracts/staking/contracts/src/Staking.sol
@@ -75,4 +75,341 @@ contract Staking is
             _zrxVaultAddress
         );
     }
+
+    /// @dev This function will fail if the storage layout of this contract deviates from
+    ///      the original staking contract's storage. The use of this function provides assurance
+    ///      that regressions from the original storage layout will not occur.
+    function _assertStorageLayout()
+        internal
+        pure
+    {
+        assembly {
+            let slot := 0x0
+            let offset := 0x0
+
+            /// Ownable
+
+            assertSlotAndOffset(
+                owner_slot,
+                owner_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            /// Authorizable
+
+            assertSlotAndOffset(
+                authorized_slot,
+                authorized_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                authorities_slot,
+                authorities_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            /// MixinStorage
+
+            assertSlotAndOffset(
+                wethAssetProxy_slot,
+                wethAssetProxy_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                stakingContract_slot,
+                stakingContract_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                readOnlyProxy_slot,
+                readOnlyProxy_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                readOnlyProxyCallee_slot,
+                readOnlyProxyCallee_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                globalStakeByStatus_slot,
+                globalStakeByStatus_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                _activeStakeByOwner_slot,
+                _activeStakeByOwner_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                _inactiveStakeByOwner_slot,
+                _inactiveStakeByOwner_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                _delegatedStakeByOwner_slot,
+                _delegatedStakeByOwner_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                _delegatedStakeToPoolByOwner_slot,
+                _delegatedStakeToPoolByOwner_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                _delegatedStakeByPoolId_slot,
+                _delegatedStakeByPoolId_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                _withdrawableStakeByOwner_slot,
+                _withdrawableStakeByOwner_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                nextPoolId_slot,
+                nextPoolId_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                poolJoinedByMakerAddress_slot,
+                poolJoinedByMakerAddress_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                _poolById_slot,
+                _poolById_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                rewardsByPoolId_slot,
+                rewardsByPoolId_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                currentEpoch_slot,
+                currentEpoch_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                currentEpochStartTimeInSeconds_slot,
+                currentEpochStartTimeInSeconds_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                _cumulativeRewardsByPool_slot,
+                _cumulativeRewardsByPool_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                _cumulativeRewardsByPoolReferenceCounter_slot,
+                _cumulativeRewardsByPoolReferenceCounter_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                _cumulativeRewardsByPoolLastStored_slot,
+                _cumulativeRewardsByPoolLastStored_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                validExchanges_slot,
+                validExchanges_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                zrxVault_slot,
+                zrxVault_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                epochDurationInSeconds_slot,
+                epochDurationInSeconds_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                rewardDelegatedStakeWeight_slot,
+                rewardDelegatedStakeWeight_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                minimumPoolStake_slot,
+                minimumPoolStake_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                maximumMakersInPool_slot,
+                maximumMakersInPool_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                cobbDouglasAlphaNumerator_slot,
+                cobbDouglasAlphaNumerator_offset,
+                slot,
+                offset
+            )
+            offset := add(offset, 0x4)
+
+            // This number will be tightly packed into the previous values storage slot since
+            // they are both `uint32`. Because of this tight packing, the offset of this value
+            // must be 4, since the previous value is a 4 byte number.
+            assertSlotAndOffset(
+                cobbDouglasAlphaDenominator_slot,
+                cobbDouglasAlphaDenominator_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+            offset := 0x0
+
+            assertSlotAndOffset(
+                totalFeesCollectedThisEpoch_slot,
+                totalFeesCollectedThisEpoch_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                totalWeightedStakeThisEpoch_slot,
+                totalWeightedStakeThisEpoch_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                _activePoolsByEpoch_slot,
+                _activePoolsByEpoch_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                numActivePoolsThisEpoch_slot,
+                numActivePoolsThisEpoch_offset,
+                slot,
+                offset
+            )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                unfinalizedState_slot,
+                unfinalizedState_offset,
+                slot,
+                offset
+            )
+
+            // This assembly function will assert that the actual values for `_slot` and `_offset` are
+            // correct and will revert with a rich error if they are different than the expected values.
+            function assertSlotAndOffset(
+                actual_slot,
+                actual_offset,
+                expected_slot,
+                expected_offset
+            ) {
+                // If expected_slot is not equal to actual_slot, revert with a rich error.
+                if iszero(eq(expected_slot, actual_slot)) {
+                    mstore(0x0, 0x213eb13400000000000000000000000000000000000000000000000000000000) // Rich error selector
+                    mstore(0x4, 0x0)                                                                // Unexpected slot error code
+                    mstore(0x24, expected_slot)                                                     // Expected slot
+                    mstore(0x44, actual_slot)                                                       // Actual slot
+                    revert(0x0, 0x64)
+                }
+
+                // If expected_offset is not equal to actual_offset, revert with a rich error.
+                if iszero(eq(expected_offset, actual_offset)) {
+                    mstore(0x0, 0x213eb13400000000000000000000000000000000000000000000000000000000) // Rich error selector
+                    mstore(0x4, 0x1)                                                                // Unexpected offset error code
+                    mstore(0x24, expected_offset)                                                   // Expected offset
+                    mstore(0x44, actual_offset)                                                     // Actual offset
+                    revert(0x0, 0x64)
+                }
+            }
+        }
+    }
 }

--- a/contracts/staking/contracts/src/Staking.sol
+++ b/contracts/staking/contracts/src/Staking.sol
@@ -383,6 +383,14 @@ contract Staking is
                 slot,
                 offset
             )
+            slot := add(slot, 0x1)
+
+            assertSlotAndOffset(
+                _wethReservedForPoolRewards_slot,
+                _wethReservedForPoolRewards_offset,
+                slot,
+                offset
+            )
 
             // This assembly function will assert that the actual values for `_slot` and `_offset` are
             // correct and will revert with a rich error if they are different than the expected values.

--- a/contracts/staking/contracts/src/interfaces/IStakingEvents.sol
+++ b/contracts/staking/contracts/src/interfaces/IStakingEvents.sol
@@ -108,16 +108,6 @@ interface IStakingEvents {
         address zrxVaultAddress
     );
 
-     /// @dev Emitted by MixinScheduler when the timeLock period is changed.
-     /// @param timeLockPeriod The timeLock period we changed to.
-     /// @param startEpoch The epoch this period started.
-     /// @param endEpoch The epoch this period ends.
-    event TimeLockPeriodChanged(
-        uint256 timeLockPeriod,
-        uint256 startEpoch,
-        uint256 endEpoch
-    );
-
     /// @dev Emitted by MixinStakingPool when a new pool is created.
     /// @param poolId Unique id generated for pool.
     /// @param operator The operator (creator) of pool.
@@ -132,7 +122,7 @@ interface IStakingEvents {
     /// @param poolId Unique id of pool.
     /// @param makerAddress Adress of maker joining the pool.
     event PendingAddMakerToPool(
-        bytes32 poolId,
+        bytes32 indexed poolId,
         address makerAddress
     );
 
@@ -140,7 +130,7 @@ interface IStakingEvents {
     /// @param poolId Unique id of pool.
     /// @param makerAddress Adress of maker added to pool.
     event MakerAddedToStakingPool(
-        bytes32 poolId,
+        bytes32 indexed poolId,
         address makerAddress
     );
 
@@ -148,7 +138,7 @@ interface IStakingEvents {
     /// @param poolId Unique id of pool.
     /// @param makerAddress Adress of maker added to pool.
     event MakerRemovedFromStakingPool(
-        bytes32 poolId,
+        bytes32 indexed poolId,
         address makerAddress
     );
 

--- a/contracts/staking/contracts/src/interfaces/IZrxVault.sol
+++ b/contracts/staking/contracts/src/interfaces/IZrxVault.sol
@@ -29,21 +29,17 @@ pragma solidity ^0.5.9;
 interface IZrxVault {
 
     /// @dev Emitted when Zrx Tokens are deposited into the vault.
-    /// @param sender Address of sender (`msg.sender`).
     /// @param owner of Zrx Tokens.
     /// @param amount of Zrx Tokens deposited.
     event ZrxDepositedIntoVault(
-        address indexed sender,
         address indexed owner,
         uint256 amount
     );
 
     /// @dev Emitted when Zrx Tokens are withdrawn from the vault.
-    /// @param sender Address of sender (`msg.sender`).
     /// @param owner of Zrx Tokens.
     /// @param amount of Zrx Tokens withdrawn.
     event ZrxWithdrawnFromVault(
-        address indexed sender,
         address indexed owner,
         uint256 amount
     );

--- a/contracts/staking/contracts/src/interfaces/IZrxVault.sol
+++ b/contracts/staking/contracts/src/interfaces/IZrxVault.sol
@@ -31,7 +31,7 @@ interface IZrxVault {
     /// @dev Emitted when Zrx Tokens are deposited into the vault.
     /// @param owner of Zrx Tokens.
     /// @param amount of Zrx Tokens deposited.
-    event ZrxDepositedIntoVault(
+    event Deposit(
         address indexed owner,
         uint256 amount
     );
@@ -39,7 +39,7 @@ interface IZrxVault {
     /// @dev Emitted when Zrx Tokens are withdrawn from the vault.
     /// @param owner of Zrx Tokens.
     /// @param amount of Zrx Tokens withdrawn.
-    event ZrxWithdrawnFromVault(
+    event Withdraw(
         address indexed owner,
         uint256 amount
     );

--- a/contracts/staking/contracts/src/vaults/ZrxVault.sol
+++ b/contracts/staking/contracts/src/vaults/ZrxVault.sol
@@ -96,7 +96,7 @@ contract ZrxVault is
         _balances[owner] = _balances[owner].safeAdd(amount);
 
         // notify
-        emit ZrxDepositedIntoVault(owner, amount);
+        emit Deposit(owner, amount);
 
         // deposit ZRX from owner
         zrxAssetProxy.transferFrom(
@@ -158,7 +158,7 @@ contract ZrxVault is
         _balances[owner] = _balances[owner].safeSub(amount);
 
         // notify
-        emit ZrxWithdrawnFromVault(owner, amount);
+        emit Withdraw(owner, amount);
 
         // withdraw ZRX to owner
         _zrxToken.transfer(

--- a/contracts/staking/contracts/src/vaults/ZrxVault.sol
+++ b/contracts/staking/contracts/src/vaults/ZrxVault.sol
@@ -96,7 +96,7 @@ contract ZrxVault is
         _balances[owner] = _balances[owner].safeAdd(amount);
 
         // notify
-        emit ZrxDepositedIntoVault(msg.sender, owner, amount);
+        emit ZrxDepositedIntoVault(owner, amount);
 
         // deposit ZRX from owner
         zrxAssetProxy.transferFrom(
@@ -158,7 +158,7 @@ contract ZrxVault is
         _balances[owner] = _balances[owner].safeSub(amount);
 
         // notify
-        emit ZrxWithdrawnFromVault(msg.sender, owner, amount);
+        emit ZrxWithdrawnFromVault(owner, amount);
 
         // withdraw ZRX to owner
         _zrxToken.transfer(


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
### New PR
The series of unfortunate merges continues with this latest installment of your favorite "Storage Layout Assertions PR". This is needed because I made the mistake of merging the old (but also new) PR into a branch that was not 3.0. Sorry!

### Events
Some events were changed, or even deleted. Most of the changes removed event fields or changed the `indexed` status of an event field.

- `TimeLockPeriodChanged`
    - This event was removed entirely because it was not used.
- `PendingAddMakerToPool`
    - `poolId` field is now indexed. This allows this handshaking event to be filtered by `poolId`, which could be useful when analyzing pool registration behavior.
- `MakerAddedToStakingPool`
   - `poolId` is indexed, just like the above event.
- `MakerRemovedFromStakingPool`
   - `poolId` is indexed, just like the above two events.
- `ZrxDepositedIntoVault`
   - `sender` is removed entirely. This event is emitted in a function that uses the `onlyStakingProxy` modifier, and the `sender` field was always populated by `msg.sender`. Since the staking contract will rarely change, the benefit of logging this field is negligible. This field should be completely derivable from the `blocknumber` of the event emission in all but exceedingly rare cases.
- `ZrxWithdrawnFromVault`
   - `sender` is removed entirely. This was removed for the same reason as the above `sender` field.


### Storage Layout Assertions
A sequence of assertions has been added to the constructor of the contract. These assertions will lock in the storage layout for the staking contracts, which should make it easier to develop future versions that are fully compatible. 

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

* New feature (non-breaking change which adds functionality)
<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
