### PR TITLE
Simplify staking state

### DIFF
--- a/contracts/staking/contracts/src/ZrxVault.sol
+++ b/contracts/staking/contracts/src/ZrxVault.sol
@@ -188,7 +188,7 @@ contract ZrxVault is
     }
 
     /// @dev Returns the entire balance of Zrx tokens in the vault.
-    function balanceOfVault()
+    function balanceOfZrxVault()
         external
         view
         returns (uint256)

--- a/contracts/staking/contracts/src/ZrxVault.sol
+++ b/contracts/staking/contracts/src/ZrxVault.sol
@@ -52,6 +52,24 @@ contract ZrxVault is
     // Asset data for the ERC20 Proxy
     bytes internal _zrxAssetData;
 
+    /// @dev Only stakingProxy can call this function.
+    modifier onlyStakingProxy() {
+        _assertSenderIsStakingProxy();
+        _;
+    }
+
+    /// @dev Function can only be called in catastrophic failure mode.
+    modifier onlyInCatastrophicFailure() {
+        _assertInCatastrophicFailure();
+        _;
+    }
+
+    /// @dev Function can only be called not in catastropic failure mode
+    modifier onlyNotInCatastrophicFailure() {
+        _assertNotInCatastrophicFailure();
+        _;
+    }
+
     /// @dev Constructor.
     /// @param _zrxProxyAddress Address of the 0x Zrx Proxy.
     /// @param _zrxTokenAddress Address of the Zrx Token.
@@ -169,6 +187,15 @@ contract ZrxVault is
         return _balances[staker];
     }
 
+    /// @dev Returns the entire balance of Zrx tokens in the vault.
+    function balanceOfVault()
+        external
+        view
+        returns (uint256)
+    {
+        return _zrxToken.balanceOf(address(this));
+    }
+
     /// @dev Withdraw an `amount` of Zrx Tokens to `staker` from the vault.
     /// @param staker of Zrx Tokens.
     /// @param amount of Zrx Tokens to withdraw.
@@ -190,21 +217,7 @@ contract ZrxVault is
         );
     }
 
-    modifier onlyStakingProxy() {
-        _assertSenderIsStakingProxy();
-        _;
-    }
-
-    modifier onlyInCatastrophicFailure() {
-        _assertInCatastrophicFailure();
-        _;
-    }
-
-    modifier onlyNotInCatastrophicFailure() {
-        _assertNotInCatastrophicFailure();
-        _;
-    }
-
+    /// @dev Asserts that sender is stakingProxy contract.
     function _assertSenderIsStakingProxy()
         private
         view
@@ -216,6 +229,7 @@ contract ZrxVault is
         }
     }
 
+    /// @dev Asserts that vault is in catastrophic failure mode.
     function _assertInCatastrophicFailure()
         private
         view
@@ -225,6 +239,7 @@ contract ZrxVault is
         }
     }
 
+    /// @dev Asserts that vault is not in catastrophic failure mode.
     function _assertNotInCatastrophicFailure()
         private
         view

--- a/contracts/staking/contracts/src/immutable/MixinStorage.sol
+++ b/contracts/staking/contracts/src/immutable/MixinStorage.sol
@@ -43,7 +43,8 @@ contract MixinStorage is
 
     // mapping from StakeStatus to the total amount of stake in that status for the entire
     // staking system.
-    mapping (uint8 => IStructs.StoredBalance) public globalStakeByStatus;
+    // (access using _loadSyncedBalance or _loadUnsyncedBalance)
+    mapping (uint8 => IStructs.StoredBalance) internal _globalStakeByStatus;
 
     // mapping from StakeStatus to address of staker to stored balance
     // (access using _loadSyncedBalance or _loadUnsyncedBalance)

--- a/contracts/staking/contracts/src/immutable/MixinStorage.sol
+++ b/contracts/staking/contracts/src/immutable/MixinStorage.sol
@@ -41,9 +41,11 @@ contract MixinStorage is
     // address for read-only proxy to call
     address public readOnlyProxyCallee;
 
-    // amount of stake currently being delegated in the system
+    // mapping from StakeStatus to gloabl stored balance
     // (access using _loadSyncedBalance or _loadUnsyncedBalance)
-    IStructs.StoredBalance internal _globalDelegatedStake;
+    // NOTE: only Status.DELEGATED is used to access this mapping, but this format
+    // is used for extensibility
+    mapping (uint8 => IStructs.StoredBalance) internal _globalStakeByStatus;
 
     // mapping from StakeStatus to address of staker to stored balance
     // (access using _loadSyncedBalance or _loadUnsyncedBalance)

--- a/contracts/staking/contracts/src/immutable/MixinStorage.sol
+++ b/contracts/staking/contracts/src/immutable/MixinStorage.sol
@@ -41,10 +41,9 @@ contract MixinStorage is
     // address for read-only proxy to call
     address public readOnlyProxyCallee;
 
-    // mapping from StakeStatus to the total amount of stake in that status for the entire
-    // staking system.
+    // amount of stake currently being delegated in the system
     // (access using _loadSyncedBalance or _loadUnsyncedBalance)
-    mapping (uint8 => IStructs.StoredBalance) internal _globalStakeByStatus;
+    IStructs.StoredBalance internal _globalDelegatedStake;
 
     // mapping from StakeStatus to address of staker to stored balance
     // (access using _loadSyncedBalance or _loadUnsyncedBalance)

--- a/contracts/staking/contracts/src/immutable/MixinStorage.sol
+++ b/contracts/staking/contracts/src/immutable/MixinStorage.sol
@@ -45,17 +45,9 @@ contract MixinStorage is
     // staking system.
     mapping (uint8 => IStructs.StoredBalance) public globalStakeByStatus;
 
-    // mapping from Owner to Amount of Active Stake
+    // mapping from StakeStatus to address of staker to stored balance
     // (access using _loadSyncedBalance or _loadUnsyncedBalance)
-    mapping (address => IStructs.StoredBalance) internal _activeStakeByOwner;
-
-    // Mapping from Owner to Amount of Inactive Stake
-    // (access using _loadSyncedBalance or _loadUnsyncedBalance)
-    mapping (address => IStructs.StoredBalance) internal _inactiveStakeByOwner;
-
-    // Mapping from Owner to Amount Delegated
-    // (access using _loadSyncedBalance or _loadUnsyncedBalance)
-    mapping (address => IStructs.StoredBalance) internal _delegatedStakeByOwner;
+    mapping (uint8 => mapping (address => IStructs.StoredBalance)) internal _ownerStakeByStatus;
 
     // Mapping from Owner to Pool Id to Amount Delegated
     // (access using _loadSyncedBalance or _loadUnsyncedBalance)
@@ -64,9 +56,6 @@ contract MixinStorage is
     // Mapping from Pool Id to Amount Delegated
     // (access using _loadSyncedBalance or _loadUnsyncedBalance)
     mapping (bytes32 => IStructs.StoredBalance) internal _delegatedStakeByPoolId;
-
-    // mapping from Owner to Amount of Withdrawable Stake
-    mapping (address => uint256) internal _withdrawableStakeByOwner;
 
     // tracking Pool Id, a unique identifier for each staking pool.
     bytes32 public lastPoolId;

--- a/contracts/staking/contracts/src/interfaces/IStaking.sol
+++ b/contracts/staking/contracts/src/interfaces/IStaking.sol
@@ -24,7 +24,8 @@ import "./IStructs.sol";
 
 interface IStaking {
 
-    /// @dev Moves stake between statuses: 'active', 'inactive' or 'delegated'.
+    /// @dev Moves stake between statuses: 'undelegated' or 'delegated'.
+    ///      Delegated stake can also be moved between pools.
     ///      This change comes into effect next epoch.
     /// @param from status to move stake out of.
     /// @param to status to move stake into.

--- a/contracts/staking/contracts/src/interfaces/IStructs.sol
+++ b/contracts/staking/contracts/src/interfaces/IStructs.sol
@@ -63,8 +63,9 @@ interface IStructs {
     }
 
     /// @dev Statuses that stake can exist in.
+    ///      Any stake can be (re)delegated effective at the next epoch
+    ///      Inactive stake can be withdrawn if it is available in both the current and next epoch
     enum StakeStatus {
-        ACTIVE,
         INACTIVE,
         DELEGATED
     }

--- a/contracts/staking/contracts/src/interfaces/IStructs.sol
+++ b/contracts/staking/contracts/src/interfaces/IStructs.sol
@@ -57,7 +57,7 @@ interface IStructs {
     /// @param currentEpochBalance balance in the current epoch.
     /// @param nextEpochBalance balance in `currentEpoch+1`.
     struct StoredBalance {
-        uint32 currentEpoch;
+        uint64 currentEpoch;
         uint96 currentEpochBalance;
         uint96 nextEpochBalance;
     }
@@ -66,7 +66,7 @@ interface IStructs {
     ///      Any stake can be (re)delegated effective at the next epoch
     ///      Inactive stake can be withdrawn if it is available in both the current and next epoch
     enum StakeStatus {
-        INACTIVE,
+        UNDELEGATED,
         DELEGATED
     }
 

--- a/contracts/staking/contracts/src/interfaces/IStructs.sol
+++ b/contracts/staking/contracts/src/interfaces/IStructs.sol
@@ -53,12 +53,10 @@ interface IStructs {
     /// Note that these balances may be stale if the current epoch
     /// is greater than `currentEpoch`.
     /// Always load this struct using _loadSyncedBalance or _loadUnsyncedBalance.
-    /// @param isInitialized
     /// @param currentEpoch the current epoch
     /// @param currentEpochBalance balance in the current epoch.
     /// @param nextEpochBalance balance in `currentEpoch+1`.
     struct StoredBalance {
-        bool isInitialized;
         uint32 currentEpoch;
         uint96 currentEpochBalance;
         uint96 nextEpochBalance;

--- a/contracts/staking/contracts/src/interfaces/IStructs.sol
+++ b/contracts/staking/contracts/src/interfaces/IStructs.sol
@@ -62,14 +62,6 @@ interface IStructs {
         uint96 nextEpochBalance;
     }
 
-    /// @dev Balance struct for stake.
-    /// @param currentEpochBalance Balance in the current epoch.
-    /// @param nextEpochBalance Balance in the next epoch.
-    struct StakeBalance {
-        uint256 currentEpochBalance;
-        uint256 nextEpochBalance;
-    }
-
     /// @dev Statuses that stake can exist in.
     enum StakeStatus {
         ACTIVE,

--- a/contracts/staking/contracts/src/interfaces/IStructs.sol
+++ b/contracts/staking/contracts/src/interfaces/IStructs.sol
@@ -64,7 +64,7 @@ interface IStructs {
 
     /// @dev Statuses that stake can exist in.
     ///      Any stake can be (re)delegated effective at the next epoch
-    ///      Inactive stake can be withdrawn if it is available in both the current and next epoch
+    ///      Undelegated stake can be withdrawn if it is available in both the current and next epoch
     enum StakeStatus {
         UNDELEGATED,
         DELEGATED

--- a/contracts/staking/contracts/src/interfaces/IZrxVault.sol
+++ b/contracts/staking/contracts/src/interfaces/IZrxVault.sol
@@ -95,4 +95,10 @@ interface IZrxVault {
         external
         view
         returns (uint256);
+
+    /// @dev Returns the entire balance of Zrx tokens in the vault.
+    function balanceOfVault()
+        external
+        view
+        returns (uint256);
 }

--- a/contracts/staking/contracts/src/interfaces/IZrxVault.sol
+++ b/contracts/staking/contracts/src/interfaces/IZrxVault.sol
@@ -97,7 +97,7 @@ interface IZrxVault {
         returns (uint256);
 
     /// @dev Returns the entire balance of Zrx tokens in the vault.
-    function balanceOfVault()
+    function balanceOfZrxVault()
         external
         view
         returns (uint256);

--- a/contracts/staking/contracts/src/libs/LibStakingRichErrors.sol
+++ b/contracts/staking/contracts/src/libs/LibStakingRichErrors.sol
@@ -92,10 +92,6 @@ library LibStakingRichErrors {
     bytes4 internal constant POOL_EXISTENCE_ERROR_SELECTOR =
         0x9ae94f01;
 
-    // bytes4(keccak256("InvalidStakeStatusError(uint8)"))
-    bytes4 internal constant INVALID_STAKE_STATUS_ERROR_SELECTOR =
-        0x7cf20260;
-
     // bytes4(keccak256("ProxyDestinationCannotBeNilError()"))
     bytes internal constant PROXY_DESTINATION_CANNOT_BE_NIL_ERROR =
         hex"6eff8285";
@@ -265,17 +261,6 @@ library LibStakingRichErrors {
             errorCodes,
             expectedProtocolFeePaid,
             actualProtocolFeePaid
-        );
-    }
-
-    function InvalidStakeStatusError(IStructs.StakeStatus status)
-        internal
-        pure
-        returns (bytes memory)
-    {
-        return abi.encodeWithSelector(
-            INVALID_STAKE_STATUS_ERROR_SELECTOR,
-            status
         );
     }
 

--- a/contracts/staking/contracts/src/stake/MixinStake.sol
+++ b/contracts/staking/contracts/src/stake/MixinStake.sol
@@ -42,7 +42,7 @@ contract MixinStake is
 
         // mint stake
         _increaseCurrentAndNextBalance(
-            _ownerStakeByStatus[uint8(IStructs.StakeStatus.INACTIVE)][staker],
+            _ownerStakeByStatus[uint8(IStructs.StakeStatus.UNDELEGATED)][staker],
             amount
         );
 
@@ -63,7 +63,7 @@ contract MixinStake is
         address staker = msg.sender;
 
         IStructs.StoredBalance memory inactiveBalance =
-            _loadSyncedBalance(_ownerStakeByStatus[uint8(IStructs.StakeStatus.INACTIVE)][staker]);
+            _loadSyncedBalance(_ownerStakeByStatus[uint8(IStructs.StakeStatus.UNDELEGATED)][staker]);
 
         // stake must be inactive in current and next epoch to be withdrawn
         uint256 currentWithdrawableStake = LibSafeMath.min256(
@@ -82,7 +82,7 @@ contract MixinStake is
 
         // burn inactive stake
         _decreaseCurrentAndNextBalance(
-            _ownerStakeByStatus[uint8(IStructs.StakeStatus.INACTIVE)][staker],
+            _ownerStakeByStatus[uint8(IStructs.StakeStatus.UNDELEGATED)][staker],
             amount
         );
 
@@ -181,7 +181,7 @@ contract MixinStake is
 
         // Increase next balance of global delegated stake
         _increaseNextBalance(
-            _globalDelegatedStake,
+            _globalStakeByStatus[uint8(IStructs.StakeStatus.DELEGATED)],
             amount
         );
     }
@@ -219,7 +219,7 @@ contract MixinStake is
 
         // decrease next balance of global delegated stake
         _decreaseNextBalance(
-            _globalDelegatedStake,
+            _globalStakeByStatus[uint8(IStructs.StakeStatus.DELEGATED)],
             amount
         );
     }

--- a/contracts/staking/contracts/src/stake/MixinStake.sol
+++ b/contracts/staking/contracts/src/stake/MixinStake.sol
@@ -48,7 +48,7 @@ contract MixinStake is
 
         // update global total of active stake
         _increaseCurrentAndNextBalance(
-            globalStakeByStatus[uint8(IStructs.StakeStatus.ACTIVE)],
+            _globalStakeByStatus[uint8(IStructs.StakeStatus.ACTIVE)],
             amount
         );
 
@@ -94,7 +94,7 @@ contract MixinStake is
 
         // update global total of inactive stake
         _decreaseCurrentAndNextBalance(
-            globalStakeByStatus[uint8(IStructs.StakeStatus.INACTIVE)],
+            _globalStakeByStatus[uint8(IStructs.StakeStatus.INACTIVE)],
             amount
         );
 
@@ -151,8 +151,8 @@ contract MixinStake is
 
         // update global total of stake in the statuses being moved between
         _moveStake(
-            globalStakeByStatus[uint8(from.status)],
-            globalStakeByStatus[uint8(to.status)],
+            _globalStakeByStatus[uint8(from.status)],
+            _globalStakeByStatus[uint8(to.status)],
             amount
         );
 

--- a/contracts/staking/contracts/src/stake/MixinStake.sol
+++ b/contracts/staking/contracts/src/stake/MixinStake.sol
@@ -42,13 +42,13 @@ contract MixinStake is
 
         // mint stake
         _increaseCurrentAndNextBalance(
-            _ownerStakeByStatus[uint8(IStructs.StakeStatus.ACTIVE)][staker],
+            _ownerStakeByStatus[uint8(IStructs.StakeStatus.INACTIVE)][staker],
             amount
         );
 
         // update global total of active stake
         _increaseCurrentAndNextBalance(
-            _globalStakeByStatus[uint8(IStructs.StakeStatus.ACTIVE)],
+            _globalStakeByStatus[uint8(IStructs.StakeStatus.INACTIVE)],
             amount
         );
 

--- a/contracts/staking/contracts/src/stake/MixinStake.sol
+++ b/contracts/staking/contracts/src/stake/MixinStake.sol
@@ -46,12 +46,6 @@ contract MixinStake is
             amount
         );
 
-        // update global total of active stake
-        _increaseCurrentAndNextBalance(
-            _globalStakeByStatus[uint8(IStructs.StakeStatus.INACTIVE)],
-            amount
-        );
-
         // notify
         emit Stake(
             staker,
@@ -89,12 +83,6 @@ contract MixinStake is
         // burn inactive stake
         _decreaseCurrentAndNextBalance(
             _ownerStakeByStatus[uint8(IStructs.StakeStatus.INACTIVE)][staker],
-            amount
-        );
-
-        // update global total of inactive stake
-        _decreaseCurrentAndNextBalance(
-            _globalStakeByStatus[uint8(IStructs.StakeStatus.INACTIVE)],
             amount
         );
 
@@ -149,13 +137,6 @@ contract MixinStake is
             amount
         );
 
-        // update global total of stake in the statuses being moved between
-        _moveStake(
-            _globalStakeByStatus[uint8(from.status)],
-            _globalStakeByStatus[uint8(to.status)],
-            amount
-        );
-
         // notify
         emit MoveStake(
             staker,
@@ -197,6 +178,12 @@ contract MixinStake is
             _delegatedStakeByPoolId[poolId],
             amount
         );
+
+        // Increase next balance of global delegated stake
+        _increaseNextBalance(
+            _globalDelegatedStake,
+            amount
+        );
     }
 
     /// @dev Un-Delegates a owners stake from a staking pool.
@@ -227,6 +214,12 @@ contract MixinStake is
         // decrement how much stake has been delegated to pool
         _decreaseNextBalance(
             _delegatedStakeByPoolId[poolId],
+            amount
+        );
+
+        // decrease next balance of global delegated stake
+        _decreaseNextBalance(
+            _globalDelegatedStake,
             amount
         );
     }

--- a/contracts/staking/contracts/src/stake/MixinStakeBalances.sol
+++ b/contracts/staking/contracts/src/stake/MixinStakeBalances.sol
@@ -30,18 +30,20 @@ contract MixinStakeBalances is
     using LibSafeMath for uint256;
 
     /// @dev Gets global stake for a given status.
-    /// @param stakeStatus INACTIVE or DELEGATED
+    /// @param stakeStatus UNDELEGATED or DELEGATED
     /// @return Global stake for given status.
     function getGlobalStakeByStatus(IStructs.StakeStatus stakeStatus)
         external
         view
         returns (IStructs.StoredBalance memory balance)
     {
-        balance = _loadSyncedBalance(_globalDelegatedStake);
-        if (stakeStatus == IStructs.StakeStatus.INACTIVE) {
+        balance = _loadSyncedBalance(
+            _globalStakeByStatus[uint8(IStructs.StakeStatus.DELEGATED)]
+        );
+        if (stakeStatus == IStructs.StakeStatus.UNDELEGATED) {
             // Inactive stake is the difference between total stake and delegated stake
             // Note that any Zrx erroneously sent to the vault will be counted as inactive stake
-            uint256 totalStake = getZrxVault().balanceOfVault();
+            uint256 totalStake = getZrxVault().balanceOfZrxVault();
             balance.currentEpochBalance = totalStake.safeSub(balance.currentEpochBalance).downcastToUint96();
             balance.nextEpochBalance = totalStake.safeSub(balance.nextEpochBalance).downcastToUint96();
         }
@@ -50,7 +52,7 @@ contract MixinStakeBalances is
 
     /// @dev Gets an owner's stake balances by status.
     /// @param staker Owner of stake.
-    /// @param stakeStatus INACTIVE or DELEGATED
+    /// @param stakeStatus UNDELEGATED or DELEGATED
     /// @return Owner's stake balances for given status.
     function getOwnerStakeByStatus(
         address staker,

--- a/contracts/staking/contracts/src/stake/MixinStakeBalances.sol
+++ b/contracts/staking/contracts/src/stake/MixinStakeBalances.sol
@@ -29,52 +29,36 @@ contract MixinStakeBalances is
 {
     using LibSafeMath for uint256;
 
-    /// @dev Returns the total active stake across the entire staking system.
-    /// @return Global active stake.
-    function getGlobalActiveStake()
+    /// @dev Gets global stake for a given status.
+    /// @param stakeStatus ACTIVE, INACTIVE, or DELEGATED
+    /// @return Global stake for given status.
+    function getGlobalStakeByStatus(IStructs.StakeStatus stakeStatus)
         external
         view
-        returns (IStructs.StakeBalance memory balance)
+        returns (IStructs.StoredBalance memory balance)
     {
-        IStructs.StoredBalance memory storedBalance = _loadSyncedBalance(
-            globalStakeByStatus[uint8(IStructs.StakeStatus.ACTIVE)]
+        balance = _loadSyncedBalance(
+            _globalStakeByStatus[uint8(stakeStatus)]
         );
-        return IStructs.StakeBalance({
-            currentEpochBalance: storedBalance.currentEpochBalance,
-            nextEpochBalance: storedBalance.nextEpochBalance
-        });
+        return balance;
     }
 
-    /// @dev Returns the total inactive stake across the entire staking system.
-    /// @return Global inactive stake.
-    function getGlobalInactiveStake()
+    /// @dev Gets an owner's stake balances by status.
+    /// @param staker Owner of stake.
+    /// @param stakeStatus ACTIVE, INACTIVE, or DELEGATED
+    /// @return Owner's stake balances for given status.
+    function getOwnerStakeByStatus(
+        address staker,
+        IStructs.StakeStatus stakeStatus
+    )
         external
         view
-        returns (IStructs.StakeBalance memory balance)
+        returns (IStructs.StoredBalance memory balance)
     {
-        IStructs.StoredBalance memory storedBalance = _loadSyncedBalance(
-            globalStakeByStatus[uint8(IStructs.StakeStatus.INACTIVE)]
+        balance = _loadSyncedBalance(
+            _ownerStakeByStatus[uint8(stakeStatus)][staker]
         );
-        return IStructs.StakeBalance({
-            currentEpochBalance: storedBalance.currentEpochBalance,
-            nextEpochBalance: storedBalance.nextEpochBalance
-        });
-    }
-
-    /// @dev Returns the total stake delegated across the entire staking system.
-    /// @return Global delegated stake.
-    function getGlobalDelegatedStake()
-        external
-        view
-        returns (IStructs.StakeBalance memory balance)
-    {
-        IStructs.StoredBalance memory storedBalance = _loadSyncedBalance(
-            globalStakeByStatus[uint8(IStructs.StakeStatus.DELEGATED)]
-        );
-        return IStructs.StakeBalance({
-            currentEpochBalance: storedBalance.currentEpochBalance,
-            nextEpochBalance: storedBalance.nextEpochBalance
-        });
+        return balance;
     }
 
     /// @dev Returns the total stake for a given staker.
@@ -88,68 +72,17 @@ contract MixinStakeBalances is
         return getZrxVault().balanceOf(staker);
     }
 
-    /// @dev Returns the active stake for a given staker.
-    /// @param staker of stake.
-    /// @return Active stake for staker.
-    function getActiveStake(address staker)
-        external
-        view
-        returns (IStructs.StakeBalance memory balance)
-    {
-        IStructs.StoredBalance memory storedBalance =
-            _loadSyncedBalance(_ownerStakeByStatus[uint8(IStructs.StakeStatus.ACTIVE)][staker]);
-        return IStructs.StakeBalance({
-            currentEpochBalance: storedBalance.currentEpochBalance,
-            nextEpochBalance: storedBalance.nextEpochBalance
-        });
-    }
-
-    /// @dev Returns the inactive stake for a given staker.
-    /// @param staker of stake.
-    /// @return Inactive stake for staker.
-    function getInactiveStake(address staker)
-        external
-        view
-        returns (IStructs.StakeBalance memory balance)
-    {
-        IStructs.StoredBalance memory storedBalance =
-            _loadSyncedBalance(_ownerStakeByStatus[uint8(IStructs.StakeStatus.INACTIVE)][staker]);
-        return IStructs.StakeBalance({
-            currentEpochBalance: storedBalance.currentEpochBalance,
-            nextEpochBalance: storedBalance.nextEpochBalance
-        });
-    }
-
-    /// @dev Returns the stake delegated by a given staker.
-    /// @param staker of stake.
-    /// @return Delegated stake for staker.
-    function getStakeDelegatedByOwner(address staker)
-        external
-        view
-        returns (IStructs.StakeBalance memory balance)
-    {
-        IStructs.StoredBalance memory storedBalance =
-            _loadSyncedBalance(_ownerStakeByStatus[uint8(IStructs.StakeStatus.DELEGATED)][staker]);
-        return IStructs.StakeBalance({
-            currentEpochBalance: storedBalance.currentEpochBalance,
-            nextEpochBalance: storedBalance.nextEpochBalance
-        });
-    }
-
     /// @dev Returns the stake delegated to a specific staking pool, by a given staker.
     /// @param staker of stake.
     /// @param poolId Unique Id of pool.
-    /// @return Stake delegaated to pool by staker.
+    /// @return Stake delegated to pool by staker.
     function getStakeDelegatedToPoolByOwner(address staker, bytes32 poolId)
         public
         view
-        returns (IStructs.StakeBalance memory balance)
+        returns (IStructs.StoredBalance memory balance)
     {
-        IStructs.StoredBalance memory storedBalance = _loadSyncedBalance(_delegatedStakeToPoolByOwner[staker][poolId]);
-        return IStructs.StakeBalance({
-            currentEpochBalance: storedBalance.currentEpochBalance,
-            nextEpochBalance: storedBalance.nextEpochBalance
-        });
+        balance = _loadSyncedBalance(_delegatedStakeToPoolByOwner[staker][poolId]);
+        return balance;
     }
 
     /// @dev Returns the total stake delegated to a specific staking pool,
@@ -159,12 +92,9 @@ contract MixinStakeBalances is
     function getTotalStakeDelegatedToPool(bytes32 poolId)
         public
         view
-        returns (IStructs.StakeBalance memory balance)
+        returns (IStructs.StoredBalance memory balance)
     {
-        IStructs.StoredBalance memory storedBalance = _loadSyncedBalance(_delegatedStakeByPoolId[poolId]);
-        return IStructs.StakeBalance({
-            currentEpochBalance: storedBalance.currentEpochBalance,
-            nextEpochBalance: storedBalance.nextEpochBalance
-        });
+        balance = _loadSyncedBalance(_delegatedStakeByPoolId[poolId]);
+        return balance;
     }
 }

--- a/contracts/staking/contracts/src/stake/MixinStakeBalances.sol
+++ b/contracts/staking/contracts/src/stake/MixinStakeBalances.sol
@@ -41,8 +41,8 @@ contract MixinStakeBalances is
             _globalStakeByStatus[uint8(IStructs.StakeStatus.DELEGATED)]
         );
         if (stakeStatus == IStructs.StakeStatus.UNDELEGATED) {
-            // Inactive stake is the difference between total stake and delegated stake
-            // Note that any Zrx erroneously sent to the vault will be counted as inactive stake
+            // Undelegated stake is the difference between total stake and delegated stake
+            // Note that any ZRX erroneously sent to the vault will be counted as undelegated stake
             uint256 totalStake = getZrxVault().balanceOfZrxVault();
             balance.currentEpochBalance = totalStake.safeSub(balance.currentEpochBalance).downcastToUint96();
             balance.nextEpochBalance = totalStake.safeSub(balance.nextEpochBalance).downcastToUint96();

--- a/contracts/staking/contracts/src/stake/MixinStakeStorage.sol
+++ b/contracts/staking/contracts/src/stake/MixinStakeStorage.sol
@@ -31,7 +31,7 @@ contract MixinStakeStorage is
     using LibSafeMath for uint256;
     using LibSafeDowncast for uint256;
 
-    /// @dev Moves stake between states: 'active', 'inactive' or 'delegated'.
+    /// @dev Moves stake between states: 'undelegated' or 'delegated'.
     ///      This change comes into effect next epoch.
     /// @param fromPtr pointer to storage location of `from` stake.
     /// @param toPtr pointer to storage location of `to` stake.

--- a/contracts/staking/contracts/src/stake/MixinStakeStorage.sol
+++ b/contracts/staking/contracts/src/stake/MixinStakeStorage.sol
@@ -176,7 +176,7 @@ contract MixinStakeStorage is
         private
     {
         // note - this compresses into a single `sstore` when optimizations are enabled,
-        // since the StakeBalance struct occupies a single word of storage.
+        // since the StoredBalance struct occupies a single word of storage.
         balancePtr.currentEpoch = balance.currentEpoch;
         balancePtr.nextEpochBalance = balance.nextEpochBalance;
         balancePtr.currentEpochBalance = balance.currentEpochBalance;

--- a/contracts/staking/contracts/src/stake/MixinStakeStorage.sol
+++ b/contracts/staking/contracts/src/stake/MixinStakeStorage.sol
@@ -177,7 +177,6 @@ contract MixinStakeStorage is
     {
         // note - this compresses into a single `sstore` when optimizations are enabled,
         // since the StakeBalance struct occupies a single word of storage.
-        balancePtr.isInitialized = true;
         balancePtr.currentEpoch = balance.currentEpoch;
         balancePtr.nextEpochBalance = balance.nextEpochBalance;
         balancePtr.currentEpochBalance = balance.currentEpochBalance;

--- a/contracts/staking/contracts/src/stake/MixinStakeStorage.sol
+++ b/contracts/staking/contracts/src/stake/MixinStakeStorage.sol
@@ -87,7 +87,7 @@ contract MixinStakeStorage is
         // sync
         uint256 currentEpoch_ = currentEpoch;
         if (currentEpoch_ > balance.currentEpoch) {
-            balance.currentEpoch = currentEpoch_.downcastToUint32();
+            balance.currentEpoch = currentEpoch_.downcastToUint64();
             balance.currentEpochBalance = balance.nextEpochBalance;
         }
         return balance;

--- a/contracts/staking/contracts/src/staking_pools/MixinStakingPool.sol
+++ b/contracts/staking/contracts/src/staking_pools/MixinStakingPool.sol
@@ -137,7 +137,6 @@ contract MixinStakingPool is
     function _assertStakingPoolExists(bytes32 poolId)
         internal
         view
-        returns (bool)
     {
         if (_poolById[poolId].operator == NIL_ADDRESS) {
             // we use the pool's operator as a proxy for its existence

--- a/contracts/staking/contracts/test/TestDelegatorRewards.sol
+++ b/contracts/staking/contracts/test/TestDelegatorRewards.sol
@@ -117,7 +117,6 @@ contract TestDelegatorRewards is
             delegator
         );
         IStructs.StoredBalance storage _stake = _delegatedStakeToPoolByOwner[delegator][poolId];
-        _stake.isInitialized = true;
         _stake.currentEpochBalance += uint96(stake);
         _stake.nextEpochBalance += uint96(stake);
         _stake.currentEpoch = uint32(currentEpoch);
@@ -146,7 +145,6 @@ contract TestDelegatorRewards is
         if (_stake.currentEpoch < currentEpoch) {
             _stake.currentEpochBalance = _stake.nextEpochBalance;
         }
-        _stake.isInitialized = true;
         _stake.nextEpochBalance += uint96(stake);
         _stake.currentEpoch = uint32(currentEpoch);
     }
@@ -170,7 +168,6 @@ contract TestDelegatorRewards is
         if (_stake.currentEpoch < currentEpoch) {
             _stake.currentEpochBalance = _stake.nextEpochBalance;
         }
-        _stake.isInitialized = true;
         _stake.nextEpochBalance -= uint96(stake);
         _stake.currentEpoch = uint32(currentEpoch);
     }

--- a/contracts/staking/contracts/test/TestProtocolFees.sol
+++ b/contracts/staking/contracts/test/TestProtocolFees.sol
@@ -104,7 +104,7 @@ contract TestProtocolFees is
         TestPool memory pool = _testPools[poolId];
         uint96 stake = pool.operatorStake + pool.membersStake;
         return IStructs.StoredBalance({
-            currentEpoch: currentEpoch.downcastToUint32(),
+            currentEpoch: currentEpoch.downcastToUint64(),
             currentEpochBalance: stake,
             nextEpochBalance: stake
         });
@@ -118,7 +118,7 @@ contract TestProtocolFees is
     {
         TestPool memory pool = _testPools[poolId];
         return IStructs.StoredBalance({
-            currentEpoch: currentEpoch.downcastToUint32(),
+            currentEpoch: currentEpoch.downcastToUint64(),
             currentEpochBalance: pool.operatorStake,
             nextEpochBalance: pool.operatorStake
         });

--- a/contracts/staking/contracts/test/TestProtocolFees.sol
+++ b/contracts/staking/contracts/test/TestProtocolFees.sol
@@ -27,8 +27,8 @@ contract TestProtocolFees is
     TestStakingNoWETH
 {
     struct TestPool {
-        uint256 operatorStake;
-        uint256 membersStake;
+        uint96 operatorStake;
+        uint96 membersStake;
         mapping(address => bool) isMaker;
     }
 
@@ -57,8 +57,8 @@ contract TestProtocolFees is
     /// @dev Create a test pool.
     function createTestPool(
         bytes32 poolId,
-        uint256 operatorStake,
-        uint256 membersStake,
+        uint96 operatorStake,
+        uint96 membersStake,
         address[] calldata makerAddresses
     )
         external
@@ -99,11 +99,12 @@ contract TestProtocolFees is
     function getTotalStakeDelegatedToPool(bytes32 poolId)
         public
         view
-        returns (IStructs.StakeBalance memory balance)
+        returns (IStructs.StoredBalance memory balance)
     {
         TestPool memory pool = _testPools[poolId];
-        uint256 stake = pool.operatorStake + pool.membersStake;
-        return IStructs.StakeBalance({
+        uint96 stake = pool.operatorStake + pool.membersStake;
+        return IStructs.StoredBalance({
+            currentEpoch: currentEpoch.downcastToUint32(),
             currentEpochBalance: stake,
             nextEpochBalance: stake
         });
@@ -113,10 +114,11 @@ contract TestProtocolFees is
     function getStakeDelegatedToPoolByOwner(address, bytes32 poolId)
         public
         view
-        returns (IStructs.StakeBalance memory balance)
+        returns (IStructs.StoredBalance memory balance)
     {
         TestPool memory pool = _testPools[poolId];
-        return IStructs.StakeBalance({
+        return IStructs.StoredBalance({
+            currentEpoch: currentEpoch.downcastToUint32(),
             currentEpochBalance: pool.operatorStake,
             nextEpochBalance: pool.operatorStake
         });

--- a/contracts/staking/contracts/test/TestStorageLayoutAndConstants.sol
+++ b/contracts/staking/contracts/test/TestStorageLayoutAndConstants.sol
@@ -119,8 +119,8 @@ contract TestStorageLayoutAndConstants is
             slot := add(slot, 0x1)
 
             assertSlotAndOffset(
-                _globalDelegatedStake_slot,
-                _globalDelegatedStake_offset,
+                _globalStakeByStatus_slot,
+                _globalStakeByStatus_offset,
                 slot,
                 offset
             )

--- a/contracts/staking/contracts/test/TestStorageLayoutAndConstants.sol
+++ b/contracts/staking/contracts/test/TestStorageLayoutAndConstants.sol
@@ -127,24 +127,8 @@ contract TestStorageLayoutAndConstants is
             slot := add(slot, 0x1)
 
             assertSlotAndOffset(
-                _activeStakeByOwner_slot,
-                _activeStakeByOwner_offset,
-                slot,
-                offset
-            )
-            slot := add(slot, 0x1)
-
-            assertSlotAndOffset(
-                _inactiveStakeByOwner_slot,
-                _inactiveStakeByOwner_offset,
-                slot,
-                offset
-            )
-            slot := add(slot, 0x1)
-
-            assertSlotAndOffset(
-                _delegatedStakeByOwner_slot,
-                _delegatedStakeByOwner_offset,
+                _ownerStakeByStatus_slot,
+                _ownerStakeByStatus_offset,
                 slot,
                 offset
             )
@@ -161,14 +145,6 @@ contract TestStorageLayoutAndConstants is
             assertSlotAndOffset(
                 _delegatedStakeByPoolId_slot,
                 _delegatedStakeByPoolId_offset,
-                slot,
-                offset
-            )
-            slot := add(slot, 0x1)
-
-            assertSlotAndOffset(
-                _withdrawableStakeByOwner_slot,
-                _withdrawableStakeByOwner_offset,
                 slot,
                 offset
             )

--- a/contracts/staking/contracts/test/TestStorageLayoutAndConstants.sol
+++ b/contracts/staking/contracts/test/TestStorageLayoutAndConstants.sol
@@ -119,8 +119,8 @@ contract TestStorageLayoutAndConstants is
             slot := add(slot, 0x1)
 
             assertSlotAndOffset(
-                _globalStakeByStatus_slot,
-                _globalStakeByStatus_offset,
+                _globalDelegatedStake_slot,
+                _globalDelegatedStake_offset,
                 slot,
                 offset
             )

--- a/contracts/staking/contracts/test/TestStorageLayoutAndConstants.sol
+++ b/contracts/staking/contracts/test/TestStorageLayoutAndConstants.sol
@@ -119,8 +119,8 @@ contract TestStorageLayoutAndConstants is
             slot := add(slot, 0x1)
 
             assertSlotAndOffset(
-                globalStakeByStatus_slot,
-                globalStakeByStatus_offset,
+                _globalStakeByStatus_slot,
+                _globalStakeByStatus_offset,
                 slot,
                 offset
             )

--- a/contracts/staking/package.json
+++ b/contracts/staking/package.json
@@ -55,7 +55,6 @@
         "@0x/dev-utils": "^2.4.0-beta.0",
         "@0x/sol-compiler": "^3.2.0-beta.0",
         "@0x/tslint-config": "^3.0.1",
-        "@0x/utils": "^4.5.2",
         "@types/lodash": "4.14.104",
         "@types/node": "*",
         "chai": "^4.0.1",

--- a/contracts/staking/test/actors/staker_actor.ts
+++ b/contracts/staking/test/actors/staker_actor.ts
@@ -148,7 +148,7 @@ export class StakerActor extends BaseActor {
     public async stakeWithPoolAsync(poolId: string, amount: BigNumber): Promise<void> {
         await this.stakeAsync(amount);
         await this.moveStakeAsync(
-            new StakeInfo(StakeStatus.Inactive),
+            new StakeInfo(StakeStatus.Undelegated),
             new StakeInfo(StakeStatus.Delegated, poolId),
             amount,
         );
@@ -202,14 +202,14 @@ export class StakerActor extends BaseActor {
             stakeBalanceInVault: await this._stakingApiWrapper.zrxVaultContract.balanceOf.callAsync(this._owner),
             inactiveStakeBalance: await this._stakingApiWrapper.stakingContract.getOwnerStakeByStatus.callAsync(
                 this._owner,
-                StakeStatus.Inactive,
+                StakeStatus.Undelegated,
             ),
             delegatedStakeBalance: await this._stakingApiWrapper.stakingContract.getOwnerStakeByStatus.callAsync(
                 this._owner,
                 StakeStatus.Delegated,
             ),
             globalInactiveStakeBalance: await this._stakingApiWrapper.stakingContract.getGlobalStakeByStatus.callAsync(
-                StakeStatus.Inactive,
+                StakeStatus.Undelegated,
             ),
             globalDelegatedStakeBalance: await this._stakingApiWrapper.stakingContract.getGlobalStakeByStatus.callAsync(
                 StakeStatus.Delegated,
@@ -289,7 +289,7 @@ export class StakerActor extends BaseActor {
         // @TODO check receipt logs and return value via eth_call
         // check balances
         // from
-        if (from.status === StakeStatus.Inactive) {
+        if (from.status === StakeStatus.Undelegated) {
             StakerActor._decrementNextBalance(expectedBalances.inactiveStakeBalance, amount);
             StakerActor._decrementNextBalance(expectedBalances.globalInactiveStakeBalance, amount);
         } else if (from.status === StakeStatus.Delegated && from.poolId !== undefined) {
@@ -299,7 +299,7 @@ export class StakerActor extends BaseActor {
             StakerActor._decrementNextBalance(expectedBalances.totalDelegatedStakeByPool[from.poolId], amount);
         }
         // to
-        if (to.status === StakeStatus.Inactive) {
+        if (to.status === StakeStatus.Undelegated) {
             StakerActor._incrementNextBalance(expectedBalances.inactiveStakeBalance, amount);
             StakerActor._incrementNextBalance(expectedBalances.globalInactiveStakeBalance, amount);
         } else if (to.status === StakeStatus.Delegated && to.poolId !== undefined) {

--- a/contracts/staking/test/catastrophe_test.ts
+++ b/contracts/staking/test/catastrophe_test.ts
@@ -42,7 +42,7 @@ blockchainTests.resets('Catastrophe Tests', env => {
             });
             const inactiveStakeBalance = await stakingApiWrapper.stakingContract.getOwnerStakeByStatus.callAsync(
                 actors[0],
-                StakeStatus.Inactive,
+                StakeStatus.Undelegated,
             );
             expect(inactiveStakeBalance.currentEpochBalance).to.be.bignumber.equal(amountToStake);
         });
@@ -56,7 +56,7 @@ blockchainTests.resets('Catastrophe Tests', env => {
             });
             const inactiveStakeBalance = await stakingApiWrapper.stakingContract.getOwnerStakeByStatus.callAsync(
                 actors[0],
-                StakeStatus.Inactive,
+                StakeStatus.Undelegated,
             );
             expect(inactiveStakeBalance.currentEpochBalance).to.be.bignumber.equal(ZERO);
         });
@@ -71,7 +71,7 @@ blockchainTests.resets('Catastrophe Tests', env => {
             // read stake balance in read-only mode
             const inactiveStakeBalanceReadOnly = await stakingApiWrapper.stakingContract.getOwnerStakeByStatus.callAsync(
                 actors[0],
-                StakeStatus.Inactive,
+                StakeStatus.Undelegated,
             );
             expect(inactiveStakeBalanceReadOnly.currentEpochBalance).to.be.bignumber.equal(amountToStake);
         });
@@ -86,7 +86,7 @@ blockchainTests.resets('Catastrophe Tests', env => {
             });
             const inactiveStakeBalance = await stakingApiWrapper.stakingContract.getOwnerStakeByStatus.callAsync(
                 actors[0],
-                StakeStatus.Inactive,
+                StakeStatus.Undelegated,
             );
             expect(inactiveStakeBalance.currentEpochBalance).to.be.bignumber.equal(amountToStake);
         });

--- a/contracts/staking/test/catastrophe_test.ts
+++ b/contracts/staking/test/catastrophe_test.ts
@@ -8,6 +8,7 @@ import { StakingProxyReadOnlyModeSetEventArgs } from '../src';
 
 import { deployAndConfigureContractsAsync, StakingApiWrapper } from './utils/api_wrapper';
 import { toBaseUnitAmount } from './utils/number_utils';
+import { StakeStatus } from './utils/types';
 
 // tslint:disable:no-unnecessary-type-assertion
 blockchainTests.resets('Catastrophe Tests', env => {
@@ -39,7 +40,10 @@ blockchainTests.resets('Catastrophe Tests', env => {
             await stakingApiWrapper.stakingContract.stake.awaitTransactionSuccessAsync(amountToStake, {
                 from: actors[0],
             });
-            const activeStakeBalance = await stakingApiWrapper.stakingContract.getActiveStake.callAsync(actors[0]);
+            const activeStakeBalance = await stakingApiWrapper.stakingContract.getOwnerStakeByStatus.callAsync(
+                actors[0],
+                StakeStatus.Active,
+            );
             expect(activeStakeBalance.currentEpochBalance).to.be.bignumber.equal(amountToStake);
         });
         it('should not change state when in read-only mode', async () => {
@@ -50,7 +54,10 @@ blockchainTests.resets('Catastrophe Tests', env => {
             await stakingApiWrapper.stakingContract.stake.awaitTransactionSuccessAsync(amountToStake, {
                 from: actors[0],
             });
-            const activeStakeBalance = await stakingApiWrapper.stakingContract.getActiveStake.callAsync(actors[0]);
+            const activeStakeBalance = await stakingApiWrapper.stakingContract.getOwnerStakeByStatus.callAsync(
+                actors[0],
+                StakeStatus.Active,
+            );
             expect(activeStakeBalance.currentEpochBalance).to.be.bignumber.equal(ZERO);
         });
         it('should read values correctly when in read-only mode', async () => {
@@ -62,8 +69,9 @@ blockchainTests.resets('Catastrophe Tests', env => {
             // set to read-only mode
             await stakingApiWrapper.stakingProxyContract.setReadOnlyMode.awaitTransactionSuccessAsync(true);
             // read stake balance in read-only mode
-            const activeStakeBalanceReadOnly = await stakingApiWrapper.stakingContract.getActiveStake.callAsync(
+            const activeStakeBalanceReadOnly = await stakingApiWrapper.stakingContract.getOwnerStakeByStatus.callAsync(
                 actors[0],
+                StakeStatus.Active,
             );
             expect(activeStakeBalanceReadOnly.currentEpochBalance).to.be.bignumber.equal(amountToStake);
         });
@@ -76,7 +84,10 @@ blockchainTests.resets('Catastrophe Tests', env => {
             await stakingApiWrapper.stakingContract.stake.awaitTransactionSuccessAsync(amountToStake, {
                 from: actors[0],
             });
-            const activeStakeBalance = await stakingApiWrapper.stakingContract.getActiveStake.callAsync(actors[0]);
+            const activeStakeBalance = await stakingApiWrapper.stakingContract.getOwnerStakeByStatus.callAsync(
+                actors[0],
+                StakeStatus.Active,
+            );
             expect(activeStakeBalance.currentEpochBalance).to.be.bignumber.equal(amountToStake);
         });
         it('should emit event when setting read-only mode', async () => {

--- a/contracts/staking/test/catastrophe_test.ts
+++ b/contracts/staking/test/catastrophe_test.ts
@@ -40,11 +40,11 @@ blockchainTests.resets('Catastrophe Tests', env => {
             await stakingApiWrapper.stakingContract.stake.awaitTransactionSuccessAsync(amountToStake, {
                 from: actors[0],
             });
-            const activeStakeBalance = await stakingApiWrapper.stakingContract.getOwnerStakeByStatus.callAsync(
+            const inactiveStakeBalance = await stakingApiWrapper.stakingContract.getOwnerStakeByStatus.callAsync(
                 actors[0],
-                StakeStatus.Active,
+                StakeStatus.Inactive,
             );
-            expect(activeStakeBalance.currentEpochBalance).to.be.bignumber.equal(amountToStake);
+            expect(inactiveStakeBalance.currentEpochBalance).to.be.bignumber.equal(amountToStake);
         });
         it('should not change state when in read-only mode', async () => {
             // set to read-only mode
@@ -54,11 +54,11 @@ blockchainTests.resets('Catastrophe Tests', env => {
             await stakingApiWrapper.stakingContract.stake.awaitTransactionSuccessAsync(amountToStake, {
                 from: actors[0],
             });
-            const activeStakeBalance = await stakingApiWrapper.stakingContract.getOwnerStakeByStatus.callAsync(
+            const inactiveStakeBalance = await stakingApiWrapper.stakingContract.getOwnerStakeByStatus.callAsync(
                 actors[0],
-                StakeStatus.Active,
+                StakeStatus.Inactive,
             );
-            expect(activeStakeBalance.currentEpochBalance).to.be.bignumber.equal(ZERO);
+            expect(inactiveStakeBalance.currentEpochBalance).to.be.bignumber.equal(ZERO);
         });
         it('should read values correctly when in read-only mode', async () => {
             // stake some zrx
@@ -69,11 +69,11 @@ blockchainTests.resets('Catastrophe Tests', env => {
             // set to read-only mode
             await stakingApiWrapper.stakingProxyContract.setReadOnlyMode.awaitTransactionSuccessAsync(true);
             // read stake balance in read-only mode
-            const activeStakeBalanceReadOnly = await stakingApiWrapper.stakingContract.getOwnerStakeByStatus.callAsync(
+            const inactiveStakeBalanceReadOnly = await stakingApiWrapper.stakingContract.getOwnerStakeByStatus.callAsync(
                 actors[0],
-                StakeStatus.Active,
+                StakeStatus.Inactive,
             );
-            expect(activeStakeBalanceReadOnly.currentEpochBalance).to.be.bignumber.equal(amountToStake);
+            expect(inactiveStakeBalanceReadOnly.currentEpochBalance).to.be.bignumber.equal(amountToStake);
         });
         it('should exit read-only mode', async () => {
             // set to read-only mode
@@ -84,11 +84,11 @@ blockchainTests.resets('Catastrophe Tests', env => {
             await stakingApiWrapper.stakingContract.stake.awaitTransactionSuccessAsync(amountToStake, {
                 from: actors[0],
             });
-            const activeStakeBalance = await stakingApiWrapper.stakingContract.getOwnerStakeByStatus.callAsync(
+            const inactiveStakeBalance = await stakingApiWrapper.stakingContract.getOwnerStakeByStatus.callAsync(
                 actors[0],
-                StakeStatus.Active,
+                StakeStatus.Inactive,
             );
-            expect(activeStakeBalance.currentEpochBalance).to.be.bignumber.equal(amountToStake);
+            expect(inactiveStakeBalance.currentEpochBalance).to.be.bignumber.equal(amountToStake);
         });
         it('should emit event when setting read-only mode', async () => {
             // set to read-only mode

--- a/contracts/staking/test/catastrophe_test.ts
+++ b/contracts/staking/test/catastrophe_test.ts
@@ -40,11 +40,11 @@ blockchainTests.resets('Catastrophe Tests', env => {
             await stakingApiWrapper.stakingContract.stake.awaitTransactionSuccessAsync(amountToStake, {
                 from: actors[0],
             });
-            const inactiveStakeBalance = await stakingApiWrapper.stakingContract.getOwnerStakeByStatus.callAsync(
+            const undelegatedStakeBalance = await stakingApiWrapper.stakingContract.getOwnerStakeByStatus.callAsync(
                 actors[0],
                 StakeStatus.Undelegated,
             );
-            expect(inactiveStakeBalance.currentEpochBalance).to.be.bignumber.equal(amountToStake);
+            expect(undelegatedStakeBalance.currentEpochBalance).to.be.bignumber.equal(amountToStake);
         });
         it('should not change state when in read-only mode', async () => {
             // set to read-only mode
@@ -54,11 +54,11 @@ blockchainTests.resets('Catastrophe Tests', env => {
             await stakingApiWrapper.stakingContract.stake.awaitTransactionSuccessAsync(amountToStake, {
                 from: actors[0],
             });
-            const inactiveStakeBalance = await stakingApiWrapper.stakingContract.getOwnerStakeByStatus.callAsync(
+            const undelegatedStakeBalance = await stakingApiWrapper.stakingContract.getOwnerStakeByStatus.callAsync(
                 actors[0],
                 StakeStatus.Undelegated,
             );
-            expect(inactiveStakeBalance.currentEpochBalance).to.be.bignumber.equal(ZERO);
+            expect(undelegatedStakeBalance.currentEpochBalance).to.be.bignumber.equal(ZERO);
         });
         it('should read values correctly when in read-only mode', async () => {
             // stake some zrx
@@ -69,11 +69,11 @@ blockchainTests.resets('Catastrophe Tests', env => {
             // set to read-only mode
             await stakingApiWrapper.stakingProxyContract.setReadOnlyMode.awaitTransactionSuccessAsync(true);
             // read stake balance in read-only mode
-            const inactiveStakeBalanceReadOnly = await stakingApiWrapper.stakingContract.getOwnerStakeByStatus.callAsync(
+            const undelegatedStakeBalanceReadOnly = await stakingApiWrapper.stakingContract.getOwnerStakeByStatus.callAsync(
                 actors[0],
                 StakeStatus.Undelegated,
             );
-            expect(inactiveStakeBalanceReadOnly.currentEpochBalance).to.be.bignumber.equal(amountToStake);
+            expect(undelegatedStakeBalanceReadOnly.currentEpochBalance).to.be.bignumber.equal(amountToStake);
         });
         it('should exit read-only mode', async () => {
             // set to read-only mode
@@ -84,11 +84,11 @@ blockchainTests.resets('Catastrophe Tests', env => {
             await stakingApiWrapper.stakingContract.stake.awaitTransactionSuccessAsync(amountToStake, {
                 from: actors[0],
             });
-            const inactiveStakeBalance = await stakingApiWrapper.stakingContract.getOwnerStakeByStatus.callAsync(
+            const undelegatedStakeBalance = await stakingApiWrapper.stakingContract.getOwnerStakeByStatus.callAsync(
                 actors[0],
                 StakeStatus.Undelegated,
             );
-            expect(inactiveStakeBalance.currentEpochBalance).to.be.bignumber.equal(amountToStake);
+            expect(undelegatedStakeBalance.currentEpochBalance).to.be.bignumber.equal(amountToStake);
         });
         it('should emit event when setting read-only mode', async () => {
             // set to read-only mode

--- a/contracts/staking/test/codesize_test.ts
+++ b/contracts/staking/test/codesize_test.ts
@@ -2,7 +2,7 @@ import { constants, expect, getCodesizeFromArtifact } from '@0x/contracts-test-u
 
 import { artifacts } from '../src';
 
-describe.skip('Contract Size Checks', () => {
+describe('Contract Size Checks', () => {
     describe('Staking', () => {
         it('should have a codesize less than the maximum', async () => {
             const actualSize = getCodesizeFromArtifact(artifacts.Staking);

--- a/contracts/staking/test/rewards_test.ts
+++ b/contracts/staking/test/rewards_test.ts
@@ -176,7 +176,7 @@ blockchainTests.resets('Testing Rewards', env => {
             const amount = toBaseUnitAmount(4);
             await stakers[0].stakeAsync(amount);
             await stakers[0].moveStakeAsync(
-                new StakeInfo(StakeStatus.Active),
+                new StakeInfo(StakeStatus.Inactive),
                 new StakeInfo(StakeStatus.Delegated, poolId),
                 amount,
             );
@@ -248,7 +248,7 @@ blockchainTests.resets('Testing Rewards', env => {
             const totalStakeAmount = toBaseUnitAmount(10);
             await stakers[0].stakeAsync(stakeAmounts[0]);
             await stakers[0].moveStakeAsync(
-                new StakeInfo(StakeStatus.Active),
+                new StakeInfo(StakeStatus.Inactive),
                 new StakeInfo(StakeStatus.Delegated, poolId),
                 stakeAmounts[0],
             );
@@ -259,7 +259,7 @@ blockchainTests.resets('Testing Rewards', env => {
             // second staker delegates (epoch 1)
             await stakers[1].stakeAsync(stakeAmounts[1]);
             await stakers[1].moveStakeAsync(
-                new StakeInfo(StakeStatus.Active),
+                new StakeInfo(StakeStatus.Inactive),
                 new StakeInfo(StakeStatus.Delegated, poolId),
                 stakeAmounts[1],
             );
@@ -355,7 +355,7 @@ blockchainTests.resets('Testing Rewards', env => {
             // undelegate (withdraws delegator's rewards)
             await stakers[0].moveStakeAsync(
                 new StakeInfo(StakeStatus.Delegated, poolId),
-                new StakeInfo(StakeStatus.Active),
+                new StakeInfo(StakeStatus.Inactive),
                 stakeAmount,
             );
             // sanity check final balances
@@ -436,7 +436,7 @@ blockchainTests.resets('Testing Rewards', env => {
             // undelegate stake and finalize epoch
             await stakers[0].moveStakeAsync(
                 new StakeInfo(StakeStatus.Delegated, poolId),
-                new StakeInfo(StakeStatus.Active),
+                new StakeInfo(StakeStatus.Inactive),
                 stakeAmount,
             );
 
@@ -472,7 +472,7 @@ blockchainTests.resets('Testing Rewards', env => {
             // undelegate stake and finalize epoch
             await stakers[0].moveStakeAsync(
                 new StakeInfo(StakeStatus.Delegated, poolId),
-                new StakeInfo(StakeStatus.Active),
+                new StakeInfo(StakeStatus.Inactive),
                 stakeAmount,
             );
             await payProtocolFeeAndFinalize();
@@ -499,7 +499,7 @@ blockchainTests.resets('Testing Rewards', env => {
             // undelegate stake and finalize epoch
             await stakers[0].moveStakeAsync(
                 new StakeInfo(StakeStatus.Delegated, poolId),
-                new StakeInfo(StakeStatus.Active),
+                new StakeInfo(StakeStatus.Inactive),
                 stakeAmount,
             );
             await payProtocolFeeAndFinalize();
@@ -507,7 +507,7 @@ blockchainTests.resets('Testing Rewards', env => {
             await payProtocolFeeAndFinalize(rewardNotForDelegator);
             // delegate stake and go to next epoch
             await stakers[0].moveStakeAsync(
-                new StakeInfo(StakeStatus.Active),
+                new StakeInfo(StakeStatus.Inactive),
                 new StakeInfo(StakeStatus.Delegated, poolId),
                 stakeAmount,
             );
@@ -530,7 +530,7 @@ blockchainTests.resets('Testing Rewards', env => {
             const stakeAmount = toBaseUnitAmount(4);
             await stakers[0].stakeAsync(stakeAmount);
             await stakers[0].moveStakeAsync(
-                new StakeInfo(StakeStatus.Active),
+                new StakeInfo(StakeStatus.Inactive),
                 new StakeInfo(StakeStatus.Delegated, poolId),
                 stakeAmount,
             );
@@ -539,7 +539,7 @@ blockchainTests.resets('Testing Rewards', env => {
             // undelegate stake and finalize epoch
             await stakers[0].moveStakeAsync(
                 new StakeInfo(StakeStatus.Delegated, poolId),
-                new StakeInfo(StakeStatus.Active),
+                new StakeInfo(StakeStatus.Inactive),
                 stakeAmount,
             );
             // this should go to the delegator
@@ -547,7 +547,7 @@ blockchainTests.resets('Testing Rewards', env => {
             // delegate stake ~ this will result in a payout where rewards are computed on
             // the balance's `currentEpochBalance` field but not the `nextEpochBalance` field.
             await stakers[0].moveStakeAsync(
-                new StakeInfo(StakeStatus.Active),
+                new StakeInfo(StakeStatus.Inactive),
                 new StakeInfo(StakeStatus.Delegated, poolId),
                 stakeAmount,
             );
@@ -565,7 +565,7 @@ blockchainTests.resets('Testing Rewards', env => {
             const stakeAmount = toBaseUnitAmount(4);
             await stakers[0].stakeAsync(stakeAmount);
             await stakers[0].moveStakeAsync(
-                new StakeInfo(StakeStatus.Active),
+                new StakeInfo(StakeStatus.Inactive),
                 new StakeInfo(StakeStatus.Delegated, poolId),
                 stakeAmount,
             );
@@ -595,7 +595,7 @@ blockchainTests.resets('Testing Rewards', env => {
             const undelegateAmount = toBaseUnitAmount(2.5);
             await staker.moveStakeAsync(
                 new StakeInfo(StakeStatus.Delegated, poolId),
-                new StakeInfo(StakeStatus.Active),
+                new StakeInfo(StakeStatus.Inactive),
                 undelegateAmount,
             );
             // finalize

--- a/contracts/staking/test/rewards_test.ts
+++ b/contracts/staking/test/rewards_test.ts
@@ -176,7 +176,7 @@ blockchainTests.resets('Testing Rewards', env => {
             const amount = toBaseUnitAmount(4);
             await stakers[0].stakeAsync(amount);
             await stakers[0].moveStakeAsync(
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 new StakeInfo(StakeStatus.Delegated, poolId),
                 amount,
             );
@@ -248,7 +248,7 @@ blockchainTests.resets('Testing Rewards', env => {
             const totalStakeAmount = toBaseUnitAmount(10);
             await stakers[0].stakeAsync(stakeAmounts[0]);
             await stakers[0].moveStakeAsync(
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 new StakeInfo(StakeStatus.Delegated, poolId),
                 stakeAmounts[0],
             );
@@ -259,7 +259,7 @@ blockchainTests.resets('Testing Rewards', env => {
             // second staker delegates (epoch 1)
             await stakers[1].stakeAsync(stakeAmounts[1]);
             await stakers[1].moveStakeAsync(
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 new StakeInfo(StakeStatus.Delegated, poolId),
                 stakeAmounts[1],
             );
@@ -355,7 +355,7 @@ blockchainTests.resets('Testing Rewards', env => {
             // undelegate (withdraws delegator's rewards)
             await stakers[0].moveStakeAsync(
                 new StakeInfo(StakeStatus.Delegated, poolId),
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 stakeAmount,
             );
             // sanity check final balances
@@ -436,7 +436,7 @@ blockchainTests.resets('Testing Rewards', env => {
             // undelegate stake and finalize epoch
             await stakers[0].moveStakeAsync(
                 new StakeInfo(StakeStatus.Delegated, poolId),
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 stakeAmount,
             );
 
@@ -472,7 +472,7 @@ blockchainTests.resets('Testing Rewards', env => {
             // undelegate stake and finalize epoch
             await stakers[0].moveStakeAsync(
                 new StakeInfo(StakeStatus.Delegated, poolId),
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 stakeAmount,
             );
             await payProtocolFeeAndFinalize();
@@ -499,7 +499,7 @@ blockchainTests.resets('Testing Rewards', env => {
             // undelegate stake and finalize epoch
             await stakers[0].moveStakeAsync(
                 new StakeInfo(StakeStatus.Delegated, poolId),
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 stakeAmount,
             );
             await payProtocolFeeAndFinalize();
@@ -507,7 +507,7 @@ blockchainTests.resets('Testing Rewards', env => {
             await payProtocolFeeAndFinalize(rewardNotForDelegator);
             // delegate stake and go to next epoch
             await stakers[0].moveStakeAsync(
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 new StakeInfo(StakeStatus.Delegated, poolId),
                 stakeAmount,
             );
@@ -530,7 +530,7 @@ blockchainTests.resets('Testing Rewards', env => {
             const stakeAmount = toBaseUnitAmount(4);
             await stakers[0].stakeAsync(stakeAmount);
             await stakers[0].moveStakeAsync(
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 new StakeInfo(StakeStatus.Delegated, poolId),
                 stakeAmount,
             );
@@ -539,7 +539,7 @@ blockchainTests.resets('Testing Rewards', env => {
             // undelegate stake and finalize epoch
             await stakers[0].moveStakeAsync(
                 new StakeInfo(StakeStatus.Delegated, poolId),
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 stakeAmount,
             );
             // this should go to the delegator
@@ -547,7 +547,7 @@ blockchainTests.resets('Testing Rewards', env => {
             // delegate stake ~ this will result in a payout where rewards are computed on
             // the balance's `currentEpochBalance` field but not the `nextEpochBalance` field.
             await stakers[0].moveStakeAsync(
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 new StakeInfo(StakeStatus.Delegated, poolId),
                 stakeAmount,
             );
@@ -565,7 +565,7 @@ blockchainTests.resets('Testing Rewards', env => {
             const stakeAmount = toBaseUnitAmount(4);
             await stakers[0].stakeAsync(stakeAmount);
             await stakers[0].moveStakeAsync(
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 new StakeInfo(StakeStatus.Delegated, poolId),
                 stakeAmount,
             );
@@ -595,7 +595,7 @@ blockchainTests.resets('Testing Rewards', env => {
             const undelegateAmount = toBaseUnitAmount(2.5);
             await staker.moveStakeAsync(
                 new StakeInfo(StakeStatus.Delegated, poolId),
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 undelegateAmount,
             );
             // finalize

--- a/contracts/staking/test/stake_test.ts
+++ b/contracts/staking/test/stake_test.ts
@@ -344,12 +344,11 @@ blockchainTests.resets('Stake Statuses', env => {
             const amount = toBaseUnitAmount(0);
             await staker.unstakeAsync(amount);
         });
-        it('should successfully unstake after being inactive for 1 epoch', async () => {
+        it('should successfully unstake after becoming inactive', async () => {
             const amount = toBaseUnitAmount(10);
             await staker.stakeAsync(amount);
             await staker.moveStakeAsync(new StakeInfo(StakeStatus.Active), new StakeInfo(StakeStatus.Inactive), amount);
             await staker.goToNextEpochAsync(); // stake is now inactive
-            await staker.goToNextEpochAsync(); // stake is now withdrawable
             await staker.unstakeAsync(amount);
         });
         it('should fail to unstake with insufficient balance', async () => {
@@ -363,30 +362,21 @@ blockchainTests.resets('Stake Statuses', env => {
             await staker.moveStakeAsync(new StakeInfo(StakeStatus.Active), new StakeInfo(StakeStatus.Inactive), amount);
             await staker.unstakeAsync(amount, new StakingRevertErrors.InsufficientBalanceError(amount, ZERO));
         });
-        it('should fail to unstake after being inactive for <1 epoch', async () => {
-            const amount = toBaseUnitAmount(10);
-            await staker.stakeAsync(amount);
-            await staker.moveStakeAsync(new StakeInfo(StakeStatus.Active), new StakeInfo(StakeStatus.Inactive), amount);
-            await staker.goToNextEpochAsync();
-            await staker.unstakeAsync(amount, new StakingRevertErrors.InsufficientBalanceError(amount, ZERO));
-        });
-        it('should fail to unstake in same epoch that inactive/withdrawable stake has been reactivated', async () => {
+        it('should fail to unstake in same epoch that inactive stake has been reactivated', async () => {
             const amount = toBaseUnitAmount(10);
             await staker.stakeAsync(amount);
             await staker.moveStakeAsync(new StakeInfo(StakeStatus.Active), new StakeInfo(StakeStatus.Inactive), amount);
             await staker.goToNextEpochAsync(); // stake is now inactive
-            await staker.goToNextEpochAsync(); // stake is now withdrawable
             await staker.moveStakeAsync(new StakeInfo(StakeStatus.Inactive), new StakeInfo(StakeStatus.Active), amount);
             await staker.unstakeAsync(amount, new StakingRevertErrors.InsufficientBalanceError(amount, ZERO));
         });
-        it('should fail to unstake one epoch after inactive/withdrawable stake has been reactivated', async () => {
+        it('should fail to unstake one epoch after inactive stake has been reactivated', async () => {
             const amount = toBaseUnitAmount(10);
             await staker.stakeAsync(amount);
             await staker.moveStakeAsync(new StakeInfo(StakeStatus.Active), new StakeInfo(StakeStatus.Inactive), amount);
             await staker.goToNextEpochAsync(); // stake is now inactive
-            await staker.goToNextEpochAsync(); // stake is now withdrawable
             await staker.moveStakeAsync(new StakeInfo(StakeStatus.Inactive), new StakeInfo(StakeStatus.Active), amount);
-            await staker.goToNextEpochAsync(); // stake is active and not withdrawable
+            await staker.goToNextEpochAsync(); // stake is active
             await staker.unstakeAsync(amount, new StakingRevertErrors.InsufficientBalanceError(amount, ZERO));
         });
         it('should fail to unstake >1 epoch after inactive/withdrawable stake has been reactivated', async () => {

--- a/contracts/staking/test/stake_test.ts
+++ b/contracts/staking/test/stake_test.ts
@@ -76,11 +76,31 @@ blockchainTests.resets('Stake Statuses', env => {
             // epoch 1
             const amount = toBaseUnitAmount(10);
             await staker.stakeAsync(amount);
-            await staker.moveStakeAsync(new StakeInfo(StakeStatus.Active), new StakeInfo(StakeStatus.Inactive), amount);
-            // still epoch 1 ~ should be able to move stake again
             await staker.moveStakeAsync(
                 new StakeInfo(StakeStatus.Inactive),
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
+                amount,
+            );
+            // still epoch 1 ~ should be able to move stake again
+            await staker.moveStakeAsync(
+                new StakeInfo(StakeStatus.Delegated, poolIds[0]),
+                new StakeInfo(StakeStatus.Inactive),
+                amount,
+            );
+        });
+        it("should be able to reassign next epoch's stake", async () => {
+            // epoch 1
+            const amount = toBaseUnitAmount(10);
+            await staker.stakeAsync(amount);
+            await staker.moveStakeAsync(
+                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Delegated, poolIds[0]),
+                amount,
+            );
+            // still epoch 1 ~ should be able to move stake again
+            await staker.moveStakeAsync(
+                new StakeInfo(StakeStatus.Delegated, poolIds[0]),
+                new StakeInfo(StakeStatus.Delegated, poolIds[1]),
                 amount,
             );
         });
@@ -88,30 +108,15 @@ blockchainTests.resets('Stake Statuses', env => {
             // epoch 1
             const amount = toBaseUnitAmount(10);
             await staker.stakeAsync(amount);
-            await staker.moveStakeAsync(new StakeInfo(StakeStatus.Active), new StakeInfo(StakeStatus.Inactive), amount);
-            // stake is now inactive, should not be able to move it out of active status again
-            await staker.moveStakeAsync(
-                new StakeInfo(StakeStatus.Active),
-                new StakeInfo(StakeStatus.Inactive),
-                amount,
-                new StakingRevertErrors.InsufficientBalanceError(amount, ZERO),
-            );
-        });
-        it('should fail to reassign stake', async () => {
-            // epoch 1
-            const amount = toBaseUnitAmount(10);
-            await staker.stakeAsync(amount);
-            await staker.moveStakeAsync(new StakeInfo(StakeStatus.Active), new StakeInfo(StakeStatus.Inactive), amount);
-            // still epoch 1 ~ should be able to move stake again
             await staker.moveStakeAsync(
                 new StakeInfo(StakeStatus.Inactive),
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
                 amount,
             );
-            // stake is now delegated; should fail to re-assign it from inactive back to active
+            // stake is now inactive, should not be able to move it out of active status again
             await staker.moveStakeAsync(
                 new StakeInfo(StakeStatus.Inactive),
-                new StakeInfo(StakeStatus.Active),
+                new StakeInfo(StakeStatus.Delegated, poolIds[1]),
                 amount,
                 new StakingRevertErrors.InsufficientBalanceError(amount, ZERO),
             );
@@ -122,14 +127,14 @@ blockchainTests.resets('Stake Statuses', env => {
             // epoch 1
             const amount = toBaseUnitAmount(10);
             await staker.stakeAndMoveAsync(
-                new StakeInfo(StakeStatus.Active),
                 new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Delegated, poolIds[0]),
                 amount,
             );
             // still epoch 1 ~ should be able to move stake again
             await staker.moveStakeAsync(
-                new StakeInfo(StakeStatus.Inactive),
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
+                new StakeInfo(StakeStatus.Inactive),
                 amount,
             );
         });
@@ -137,58 +142,20 @@ blockchainTests.resets('Stake Statuses', env => {
             // epoch 1
             const amount = toBaseUnitAmount(10);
             await staker.stakeAndMoveAsync(
-                new StakeInfo(StakeStatus.Active),
-                new StakeInfo(StakeStatus.Inactive),
-                amount,
-            );
-            // stake is now inactive, should not be able to move it out of active status again
-            await staker.moveStakeAsync(
-                new StakeInfo(StakeStatus.Active),
-                new StakeInfo(StakeStatus.Inactive),
-                amount,
-                new StakingRevertErrors.InsufficientBalanceError(amount, ZERO),
-            );
-        });
-        it('should fail to reassign stake', async () => {
-            // epoch 1
-            const amount = toBaseUnitAmount(10);
-            await staker.stakeAndMoveAsync(
-                new StakeInfo(StakeStatus.Active),
-                new StakeInfo(StakeStatus.Inactive),
-                amount,
-            );
-            // still epoch 1 ~ should be able to move stake again
-            await staker.moveStakeAsync(
                 new StakeInfo(StakeStatus.Inactive),
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
                 amount,
             );
-            // stake is now delegated; should fail to re-assign it from inactive back to active
+            // stake is now inactive, should not be able to move it out of active status again
             await staker.moveStakeAsync(
                 new StakeInfo(StakeStatus.Inactive),
-                new StakeInfo(StakeStatus.Active),
+                new StakeInfo(StakeStatus.Delegated, poolIds[1]),
                 amount,
                 new StakingRevertErrors.InsufficientBalanceError(amount, ZERO),
             );
         });
     });
     describe('Move Zero Stake', () => {
-        it('active -> active', async () => {
-            await staker.moveStakeAsync(new StakeInfo(StakeStatus.Active), new StakeInfo(StakeStatus.Active), ZERO);
-        });
-        it('active -> inactive', async () => {
-            await staker.moveStakeAsync(new StakeInfo(StakeStatus.Active), new StakeInfo(StakeStatus.Inactive), ZERO);
-        });
-        it('active -> delegated', async () => {
-            await staker.moveStakeAsync(
-                new StakeInfo(StakeStatus.Active),
-                new StakeInfo(StakeStatus.Delegated, poolIds[0]),
-                ZERO,
-            );
-        });
-        it('inactive -> active', async () => {
-            await staker.moveStakeAsync(new StakeInfo(StakeStatus.Inactive), new StakeInfo(StakeStatus.Active), ZERO);
-        });
         it('inactive -> inactive', async () => {
             await staker.moveStakeAsync(new StakeInfo(StakeStatus.Inactive), new StakeInfo(StakeStatus.Inactive), ZERO);
         });
@@ -196,13 +163,6 @@ blockchainTests.resets('Stake Statuses', env => {
             await staker.moveStakeAsync(
                 new StakeInfo(StakeStatus.Inactive),
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
-                ZERO,
-            );
-        });
-        it('delegated -> active', async () => {
-            await staker.moveStakeAsync(
-                new StakeInfo(StakeStatus.Delegated, poolIds[0]),
-                new StakeInfo(StakeStatus.Active),
                 ZERO,
             );
         });
@@ -233,8 +193,8 @@ blockchainTests.resets('Stake Statuses', env => {
             // setup
             const amount = toBaseUnitAmount(10);
             await staker.stakeAsync(amount);
-            if (from.status !== StakeStatus.Active) {
-                await staker.moveStakeAsync(new StakeInfo(StakeStatus.Active), from, amount);
+            if (from.status !== StakeStatus.Inactive) {
+                await staker.moveStakeAsync(new StakeInfo(StakeStatus.Inactive), from, amount);
             }
             // run test, checking balances in epochs [n .. n + 2]
             // in epoch `n` - `next` is set
@@ -242,21 +202,6 @@ blockchainTests.resets('Stake Statuses', env => {
             await staker.moveStakeAsync(from, to, amount.div(2));
             await staker.goToNextEpochAsync();
         };
-        it('active -> active', async () => {
-            await testMovePartialStake(new StakeInfo(StakeStatus.Active), new StakeInfo(StakeStatus.Active));
-        });
-        it('active -> inactive', async () => {
-            await testMovePartialStake(new StakeInfo(StakeStatus.Active), new StakeInfo(StakeStatus.Inactive));
-        });
-        it('active -> delegated', async () => {
-            await testMovePartialStake(
-                new StakeInfo(StakeStatus.Active),
-                new StakeInfo(StakeStatus.Delegated, poolIds[0]),
-            );
-        });
-        it('inactive -> active', async () => {
-            await testMovePartialStake(new StakeInfo(StakeStatus.Inactive), new StakeInfo(StakeStatus.Active));
-        });
         it('inactive -> inactive', async () => {
             await testMovePartialStake(new StakeInfo(StakeStatus.Inactive), new StakeInfo(StakeStatus.Inactive));
         });
@@ -264,12 +209,6 @@ blockchainTests.resets('Stake Statuses', env => {
             await testMovePartialStake(
                 new StakeInfo(StakeStatus.Inactive),
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
-            );
-        });
-        it('delegated -> active', async () => {
-            await testMovePartialStake(
-                new StakeInfo(StakeStatus.Delegated, poolIds[0]),
-                new StakeInfo(StakeStatus.Active),
             );
         });
         it('delegated -> inactive', async () => {
@@ -290,20 +229,9 @@ blockchainTests.resets('Stake Statuses', env => {
                 new StakeInfo(StakeStatus.Delegated, poolIds[1]),
             );
         });
-        it('active -> delegated (non-existent pool)', async () => {
-            const amount = toBaseUnitAmount(10);
-            await staker.stakeAsync(amount);
-            await staker.moveStakeAsync(
-                new StakeInfo(StakeStatus.Active),
-                new StakeInfo(StakeStatus.Delegated, unusedPoolId),
-                amount,
-                new StakingRevertErrors.PoolExistenceError(unusedPoolId, false),
-            );
-        });
         it('inactive -> delegated (non-existent pool)', async () => {
             const amount = toBaseUnitAmount(10);
             await staker.stakeAsync(amount);
-            await staker.moveStakeAsync(new StakeInfo(StakeStatus.Active), new StakeInfo(StakeStatus.Inactive), amount);
             await staker.moveStakeAsync(
                 new StakeInfo(StakeStatus.Inactive),
                 new StakeInfo(StakeStatus.Delegated, unusedPoolId),
@@ -315,23 +243,13 @@ blockchainTests.resets('Stake Statuses', env => {
             const amount = toBaseUnitAmount(10);
             await staker.stakeAsync(amount);
             await staker.moveStakeAsync(
-                new StakeInfo(StakeStatus.Active),
+                new StakeInfo(StakeStatus.Inactive),
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
                 amount,
             );
             await staker.moveStakeAsync(
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
                 new StakeInfo(StakeStatus.Delegated, unusedPoolId),
-                amount,
-                new StakingRevertErrors.PoolExistenceError(unusedPoolId, false),
-            );
-        });
-        it('delegated (non-existent pool) -> active', async () => {
-            const amount = toBaseUnitAmount(10);
-            await staker.stakeAsync(amount);
-            await staker.moveStakeAsync(
-                new StakeInfo(StakeStatus.Delegated, unusedPoolId),
-                new StakeInfo(StakeStatus.Active),
                 amount,
                 new StakingRevertErrors.PoolExistenceError(unusedPoolId, false),
             );
@@ -345,102 +263,126 @@ blockchainTests.resets('Stake Statuses', env => {
         it('should successfully unstake after becoming inactive', async () => {
             const amount = toBaseUnitAmount(10);
             await staker.stakeAsync(amount);
-            await staker.moveStakeAsync(new StakeInfo(StakeStatus.Active), new StakeInfo(StakeStatus.Inactive), amount);
+            await staker.moveStakeAsync(
+                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Delegated, poolIds[0]),
+                amount,
+            );
+            await staker.moveStakeAsync(
+                new StakeInfo(StakeStatus.Delegated, poolIds[0]),
+                new StakeInfo(StakeStatus.Inactive),
+                amount,
+            );
             await staker.goToNextEpochAsync(); // stake is now inactive
             await staker.unstakeAsync(amount);
-        });
-        it('should fail to unstake with insufficient balance', async () => {
-            const amount = toBaseUnitAmount(10);
-            await staker.stakeAsync(amount);
-            await staker.unstakeAsync(amount, new StakingRevertErrors.InsufficientBalanceError(amount, ZERO));
         });
         it('should fail to unstake in the same epoch as stake was set to inactive', async () => {
             const amount = toBaseUnitAmount(10);
             await staker.stakeAsync(amount);
-            await staker.moveStakeAsync(new StakeInfo(StakeStatus.Active), new StakeInfo(StakeStatus.Inactive), amount);
+            await staker.moveStakeAsync(
+                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Delegated, poolIds[0]),
+                amount,
+            );
+            await staker.goToNextEpochAsync(); // stake is now delegated
+            await staker.moveStakeAsync(
+                new StakeInfo(StakeStatus.Delegated, poolIds[0]),
+                new StakeInfo(StakeStatus.Inactive),
+                amount,
+            );
             await staker.unstakeAsync(amount, new StakingRevertErrors.InsufficientBalanceError(amount, ZERO));
         });
         it('should fail to unstake in same epoch that inactive stake has been reactivated', async () => {
             const amount = toBaseUnitAmount(10);
             await staker.stakeAsync(amount);
-            await staker.moveStakeAsync(new StakeInfo(StakeStatus.Active), new StakeInfo(StakeStatus.Inactive), amount);
-            await staker.goToNextEpochAsync(); // stake is now inactive
-            await staker.moveStakeAsync(new StakeInfo(StakeStatus.Inactive), new StakeInfo(StakeStatus.Active), amount);
+            await staker.moveStakeAsync(
+                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Delegated, poolIds[0]),
+                amount,
+            );
             await staker.unstakeAsync(amount, new StakingRevertErrors.InsufficientBalanceError(amount, ZERO));
         });
         it('should fail to unstake one epoch after inactive stake has been reactivated', async () => {
             const amount = toBaseUnitAmount(10);
             await staker.stakeAsync(amount);
-            await staker.moveStakeAsync(new StakeInfo(StakeStatus.Active), new StakeInfo(StakeStatus.Inactive), amount);
+            await staker.moveStakeAsync(
+                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Delegated, poolIds[0]),
+                amount,
+            );
             await staker.goToNextEpochAsync(); // stake is now inactive
-            await staker.moveStakeAsync(new StakeInfo(StakeStatus.Inactive), new StakeInfo(StakeStatus.Active), amount);
-            await staker.goToNextEpochAsync(); // stake is active
             await staker.unstakeAsync(amount, new StakingRevertErrors.InsufficientBalanceError(amount, ZERO));
         });
-        it('should fail to unstake >1 epoch after inactive/withdrawable stake has been reactivated', async () => {
+        it('should fail to unstake >1 epoch after inactive stake has been reactivated', async () => {
             const amount = toBaseUnitAmount(10);
             await staker.stakeAsync(amount);
-            await staker.moveStakeAsync(new StakeInfo(StakeStatus.Active), new StakeInfo(StakeStatus.Inactive), amount);
+            await staker.moveStakeAsync(
+                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Delegated, poolIds[0]),
+                amount,
+            );
             await staker.goToNextEpochAsync(); // stake is now inactive
             await staker.goToNextEpochAsync(); // stake is now withdrawable
-            await staker.moveStakeAsync(new StakeInfo(StakeStatus.Inactive), new StakeInfo(StakeStatus.Active), amount);
-            await staker.goToNextEpochAsync(); // stake is active and not withdrawable
-            await staker.goToNextEpochAsync(); // stake is active and not withdrawable
             await staker.unstakeAsync(amount, new StakingRevertErrors.InsufficientBalanceError(amount, ZERO));
+        });
+        it('should successfuly unstake freshly deposited stake', async () => {
+            const amount = toBaseUnitAmount(10);
+            await staker.stakeAsync(amount);
+            await staker.unstakeAsync(amount);
         });
     });
     describe('Simulations', () => {
-        it('Simulation from Staking Spec', async () => {
-            // Epoch 1: Stake some ZRX
-            await staker.stakeAsync(toBaseUnitAmount(4));
-            // Later in Epoch 1: User delegates and deactivates some stake
-            await staker.moveStakeAsync(
-                new StakeInfo(StakeStatus.Active),
-                new StakeInfo(StakeStatus.Inactive),
-                toBaseUnitAmount(1),
-            );
-            await staker.moveStakeAsync(
-                new StakeInfo(StakeStatus.Active),
-                new StakeInfo(StakeStatus.Delegated, poolIds[0]),
-                toBaseUnitAmount(2),
-            );
-            // Epoch 2: Status updates (no user intervention required)
-            await staker.goToNextEpochAsync();
-            // Epoch 3: Stake that has been inactive for an epoch can be withdrawn (no user intervention required)
-            await staker.goToNextEpochAsync();
-            // Later in Epoch 3: User reactivates half of their inactive stake; this becomes Active next epoch
-            await staker.moveStakeAsync(
-                new StakeInfo(StakeStatus.Inactive),
-                new StakeInfo(StakeStatus.Active),
-                toBaseUnitAmount(0.5),
-            );
-            // Later in Epoch 3: User re-delegates half of their stake from Pool 1 to Pool 2
-            await staker.moveStakeAsync(
-                new StakeInfo(StakeStatus.Delegated, poolIds[0]),
-                new StakeInfo(StakeStatus.Delegated, poolIds[1]),
-                toBaseUnitAmount(1),
-            );
-            // Epoch 4: Status updates (no user intervention required)
-            await staker.goToNextEpochAsync();
-            // Later in Epoch 4: User deactivates all active stake
-            await staker.moveStakeAsync(
-                new StakeInfo(StakeStatus.Active),
-                new StakeInfo(StakeStatus.Inactive),
-                toBaseUnitAmount(1.5),
-            );
-            // Later in Epoch 4: User withdraws all available inactive stake
-            await staker.unstakeAsync(toBaseUnitAmount(0.5));
-            // Epoch 5: Status updates (no user intervention required)
-            await staker.goToNextEpochAsync();
-            // Later in Epoch 5: User reactivates a portion of their stake
-            await staker.moveStakeAsync(
-                new StakeInfo(StakeStatus.Inactive),
-                new StakeInfo(StakeStatus.Active),
-                toBaseUnitAmount(1),
-            );
-            // Epoch 6: Status updates (no user intervention required)
-            await staker.goToNextEpochAsync();
-        });
+        // it('Simulation from Staking Spec', async () => {
+        //     // Epoch 1: Stake some ZRX
+        //     await staker.stakeAsync(toBaseUnitAmount(4));
+        //     // Later in Epoch 1: User delegates and deactivates some stake
+        //     await staker.moveStakeAsync(
+        //         new StakeInfo(StakeStatus.Active),
+        //         new StakeInfo(StakeStatus.Inactive),
+        //         toBaseUnitAmount(1),
+        //     );
+        //     await staker.moveStakeAsync(
+        //         new StakeInfo(StakeStatus.Active),
+        //         new StakeInfo(StakeStatus.Delegated, poolIds[0]),
+        //         toBaseUnitAmount(2),
+        //     );
+        //     // Epoch 2: Status updates (no user intervention required)
+        //     await staker.goToNextEpochAsync();
+        //     // Epoch 3: Stake that has been inactive for an epoch can be withdrawn (no user intervention required)
+        //     await staker.goToNextEpochAsync();
+        //     // Later in Epoch 3: User reactivates half of their inactive stake; this becomes Active next epoch
+        //     await staker.moveStakeAsync(
+        //         new StakeInfo(StakeStatus.Inactive),
+        //         new StakeInfo(StakeStatus.Active),
+        //         toBaseUnitAmount(0.5),
+        //     );
+        //     // Later in Epoch 3: User re-delegates half of their stake from Pool 1 to Pool 2
+        //     await staker.moveStakeAsync(
+        //         new StakeInfo(StakeStatus.Delegated, poolIds[0]),
+        //         new StakeInfo(StakeStatus.Delegated, poolIds[1]),
+        //         toBaseUnitAmount(1),
+        //     );
+        //     // Epoch 4: Status updates (no user intervention required)
+        //     await staker.goToNextEpochAsync();
+        //     // Later in Epoch 4: User deactivates all active stake
+        //     await staker.moveStakeAsync(
+        //         new StakeInfo(StakeStatus.Active),
+        //         new StakeInfo(StakeStatus.Inactive),
+        //         toBaseUnitAmount(1.5),
+        //     );
+        //     // Later in Epoch 4: User withdraws all available inactive stake
+        //     await staker.unstakeAsync(toBaseUnitAmount(0.5));
+        //     // Epoch 5: Status updates (no user intervention required)
+        //     await staker.goToNextEpochAsync();
+        //     // Later in Epoch 5: User reactivates a portion of their stake
+        //     await staker.moveStakeAsync(
+        //         new StakeInfo(StakeStatus.Inactive),
+        //         new StakeInfo(StakeStatus.Active),
+        //         toBaseUnitAmount(1),
+        //     );
+        //     // Epoch 6: Status updates (no user intervention required)
+        //     await staker.goToNextEpochAsync();
+        // });
     });
 });
 // tslint:enable:no-unnecessary-type-assertion

--- a/contracts/staking/test/stake_test.ts
+++ b/contracts/staking/test/stake_test.ts
@@ -113,7 +113,7 @@ blockchainTests.resets('Stake Statuses', env => {
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
                 amount,
             );
-            // stake is now inactive, should not be able to move it out of active status again
+            // stake is now undelegated, should not be able to move it out of active status again
             await staker.moveStakeAsync(
                 new StakeInfo(StakeStatus.Undelegated),
                 new StakeInfo(StakeStatus.Delegated, poolIds[1]),
@@ -146,7 +146,7 @@ blockchainTests.resets('Stake Statuses', env => {
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
                 amount,
             );
-            // stake is now inactive, should not be able to move it out of active status again
+            // stake is now undelegated, should not be able to move it out of active status again
             await staker.moveStakeAsync(
                 new StakeInfo(StakeStatus.Undelegated),
                 new StakeInfo(StakeStatus.Delegated, poolIds[1]),
@@ -156,21 +156,21 @@ blockchainTests.resets('Stake Statuses', env => {
         });
     });
     describe('Move Zero Stake', () => {
-        it('inactive -> inactive', async () => {
+        it('undelegated -> undelegated', async () => {
             await staker.moveStakeAsync(
                 new StakeInfo(StakeStatus.Undelegated),
                 new StakeInfo(StakeStatus.Undelegated),
                 ZERO,
             );
         });
-        it('inactive -> delegated', async () => {
+        it('undelegated -> delegated', async () => {
             await staker.moveStakeAsync(
                 new StakeInfo(StakeStatus.Undelegated),
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
                 ZERO,
             );
         });
-        it('delegated -> inactive', async () => {
+        it('delegated -> undelegated', async () => {
             await staker.moveStakeAsync(
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
                 new StakeInfo(StakeStatus.Undelegated),
@@ -206,16 +206,16 @@ blockchainTests.resets('Stake Statuses', env => {
             await staker.moveStakeAsync(from, to, amount.div(2));
             await staker.goToNextEpochAsync();
         };
-        it('inactive -> inactive', async () => {
+        it('undelegated -> undelegated', async () => {
             await testMovePartialStake(new StakeInfo(StakeStatus.Undelegated), new StakeInfo(StakeStatus.Undelegated));
         });
-        it('inactive -> delegated', async () => {
+        it('undelegated -> delegated', async () => {
             await testMovePartialStake(
                 new StakeInfo(StakeStatus.Undelegated),
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
             );
         });
-        it('delegated -> inactive', async () => {
+        it('delegated -> undelegated', async () => {
             await testMovePartialStake(
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
                 new StakeInfo(StakeStatus.Undelegated),
@@ -233,7 +233,7 @@ blockchainTests.resets('Stake Statuses', env => {
                 new StakeInfo(StakeStatus.Delegated, poolIds[1]),
             );
         });
-        it('inactive -> delegated (non-existent pool)', async () => {
+        it('undelegated -> delegated (non-existent pool)', async () => {
             const amount = toBaseUnitAmount(10);
             await staker.stakeAsync(amount);
             await staker.moveStakeAsync(
@@ -264,7 +264,7 @@ blockchainTests.resets('Stake Statuses', env => {
             const amount = toBaseUnitAmount(0);
             await staker.unstakeAsync(amount);
         });
-        it('should successfully unstake after becoming inactive', async () => {
+        it('should successfully unstake after becoming undelegated', async () => {
             const amount = toBaseUnitAmount(10);
             await staker.stakeAsync(amount);
             await staker.moveStakeAsync(
@@ -277,10 +277,10 @@ blockchainTests.resets('Stake Statuses', env => {
                 new StakeInfo(StakeStatus.Undelegated),
                 amount,
             );
-            await staker.goToNextEpochAsync(); // stake is now inactive
+            await staker.goToNextEpochAsync(); // stake is now undelegated
             await staker.unstakeAsync(amount);
         });
-        it('should fail to unstake in the same epoch as stake was set to inactive', async () => {
+        it('should fail to unstake in the same epoch as stake was undelegated', async () => {
             const amount = toBaseUnitAmount(10);
             await staker.stakeAsync(amount);
             await staker.moveStakeAsync(
@@ -296,7 +296,7 @@ blockchainTests.resets('Stake Statuses', env => {
             );
             await staker.unstakeAsync(amount, new StakingRevertErrors.InsufficientBalanceError(amount, ZERO));
         });
-        it('should fail to unstake in same epoch that inactive stake has been reactivated', async () => {
+        it('should fail to unstake in same epoch that undelegated stake has been delegated', async () => {
             const amount = toBaseUnitAmount(10);
             await staker.stakeAsync(amount);
             await staker.moveStakeAsync(
@@ -306,7 +306,7 @@ blockchainTests.resets('Stake Statuses', env => {
             );
             await staker.unstakeAsync(amount, new StakingRevertErrors.InsufficientBalanceError(amount, ZERO));
         });
-        it('should fail to unstake one epoch after inactive stake has been reactivated', async () => {
+        it('should fail to unstake one epoch after undelegated stake has been delegated', async () => {
             const amount = toBaseUnitAmount(10);
             await staker.stakeAsync(amount);
             await staker.moveStakeAsync(
@@ -314,10 +314,10 @@ blockchainTests.resets('Stake Statuses', env => {
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
                 amount,
             );
-            await staker.goToNextEpochAsync(); // stake is now inactive
+            await staker.goToNextEpochAsync(); // stake is now undelegated
             await staker.unstakeAsync(amount, new StakingRevertErrors.InsufficientBalanceError(amount, ZERO));
         });
-        it('should fail to unstake >1 epoch after inactive stake has been reactivated', async () => {
+        it('should fail to unstake >1 epoch after undelegated stake has been delegated', async () => {
             const amount = toBaseUnitAmount(10);
             await staker.stakeAsync(amount);
             await staker.moveStakeAsync(
@@ -325,7 +325,7 @@ blockchainTests.resets('Stake Statuses', env => {
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
                 amount,
             );
-            await staker.goToNextEpochAsync(); // stake is now inactive
+            await staker.goToNextEpochAsync(); // stake is now undelegated
             await staker.goToNextEpochAsync(); // stake is now withdrawable
             await staker.unstakeAsync(amount, new StakingRevertErrors.InsufficientBalanceError(amount, ZERO));
         });
@@ -352,9 +352,9 @@ blockchainTests.resets('Stake Statuses', env => {
         //     );
         //     // Epoch 2: Status updates (no user intervention required)
         //     await staker.goToNextEpochAsync();
-        //     // Epoch 3: Stake that has been inactive for an epoch can be withdrawn (no user intervention required)
+        //     // Epoch 3: Stake that has been undelegated for an epoch can be withdrawn (no user intervention required)
         //     await staker.goToNextEpochAsync();
-        //     // Later in Epoch 3: User reactivates half of their inactive stake; this becomes Active next epoch
+        //     // Later in Epoch 3: User reactivates half of their undelegated stake; this becomes Active next epoch
         //     await staker.moveStakeAsync(
         //         new StakeInfo(StakeStatus.Undelegated),
         //         new StakeInfo(StakeStatus.Active),
@@ -374,7 +374,7 @@ blockchainTests.resets('Stake Statuses', env => {
         //         new StakeInfo(StakeStatus.Undelegated),
         //         toBaseUnitAmount(1.5),
         //     );
-        //     // Later in Epoch 4: User withdraws all available inactive stake
+        //     // Later in Epoch 4: User withdraws all available undelegated stake
         //     await staker.unstakeAsync(toBaseUnitAmount(0.5));
         //     // Epoch 5: Status updates (no user intervention required)
         //     await staker.goToNextEpochAsync();

--- a/contracts/staking/test/stake_test.ts
+++ b/contracts/staking/test/stake_test.ts
@@ -239,9 +239,7 @@ blockchainTests.resets('Stake Statuses', env => {
             // run test, checking balances in epochs [n .. n + 2]
             // in epoch `n` - `next` is set
             // in epoch `n+1` - `current` is set
-            // in epoch `n+2` - only withdrawable balance should change.
             await staker.moveStakeAsync(from, to, amount.div(2));
-            await staker.goToNextEpochAsync();
             await staker.goToNextEpochAsync();
         };
         it('active -> active', async () => {

--- a/contracts/staking/test/stake_test.ts
+++ b/contracts/staking/test/stake_test.ts
@@ -77,14 +77,14 @@ blockchainTests.resets('Stake Statuses', env => {
             const amount = toBaseUnitAmount(10);
             await staker.stakeAsync(amount);
             await staker.moveStakeAsync(
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
                 amount,
             );
             // still epoch 1 ~ should be able to move stake again
             await staker.moveStakeAsync(
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 amount,
             );
         });
@@ -93,7 +93,7 @@ blockchainTests.resets('Stake Statuses', env => {
             const amount = toBaseUnitAmount(10);
             await staker.stakeAsync(amount);
             await staker.moveStakeAsync(
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
                 amount,
             );
@@ -109,13 +109,13 @@ blockchainTests.resets('Stake Statuses', env => {
             const amount = toBaseUnitAmount(10);
             await staker.stakeAsync(amount);
             await staker.moveStakeAsync(
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
                 amount,
             );
             // stake is now inactive, should not be able to move it out of active status again
             await staker.moveStakeAsync(
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 new StakeInfo(StakeStatus.Delegated, poolIds[1]),
                 amount,
                 new StakingRevertErrors.InsufficientBalanceError(amount, ZERO),
@@ -127,14 +127,14 @@ blockchainTests.resets('Stake Statuses', env => {
             // epoch 1
             const amount = toBaseUnitAmount(10);
             await staker.stakeAndMoveAsync(
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
                 amount,
             );
             // still epoch 1 ~ should be able to move stake again
             await staker.moveStakeAsync(
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 amount,
             );
         });
@@ -142,13 +142,13 @@ blockchainTests.resets('Stake Statuses', env => {
             // epoch 1
             const amount = toBaseUnitAmount(10);
             await staker.stakeAndMoveAsync(
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
                 amount,
             );
             // stake is now inactive, should not be able to move it out of active status again
             await staker.moveStakeAsync(
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 new StakeInfo(StakeStatus.Delegated, poolIds[1]),
                 amount,
                 new StakingRevertErrors.InsufficientBalanceError(amount, ZERO),
@@ -157,11 +157,15 @@ blockchainTests.resets('Stake Statuses', env => {
     });
     describe('Move Zero Stake', () => {
         it('inactive -> inactive', async () => {
-            await staker.moveStakeAsync(new StakeInfo(StakeStatus.Inactive), new StakeInfo(StakeStatus.Inactive), ZERO);
+            await staker.moveStakeAsync(
+                new StakeInfo(StakeStatus.Undelegated),
+                new StakeInfo(StakeStatus.Undelegated),
+                ZERO,
+            );
         });
         it('inactive -> delegated', async () => {
             await staker.moveStakeAsync(
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
                 ZERO,
             );
@@ -169,7 +173,7 @@ blockchainTests.resets('Stake Statuses', env => {
         it('delegated -> inactive', async () => {
             await staker.moveStakeAsync(
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 ZERO,
             );
         });
@@ -193,8 +197,8 @@ blockchainTests.resets('Stake Statuses', env => {
             // setup
             const amount = toBaseUnitAmount(10);
             await staker.stakeAsync(amount);
-            if (from.status !== StakeStatus.Inactive) {
-                await staker.moveStakeAsync(new StakeInfo(StakeStatus.Inactive), from, amount);
+            if (from.status !== StakeStatus.Undelegated) {
+                await staker.moveStakeAsync(new StakeInfo(StakeStatus.Undelegated), from, amount);
             }
             // run test, checking balances in epochs [n .. n + 2]
             // in epoch `n` - `next` is set
@@ -203,18 +207,18 @@ blockchainTests.resets('Stake Statuses', env => {
             await staker.goToNextEpochAsync();
         };
         it('inactive -> inactive', async () => {
-            await testMovePartialStake(new StakeInfo(StakeStatus.Inactive), new StakeInfo(StakeStatus.Inactive));
+            await testMovePartialStake(new StakeInfo(StakeStatus.Undelegated), new StakeInfo(StakeStatus.Undelegated));
         });
         it('inactive -> delegated', async () => {
             await testMovePartialStake(
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
             );
         });
         it('delegated -> inactive', async () => {
             await testMovePartialStake(
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
             );
         });
         it('delegated -> delegated (same pool)', async () => {
@@ -233,7 +237,7 @@ blockchainTests.resets('Stake Statuses', env => {
             const amount = toBaseUnitAmount(10);
             await staker.stakeAsync(amount);
             await staker.moveStakeAsync(
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 new StakeInfo(StakeStatus.Delegated, unusedPoolId),
                 amount,
                 new StakingRevertErrors.PoolExistenceError(unusedPoolId, false),
@@ -243,7 +247,7 @@ blockchainTests.resets('Stake Statuses', env => {
             const amount = toBaseUnitAmount(10);
             await staker.stakeAsync(amount);
             await staker.moveStakeAsync(
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
                 amount,
             );
@@ -264,13 +268,13 @@ blockchainTests.resets('Stake Statuses', env => {
             const amount = toBaseUnitAmount(10);
             await staker.stakeAsync(amount);
             await staker.moveStakeAsync(
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
                 amount,
             );
             await staker.moveStakeAsync(
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 amount,
             );
             await staker.goToNextEpochAsync(); // stake is now inactive
@@ -280,14 +284,14 @@ blockchainTests.resets('Stake Statuses', env => {
             const amount = toBaseUnitAmount(10);
             await staker.stakeAsync(amount);
             await staker.moveStakeAsync(
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
                 amount,
             );
             await staker.goToNextEpochAsync(); // stake is now delegated
             await staker.moveStakeAsync(
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 amount,
             );
             await staker.unstakeAsync(amount, new StakingRevertErrors.InsufficientBalanceError(amount, ZERO));
@@ -296,7 +300,7 @@ blockchainTests.resets('Stake Statuses', env => {
             const amount = toBaseUnitAmount(10);
             await staker.stakeAsync(amount);
             await staker.moveStakeAsync(
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
                 amount,
             );
@@ -306,7 +310,7 @@ blockchainTests.resets('Stake Statuses', env => {
             const amount = toBaseUnitAmount(10);
             await staker.stakeAsync(amount);
             await staker.moveStakeAsync(
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
                 amount,
             );
@@ -317,7 +321,7 @@ blockchainTests.resets('Stake Statuses', env => {
             const amount = toBaseUnitAmount(10);
             await staker.stakeAsync(amount);
             await staker.moveStakeAsync(
-                new StakeInfo(StakeStatus.Inactive),
+                new StakeInfo(StakeStatus.Undelegated),
                 new StakeInfo(StakeStatus.Delegated, poolIds[0]),
                 amount,
             );
@@ -338,7 +342,7 @@ blockchainTests.resets('Stake Statuses', env => {
         //     // Later in Epoch 1: User delegates and deactivates some stake
         //     await staker.moveStakeAsync(
         //         new StakeInfo(StakeStatus.Active),
-        //         new StakeInfo(StakeStatus.Inactive),
+        //         new StakeInfo(StakeStatus.Undelegated),
         //         toBaseUnitAmount(1),
         //     );
         //     await staker.moveStakeAsync(
@@ -352,7 +356,7 @@ blockchainTests.resets('Stake Statuses', env => {
         //     await staker.goToNextEpochAsync();
         //     // Later in Epoch 3: User reactivates half of their inactive stake; this becomes Active next epoch
         //     await staker.moveStakeAsync(
-        //         new StakeInfo(StakeStatus.Inactive),
+        //         new StakeInfo(StakeStatus.Undelegated),
         //         new StakeInfo(StakeStatus.Active),
         //         toBaseUnitAmount(0.5),
         //     );
@@ -367,7 +371,7 @@ blockchainTests.resets('Stake Statuses', env => {
         //     // Later in Epoch 4: User deactivates all active stake
         //     await staker.moveStakeAsync(
         //         new StakeInfo(StakeStatus.Active),
-        //         new StakeInfo(StakeStatus.Inactive),
+        //         new StakeInfo(StakeStatus.Undelegated),
         //         toBaseUnitAmount(1.5),
         //     );
         //     // Later in Epoch 4: User withdraws all available inactive stake
@@ -376,7 +380,7 @@ blockchainTests.resets('Stake Statuses', env => {
         //     await staker.goToNextEpochAsync();
         //     // Later in Epoch 5: User reactivates a portion of their stake
         //     await staker.moveStakeAsync(
-        //         new StakeInfo(StakeStatus.Inactive),
+        //         new StakeInfo(StakeStatus.Undelegated),
         //         new StakeInfo(StakeStatus.Active),
         //         toBaseUnitAmount(1),
         //     );

--- a/contracts/staking/test/unit_tests/mixin_stake_storage_test.ts
+++ b/contracts/staking/test/unit_tests/mixin_stake_storage_test.ts
@@ -26,19 +26,16 @@ blockchainTests.resets('MixinStakeStorage unit tests', env => {
         );
         await testContract.setCurrentEpoch.awaitTransactionSuccessAsync(CURRENT_EPOCH);
         defaultUninitializedBalance = {
-            isInitialized: false,
             currentEpoch: constants.INITIAL_EPOCH,
             currentEpochBalance: new BigNumber(0),
             nextEpochBalance: new BigNumber(0),
         };
         defaultSyncedBalance = {
-            isInitialized: true,
             currentEpoch: CURRENT_EPOCH,
             currentEpochBalance: new BigNumber(16),
             nextEpochBalance: new BigNumber(16),
         };
         defaultUnsyncedBalance = {
-            isInitialized: true,
             currentEpoch: CURRENT_EPOCH.minus(1),
             currentEpochBalance: new BigNumber(10),
             nextEpochBalance: new BigNumber(16),
@@ -48,7 +45,6 @@ blockchainTests.resets('MixinStakeStorage unit tests', env => {
     async function getTestBalancesAsync(index: Numberish): Promise<StoredBalance> {
         const storedBalance: Partial<StoredBalance> = {};
         [
-            storedBalance.isInitialized,
             storedBalance.currentEpoch,
             storedBalance.currentEpochBalance,
             storedBalance.nextEpochBalance,

--- a/contracts/staking/test/unit_tests/mixin_stake_storage_test.ts
+++ b/contracts/staking/test/unit_tests/mixin_stake_storage_test.ts
@@ -67,13 +67,11 @@ blockchainTests.resets('MixinStakeStorage unit tests', env => {
                 getTestBalancesAsync(INDEX_ONE),
             ]);
             expect(actualBalances[0]).to.deep.equal({
-                isInitialized: true,
                 currentEpoch: CURRENT_EPOCH,
                 currentEpochBalance: fromBalance.currentEpochBalance,
                 nextEpochBalance: fromBalance.nextEpochBalance.minus(amount),
             });
             expect(actualBalances[1]).to.deep.equal({
-                isInitialized: true,
                 currentEpoch: CURRENT_EPOCH,
                 currentEpochBalance: toBalance.currentEpochBalance,
                 nextEpochBalance: toBalance.nextEpochBalance.plus(amount),

--- a/contracts/staking/test/utils/cumulative_reward_tracking_simulation.ts
+++ b/contracts/staking/test/utils/cumulative_reward_tracking_simulation.ts
@@ -120,7 +120,7 @@ export class CumulativeRewardTrackingSimulation {
                         from: this._staker,
                     });
                     receipt = await this._stakingApiWrapper.stakingContract.moveStake.awaitTransactionSuccessAsync(
-                        new StakeInfo(StakeStatus.Active),
+                        new StakeInfo(StakeStatus.Inactive),
                         new StakeInfo(StakeStatus.Delegated, this._poolId),
                         this._amountToStake,
                         { from: this._staker },
@@ -130,7 +130,7 @@ export class CumulativeRewardTrackingSimulation {
                 case TestAction.Undelegate:
                     receipt = await this._stakingApiWrapper.stakingContract.moveStake.awaitTransactionSuccessAsync(
                         new StakeInfo(StakeStatus.Delegated, this._poolId),
-                        new StakeInfo(StakeStatus.Active),
+                        new StakeInfo(StakeStatus.Inactive),
                         this._amountToStake,
                         { from: this._staker },
                     );

--- a/contracts/staking/test/utils/cumulative_reward_tracking_simulation.ts
+++ b/contracts/staking/test/utils/cumulative_reward_tracking_simulation.ts
@@ -120,7 +120,7 @@ export class CumulativeRewardTrackingSimulation {
                         from: this._staker,
                     });
                     receipt = await this._stakingApiWrapper.stakingContract.moveStake.awaitTransactionSuccessAsync(
-                        new StakeInfo(StakeStatus.Inactive),
+                        new StakeInfo(StakeStatus.Undelegated),
                         new StakeInfo(StakeStatus.Delegated, this._poolId),
                         this._amountToStake,
                         { from: this._staker },
@@ -130,7 +130,7 @@ export class CumulativeRewardTrackingSimulation {
                 case TestAction.Undelegate:
                     receipt = await this._stakingApiWrapper.stakingContract.moveStake.awaitTransactionSuccessAsync(
                         new StakeInfo(StakeStatus.Delegated, this._poolId),
-                        new StakeInfo(StakeStatus.Inactive),
+                        new StakeInfo(StakeStatus.Undelegated),
                         this._amountToStake,
                         { from: this._staker },
                     );

--- a/contracts/staking/test/utils/types.ts
+++ b/contracts/staking/test/utils/types.ts
@@ -59,7 +59,6 @@ export interface EndOfEpochInfo {
 }
 
 export interface StoredBalance {
-    isInitialized: boolean;
     currentEpoch: number | BigNumber;
     currentEpochBalance: BigNumber;
     nextEpochBalance: BigNumber;

--- a/contracts/staking/test/utils/types.ts
+++ b/contracts/staking/test/utils/types.ts
@@ -58,7 +58,7 @@ export interface EndOfEpochInfo {
 }
 
 export interface StoredBalance {
-    currentEpoch: number | BigNumber;
+    currentEpoch: BigNumber;
     currentEpochBalance: BigNumber;
     nextEpochBalance: BigNumber;
 }
@@ -68,7 +68,7 @@ export interface StakeBalanceByPool {
 }
 
 export enum StakeStatus {
-    Inactive,
+    Undelegated,
     Delegated,
 }
 

--- a/contracts/staking/test/utils/types.ts
+++ b/contracts/staking/test/utils/types.ts
@@ -16,7 +16,6 @@ export interface StakerBalances {
     zrxBalance: BigNumber;
     stakeBalance: BigNumber;
     stakeBalanceInVault: BigNumber;
-    withdrawableStakeBalance: BigNumber;
     activatableStakeBalance: BigNumber;
     activatedStakeBalance: BigNumber;
     deactivatedStakeBalance: BigNumber;
@@ -93,7 +92,6 @@ export interface StakeBalances {
     zrxBalance: BigNumber;
     stakeBalance: BigNumber;
     stakeBalanceInVault: BigNumber;
-    withdrawableStakeBalance: BigNumber;
     activeStakeBalance: StakeBalance;
     inactiveStakeBalance: StakeBalance;
     delegatedStakeBalance: StakeBalance;

--- a/contracts/staking/test/utils/types.ts
+++ b/contracts/staking/test/utils/types.ts
@@ -63,13 +63,8 @@ export interface StoredBalance {
     nextEpochBalance: BigNumber;
 }
 
-export interface StakeBalance {
-    currentEpochBalance: BigNumber;
-    nextEpochBalance: BigNumber;
-}
-
 export interface StakeBalanceByPool {
-    [key: string]: StakeBalance;
+    [key: string]: StoredBalance;
 }
 
 export enum StakeStatus {
@@ -89,15 +84,16 @@ export class StakeInfo {
 }
 
 export interface StakeBalances {
+    currentEpoch: BigNumber;
     zrxBalance: BigNumber;
     stakeBalance: BigNumber;
     stakeBalanceInVault: BigNumber;
-    activeStakeBalance: StakeBalance;
-    inactiveStakeBalance: StakeBalance;
-    delegatedStakeBalance: StakeBalance;
-    globalActiveStakeBalance: StakeBalance;
-    globalInactiveStakeBalance: StakeBalance;
-    globalDelegatedStakeBalance: StakeBalance;
+    activeStakeBalance: StoredBalance;
+    inactiveStakeBalance: StoredBalance;
+    delegatedStakeBalance: StoredBalance;
+    globalActiveStakeBalance: StoredBalance;
+    globalInactiveStakeBalance: StoredBalance;
+    globalDelegatedStakeBalance: StoredBalance;
     delegatedStakeByPool: StakeBalanceByPool;
     totalDelegatedStakeByPool: StakeBalanceByPool;
 }

--- a/contracts/staking/test/utils/types.ts
+++ b/contracts/staking/test/utils/types.ts
@@ -68,7 +68,6 @@ export interface StakeBalanceByPool {
 }
 
 export enum StakeStatus {
-    Active,
     Inactive,
     Delegated,
 }
@@ -88,10 +87,8 @@ export interface StakeBalances {
     zrxBalance: BigNumber;
     stakeBalance: BigNumber;
     stakeBalanceInVault: BigNumber;
-    activeStakeBalance: StoredBalance;
     inactiveStakeBalance: StoredBalance;
     delegatedStakeBalance: StoredBalance;
-    globalActiveStakeBalance: StoredBalance;
     globalInactiveStakeBalance: StoredBalance;
     globalDelegatedStakeBalance: StoredBalance;
     delegatedStakeByPool: StakeBalanceByPool;

--- a/contracts/staking/test/utils/types.ts
+++ b/contracts/staking/test/utils/types.ts
@@ -87,9 +87,9 @@ export interface StakeBalances {
     zrxBalance: BigNumber;
     stakeBalance: BigNumber;
     stakeBalanceInVault: BigNumber;
-    inactiveStakeBalance: StoredBalance;
+    undelegatedStakeBalance: StoredBalance;
     delegatedStakeBalance: StoredBalance;
-    globalInactiveStakeBalance: StoredBalance;
+    globalUndelegatedStakeBalance: StoredBalance;
     globalDelegatedStakeBalance: StoredBalance;
     delegatedStakeByPool: StakeBalanceByPool;
     totalDelegatedStakeByPool: StakeBalanceByPool;

--- a/packages/order-utils/src/staking_revert_errors.ts
+++ b/packages/order-utils/src/staking_revert_errors.ts
@@ -142,12 +142,6 @@ export class InvalidParamValueError extends RevertError {
     }
 }
 
-export class InvalidStakeStatusError extends RevertError {
-    constructor(status?: BigNumber | number | string) {
-        super('InvalidStakeStatusError', 'InvalidStakeStatusError(uint8 status)', { status });
-    }
-}
-
 export class InvalidProtocolFeePaymentError extends RevertError {
     constructor(
         errorCode?: ProtocolFeePaymentErrorCodes,
@@ -190,7 +184,6 @@ const types = [
     InitializationError,
     InsufficientBalanceError,
     InvalidProtocolFeePaymentError,
-    InvalidStakeStatusError,
     InvalidParamValueError,
     MakerPoolAssignmentError,
     OnlyCallableByExchangeError,


### PR DESCRIPTION
## Description

This PR makes the following changes in order to simplify some of the accounting in the staking contracts:

- Withdrawable stake is now simply the stake that is inactive in both the current and next epoch. This considerably simplifies the logic for `unstake`. This does, however, actually change the functionality of withdrawals. Stakers can now withdraw immediately at the next epoch after moving their stake to `INACTIVE`. They will still forfeit their rewards for the epoch in which they withdraw, though. Open to hearing people's thoughts on this.

- Completely removes the `ACTIVE` stake status. Being able to think about the state in 1 less dimension removes a lot of complexity IMO. Newly staked ZRX is now `INACTIVE`. The only functional change here is that a user can deposit and withdraw in the same epoch (but will not receive any actual benefits of staking for doing so).

- Introduces an `_ownerStakeByStatus` mapping, rather than having multiple mappings for each state.

- Since there are now only 2 stake statuses, we don't need to store global stake balances for both. We now only store the global delegated stake, and inactive stake is calculated as:

```solidity
uint256 totalStake = getZrxVault().balanceOfVault();
balance.currentEpochBalance = totalStake.safeSub(balance.currentEpochBalance).downcastToUint96();
balance.nextEpochBalance = totalStake.safeSub(balance.nextEpochBalance).downcastToUint96();
```

We also finally are under the codesize limit with full optimization settings. Yay!

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
