### PR TITLE
refundFinalBalanceNoReentry

### DIFF
--- a/contracts/exchange/contracts/src/MixinExchangeCore.sol
+++ b/contracts/exchange/contracts/src/MixinExchangeCore.sol
@@ -61,8 +61,7 @@ contract MixinExchangeCore is
     function cancelOrdersUpTo(uint256 targetOrderEpoch)
         external
         payable
-        nonReentrant
-        refundFinalBalance
+        refundFinalBalanceNoReentry
     {
         address makerAddress = _getCurrentContextAddress();
         // If this function is called via `executeTransaction`, we only update the orderEpoch for the makerAddress/msg.sender combination.
@@ -103,8 +102,7 @@ contract MixinExchangeCore is
     )
         public
         payable
-        nonReentrant
-        refundFinalBalance
+        refundFinalBalanceNoReentry
         returns (LibFillResults.FillResults memory fillResults)
     {
         fillResults = _fillOrder(
@@ -120,8 +118,7 @@ contract MixinExchangeCore is
     function cancelOrder(LibOrder.Order memory order)
         public
         payable
-        nonReentrant
-        refundFinalBalance
+        refundFinalBalanceNoReentry
     {
         _cancelOrder(order);
     }

--- a/contracts/exchange/contracts/src/MixinMatchOrders.sol
+++ b/contracts/exchange/contracts/src/MixinMatchOrders.sol
@@ -51,8 +51,7 @@ contract MixinMatchOrders is
     )
         public
         payable
-        nonReentrant
-        refundFinalBalance
+        refundFinalBalanceNoReentry
         returns (LibFillResults.BatchMatchedFillResults memory batchMatchedFillResults)
     {
         return _batchMatchOrders(
@@ -81,8 +80,7 @@ contract MixinMatchOrders is
     )
         public
         payable
-        nonReentrant
-        refundFinalBalance
+        refundFinalBalanceNoReentry
         returns (LibFillResults.BatchMatchedFillResults memory batchMatchedFillResults)
     {
         return _batchMatchOrders(
@@ -111,8 +109,7 @@ contract MixinMatchOrders is
     )
         public
         payable
-        nonReentrant
-        refundFinalBalance
+        refundFinalBalanceNoReentry
         returns (LibFillResults.MatchedFillResults memory matchedFillResults)
     {
         return _matchOrders(
@@ -141,8 +138,7 @@ contract MixinMatchOrders is
     )
         public
         payable
-        nonReentrant
-        refundFinalBalance
+        refundFinalBalanceNoReentry
         returns (LibFillResults.MatchedFillResults memory matchedFillResults)
     {
         return _matchOrders(

--- a/contracts/exchange/contracts/src/MixinSignatureValidator.sol
+++ b/contracts/exchange/contracts/src/MixinSignatureValidator.sol
@@ -22,7 +22,6 @@ pragma experimental ABIEncoderV2;
 import "@0x/contracts-utils/contracts/src/LibBytes.sol";
 import "@0x/contracts-utils/contracts/src/LibEIP1271.sol";
 import "@0x/contracts-utils/contracts/src/LibRichErrors.sol";
-import "@0x/contracts-utils/contracts/src/ReentrancyGuard.sol";
 import "@0x/contracts-exchange-libs/contracts/src/LibOrder.sol";
 import "@0x/contracts-exchange-libs/contracts/src/LibZeroExTransaction.sol";
 import "@0x/contracts-exchange-libs/contracts/src/LibEIP712ExchangeDomain.sol";
@@ -35,7 +34,6 @@ import "./MixinTransactions.sol";
 
 
 contract MixinSignatureValidator is
-    ReentrancyGuard,
     LibEIP712ExchangeDomain,
     LibEIP1271,
     ISignatureValidator,
@@ -61,8 +59,7 @@ contract MixinSignatureValidator is
     function preSign(bytes32 hash)
         external
         payable
-        nonReentrant
-        refundFinalBalance
+        refundFinalBalanceNoReentry
     {
         address signerAddress = _getCurrentContextAddress();
         preSigned[hash][signerAddress] = true;
@@ -78,8 +75,7 @@ contract MixinSignatureValidator is
     )
         external
         payable
-        nonReentrant
-        refundFinalBalance
+        refundFinalBalanceNoReentry
     {
         address signerAddress = _getCurrentContextAddress();
         allowedValidators[signerAddress][validatorAddress] = approval;
@@ -465,7 +461,7 @@ contract MixinSignatureValidator is
         return signatureType;
     }
 
-    /// @dev ABI encodes an order and hash with a selector to be passed into 
+    /// @dev ABI encodes an order and hash with a selector to be passed into
     ///      an EIP1271 compliant `isValidSignature` function.
     function _encodeEIP1271OrderWithHash(
         LibOrder.Order memory order,
@@ -482,7 +478,7 @@ contract MixinSignatureValidator is
         );
     }
 
-    /// @dev ABI encodes a transaction and hash with a selector to be passed into 
+    /// @dev ABI encodes a transaction and hash with a selector to be passed into
     ///      an EIP1271 compliant `isValidSignature` function.
     function _encodeEIP1271TransactionWithHash(
         LibZeroExTransaction.ZeroExTransaction memory transaction,

--- a/contracts/exchange/contracts/src/MixinWrapperFunctions.sol
+++ b/contracts/exchange/contracts/src/MixinWrapperFunctions.sol
@@ -47,8 +47,7 @@ contract MixinWrapperFunctions is
     )
         public
         payable
-        nonReentrant
-        refundFinalBalance
+        refundFinalBalanceNoReentry
         returns (LibFillResults.FillResults memory fillResults)
     {
         fillResults = _fillOrKillOrder(
@@ -71,8 +70,7 @@ contract MixinWrapperFunctions is
     )
         public
         payable
-        nonReentrant
-        refundFinalBalance
+        refundFinalBalanceNoReentry
         returns (LibFillResults.FillResults[] memory fillResults)
     {
         uint256 ordersLength = orders.length;
@@ -99,8 +97,7 @@ contract MixinWrapperFunctions is
     )
         public
         payable
-        nonReentrant
-        refundFinalBalance
+        refundFinalBalanceNoReentry
         returns (LibFillResults.FillResults[] memory fillResults)
     {
         uint256 ordersLength = orders.length;
@@ -287,8 +284,7 @@ contract MixinWrapperFunctions is
     function batchCancelOrders(LibOrder.Order[] memory orders)
         public
         payable
-        nonReentrant
-        refundFinalBalance
+        refundFinalBalanceNoReentry
     {
         uint256 ordersLength = orders.length;
         for (uint256 i = 0; i != ordersLength; i++) {

--- a/contracts/utils/contracts/src/Refundable.sol
+++ b/contracts/utils/contracts/src/Refundable.sol
@@ -18,8 +18,12 @@
 
 pragma solidity ^0.5.9;
 
+import "./ReentrancyGuard.sol";
 
-contract Refundable {
+
+contract Refundable is
+    ReentrancyGuard
+{
 
     // This bool is used by the refund modifier to allow for lazily evaluated refunds.
     bool internal _shouldNotRefund;
@@ -27,6 +31,13 @@ contract Refundable {
     modifier refundFinalBalance {
         _;
         _refundNonZeroBalanceIfEnabled();
+    }
+
+    modifier refundFinalBalanceNoReentry {
+        _lockMutexOrThrowIfAlreadyLocked();
+        _;
+        _refundNonZeroBalanceIfEnabled();
+        _unlockMutex();
     }
 
     modifier disableRefundUntilEnd {


### PR DESCRIPTION
Addresses https://github.com/0xProject/protocol-development-sprint/issues/10
Introduces non-reentrant version of `refundFinalBalance`, to avoid cognitive overhead of always keeping the `nonReentrant` modifier before `refundFinalBalance` in functions that use both

## Description

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
