### PR TITLE
Staking readability improvements

### DIFF
--- a/contracts/integrations/package.json
+++ b/contracts/integrations/package.json
@@ -80,7 +80,6 @@
         "@0x/contracts-exchange": "^2.2.0-beta.0",
         "@0x/contracts-exchange-forwarder": "^3.1.0-beta.0",
         "@0x/contracts-exchange-libs": "^3.1.0-beta.0",
-        "@0x/contracts-extensions": "^4.1.0-beta.0",
         "@0x/contracts-multisig": "^3.2.0-beta.0",
         "@0x/contracts-staking": "^1.1.0-beta.0",
         "@0x/contracts-test-utils": "^3.2.0-beta.0",

--- a/contracts/staking/contracts/src/ZrxVault.sol
+++ b/contracts/staking/contracts/src/ZrxVault.sol
@@ -35,7 +35,7 @@ contract ZrxVault is
     using LibSafeMath for uint256;
 
     // Address of staking proxy contract
-    address payable public stakingProxyAddress;
+    address public stakingProxyAddress;
 
     // True iff vault has been set to Catastrophic Failure Mode
     bool public isInCatastrophicFailure;
@@ -91,7 +91,7 @@ contract ZrxVault is
     /// @dev Sets the address of the StakingProxy contract.
     /// Note that only the contract owner can call this function.
     /// @param _stakingProxyAddress Address of Staking proxy contract.
-    function setStakingProxy(address payable _stakingProxyAddress)
+    function setStakingProxy(address _stakingProxyAddress)
         external
         onlyAuthorized
     {

--- a/contracts/staking/contracts/src/interfaces/IStructs.sol
+++ b/contracts/staking/contracts/src/interfaces/IStructs.sol
@@ -97,7 +97,7 @@ interface IStructs {
     /// @param operator of the pool.
     /// @param operatorShare Fraction of the total balance owned by the operator, in ppm.
     struct Pool {
-        address payable operator;
+        address operator;
         uint32 operatorShare;
     }
 }

--- a/contracts/staking/contracts/src/interfaces/IStructs.sol
+++ b/contracts/staking/contracts/src/interfaces/IStructs.sol
@@ -94,11 +94,9 @@ interface IStructs {
     }
 
     /// @dev Holds the metadata for a staking pool.
-    /// @param initialized True iff the balance struct is initialized.
     /// @param operator of the pool.
     /// @param operatorShare Fraction of the total balance owned by the operator, in ppm.
     struct Pool {
-        bool initialized;
         address payable operator;
         uint32 operatorShare;
     }

--- a/contracts/staking/contracts/src/interfaces/IZrxVault.sol
+++ b/contracts/staking/contracts/src/interfaces/IZrxVault.sol
@@ -50,7 +50,7 @@ interface IZrxVault {
     /// @dev Sets the address of the StakingProxy contract.
     /// Note that only the contract staker can call this function.
     /// @param _stakingProxyAddress Address of Staking proxy contract.
-    function setStakingProxy(address payable _stakingProxyAddress)
+    function setStakingProxy(address _stakingProxyAddress)
         external;
 
     /// @dev Vault enters into Catastrophic Failure Mode.

--- a/contracts/staking/contracts/src/stake/MixinStake.sol
+++ b/contracts/staking/contracts/src/stake/MixinStake.sol
@@ -35,7 +35,7 @@ contract MixinStake is
     function stake(uint256 amount)
         external
     {
-        address payable staker = msg.sender;
+        address staker = msg.sender;
 
         // deposit equivalent amount of ZRX into vault
         getZrxVault().depositFrom(staker, amount);
@@ -109,7 +109,7 @@ contract MixinStake is
     )
         external
     {
-        address payable staker = msg.sender;
+        address staker = msg.sender;
 
         // handle delegation
         if (from.status == IStructs.StakeStatus.DELEGATED) {
@@ -154,7 +154,7 @@ contract MixinStake is
     /// @param amount Amount of stake to delegate.
     function _delegateStake(
         bytes32 poolId,
-        address payable staker,
+        address staker,
         uint256 amount
     )
         private
@@ -192,7 +192,7 @@ contract MixinStake is
     /// @param amount Amount of stake to un-delegate.
     function _undelegateStake(
         bytes32 poolId,
-        address payable staker,
+        address staker,
         uint256 amount
     )
         private

--- a/contracts/staking/contracts/src/staking_pools/MixinCumulativeRewards.sol
+++ b/contracts/staking/contracts/src/staking_pools/MixinCumulativeRewards.sol
@@ -70,10 +70,7 @@ contract MixinCumulativeRewards is
     {
         uint256 currentEpoch_ = currentEpoch;
         _cumulativeRewardsByPool[poolId][currentEpoch_] = value;
-        
         // Update state to reflect the most recent cumulative reward
-        uint256 currentMostRecentEpoch = _cumulativeRewardsByPoolLastStored[poolId];
-        assert(currentEpoch_ >= currentMostRecentEpoch);
         _cumulativeRewardsByPoolLastStored[poolId] = currentEpoch_;
     }
 

--- a/contracts/staking/contracts/src/staking_pools/MixinStakingPool.sol
+++ b/contracts/staking/contracts/src/staking_pools/MixinStakingPool.sol
@@ -65,7 +65,6 @@ contract MixinStakingPool is
 
         // create and store pool
         IStructs.Pool memory pool = IStructs.Pool({
-            initialized: true,
             operator: operator,
             operatorShare: operatorShare
         });

--- a/contracts/staking/contracts/src/staking_pools/MixinStakingPool.sol
+++ b/contracts/staking/contracts/src/staking_pools/MixinStakingPool.sol
@@ -51,7 +51,7 @@ contract MixinStakingPool is
         returns (bytes32 poolId)
     {
         // note that an operator must be payable
-        address payable operator = msg.sender;
+        address operator = msg.sender;
 
         // compute unique id for this pool
         poolId = lastPoolId = bytes32(uint256(lastPoolId).safeAdd(1));

--- a/contracts/staking/contracts/src/staking_pools/MixinStakingPoolRewards.sol
+++ b/contracts/staking/contracts/src/staking_pools/MixinStakingPoolRewards.sol
@@ -139,12 +139,10 @@ contract MixinStakingPoolRewards is
         }
 
         // Add a cumulative reward entry for this epoch.
-        if (!_isCumulativeRewardSet(_cumulativeRewardsByPool[poolId][currentEpoch])) {
-            _forceSetCumulativeReward(
-                poolId,
-                _getMostRecentCumulativeReward(poolId)
-            );
-        }
+        _forceSetCumulativeReward(
+            poolId,
+            _getMostRecentCumulativeReward(poolId)
+        );
     }
 
     /// @dev Handles a pool's reward at the current epoch.

--- a/contracts/staking/contracts/src/sys/MixinAbstract.sol
+++ b/contracts/staking/contracts/src/sys/MixinAbstract.sol
@@ -35,12 +35,7 @@ contract MixinAbstract {
     /// @return membersStake The total stake for all non-operator members in
     ///         this pool.
     function finalizePool(bytes32 poolId)
-        public
-        returns (
-            uint256 operatorReward,
-            uint256 membersReward,
-            uint256 membersStake
-        );
+        public;
 
     /// @dev Computes the reward owed to a pool during finalization.
     ///      Does nothing if the pool is already finalized.

--- a/contracts/staking/contracts/test/TestDelegatorRewards.sol
+++ b/contracts/staking/contracts/test/TestDelegatorRewards.sol
@@ -177,11 +177,6 @@ contract TestDelegatorRewards is
     ///      the current epoch and emit a event,
     function finalizePool(bytes32 poolId)
         public
-        returns (
-            uint256 operatorReward,
-            uint256 membersReward,
-            uint256 membersStake
-        )
     {
         UnfinalizedPoolReward memory reward = unfinalizedPoolRewardsByEpoch[currentEpoch][poolId];
         delete unfinalizedPoolRewardsByEpoch[currentEpoch][poolId];
@@ -189,8 +184,8 @@ contract TestDelegatorRewards is
         _setOperatorShare(poolId, reward.operatorReward, reward.membersReward);
 
         uint256 totalRewards = reward.operatorReward + reward.membersReward;
-        membersStake = reward.membersStake;
-        (operatorReward, membersReward) =
+        uint256 membersStake = reward.membersStake;
+        (uint256 operatorReward, uint256 membersReward) =
             _syncPoolRewards(poolId, totalRewards, membersStake);
         emit FinalizePool(poolId, operatorReward, membersReward, membersStake);
     }

--- a/contracts/staking/test/cumulative_reward_tracking_test.ts
+++ b/contracts/staking/test/cumulative_reward_tracking_test.ts
@@ -53,7 +53,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Creates CR for epoch 1
                     TestAction.Delegate,
                 ],
-                [],
+                [{ event: 'SetCumulativeReward', epoch: 0 }],
             );
         });
         it('re-delegating in the same epoch', async () => {
@@ -68,7 +68,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Updates CR for epoch 0
                     TestAction.Delegate,
                 ],
-                [],
+                [{ event: 'SetCumulativeReward', epoch: 0 }, { event: 'SetCumulativeReward', epoch: 0 }],
             );
         });
         it('delegating in new epoch', async () => {
@@ -268,7 +268,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Clears CR for epoch 2
                     TestAction.Delegate,
                 ],
-                [],
+                [{ event: 'SetCumulativeReward', epoch: 3 }],
             );
         });
         it('delegate in epoch 0 and 1, earn reward in epoch 3, then undelegate half', async () => {
@@ -303,7 +303,7 @@ blockchainTests.resets('Cumulative Reward Tracking', env => {
                     // Clears CR for epoch 2
                     TestAction.Undelegate,
                 ],
-                [],
+                [{ event: 'SetCumulativeReward', epoch: 3 }],
             );
         });
         it('delegate in epoch 1, 2, earn rewards in epoch 3, skip to epoch 4, then delegate', async () => {


### PR DESCRIPTION
## Description

Some pretty small changes in this PR that primarily aim to improve readability.

- Removes an unnecessary SLOAD + assert. It is pretty easy to see that this assert will never be hit.
- Always set cumulative rewards when `_withdrawAndSyncDelegatorRewards` is called. The removed check is just an extra cost post hard-fork. We also didn't make this check in other places.
- Removes `creditRewardsToPool` and inlines the logic into `finalizePool`.
- Get's rid of return values in `finalizePool`. They were never being used, and I'd be pretty surprised if they do end up getting used in other contracts.
- Removes `initialized` parameter from the `Pool` struct (unused).

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
