### PR TITLE
Fix `LibFixedMath._mul()` overflow

### DIFF
--- a/contracts/staking/CHANGELOG.json
+++ b/contracts/staking/CHANGELOG.json
@@ -21,6 +21,10 @@
             {
                 "note": "The fallback function in `StakingProxy` reverts if there is no staking contract attached",
                 "pr": 2310
+            },
+            {
+                "note": "Fix overflow w/ `LibFixedMath._mul(-1, -2*255)",
+                "pr": 2311
             }
         ]
     },

--- a/contracts/staking/contracts/src/libs/LibFixedMath.sol
+++ b/contracts/staking/contracts/src/libs/LibFixedMath.sol
@@ -349,7 +349,7 @@ library LibFixedMath {
             return 0;
         }
         c = a * b;
-        if (c / a != b) {
+        if (c / a != b || c / b != a) {
             LibRichErrors.rrevert(LibFixedMathRichErrors.BinOpError(
                 LibFixedMathRichErrors.BinOpErrorCodes.MULTIPLICATION_OVERFLOW,
                 a,

--- a/contracts/staking/test/unit_tests/lib_fixed_math_test.ts
+++ b/contracts/staking/test/unit_tests/lib_fixed_math_test.ts
@@ -184,14 +184,14 @@ blockchainTests('LibFixedMath unit tests', env => {
             return expect(tx).to.revertWith(expectedError);
         });
 
-        it('mulDiv(MIN_FIXED, int(-1), int(1)) throws', async () => {
-            const [a, n, d] = [MIN_FIXED_VALUE, -1, 1];
+        it('mulDiv(int(-1), MIN_FIXED, int(1)) throws', async () => {
+            const [a, n, d] = [-1, MIN_FIXED_VALUE, 1];
             const expectedError = new FixedMathRevertErrors.BinOpError(
                 FixedMathRevertErrors.BinOpErrorCodes.MultiplicationOverflow,
                 a,
                 n,
             );
-            const tx = testContract.mulDiv.callAsync(a, new BigNumber(n), new BigNumber(d));
+            const tx = testContract.mulDiv.callAsync(new BigNumber(a), n, new BigNumber(d));
             return expect(tx).to.revertWith(expectedError);
         });
 
@@ -503,6 +503,17 @@ blockchainTests('LibFixedMath unit tests', env => {
                 b,
             );
             const tx = testContract.mul.callAsync(a, new BigNumber(b));
+            return expect(tx).to.revertWith(expectedError);
+        });
+
+        it('int(-1) * MIN_FIXED throws', async () => {
+            const [a, b] = [-1, MIN_FIXED_VALUE];
+            const expectedError = new FixedMathRevertErrors.BinOpError(
+                FixedMathRevertErrors.BinOpErrorCodes.MultiplicationOverflow,
+                a,
+                b,
+            );
+            const tx = testContract.mul.callAsync(new BigNumber(a), b);
             return expect(tx).to.revertWith(expectedError);
         });
 


### PR DESCRIPTION
## Description

Fixes an overflow scenario when doing `LibFixedMath._mul(-1, MIN_FIXED_VALUE)`.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
