### PR TITLE
Remove wethAssetProxy and wethAssetData from staking contracts

### DIFF
--- a/contracts/staking/contracts/src/fees/MixinExchangeFees.sol
+++ b/contracts/staking/contracts/src/fees/MixinExchangeFees.sol
@@ -56,11 +56,13 @@ contract MixinExchangeFees is
         // Transfer the protocol fee to this address if it should be paid in
         // WETH.
         if (msg.value == 0) {
-            getWethAssetProxy().transferFrom(
-                getWethAssetData(),
-                payerAddress,
-                address(this),
-                protocolFeePaid
+            require(
+                getWethContract().transferFrom(
+                    payerAddress,
+                    address(this),
+                    protocolFeePaid
+                ),
+                "WETH_TRANSFER_FAILED"
             );
         }
 

--- a/contracts/staking/contracts/src/immutable/MixinDeploymentConstants.sol
+++ b/contracts/staking/contracts/src/immutable/MixinDeploymentConstants.sol
@@ -18,7 +18,6 @@
 
 pragma solidity ^0.5.9;
 
-import "@0x/contracts-asset-proxy/contracts/src/interfaces/IAssetProxy.sol";
 import "@0x/contracts-erc20/contracts/src/interfaces/IEtherToken.sol";
 import "../interfaces/IZrxVault.sol";
 
@@ -37,17 +36,7 @@ contract MixinDeploymentConstants {
     // Ropsten & Rinkeby WETH9 Address
     // address constant private WETH_ADDRESS = address(0xc778417e063141139fce010982780140aa0cd5ab);
 
-    // Mainnet Weth Asset Data
-    bytes constant private WETH_ASSET_DATA = hex"f47261b0000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
-
-    // Kovan Weth Asset Data
-    // bytes constant private WETH_ASSET_DATA = hex"f47261b0000000000000000000000000d0a1e359811322d97991e03f863a0c30c2cf029c";
-
-    // Ropsten & Rinkeby Weth Asset Data
-    // bytes constant private WETH_ASSET_DATA = hex"f47261b0000000000000000000000000c778417e063141139fce010982780140aa0cd5ab";
-
     // @TODO SET THESE VALUES FOR DEPLOYMENT
-    address constant private WETH_ASSET_PROXY_ADDRESS = address(1);
     address constant private ZRX_VAULT_ADDRESS = address(1);
 
     /// @dev An overridable way to access the deployed WETH contract.
@@ -60,30 +49,6 @@ contract MixinDeploymentConstants {
     {
         wethContract = IEtherToken(WETH_ADDRESS);
         return wethContract;
-    }
-
-    /// @dev An overridable way to access the deployed WETH assetData.
-    ///      Must be view to allow overrides to access state.
-    /// @return wethAssetData The assetData of the configured WETH contract.
-    function getWethAssetData()
-        public
-        view
-        returns (bytes memory wethAssetData)
-    {
-        wethAssetData = WETH_ASSET_DATA;
-        return wethAssetData;
-    }
-
-    /// @dev An overridable way to access the deployed WETH assetProxy.
-    ///      Must be view to allow overrides to access state.
-    /// @return wethAssetProxy The assetProxy used to transfer WETH.
-    function getWethAssetProxy()
-        public
-        view
-        returns (IAssetProxy wethAssetProxy)
-    {
-        wethAssetProxy = IAssetProxy(WETH_ASSET_PROXY_ADDRESS);
-        return wethAssetProxy;
     }
 
     /// @dev An overridable way to access the deployed zrxVault.

--- a/contracts/staking/contracts/src/immutable/MixinStorage.sol
+++ b/contracts/staking/contracts/src/immutable/MixinStorage.sol
@@ -19,7 +19,6 @@
 pragma solidity ^0.5.9;
 pragma experimental ABIEncoderV2;
 
-import "@0x/contracts-asset-proxy/contracts/src/interfaces/IAssetProxy.sol";
 import "@0x/contracts-utils/contracts/src/LibRichErrors.sol";
 import "@0x/contracts-utils/contracts/src/Authorizable.sol";
 import "./MixinConstants.sol";

--- a/contracts/staking/contracts/src/interfaces/IStorage.sol
+++ b/contracts/staking/contracts/src/interfaces/IStorage.sol
@@ -19,7 +19,6 @@
 pragma solidity ^0.5.9;
 pragma experimental ABIEncoderV2;
 
-import "@0x/contracts-asset-proxy/contracts/src/interfaces/IAssetProxy.sol";
 import "../interfaces/IZrxVault.sol";
 import "../interfaces/IStructs.sol";
 

--- a/contracts/staking/contracts/test/TestCumulativeRewardTracking.sol
+++ b/contracts/staking/contracts/test/TestCumulativeRewardTracking.sol
@@ -37,7 +37,6 @@ contract TestCumulativeRewardTracking is
         public
         TestStaking(
             wethAddress,
-            address(0),
             zrxVaultAddress
         )
     {}

--- a/contracts/staking/contracts/test/TestProtocolFees.sol
+++ b/contracts/staking/contracts/test/TestProtocolFees.sol
@@ -19,7 +19,6 @@
 pragma solidity ^0.5.9;
 pragma experimental ABIEncoderV2;
 
-import "@0x/contracts-asset-proxy/contracts/src/interfaces/IAssetProxy.sol";
 import "../src/interfaces/IStructs.sol";
 import "./TestStakingNoWETH.sol";
 
@@ -34,7 +33,6 @@ contract TestProtocolFees is
     }
 
     event ERC20ProxyTransferFrom(
-        bytes assetData,
         address from,
         address to,
         uint256 amount
@@ -81,14 +79,15 @@ contract TestProtocolFees is
 
     /// @dev The ERC20Proxy `transferFrom()` function.
     function transferFrom(
-        bytes calldata assetData,
         address from,
         address to,
         uint256 amount
     )
         external
+        returns (bool)
     {
-        emit ERC20ProxyTransferFrom(assetData, from, to, amount);
+        emit ERC20ProxyTransferFrom(from, to, amount);
+        return true;
     }
 
     /// @dev Overridden to use test pools.
@@ -127,12 +126,11 @@ contract TestProtocolFees is
         });
     }
 
-    function getWethAssetProxy()
+    function getWethContract()
         public
         view
-        returns (IAssetProxy wethAssetProxy)
+        returns (IEtherToken wethContract)
     {
-        wethAssetProxy = IAssetProxy(address(this));
-        return wethAssetProxy;
+        return IEtherToken(address(this));
     }
 }

--- a/contracts/staking/contracts/test/TestStaking.sol
+++ b/contracts/staking/contracts/test/TestStaking.sol
@@ -28,18 +28,15 @@ contract TestStaking is
     Staking
 {
     address public testWethAddress;
-    address public testWethAssetProxyAddress;
     address public testZrxVaultAddress;
 
     constructor(
         address wethAddress,
-        address wethAssetProxyAddress,
         address zrxVaultAddress
     )
         public
     {
         testWethAddress = wethAddress;
-        testWethAssetProxyAddress = wethAssetProxyAddress;
         testZrxVaultAddress = zrxVaultAddress;
     }
 
@@ -54,28 +51,6 @@ contract TestStaking is
         // instance of this contract.
         address wethAddress = TestStaking(address(uint160(stakingContract))).testWethAddress();
         return IEtherToken(wethAddress);
-    }
-
-    function getWethAssetData()
-        public
-        view
-        returns (bytes memory)
-    {
-        address wethAddress = TestStaking(address(uint160(stakingContract))).testWethAddress();
-        return abi.encodeWithSelector(
-            IAssetData(address(0)).ERC20Token.selector,
-            wethAddress
-        );
-    }
-
-    function getWethAssetProxy()
-        public
-        view
-        returns (IAssetProxy wethAssetProxy)
-    {
-        address wethAssetProxyAddress = TestStaking(address(uint160(stakingContract))).testWethAssetProxyAddress();
-        wethAssetProxy = IAssetProxy(wethAssetProxyAddress);
-        return wethAssetProxy;
     }
 
     function getZrxVault()

--- a/contracts/staking/contracts/test/TestStorageLayoutAndConstants.sol
+++ b/contracts/staking/contracts/test/TestStorageLayoutAndConstants.sol
@@ -43,16 +43,8 @@ contract TestStorageLayoutAndConstants is
         view
     {
         require(
-            getWethAssetData().equals(abi.encodeWithSelector(
-                IAssetData(address(0)).ERC20Token.selector,
-                getWethContract()
-            )),
-            "INVALID_WETH_ASSET_DATA"
-        );
-
-        require(
-            address(getWethAssetProxy()) != address(0),
-            "WETH_ASSET_PROXY_MUST_BE_SET"
+            address(getWethContract()) != address(0),
+            "WETH_MUST_BE_SET"
         );
 
         require(

--- a/contracts/staking/test/unit_tests/protocol_fees_test.ts
+++ b/contracts/staking/test/unit_tests/protocol_fees_test.ts
@@ -28,7 +28,6 @@ blockchainTests('Protocol Fees unit tests', env => {
     let exchangeAddress: string;
     let notExchangeAddress: string;
     let testContract: TestProtocolFeesContract;
-    let wethAssetData: string;
     let minimumStake: BigNumber;
 
     before(async () => {
@@ -46,7 +45,6 @@ blockchainTests('Protocol Fees unit tests', env => {
             exchangeAddress,
         );
 
-        wethAssetData = await testContract.getWethAssetData.callAsync();
         minimumStake = (await testContract.getParams.callAsync())[2];
     });
 
@@ -230,7 +228,6 @@ blockchainTests('Protocol Fees unit tests', env => {
                 );
                 expect(logsArgs.length).to.eq(1);
                 for (const args of logsArgs) {
-                    expect(args.assetData).to.eq(wethAssetData);
                     expect(args.from).to.eq(fromAddress);
                     expect(args.to).to.eq(testContract.address);
                     expect(args.amount).to.bignumber.eq(amount);

--- a/contracts/staking/test/utils/api_wrapper.ts
+++ b/contracts/staking/test/utils/api_wrapper.ts
@@ -243,7 +243,6 @@ export async function deployAndConfigureContractsAsync(
         env.txDefaults,
         artifacts,
         wethContract.address,
-        erc20ProxyContract.address,
         zrxVaultContract.address,
     );
 


### PR DESCRIPTION
## Description

There was some debate around if the staking contracts should use the existing `ERC20Proxy` or not for paying WETH denominated protocol fees. It's a close call, but I think requiring a separate allowance leads to greater security. It also isn't much of an inconvenience for end users, as I expect the majority of protocol fees will be paid in ETH and will therefore not require an allowance.

If the `ERC20Proxy` is not used, it doesn't really make sense to have a separate proxy at all - users can simply approve the staking proxy to spend their WETH directly. This PR removes the WETH AssetProxy from the staking codebase completely.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
