### PR TITLE
Do not authorize owner by default

### DIFF
--- a/contracts/staking/contracts/src/StakingProxy.sol
+++ b/contracts/staking/contracts/src/StakingProxy.sol
@@ -42,7 +42,15 @@ contract StakingProxy is
         MixinStorage()
     {
         readOnlyProxy = _readOnlyProxy;
+
+        // Deployer address must be authorized in order to call `init`
+        _addAuthorizedAddress(msg.sender);
+
+        // Attach the staking contract and initialize state
         _attachStakingContract(_stakingContract);
+
+        // Remove the sender as an authorized address
+        _removeAuthorizedAddressAtIndex(msg.sender, 0);
     }
 
     /// @dev Delegates calls to the staking contract, if it is set.

--- a/contracts/staking/contracts/src/ZrxVault.sol
+++ b/contracts/staking/contracts/src/ZrxVault.sol
@@ -62,8 +62,6 @@ contract ZrxVault is
         public
         Authorizable()
     {
-        _addAuthorizedAddress(owner);
-
         zrxAssetProxy = IAssetProxy(_zrxProxyAddress);
         _zrxToken = IERC20Token(_zrxTokenAddress);
         _zrxAssetData = abi.encodeWithSelector(

--- a/contracts/staking/contracts/src/immutable/MixinStorage.sol
+++ b/contracts/staking/contracts/src/immutable/MixinStorage.sol
@@ -139,12 +139,4 @@ contract MixinStorage is
 
     /// @dev The WETH balance of this contract that is reserved for pool reward payouts.
     uint256 public wethReservedForPoolRewards;
-
-    /// @dev Adds owner as an authorized address.
-    constructor()
-        public
-        Authorizable()
-    {
-        _addAuthorizedAddress(owner);
-    }
 }

--- a/contracts/staking/contracts/test/TestDelegatorRewards.sol
+++ b/contracts/staking/contracts/test/TestDelegatorRewards.sol
@@ -40,7 +40,9 @@ contract TestDelegatorRewards is
     }
 
     constructor() public {
+        _addAuthorizedAddress(msg.sender);
         init();
+        _removeAuthorizedAddressAtIndex(msg.sender, 0);
     }
 
     mapping (uint256 => mapping (bytes32 => UnfinalizedPoolReward)) private

--- a/contracts/staking/contracts/test/TestFinalizer.sol
+++ b/contracts/staking/contracts/test/TestFinalizer.sol
@@ -56,9 +56,11 @@ contract TestFinalizer is
     )
         public
     {
+        _addAuthorizedAddress(msg.sender);
         init();
         _operatorRewardsReceiver = operatorRewardsReceiver;
         _membersRewardsReceiver = membersRewardsReceiver;
+        _removeAuthorizedAddressAtIndex(msg.sender, 0);
     }
 
     /// @dev Activate a pool in the current epoch.

--- a/contracts/staking/contracts/test/TestProtocolFees.sol
+++ b/contracts/staking/contracts/test/TestProtocolFees.sol
@@ -42,8 +42,10 @@ contract TestProtocolFees is
     mapping(address => bytes32) private _makersToTestPoolIds;
 
     constructor(address exchangeAddress) public {
+        _addAuthorizedAddress(msg.sender);
         init();
         validExchanges[exchangeAddress] = true;
+        _removeAuthorizedAddressAtIndex(msg.sender, 0);
     }
 
     function addMakerToPool(bytes32 poolId, address makerAddress)

--- a/contracts/staking/test/migration_test.ts
+++ b/contracts/staking/test/migration_test.ts
@@ -28,6 +28,7 @@ blockchainTests('Migration tests', env => {
             env.txDefaults,
             artifacts,
         );
+        await stakingContract.addAuthorizedAddress.awaitTransactionSuccessAsync(authorizedAddress);
     });
 
     describe('StakingProxy', () => {
@@ -37,13 +38,15 @@ blockchainTests('Migration tests', env => {
         let revertAddress: string;
 
         async function deployStakingProxyAsync(stakingContractAddress?: string): Promise<TestStakingProxyContract> {
-            return TestStakingProxyContract.deployFrom0xArtifactAsync(
+            const proxyContract = await TestStakingProxyContract.deployFrom0xArtifactAsync(
                 artifacts.TestStakingProxy,
                 env.provider,
                 env.txDefaults,
                 artifacts,
                 stakingContractAddress || constants.NULL_ADDRESS,
             );
+            await proxyContract.addAuthorizedAddress.awaitTransactionSuccessAsync(authorizedAddress);
+            return proxyContract;
         }
 
         before(async () => {

--- a/contracts/staking/test/unit_tests/exchange_test.ts
+++ b/contracts/staking/test/unit_tests/exchange_test.ts
@@ -95,6 +95,14 @@ blockchainTests.resets('Exchange Unit Tests', env => {
             return expect(tx).to.revertWith(expectedError);
         });
 
+        it('should revert when adding an exchange if called by the (non-authorized) owner', async () => {
+            const expectedError = new AuthorizableRevertErrors.SenderNotAuthorizedError(owner);
+            const tx = exchangeManager.addExchangeAddress.awaitTransactionSuccessAsync(nonExchange, {
+                from: owner,
+            });
+            return expect(tx).to.revertWith(expectedError);
+        });
+
         it('should successfully add an exchange if called by an authorized address', async () => {
             // Register a new exchange.
             const receipt = await exchangeManager.addExchangeAddress.awaitTransactionSuccessAsync(nonExchange, {
@@ -124,6 +132,14 @@ blockchainTests.resets('Exchange Unit Tests', env => {
             const expectedError = new AuthorizableRevertErrors.SenderNotAuthorizedError(nonAuthority);
             const tx = exchangeManager.removeExchangeAddress.awaitTransactionSuccessAsync(exchange, {
                 from: nonAuthority,
+            });
+            return expect(tx).to.revertWith(expectedError);
+        });
+
+        it('should revert when removing an exchange if called by the (non-authorized) owner', async () => {
+            const expectedError = new AuthorizableRevertErrors.SenderNotAuthorizedError(owner);
+            const tx = exchangeManager.removeExchangeAddress.awaitTransactionSuccessAsync(nonExchange, {
+                from: owner,
             });
             return expect(tx).to.revertWith(expectedError);
         });

--- a/contracts/staking/test/unit_tests/exchange_test.ts
+++ b/contracts/staking/test/unit_tests/exchange_test.ts
@@ -95,20 +95,6 @@ blockchainTests.resets('Exchange Unit Tests', env => {
             return expect(tx).to.revertWith(expectedError);
         });
 
-        it('should successfully add an exchange if called by the (authorized) owner', async () => {
-            // Register a new exchange.
-            const receipt = await exchangeManager.addExchangeAddress.awaitTransactionSuccessAsync(nonExchange, {
-                from: owner,
-            });
-
-            // Ensure that the logged event was correct.
-            verifyExchangeManagerEvent(ExchangeManagerEventType.ExchangeAdded, nonExchange, receipt);
-
-            // Ensure that the exchange was successfully registered.
-            const isValidExchange = await exchangeManager.validExchanges.callAsync(nonExchange);
-            expect(isValidExchange).to.be.true();
-        });
-
         it('should successfully add an exchange if called by an authorized address', async () => {
             // Register a new exchange.
             const receipt = await exchangeManager.addExchangeAddress.awaitTransactionSuccessAsync(nonExchange, {
@@ -140,20 +126,6 @@ blockchainTests.resets('Exchange Unit Tests', env => {
                 from: nonAuthority,
             });
             return expect(tx).to.revertWith(expectedError);
-        });
-
-        it('should successfully remove an exchange if called by the (authorized) owner', async () => {
-            // Remove the registered exchange.
-            const receipt = await exchangeManager.removeExchangeAddress.awaitTransactionSuccessAsync(exchange, {
-                from: owner,
-            });
-
-            // Ensure that the logged event was correct.
-            verifyExchangeManagerEvent(ExchangeManagerEventType.ExchangeRemoved, exchange, receipt);
-
-            // Ensure that the exchange was removed.
-            const isValidExchange = await exchangeManager.validExchanges.callAsync(exchange);
-            expect(isValidExchange).to.be.false();
         });
 
         it('should successfully remove a registered exchange if called by an authorized address', async () => {

--- a/contracts/staking/test/unit_tests/params_test.ts
+++ b/contracts/staking/test/unit_tests/params_test.ts
@@ -21,6 +21,7 @@ blockchainTests('Configurable Parameters unit tests', env => {
             env.txDefaults,
             artifacts,
         );
+        await testContract.addAuthorizedAddress.awaitTransactionSuccessAsync(authorizedAddress);
     });
 
     blockchainTests.resets('setParams()', () => {

--- a/contracts/staking/test/unit_tests/zrx_vault_test.ts
+++ b/contracts/staking/test/unit_tests/zrx_vault_test.ts
@@ -57,6 +57,8 @@ blockchainTests.resets('ZrxVault unit tests', env => {
             zrxTokenContract.address,
         );
 
+        await zrxVault.addAuthorizedAddress.awaitTransactionSuccessAsync(owner);
+
         // configure erc20 proxy to accept calls from zrx vault
         await erc20ProxyContract.addAuthorizedAddress.awaitTransactionSuccessAsync(zrxVault.address);
     });

--- a/contracts/staking/test/utils/api_wrapper.ts
+++ b/contracts/staking/test/utils/api_wrapper.ts
@@ -236,6 +236,8 @@ export async function deployAndConfigureContractsAsync(
         zrxTokenContract.address,
     );
 
+    await zrxVaultContract.addAuthorizedAddress.awaitTransactionSuccessAsync(ownerAddress);
+
     // deploy staking contract
     const stakingContract = await TestStakingContract.deployFrom0xArtifactAsync(
         customStakingArtifact !== undefined ? customStakingArtifact : artifacts.TestStaking,
@@ -263,6 +265,9 @@ export async function deployAndConfigureContractsAsync(
         stakingContract.address,
         readOnlyProxyContract.address,
     );
+
+    await stakingProxyContract.addAuthorizedAddress.awaitTransactionSuccessAsync(ownerAddress);
+
     // deploy cobb douglas contract
     const cobbDouglasContract = await TestCobbDouglasContract.deployFrom0xArtifactAsync(
         artifacts.TestCobbDouglas,


### PR DESCRIPTION
## Description

The actual address used to deploy these contracts should not be authorized. The contracts are typically deployed, configured, and then their ownership is transferred to the `AssetProxyOwner`. This PR removes the owner as an authorized address in the `StakingProxy` and the `ZrxVault`.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
