### PR TITLE
Improve readability, fix `_trySetCumulativeReward` logic

### DIFF
--- a/contracts/staking/contracts/src/stake/MixinStake.sol
+++ b/contracts/staking/contracts/src/stake/MixinStake.sol
@@ -187,6 +187,11 @@ contract MixinStake is
         // Sanity check the pool we're delegating to exists.
         _assertStakingPoolExists(poolId);
 
+        _withdrawAndSyncDelegatorRewards(
+            poolId,
+            staker
+        );
+
         // Increment how much stake the staker has delegated to the input pool.
         _increaseNextBalance(
             _delegatedStakeToPoolByOwner[staker][poolId],
@@ -195,11 +200,6 @@ contract MixinStake is
 
         // Increment how much stake has been delegated to pool.
         _increaseNextBalance(_delegatedStakeByPoolId[poolId], amount);
-
-        _withdrawAndSyncDelegatorRewards(
-            poolId,
-            staker
-        );
     }
 
     /// @dev Un-Delegates a owners stake from a staking pool.
@@ -216,6 +216,11 @@ contract MixinStake is
         // sanity check the pool we're undelegating from exists
         _assertStakingPoolExists(poolId);
 
+        _withdrawAndSyncDelegatorRewards(
+            poolId,
+            staker
+        );
+
         // decrement how much stake the staker has delegated to the input pool
         _decreaseNextBalance(
             _delegatedStakeToPoolByOwner[staker][poolId],
@@ -224,11 +229,6 @@ contract MixinStake is
 
         // decrement how much stake has been delegated to pool
         _decreaseNextBalance(_delegatedStakeByPoolId[poolId], amount);
-
-        _withdrawAndSyncDelegatorRewards(
-            poolId,
-            staker
-        );
     }
 
     /// @dev Returns a storage pointer to a user's stake in a given status.

--- a/contracts/staking/contracts/src/stake/MixinStake.sol
+++ b/contracts/staking/contracts/src/stake/MixinStake.sol
@@ -187,9 +187,10 @@ contract MixinStake is
         // Sanity check the pool we're delegating to exists.
         _assertStakingPoolExists(poolId);
 
-        // Cache amount delegated to pool by staker.
-        IStructs.StoredBalance memory initDelegatedStakeToPoolByOwner =
-            _loadUnsyncedBalance(_delegatedStakeToPoolByOwner[staker][poolId]);
+        _withdrawAndSyncDelegatorRewards(
+            poolId,
+            staker
+        );
 
         // Increment how much stake the staker has delegated to the input pool.
         _increaseNextBalance(
@@ -199,12 +200,6 @@ contract MixinStake is
 
         // Increment how much stake has been delegated to pool.
         _increaseNextBalance(_delegatedStakeByPoolId[poolId], amount);
-
-        _withdrawAndSyncDelegatorRewards(
-            poolId,
-            staker,
-            initDelegatedStakeToPoolByOwner
-        );
     }
 
     /// @dev Un-Delegates a owners stake from a staking pool.
@@ -221,9 +216,10 @@ contract MixinStake is
         // sanity check the pool we're undelegating from exists
         _assertStakingPoolExists(poolId);
 
-        // Cache amount delegated to pool by staker.
-        IStructs.StoredBalance memory initDelegatedStakeToPoolByOwner =
-            _loadUnsyncedBalance(_delegatedStakeToPoolByOwner[staker][poolId]);
+        _withdrawAndSyncDelegatorRewards(
+            poolId,
+            staker
+        );
 
         // decrement how much stake the staker has delegated to the input pool
         _decreaseNextBalance(
@@ -233,12 +229,6 @@ contract MixinStake is
 
         // decrement how much stake has been delegated to pool
         _decreaseNextBalance(_delegatedStakeByPoolId[poolId], amount);
-
-        _withdrawAndSyncDelegatorRewards(
-            poolId,
-            staker,
-            initDelegatedStakeToPoolByOwner
-        );
     }
 
     /// @dev Returns a storage pointer to a user's stake in a given status.

--- a/contracts/staking/contracts/src/stake/MixinStake.sol
+++ b/contracts/staking/contracts/src/stake/MixinStake.sol
@@ -188,7 +188,7 @@ contract MixinStake is
         _assertStakingPoolExists(poolId);
 
         // Cache amount delegated to pool by staker.
-        IStructs.StoredBalance memory initDelegatedStakeToPoolByOwner =
+        IStructs.StoredBalance memory initDelegatedStake =
             _loadUnsyncedBalance(_delegatedStakeToPoolByOwner[staker][poolId]);
 
         // Increment how much stake the staker has delegated to the input pool.
@@ -202,14 +202,14 @@ contract MixinStake is
 
         // Synchronizes reward state in the pool that the owner is delegating
         // to.
-        IStructs.StoredBalance memory finalDelegatedStakeToPoolByOwner =
+        IStructs.StoredBalance memory finalDelegatedStake =
             _loadSyncedBalance(_delegatedStakeToPoolByOwner[staker][poolId]);
 
         _withdrawAndSyncDelegatorRewards(
             poolId,
             staker,
-            initDelegatedStakeToPoolByOwner,
-            finalDelegatedStakeToPoolByOwner
+            initDelegatedStake,
+            finalDelegatedStake
         );
     }
 
@@ -228,7 +228,7 @@ contract MixinStake is
         _assertStakingPoolExists(poolId);
 
         // cache amount delegated to pool by staker
-        IStructs.StoredBalance memory initDelegatedStakeToPoolByOwner =
+        IStructs.StoredBalance memory initDelegatedStake =
             _loadUnsyncedBalance(_delegatedStakeToPoolByOwner[staker][poolId]);
 
         // decrement how much stake the staker has delegated to the input pool
@@ -242,14 +242,14 @@ contract MixinStake is
 
         // synchronizes reward state in the pool that the owner is undelegating
         // from
-        IStructs.StoredBalance memory finalDelegatedStakeToPoolByOwner =
+        IStructs.StoredBalance memory finalDelegatedStake =
             _loadSyncedBalance(_delegatedStakeToPoolByOwner[staker][poolId]);
 
         _withdrawAndSyncDelegatorRewards(
             poolId,
             staker,
-            initDelegatedStakeToPoolByOwner,
-            finalDelegatedStakeToPoolByOwner
+            initDelegatedStake,
+            finalDelegatedStake
         );
     }
 

--- a/contracts/staking/contracts/src/stake/MixinStake.sol
+++ b/contracts/staking/contracts/src/stake/MixinStake.sol
@@ -42,10 +42,10 @@ contract MixinStake is
         getZrxVault().depositFrom(staker, amount);
 
         // mint stake
-        _incrementCurrentAndNextBalance(_activeStakeByOwner[staker], amount);
+        _increaseCurrentAndNextBalance(_activeStakeByOwner[staker], amount);
 
         // update global total of active stake
-        _incrementCurrentAndNextBalance(globalStakeByStatus[uint8(IStructs.StakeStatus.ACTIVE)], amount);
+        _increaseCurrentAndNextBalance(globalStakeByStatus[uint8(IStructs.StakeStatus.ACTIVE)], amount);
 
         // notify
         emit Stake(
@@ -75,10 +75,10 @@ contract MixinStake is
         }
 
         // burn inactive stake
-        _decrementCurrentAndNextBalance(_inactiveStakeByOwner[staker], amount);
+        _decreaseCurrentAndNextBalance(_inactiveStakeByOwner[staker], amount);
 
         // update global total of inactive stake
-        _decrementCurrentAndNextBalance(globalStakeByStatus[uint8(IStructs.StakeStatus.INACTIVE)], amount);
+        _decreaseCurrentAndNextBalance(globalStakeByStatus[uint8(IStructs.StakeStatus.INACTIVE)], amount);
 
         // update withdrawable field
         _withdrawableStakeByOwner[staker] =
@@ -192,13 +192,13 @@ contract MixinStake is
             _loadUnsyncedBalance(_delegatedStakeToPoolByOwner[staker][poolId]);
 
         // Increment how much stake the staker has delegated to the input pool.
-        _incrementNextBalance(
+        _increaseNextBalance(
             _delegatedStakeToPoolByOwner[staker][poolId],
             amount
         );
 
         // Increment how much stake has been delegated to pool.
-        _incrementNextBalance(_delegatedStakeByPoolId[poolId], amount);
+        _increaseNextBalance(_delegatedStakeByPoolId[poolId], amount);
 
         // Synchronizes reward state in the pool that the owner is delegating
         // to.
@@ -232,13 +232,13 @@ contract MixinStake is
             _loadUnsyncedBalance(_delegatedStakeToPoolByOwner[staker][poolId]);
 
         // decrement how much stake the staker has delegated to the input pool
-        _decrementNextBalance(
+        _decreaseNextBalance(
             _delegatedStakeToPoolByOwner[staker][poolId],
             amount
         );
 
         // decrement how much stake has been delegated to pool
-        _decrementNextBalance(_delegatedStakeByPoolId[poolId], amount);
+        _decreaseNextBalance(_delegatedStakeByPoolId[poolId], amount);
 
         // synchronizes reward state in the pool that the owner is undelegating
         // from

--- a/contracts/staking/contracts/src/stake/MixinStake.sol
+++ b/contracts/staking/contracts/src/stake/MixinStake.sol
@@ -187,10 +187,6 @@ contract MixinStake is
         // Sanity check the pool we're delegating to exists.
         _assertStakingPoolExists(poolId);
 
-        // Cache amount delegated to pool by staker.
-        IStructs.StoredBalance memory initDelegatedStake =
-            _loadUnsyncedBalance(_delegatedStakeToPoolByOwner[staker][poolId]);
-
         // Increment how much stake the staker has delegated to the input pool.
         _increaseNextBalance(
             _delegatedStakeToPoolByOwner[staker][poolId],
@@ -200,16 +196,9 @@ contract MixinStake is
         // Increment how much stake has been delegated to pool.
         _increaseNextBalance(_delegatedStakeByPoolId[poolId], amount);
 
-        // Synchronizes reward state in the pool that the owner is delegating
-        // to.
-        IStructs.StoredBalance memory finalDelegatedStake =
-            _loadSyncedBalance(_delegatedStakeToPoolByOwner[staker][poolId]);
-
         _withdrawAndSyncDelegatorRewards(
             poolId,
-            staker,
-            initDelegatedStake,
-            finalDelegatedStake
+            staker
         );
     }
 
@@ -227,10 +216,6 @@ contract MixinStake is
         // sanity check the pool we're undelegating from exists
         _assertStakingPoolExists(poolId);
 
-        // cache amount delegated to pool by staker
-        IStructs.StoredBalance memory initDelegatedStake =
-            _loadUnsyncedBalance(_delegatedStakeToPoolByOwner[staker][poolId]);
-
         // decrement how much stake the staker has delegated to the input pool
         _decreaseNextBalance(
             _delegatedStakeToPoolByOwner[staker][poolId],
@@ -240,16 +225,9 @@ contract MixinStake is
         // decrement how much stake has been delegated to pool
         _decreaseNextBalance(_delegatedStakeByPoolId[poolId], amount);
 
-        // synchronizes reward state in the pool that the owner is undelegating
-        // from
-        IStructs.StoredBalance memory finalDelegatedStake =
-            _loadSyncedBalance(_delegatedStakeToPoolByOwner[staker][poolId]);
-
         _withdrawAndSyncDelegatorRewards(
             poolId,
-            staker,
-            initDelegatedStake,
-            finalDelegatedStake
+            staker
         );
     }
 

--- a/contracts/staking/contracts/src/stake/MixinStake.sol
+++ b/contracts/staking/contracts/src/stake/MixinStake.sol
@@ -187,10 +187,9 @@ contract MixinStake is
         // Sanity check the pool we're delegating to exists.
         _assertStakingPoolExists(poolId);
 
-        _withdrawAndSyncDelegatorRewards(
-            poolId,
-            staker
-        );
+        // Cache amount delegated to pool by staker.
+        IStructs.StoredBalance memory initDelegatedStakeToPoolByOwner =
+            _loadUnsyncedBalance(_delegatedStakeToPoolByOwner[staker][poolId]);
 
         // Increment how much stake the staker has delegated to the input pool.
         _increaseNextBalance(
@@ -200,6 +199,12 @@ contract MixinStake is
 
         // Increment how much stake has been delegated to pool.
         _increaseNextBalance(_delegatedStakeByPoolId[poolId], amount);
+
+        _withdrawAndSyncDelegatorRewards(
+            poolId,
+            staker,
+            initDelegatedStakeToPoolByOwner
+        );
     }
 
     /// @dev Un-Delegates a owners stake from a staking pool.
@@ -216,10 +221,9 @@ contract MixinStake is
         // sanity check the pool we're undelegating from exists
         _assertStakingPoolExists(poolId);
 
-        _withdrawAndSyncDelegatorRewards(
-            poolId,
-            staker
-        );
+        // Cache amount delegated to pool by staker.
+        IStructs.StoredBalance memory initDelegatedStakeToPoolByOwner =
+            _loadUnsyncedBalance(_delegatedStakeToPoolByOwner[staker][poolId]);
 
         // decrement how much stake the staker has delegated to the input pool
         _decreaseNextBalance(
@@ -229,6 +233,12 @@ contract MixinStake is
 
         // decrement how much stake has been delegated to pool
         _decreaseNextBalance(_delegatedStakeByPoolId[poolId], amount);
+
+        _withdrawAndSyncDelegatorRewards(
+            poolId,
+            staker,
+            initDelegatedStakeToPoolByOwner
+        );
     }
 
     /// @dev Returns a storage pointer to a user's stake in a given status.

--- a/contracts/staking/contracts/src/stake/MixinStakeStorage.sol
+++ b/contracts/staking/contracts/src/stake/MixinStakeStorage.sol
@@ -111,7 +111,7 @@ contract MixinStakeStorage is
     /// @dev Increments both the `current` and `next` fields.
     /// @param balancePtr storage pointer to balance.
     /// @param amount to mint.
-    function _incrementCurrentAndNextBalance(IStructs.StoredBalance storage balancePtr, uint256 amount)
+    function _increaseCurrentAndNextBalance(IStructs.StoredBalance storage balancePtr, uint256 amount)
         internal
     {
         // Remove stake from balance
@@ -126,7 +126,7 @@ contract MixinStakeStorage is
     /// @dev Decrements both the `current` and `next` fields.
     /// @param balancePtr storage pointer to balance.
     /// @param amount to mint.
-    function _decrementCurrentAndNextBalance(IStructs.StoredBalance storage balancePtr, uint256 amount)
+    function _decreaseCurrentAndNextBalance(IStructs.StoredBalance storage balancePtr, uint256 amount)
         internal
     {
         // Remove stake from balance
@@ -141,7 +141,7 @@ contract MixinStakeStorage is
     /// @dev Increments the `next` field (but not the `current` field).
     /// @param balancePtr storage pointer to balance.
     /// @param amount to increment by.
-    function _incrementNextBalance(IStructs.StoredBalance storage balancePtr, uint256 amount)
+    function _increaseNextBalance(IStructs.StoredBalance storage balancePtr, uint256 amount)
         internal
     {
         // Add stake to balance
@@ -155,7 +155,7 @@ contract MixinStakeStorage is
     /// @dev Decrements the `next` field (but not the `current` field).
     /// @param balancePtr storage pointer to balance.
     /// @param amount to decrement by.
-    function _decrementNextBalance(IStructs.StoredBalance storage balancePtr, uint256 amount)
+    function _decreaseNextBalance(IStructs.StoredBalance storage balancePtr, uint256 amount)
         internal
     {
         // Remove stake from balance

--- a/contracts/staking/contracts/src/staking_pools/MixinCumulativeRewards.sol
+++ b/contracts/staking/contracts/src/staking_pools/MixinCumulativeRewards.sol
@@ -37,7 +37,6 @@ contract MixinCumulativeRewards is
         // Sets the default cumulative reward
         _forceSetCumulativeReward(
             poolId,
-            currentEpoch,
             IStructs.Fraction({
                 numerator: 0,
                 denominator: MIN_TOKEN_VALUE
@@ -60,33 +59,28 @@ contract MixinCumulativeRewards is
     /// @dev Sets a cumulative reward for `poolId` at `epoch`.
     /// This can be used to overwrite an existing value.
     /// @param poolId Unique Id of pool.
-    /// @param epoch Epoch of cumulative reward.
     /// @param value Value of cumulative reward.
     function _forceSetCumulativeReward(
         bytes32 poolId,
-        uint256 epoch,
         IStructs.Fraction memory value
     )
         internal
     {
-        _cumulativeRewardsByPool[poolId][epoch] = value;
+        uint256 currentEpoch_ = currentEpoch;
+        _cumulativeRewardsByPool[poolId][currentEpoch_] = value;
 
-        // Never set the most recent reward epoch to one in the future, because
-        // it may get removed if there are no more dependencies on it.
-        if (epoch <= currentEpoch) {
-            // Check if we should do any work
-            uint256 currentMostRecentEpoch = _cumulativeRewardsByPoolLastStored[poolId];
-            if (epoch == currentMostRecentEpoch) {
-                return;
-            }
-
-            // Update state to reflect the most recent cumulative reward
-            _forceSetMostRecentCumulativeRewardEpoch(
-                poolId,
-                currentMostRecentEpoch,
-                epoch
-            );
+        // Check if we should do any work
+        uint256 currentMostRecentEpoch = _cumulativeRewardsByPoolLastStored[poolId];
+        if (currentEpoch_ == currentMostRecentEpoch) {
+            return;
         }
+
+        // Update state to reflect the most recent cumulative reward
+        _forceSetMostRecentCumulativeRewardEpoch(
+            poolId,
+            currentMostRecentEpoch,
+            currentEpoch_
+        );
     }
 
     /// @dev Forcefully sets the epoch of the most recent cumulative reward.

--- a/contracts/staking/contracts/src/staking_pools/MixinCumulativeRewards.sol
+++ b/contracts/staking/contracts/src/staking_pools/MixinCumulativeRewards.sol
@@ -76,29 +76,8 @@ contract MixinCumulativeRewards is
         }
 
         // Update state to reflect the most recent cumulative reward
-        _forceSetMostRecentCumulativeRewardEpoch(
-            poolId,
-            currentMostRecentEpoch,
-            currentEpoch_
-        );
-    }
-
-    /// @dev Forcefully sets the epoch of the most recent cumulative reward.
-    /// @param poolId Unique Id of pool.
-    /// @param currentMostRecentEpoch Epoch of the most recent cumulative
-    ///        reward.
-    /// @param newMostRecentEpoch Epoch of the new most recent cumulative
-    ///        reward.
-    function _forceSetMostRecentCumulativeRewardEpoch(
-        bytes32 poolId,
-        uint256 currentMostRecentEpoch,
-        uint256 newMostRecentEpoch
-    )
-        internal
-    {
-        // Sanity check that we're not trying to go back in time
-        assert(newMostRecentEpoch >= currentMostRecentEpoch);
-        _cumulativeRewardsByPoolLastStored[poolId] = newMostRecentEpoch;
+        assert(currentEpoch_ > currentMostRecentEpoch);
+        _cumulativeRewardsByPoolLastStored[poolId] = currentEpoch_;
     }
 
     /// @dev Computes a member's reward over a given epoch interval.

--- a/contracts/staking/contracts/src/staking_pools/MixinCumulativeRewards.sol
+++ b/contracts/staking/contracts/src/staking_pools/MixinCumulativeRewards.sol
@@ -68,15 +68,10 @@ contract MixinCumulativeRewards is
     {
         uint256 currentEpoch_ = currentEpoch;
         _cumulativeRewardsByPool[poolId][currentEpoch_] = value;
-
-        // Check if we should do any work
-        uint256 currentMostRecentEpoch = _cumulativeRewardsByPoolLastStored[poolId];
-        if (currentEpoch_ == currentMostRecentEpoch) {
-            return;
-        }
-
+        
         // Update state to reflect the most recent cumulative reward
-        assert(currentEpoch_ > currentMostRecentEpoch);
+        uint256 currentMostRecentEpoch = _cumulativeRewardsByPoolLastStored[poolId];
+        assert(currentEpoch_ >= currentMostRecentEpoch);
         _cumulativeRewardsByPoolLastStored[poolId] = currentEpoch_;
     }
 

--- a/contracts/staking/contracts/src/staking_pools/MixinStakingPoolRewards.sol
+++ b/contracts/staking/contracts/src/staking_pools/MixinStakingPoolRewards.sol
@@ -44,23 +44,15 @@ contract MixinStakingPoolRewards is
     {
         address member = msg.sender;
 
-        IStructs.StoredBalance memory finalDelegatedStake =
-            _loadSyncedBalance(_delegatedStakeToPoolByOwner[member][poolId]);
-
-        IStructs.StoredBalance memory initDelegatedStake =
-            _loadUnsyncedBalance(_delegatedStakeToPoolByOwner[member][poolId]);
-
         _withdrawAndSyncDelegatorRewards(
             poolId,
-            member,
-            initDelegatedStake,
-            finalDelegatedStake
+            member
         );
 
         // Update stored balance with synchronized version; this prevents
         // redundant withdrawals.
         _delegatedStakeToPoolByOwner[member][poolId] =
-            finalDelegatedStake;
+            _loadSyncedBalance(_delegatedStakeToPoolByOwner[member][poolId]);
     }
 
     /// @dev Computes the reward balance in ETH of the operator of a pool.
@@ -110,7 +102,7 @@ contract MixinStakingPoolRewards is
         );
         return _computeDelegatorReward(
             poolId,
-            _loadUnsyncedBalance(_delegatedStakeToPoolByOwner[member][poolId]),
+            member,
             unfinalizedMembersReward,
             unfinalizedMembersStake
         );
@@ -120,15 +112,9 @@ contract MixinStakingPoolRewards is
     ///      withdrawing rewards and adding/removing dependencies on cumulative rewards.
     /// @param poolId Unique id of pool.
     /// @param member of the pool.
-    /// @param initDelegatedStake The member's delegated
-    ///        balance at the beginning of this transaction.
-    /// @param finalDelegatedStake The member's delegated balance
-    ///        at the end of this transaction.
     function _withdrawAndSyncDelegatorRewards(
         bytes32 poolId,
-        address member,
-        IStructs.StoredBalance memory initDelegatedStake,
-        IStructs.StoredBalance memory finalDelegatedStake
+        address member
     )
         internal
     {
@@ -138,7 +124,7 @@ contract MixinStakingPoolRewards is
         // Compute balance owed to delegator
         uint256 balance = _computeDelegatorReward(
             poolId,
-            initDelegatedStake,
+            member,
             // No unfinalized values because we ensured the pool is already
             // finalized.
             0,
@@ -158,7 +144,7 @@ contract MixinStakingPoolRewards is
         // epoch, if necessary.
         _setCumulativeRewardDependenciesForDelegator(
             poolId,
-            finalDelegatedStake
+            member
         );
     }
 
@@ -261,13 +247,13 @@ contract MixinStakingPoolRewards is
 
     /// @dev Computes the reward balance in ETH of a specific member of a pool.
     /// @param poolId Unique id of pool.
-    /// @param unsyncedStake Unsynced delegated stake to pool by staker
+    /// @param member of the pool.
     /// @param unfinalizedMembersReward Unfinalized total members reward (if any).
     /// @param unfinalizedMembersStake Unfinalized total members stake (if any).
     /// @return reward Balance in WETH.
     function _computeDelegatorReward(
         bytes32 poolId,
-        IStructs.StoredBalance memory unsyncedStake,
+        address member,
         uint256 unfinalizedMembersReward,
         uint256 unfinalizedMembersStake
     )
@@ -281,6 +267,9 @@ contract MixinStakingPoolRewards is
         if (_currentEpoch == 0) {
             return 0;
         }
+
+        IStructs.StoredBalance memory unsyncedStake =
+            _loadUnsyncedBalance(_delegatedStakeToPoolByOwner[member][poolId]);
 
         // There can be no rewards if the last epoch when stake was synced is
         // equal to the current epoch, because all prior rewards, including
@@ -368,23 +357,25 @@ contract MixinStakingPoolRewards is
     ///      A delegator always depends on the cumulative reward for the current
     ///      and next epoch, if they would still have stake in the next epoch.
     /// @param poolId Unique id of pool.
-    /// @param finalDelegatedStake Amount of stake the member has
-    ///        delegated to the pool.
+    /// @param member of the pool.
     function _setCumulativeRewardDependenciesForDelegator(
         bytes32 poolId,
-        IStructs.StoredBalance memory finalDelegatedStake
+        address member
     )
         private
     {
-        // Get the most recent cumulative reward, which will serve as a
-        // reference point when updating dependencies
-        IStructs.Fraction memory mostRecentCumulativeReward = _getMostRecentCumulativeReward(poolId);
+        IStructs.StoredBalance memory finalDelegatedStake =
+            _loadSyncedBalance(_delegatedStakeToPoolByOwner[member][poolId]);
 
         // The delegator depends on the Cumulative Reward for this epoch
         // only if they are currently staked or will be staked next epoch.
         if (finalDelegatedStake.currentEpochBalance == 0 && finalDelegatedStake.nextEpochBalance == 0) {
             return;
         }
+
+        // Get the most recent cumulative reward, which will serve as a
+        // reference point when updating dependencies
+        IStructs.Fraction memory mostRecentCumulativeReward = _getMostRecentCumulativeReward(poolId);
 
         // Delegator depends on the Cumulative Reward for this epoch - ensure it is set.
         if (!_isCumulativeRewardSet(_cumulativeRewardsByPool[poolId][finalDelegatedStake.currentEpoch])) {

--- a/contracts/staking/contracts/src/staking_pools/MixinStakingPoolRewards.sol
+++ b/contracts/staking/contracts/src/staking_pools/MixinStakingPoolRewards.sol
@@ -206,7 +206,6 @@ contract MixinStakingPoolRewards is
             // Store cumulative rewards for this epoch.
             _forceSetCumulativeReward(
                 poolId,
-                currentEpoch,
                 cumulativeReward
             );
         }
@@ -381,7 +380,6 @@ contract MixinStakingPoolRewards is
         if (!_isCumulativeRewardSet(_cumulativeRewardsByPool[poolId][finalDelegatedStake.currentEpoch])) {
             _forceSetCumulativeReward(
                 poolId,
-                finalDelegatedStake.currentEpoch,
                 mostRecentCumulativeReward
             );
         }

--- a/contracts/staking/contracts/test/TestCumulativeRewardTracking.sol
+++ b/contracts/staking/contracts/test/TestCumulativeRewardTracking.sol
@@ -51,15 +51,13 @@ contract TestCumulativeRewardTracking is
 
     function _forceSetCumulativeReward(
         bytes32 poolId,
-        uint256 epoch,
         IStructs.Fraction memory value
     )
         internal
     {
-        emit SetCumulativeReward(poolId, epoch);
+        emit SetCumulativeReward(poolId, currentEpoch);
         MixinCumulativeRewards._forceSetCumulativeReward(
             poolId,
-            epoch,
             value
         );
     }

--- a/contracts/staking/contracts/test/TestCumulativeRewardTracking.sol
+++ b/contracts/staking/contracts/test/TestCumulativeRewardTracking.sol
@@ -30,11 +30,6 @@ contract TestCumulativeRewardTracking is
         uint256 epoch
     );
 
-    event SetMostRecentCumulativeReward(
-        bytes32 poolId,
-        uint256 epoch
-    );
-
     constructor(
         address wethAddress,
         address zrxVaultAddress
@@ -59,21 +54,6 @@ contract TestCumulativeRewardTracking is
         MixinCumulativeRewards._forceSetCumulativeReward(
             poolId,
             value
-        );
-    }
-
-    function _forceSetMostRecentCumulativeRewardEpoch(
-        bytes32 poolId,
-        uint256 currentMostRecentEpoch,
-        uint256 newMostRecentEpoch
-    )
-        internal
-    {
-        emit SetMostRecentCumulativeReward(poolId, newMostRecentEpoch);
-        MixinCumulativeRewards._forceSetMostRecentCumulativeRewardEpoch(
-            poolId,
-            currentMostRecentEpoch,
-            newMostRecentEpoch
         );
     }
 }

--- a/contracts/staking/contracts/test/TestDelegatorRewards.sol
+++ b/contracts/staking/contracts/test/TestDelegatorRewards.sol
@@ -110,7 +110,10 @@ contract TestDelegatorRewards is
         external
     {
         _initGenesisCumulativeRewards(poolId);
-        IStructs.StoredBalance memory initialStake = _delegatedStakeToPoolByOwner[delegator][poolId];
+        _withdrawAndSyncDelegatorRewards(
+            poolId,
+            delegator
+        );
         IStructs.StoredBalance storage _stake = _delegatedStakeToPoolByOwner[delegator][poolId];
         _stake.isInitialized = true;
         _stake.currentEpochBalance += uint96(stake);
@@ -118,8 +121,7 @@ contract TestDelegatorRewards is
         _stake.currentEpoch = uint32(currentEpoch);
         _withdrawAndSyncDelegatorRewards(
             poolId,
-            delegator,
-            initialStake
+            delegator
         );
     }
 
@@ -134,7 +136,10 @@ contract TestDelegatorRewards is
         external
     {
         _initGenesisCumulativeRewards(poolId);
-        IStructs.StoredBalance memory initialStake = _delegatedStakeToPoolByOwner[delegator][poolId];
+        _withdrawAndSyncDelegatorRewards(
+            poolId,
+            delegator
+        );
         IStructs.StoredBalance storage _stake = _delegatedStakeToPoolByOwner[delegator][poolId];
         if (_stake.currentEpoch < currentEpoch) {
             _stake.currentEpochBalance = _stake.nextEpochBalance;
@@ -142,11 +147,6 @@ contract TestDelegatorRewards is
         _stake.isInitialized = true;
         _stake.nextEpochBalance += uint96(stake);
         _stake.currentEpoch = uint32(currentEpoch);
-        _withdrawAndSyncDelegatorRewards(
-            poolId,
-            delegator,
-            initialStake
-        );
     }
 
     /// @dev Clear stake that will occur in the next epoch
@@ -160,7 +160,10 @@ contract TestDelegatorRewards is
         external
     {
         _initGenesisCumulativeRewards(poolId);
-        IStructs.StoredBalance memory initialStake = _delegatedStakeToPoolByOwner[delegator][poolId];
+        _withdrawAndSyncDelegatorRewards(
+            poolId,
+            delegator
+        );
         IStructs.StoredBalance storage _stake = _delegatedStakeToPoolByOwner[delegator][poolId];
         if (_stake.currentEpoch < currentEpoch) {
             _stake.currentEpochBalance = _stake.nextEpochBalance;
@@ -168,11 +171,6 @@ contract TestDelegatorRewards is
         _stake.isInitialized = true;
         _stake.nextEpochBalance -= uint96(stake);
         _stake.currentEpoch = uint32(currentEpoch);
-        _withdrawAndSyncDelegatorRewards(
-            poolId,
-            delegator,
-            initialStake
-        );
     }
 
     // solhint-disable no-simple-event-func-name

--- a/contracts/staking/contracts/test/TestDelegatorRewards.sol
+++ b/contracts/staking/contracts/test/TestDelegatorRewards.sol
@@ -86,7 +86,7 @@ contract TestDelegatorRewards is
         _poolById[poolId].operator = operatorAddress;
         _setOperatorShare(poolId, operatorReward, membersReward);
         _initGenesisCumulativeRewards(poolId);
-        
+
         _syncPoolRewards(
             poolId,
             operatorReward + membersReward,
@@ -110,6 +110,7 @@ contract TestDelegatorRewards is
         external
     {
         _initGenesisCumulativeRewards(poolId);
+        IStructs.StoredBalance memory initialStake = _delegatedStakeToPoolByOwner[delegator][poolId];
         IStructs.StoredBalance storage _stake = _delegatedStakeToPoolByOwner[delegator][poolId];
         _stake.isInitialized = true;
         _stake.currentEpochBalance += uint96(stake);
@@ -117,7 +118,8 @@ contract TestDelegatorRewards is
         _stake.currentEpoch = uint32(currentEpoch);
         _withdrawAndSyncDelegatorRewards(
             poolId,
-            delegator
+            delegator,
+            initialStake
         );
     }
 
@@ -132,6 +134,7 @@ contract TestDelegatorRewards is
         external
     {
         _initGenesisCumulativeRewards(poolId);
+        IStructs.StoredBalance memory initialStake = _delegatedStakeToPoolByOwner[delegator][poolId];
         IStructs.StoredBalance storage _stake = _delegatedStakeToPoolByOwner[delegator][poolId];
         if (_stake.currentEpoch < currentEpoch) {
             _stake.currentEpochBalance = _stake.nextEpochBalance;
@@ -141,7 +144,8 @@ contract TestDelegatorRewards is
         _stake.currentEpoch = uint32(currentEpoch);
         _withdrawAndSyncDelegatorRewards(
             poolId,
-            delegator
+            delegator,
+            initialStake
         );
     }
 
@@ -156,6 +160,7 @@ contract TestDelegatorRewards is
         external
     {
         _initGenesisCumulativeRewards(poolId);
+        IStructs.StoredBalance memory initialStake = _delegatedStakeToPoolByOwner[delegator][poolId];
         IStructs.StoredBalance storage _stake = _delegatedStakeToPoolByOwner[delegator][poolId];
         if (_stake.currentEpoch < currentEpoch) {
             _stake.currentEpochBalance = _stake.nextEpochBalance;
@@ -165,7 +170,8 @@ contract TestDelegatorRewards is
         _stake.currentEpoch = uint32(currentEpoch);
         _withdrawAndSyncDelegatorRewards(
             poolId,
-            delegator
+            delegator,
+            initialStake
         );
     }
 

--- a/contracts/staking/contracts/test/TestDelegatorRewards.sol
+++ b/contracts/staking/contracts/test/TestDelegatorRewards.sol
@@ -110,7 +110,6 @@ contract TestDelegatorRewards is
         external
     {
         _initGenesisCumulativeRewards(poolId);
-        IStructs.StoredBalance memory initialStake = _delegatedStakeToPoolByOwner[delegator][poolId];
         IStructs.StoredBalance storage _stake = _delegatedStakeToPoolByOwner[delegator][poolId];
         _stake.isInitialized = true;
         _stake.currentEpochBalance += uint96(stake);
@@ -118,9 +117,7 @@ contract TestDelegatorRewards is
         _stake.currentEpoch = uint32(currentEpoch);
         _withdrawAndSyncDelegatorRewards(
             poolId,
-            delegator,
-            initialStake,
-            _stake
+            delegator
         );
     }
 
@@ -135,7 +132,6 @@ contract TestDelegatorRewards is
         external
     {
         _initGenesisCumulativeRewards(poolId);
-        IStructs.StoredBalance memory initialStake = _delegatedStakeToPoolByOwner[delegator][poolId];
         IStructs.StoredBalance storage _stake = _delegatedStakeToPoolByOwner[delegator][poolId];
         if (_stake.currentEpoch < currentEpoch) {
             _stake.currentEpochBalance = _stake.nextEpochBalance;
@@ -145,9 +141,7 @@ contract TestDelegatorRewards is
         _stake.currentEpoch = uint32(currentEpoch);
         _withdrawAndSyncDelegatorRewards(
             poolId,
-            delegator,
-            initialStake,
-            _stake
+            delegator
         );
     }
 
@@ -162,7 +156,6 @@ contract TestDelegatorRewards is
         external
     {
         _initGenesisCumulativeRewards(poolId);
-        IStructs.StoredBalance memory initialStake = _delegatedStakeToPoolByOwner[delegator][poolId];
         IStructs.StoredBalance storage _stake = _delegatedStakeToPoolByOwner[delegator][poolId];
         if (_stake.currentEpoch < currentEpoch) {
             _stake.currentEpochBalance = _stake.nextEpochBalance;
@@ -172,9 +165,7 @@ contract TestDelegatorRewards is
         _stake.currentEpoch = uint32(currentEpoch);
         _withdrawAndSyncDelegatorRewards(
             poolId,
-            delegator,
-            initialStake,
-            _stake
+            delegator
         );
     }
 

--- a/contracts/staking/contracts/test/TestStakingNoWETH.sol
+++ b/contracts/staking/contracts/test/TestStakingNoWETH.sol
@@ -22,7 +22,7 @@ pragma experimental ABIEncoderV2;
 import "../src/Staking.sol";
 
 
-// solhint-disable no-empty-blocks
+// solhint-disable no-empty-blocks,no-simple-event-func-name
 /// @dev A version of the staking contract with WETH-related functions
 ///      overridden to do nothing.
 contract TestStakingNoWETH is

--- a/contracts/staking/test/cumulative_reward_tracking_test.ts
+++ b/contracts/staking/test/cumulative_reward_tracking_test.ts
@@ -128,7 +128,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Clears CR for epoch 1
                     TestAction.Delegate,
                 ],
-                [{ event: 'SetCumulativeReward', epoch: 2 } ],
+                [{ event: 'SetCumulativeReward', epoch: 2 }],
             );
         });
         it('delegate in epoch 1 then undelegate in epoch 2', async () => {
@@ -152,7 +152,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Clear CR for epoch 1
                     TestAction.Undelegate,
                 ],
-                [{ event: 'SetCumulativeReward', epoch: 2 } ],
+                [{ event: 'SetCumulativeReward', epoch: 2 }],
             );
         });
         it('delegate in epoch 0 and epoch 1, then undelegate half in epoch 2', async () => {
@@ -181,7 +181,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Clears CR for epoch 1
                     TestAction.Undelegate,
                 ],
-                [{ event: 'SetCumulativeReward', epoch: 2 } ],
+                [{ event: 'SetCumulativeReward', epoch: 2 }],
             );
         });
         it('delegate in epoch 1 and 2 then again in 3', async () => {
@@ -210,7 +210,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Clears CR for epoch 1
                     TestAction.Delegate,
                 ],
-                [{ event: 'SetCumulativeReward', epoch: 2 } ],
+                [{ event: 'SetCumulativeReward', epoch: 2 }],
             );
         });
         it('delegate in epoch 0, earn reward in epoch 1', async () => {
@@ -233,7 +233,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Sets MRCR to epoch 2
                     TestAction.Finalize,
                 ],
-                [{ event: 'SetCumulativeReward', epoch: 2 } ],
+                [{ event: 'SetCumulativeReward', epoch: 2 }],
             );
         });
         it('delegate in epoch 0, epoch 2, earn reward in epoch 3, then delegate', async () => {
@@ -341,7 +341,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Clears CR for epoch 1
                     TestAction.Delegate,
                 ],
-                [{ event: 'SetCumulativeReward', epoch: 4 } ],
+                [{ event: 'SetCumulativeReward', epoch: 4 }],
             );
         });
         it('earn reward in epoch 1 with no stake, then delegate', async () => {
@@ -397,7 +397,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Creates CR for epoch 5
                     TestAction.Delegate,
                 ],
-                [{ event: 'SetCumulativeReward', epoch: 4 } ],
+                [{ event: 'SetCumulativeReward', epoch: 4 }],
             );
         });
         it('delegate in epoch 1, then epoch 3', async () => {
@@ -425,7 +425,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Clears CR for epoch 2
                     TestAction.Delegate,
                 ],
-                [{ event: 'SetCumulativeReward', epoch: 3 } ],
+                [{ event: 'SetCumulativeReward', epoch: 3 }],
             );
         });
     });

--- a/contracts/staking/test/cumulative_reward_tracking_test.ts
+++ b/contracts/staking/test/cumulative_reward_tracking_test.ts
@@ -39,7 +39,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
             await simulation.runTestAsync(
                 [TestAction.Finalize],
                 [TestAction.CreatePool],
-                [{ event: 'SetCumulativeReward', epoch: 1 }, { event: 'SetMostRecentCumulativeReward', epoch: 1 }],
+                [{ event: 'SetCumulativeReward', epoch: 1 }],
             );
         });
         it('delegating in the same epoch pool is created', async () => {
@@ -86,7 +86,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Unsets the CR for epoch 0
                     TestAction.Delegate,
                 ],
-                [{ event: 'SetCumulativeReward', epoch: 1 }, { event: 'SetMostRecentCumulativeReward', epoch: 1 }],
+                [{ event: 'SetCumulativeReward', epoch: 1 }],
             );
         });
         it('re-delegating in a new epoch', async () => {
@@ -105,7 +105,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Sets MRCR to epoch 1
                     TestAction.Delegate,
                 ],
-                [{ event: 'SetCumulativeReward', epoch: 1 }, { event: 'SetMostRecentCumulativeReward', epoch: 1 }],
+                [{ event: 'SetCumulativeReward', epoch: 1 }],
             );
         });
         it('delegating in epoch 1 then again in epoch 2', async () => {
@@ -128,7 +128,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Clears CR for epoch 1
                     TestAction.Delegate,
                 ],
-                [{ event: 'SetCumulativeReward', epoch: 2 }, { event: 'SetMostRecentCumulativeReward', epoch: 2 }],
+                [{ event: 'SetCumulativeReward', epoch: 2 } ],
             );
         });
         it('delegate in epoch 1 then undelegate in epoch 2', async () => {
@@ -152,7 +152,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Clear CR for epoch 1
                     TestAction.Undelegate,
                 ],
-                [{ event: 'SetCumulativeReward', epoch: 2 }, { event: 'SetMostRecentCumulativeReward', epoch: 2 }],
+                [{ event: 'SetCumulativeReward', epoch: 2 } ],
             );
         });
         it('delegate in epoch 0 and epoch 1, then undelegate half in epoch 2', async () => {
@@ -181,7 +181,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Clears CR for epoch 1
                     TestAction.Undelegate,
                 ],
-                [{ event: 'SetCumulativeReward', epoch: 2 }, { event: 'SetMostRecentCumulativeReward', epoch: 2 }],
+                [{ event: 'SetCumulativeReward', epoch: 2 } ],
             );
         });
         it('delegate in epoch 1 and 2 then again in 3', async () => {
@@ -210,7 +210,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Clears CR for epoch 1
                     TestAction.Delegate,
                 ],
-                [{ event: 'SetCumulativeReward', epoch: 2 }, { event: 'SetMostRecentCumulativeReward', epoch: 2 }],
+                [{ event: 'SetCumulativeReward', epoch: 2 } ],
             );
         });
         it('delegate in epoch 0, earn reward in epoch 1', async () => {
@@ -233,7 +233,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Sets MRCR to epoch 2
                     TestAction.Finalize,
                 ],
-                [{ event: 'SetCumulativeReward', epoch: 2 }, { event: 'SetMostRecentCumulativeReward', epoch: 2 }],
+                [{ event: 'SetCumulativeReward', epoch: 2 } ],
             );
         });
         it('delegate in epoch 0, epoch 2, earn reward in epoch 3, then delegate', async () => {
@@ -341,7 +341,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Clears CR for epoch 1
                     TestAction.Delegate,
                 ],
-                [{ event: 'SetCumulativeReward', epoch: 4 }, { event: 'SetMostRecentCumulativeReward', epoch: 4 }],
+                [{ event: 'SetCumulativeReward', epoch: 4 } ],
             );
         });
         it('earn reward in epoch 1 with no stake, then delegate', async () => {
@@ -362,7 +362,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Creates CR for epoch 2
                     TestAction.Delegate,
                 ],
-                [{ event: 'SetCumulativeReward', epoch: 1 }, { event: 'SetMostRecentCumulativeReward', epoch: 1 }],
+                [{ event: 'SetCumulativeReward', epoch: 1 }],
             );
         });
         it('delegate in epoch 1, 3, then delegate in epoch 4', async () => {
@@ -397,7 +397,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Creates CR for epoch 5
                     TestAction.Delegate,
                 ],
-                [{ event: 'SetCumulativeReward', epoch: 4 }, { event: 'SetMostRecentCumulativeReward', epoch: 4 }],
+                [{ event: 'SetCumulativeReward', epoch: 4 } ],
             );
         });
         it('delegate in epoch 1, then epoch 3', async () => {
@@ -425,7 +425,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Clears CR for epoch 2
                     TestAction.Delegate,
                 ],
-                [{ event: 'SetCumulativeReward', epoch: 3 }, { event: 'SetMostRecentCumulativeReward', epoch: 3 }],
+                [{ event: 'SetCumulativeReward', epoch: 3 } ],
             );
         });
     });

--- a/contracts/staking/test/cumulative_reward_tracking_test.ts
+++ b/contracts/staking/test/cumulative_reward_tracking_test.ts
@@ -53,7 +53,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Creates CR for epoch 1
                     TestAction.Delegate,
                 ],
-                [{ event: 'SetCumulativeReward', epoch: 0 }],
+                [],
             );
         });
         it('re-delegating in the same epoch', async () => {
@@ -68,7 +68,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Updates CR for epoch 0
                     TestAction.Delegate,
                 ],
-                [{ event: 'SetCumulativeReward', epoch: 0 }, { event: 'SetCumulativeReward', epoch: 0 }],
+                [],
             );
         });
         it('delegating in new epoch', async () => {
@@ -268,7 +268,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Clears CR for epoch 2
                     TestAction.Delegate,
                 ],
-                [{ event: 'SetCumulativeReward', epoch: 3 }],
+                [],
             );
         });
         it('delegate in epoch 0 and 1, earn reward in epoch 3, then undelegate half', async () => {
@@ -303,7 +303,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Clears CR for epoch 2
                     TestAction.Undelegate,
                 ],
-                [{ event: 'SetCumulativeReward', epoch: 3 }],
+                [],
             );
         });
         it('delegate in epoch 1, 2, earn rewards in epoch 3, skip to epoch 4, then delegate', async () => {

--- a/contracts/staking/test/utils/cumulative_reward_tracking_simulation.ts
+++ b/contracts/staking/test/utils/cumulative_reward_tracking_simulation.ts
@@ -36,12 +36,7 @@ export class CumulativeRewardTrackingSimulation {
     private static _extractTestLogs(txReceiptLogs: DecodedLogs): TestLog[] {
         const logs = [];
         for (const log of txReceiptLogs) {
-            if (log.event === TestCumulativeRewardTrackingEvents.SetMostRecentCumulativeReward) {
-                logs.push({
-                    event: log.event,
-                    epoch: log.args.epoch.toNumber(),
-                });
-            } else if (log.event === TestCumulativeRewardTrackingEvents.SetCumulativeReward) {
+            if (log.event === TestCumulativeRewardTrackingEvents.SetCumulativeReward) {
                 logs.push({
                     event: log.event,
                     epoch: log.args.epoch.toNumber(),


### PR DESCRIPTION
## Description

This PR mostly renames variables and flattens some of the logic in `MixinStakingPoolRewards` to improve readability. In the process, I came across a bug in `_trySetCumulativeReward` where it would _always_ call `_forceSetCumulativeReward`. It would return early only iff `epoch < currentEpoch && ...`. The value passed in as `epoch` was always `_loadSyncedBalance(...).currentEpoch`, which is necessarily >= `currentEpoch`.

When reviewing this PR, please note the changes in the test cases and double check that this in intended behavior.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
