### PR TITLE
fix `_computeUnfinalizedDelegatorReward()` shadowed variable and function mutability

### DIFF
--- a/contracts/staking/contracts/src/staking_pools/MixinStakingPoolRewards.sol
+++ b/contracts/staking/contracts/src/staking_pools/MixinStakingPoolRewards.sol
@@ -314,18 +314,18 @@ contract MixinStakingPoolRewards is
 
     /// @dev Computes the unfinalized rewards earned by a delegator in the last epoch.
     /// @param unsyncedStake Unsynced delegated stake to pool by staker
-    /// @param currentEpoch The epoch in which this call is executing
+    /// @param currentEpoch_ The epoch in which this call is executing
     /// @param unfinalizedMembersReward Unfinalized total members reward (if any).
     /// @param unfinalizedMembersStake Unfinalized total members stake (if any).
     /// @return reward Balance in WETH.
     function _computeUnfinalizedDelegatorReward(
         IStructs.StoredBalance memory unsyncedStake,
-        uint256 currentEpoch,
+        uint256 currentEpoch_,
         uint256 unfinalizedMembersReward,
         uint256 unfinalizedMembersStake
     )
         private
-        view
+        pure
         returns (uint256)
     {
         // If there are unfinalized rewards this epoch, compute the member's
@@ -335,8 +335,8 @@ contract MixinStakingPoolRewards is
         }
 
         // Unfinalized rewards are always earned from stake in
-        // the prior epoch so we want the stake at `currentEpoch-1`.
-        uint256 unfinalizedStakeBalance = unsyncedStake.currentEpoch >= currentEpoch.safeSub(1) ?
+        // the prior epoch so we want the stake at `currentEpoch_-1`.
+        uint256 unfinalizedStakeBalance = unsyncedStake.currentEpoch >= currentEpoch_.safeSub(1) ?
             unsyncedStake.currentEpochBalance :
             unsyncedStake.nextEpochBalance;
 


### PR DESCRIPTION
## Description

Fixes the shadowed `currentEpoch` variable in `_computeUnfinalizedDelegatorReward()` by renaming it to `currentEpoch_`. Also switched the function mutability from `view` to `pure` because I was there anyway (sorrynotsorry).

Fixes 0xProject/protocol-development-sprint#6

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
