### PR TITLE
Allow transactions to be over confirmed without resetting the confirmation time

### DIFF
--- a/contracts/multisig/contracts/src/MultiSigWalletWithTimeLock.sol
+++ b/contracts/multisig/contracts/src/MultiSigWalletWithTimeLock.sol
@@ -37,14 +37,6 @@ contract MultiSigWalletWithTimeLock is
 
     mapping (uint256 => uint256) public confirmationTimes;
 
-    modifier notFullyConfirmed(uint256 transactionId) {
-        require(
-            !isConfirmed(transactionId),
-            "TX_FULLY_CONFIRMED"
-        );
-        _;
-    }
-
     modifier fullyConfirmed(uint256 transactionId) {
         require(
             isConfirmed(transactionId),
@@ -93,11 +85,13 @@ contract MultiSigWalletWithTimeLock is
         ownerExists(msg.sender)
         transactionExists(transactionId)
         notConfirmed(transactionId, msg.sender)
-        notFullyConfirmed(transactionId)
     {
+        bool isTxFullyConfirmedBeforeConfirmation = isConfirmed(transactionId);
+
         confirmations[transactionId][msg.sender] = true;
         emit Confirmation(msg.sender, transactionId);
-        if (isConfirmed(transactionId)) {
+
+        if (!isTxFullyConfirmedBeforeConfirmation && isConfirmed(transactionId)) {
             _setConfirmationTime(transactionId, block.timestamp);
         }
     }


### PR DESCRIPTION
## Description

Allows transactions in the ZeroExGovernor to be over confirmed. This means that as long as 2/3 of the signers are honest, a single signer cannot block a transaction.

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
