### PR TITLE
HACK: Types as any until Mesh RPC client is published

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
             },
             {
                 "path": "packages/instant/umd/instant.js",
-                "maxSize": "1460kB"
+                "maxSize": "1960kB"
             }
         ],
         "ci": {

--- a/packages/instant/package.json
+++ b/packages/instant/package.json
@@ -8,7 +8,7 @@
     "description": "0x Instant React Component",
     "main": "umd/instant.js",
     "scripts": {
-        "build": "webpack --mode production",
+        "build": "NODE_ENV=production node --max_old_space_size=8192 ../../node_modules/.bin/webpack --mode production",
         "build:dev": "webpack --mode development",
         "build:ci": "yarn build",
         "dev": "dotenv webpack-dev-server -- --mode development",

--- a/packages/orderbook/src/order_provider/mesh_order_provider.ts
+++ b/packages/orderbook/src/order_provider/mesh_order_provider.ts
@@ -34,6 +34,7 @@ export class MeshOrderProvider extends BaseOrderProvider {
             : new BigNumber(0);
         // TODO(dekz): Remove the any hack when mesh is published v3
         return {
+            // tslint:disable:no-unnecessary-type-assertion
             order: orderEvent.signedOrder as any,
             metaData: {
                 orderHash: orderEvent.orderHash,

--- a/packages/orderbook/src/order_provider/mesh_order_provider.ts
+++ b/packages/orderbook/src/order_provider/mesh_order_provider.ts
@@ -32,8 +32,9 @@ export class MeshOrderProvider extends BaseOrderProvider {
         const remainingFillableTakerAssetAmount = (orderEvent as OrderEvent).fillableTakerAssetAmount
             ? (orderEvent as OrderEvent).fillableTakerAssetAmount
             : new BigNumber(0);
+        // TODO(dekz): Remove the any hack when mesh is published v3
         return {
-            order: orderEvent.signedOrder,
+            order: orderEvent.signedOrder as any,
             metaData: {
                 orderHash: orderEvent.orderHash,
                 remainingFillableTakerAssetAmount,
@@ -89,9 +90,10 @@ export class MeshOrderProvider extends BaseOrderProvider {
      */
     public async addOrdersAsync(orders: SignedOrder[]): Promise<AcceptedRejectedOrders> {
         const { accepted, rejected } = await utils.attemptAsync(() => this._wsClient.addOrdersAsync(orders));
+        // TODO(dekz): Remove the any hack when mesh is published v3
         return {
-            accepted: accepted.map(o => o.signedOrder),
-            rejected: rejected.map(o => ({ order: o.signedOrder, message: o.status.message })),
+            accepted: accepted.map(o => o.signedOrder) as any,
+            rejected: rejected.map(o => ({ order: o.signedOrder, message: o.status.message })) as any,
         };
     }
 


### PR DESCRIPTION
Circular dependencies means we are a bit stuck. Set it to `any` until mesh-rpc-client is updated.