### PR TITLE
Move chai extension types out of `@0x/typescript-typings`

### DIFF
--- a/packages/dev-utils/CHANGELOG.json
+++ b/packages/dev-utils/CHANGELOG.json
@@ -25,6 +25,10 @@
             {
                 "note": "Refactor out `Error` coercion code into the `utils` package",
                 "pr": 1819
+            },
+            {
+                "note": "Inline `Chai` namesapce extension into `chai_setup.ts`.",
+                "pr": "TODO"
             }
         ]
     },

--- a/packages/dev-utils/CHANGELOG.json
+++ b/packages/dev-utils/CHANGELOG.json
@@ -28,7 +28,7 @@
             },
             {
                 "note": "Inline `Chai` namesapce extension into `chai_setup.ts`.",
-                "pr": "TODO"
+                "pr": 2238
             }
         ]
     },

--- a/packages/dev-utils/src/chai_setup.ts
+++ b/packages/dev-utils/src/chai_setup.ts
@@ -1,9 +1,18 @@
+import { RevertError } from '@0x/utils';
 import * as chai from 'chai';
 import chaiAsPromised = require('chai-as-promised');
 import ChaiBigNumber = require('chai-bignumber');
 import * as dirtyChai from 'dirty-chai';
 
 import { revertErrorHelper } from './chai_revert_error';
+
+declare global {
+    namespace Chai {
+        export interface Assertion {
+            revertWith: (expected: string | RevertError) => Promise<void>;
+        }
+    }
+}
 
 export const chaiSetup = {
     configure(): void {

--- a/packages/typescript-typings/CHANGELOG.json
+++ b/packages/typescript-typings/CHANGELOG.json
@@ -8,7 +8,7 @@
             },
             {
                 "note": "Remove `@0x` namespace",
-                "pr": "TODO"
+                "pr": 2238
             }
         ]
     },

--- a/packages/typescript-typings/CHANGELOG.json
+++ b/packages/typescript-typings/CHANGELOG.json
@@ -5,6 +5,10 @@
             {
                 "note": "Add types for `@0x/dev-utils` chai helpers in `types/@0x`",
                 "pr": 1761
+            },
+            {
+                "note": "Remove `@0x` namespace",
+                "pr": "TODO"
             }
         ]
     },

--- a/packages/typescript-typings/types/@0x/index.d.ts
+++ b/packages/typescript-typings/types/@0x/index.d.ts
@@ -1,6 +1,0 @@
-// tslint:disable: no-namespace
-declare namespace Chai {
-    interface Assertion {
-        revertWith: (expected: string | RevertError) => Promise<void>;
-    }
-}


### PR DESCRIPTION
## Description

This PR removes the `Chai` `revertWith` namespace extensions from `@0x/typescript-typings` and inlines them in `@0x/dev-utils/.../chai_setup.ts`.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
