### PR TITLE
Force no-op when moving stake, in some scenarios

### DIFF
--- a/contracts/staking/contracts/src/stake/MixinStake.sol
+++ b/contracts/staking/contracts/src/stake/MixinStake.sol
@@ -111,6 +111,17 @@ contract MixinStake is
     {
         address staker = msg.sender;
 
+        // Sanity check: no-op if no stake is being moved.
+        if (amount == 0) {
+            return;
+        }
+
+        // Sanity check: no-op if moving stake from undelegated to undelegated.
+        if (from.status == IStructs.StakeStatus.UNDELEGATED &&
+            to.status == IStructs.StakeStatus.UNDELEGATED) {
+            return;
+        }
+
         // handle delegation
         if (from.status == IStructs.StakeStatus.DELEGATED) {
             _undelegateStake(

--- a/contracts/staking/test/unit_tests/stake_test.ts
+++ b/contracts/staking/test/unit_tests/stake_test.ts
@@ -373,7 +373,7 @@ blockchainTests.resets('MixinStake unit tests', env => {
             expect(increaseNextBalanceEvents).to.be.length(0);
         });
 
-        it('moves the owner stake between the same pointer when both are undelegated', async () => {
+        it('does nothing when moving the owner stake from undelegated to undelegated', async () => {
             const amount = getRandomInteger(0, 100e18);
             const { logs } = await testContract.moveStake.awaitTransactionSuccessAsync(
                 { status: StakeStatus.Undelegated, poolId: VALID_POOL_IDS[0] },
@@ -381,10 +381,18 @@ blockchainTests.resets('MixinStake unit tests', env => {
                 amount,
             );
             const events = filterLogsToArguments<MoveStakeStorageEventArgs>(logs, StakeEvents.MoveStakeStorage);
-            expect(events).to.be.length(1);
-            expect(events[0].fromBalanceSlot).to.eq(stakerUndelegatedStakeSlot);
-            expect(events[0].toBalanceSlot).to.eq(stakerUndelegatedStakeSlot);
-            expect(events[0].amount).to.bignumber.eq(amount);
+            expect(events).to.be.length(0);
+        });
+
+        it('does nothing when moving zero stake', async () => {
+            const amount = new BigNumber(0);
+            const { logs } = await testContract.moveStake.awaitTransactionSuccessAsync(
+                { status: StakeStatus.Delegated, poolId: VALID_POOL_IDS[0] },
+                { status: StakeStatus.Delegated, poolId: VALID_POOL_IDS[1] },
+                amount,
+            );
+            const events = filterLogsToArguments<MoveStakeStorageEventArgs>(logs, StakeEvents.MoveStakeStorage);
+            expect(events).to.be.length(0);
         });
 
         it('moves the owner stake between the same pointer when both are delegated', async () => {


### PR DESCRIPTION
## Description

This forces a no-op in the following scenarios:
  i. moving zero stake, or
  ii. moving from undelegated to undelegated.

This fixes C13.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
