### PR TITLE
CI/test-python: give launch-kit-backend CHAIN_ID, not NETWORK_ID

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,7 +219,7 @@ jobs:
             - image: 0xorg/launch-kit-backend:v3
               environment:
                   RPC_URL: 'http://localhost:8545'
-                  NETWORK_ID: 50
+                  CHAIN_ID: 1337
                   WHITELIST_ALL_TOKENS: True
                   FEE_RECIPIENT: '0x0000000000000000000000000000000000000001'
                   MAKER_FEE_UNIT_AMOUNT: 0

--- a/python-packages/sra_client/src/zero_ex/sra_client/__init__.py
+++ b/python-packages/sra_client/src/zero_ex/sra_client/__init__.py
@@ -168,7 +168,7 @@ Retrieve the order we just posted:
 >>> relayer.get_order("0x" + order_hash_hex)
 {'meta_data': {'orderHash': '0x...',
                'remainingFillableTakerAssetAmount': '2'},
- 'order': {'chainId': 50,
+ 'order': {'chainId': 1337,
            'exchangeAddress': '0x...',
            'expirationTimeSeconds': '...',
            'feeRecipientAddress': '0x0000000000000000000000000000000000000000',
@@ -195,7 +195,7 @@ of the one we just posted:
 >>> relayer.get_orders()
 {'records': [{'meta_data': {'orderHash': '0x...',
                             'remainingFillableTakerAssetAmount': '2'},
-              'order': {'chainId': 50,
+              'order': {'chainId': 1337,
                         'exchangeAddress': '0x...',
                         'expirationTimeSeconds': '...',
                         'feeRecipientAddress': '0x0000000000000000000000000000000000000000',
@@ -255,7 +255,7 @@ consists just of our order):
 {'asks': {'records': [...]},
  'bids': {'records': [{'meta_data': {'orderHash': '0x...',
                                      'remainingFillableTakerAssetAmount': '2'},
-                       'order': {'chainId': 50,
+                       'order': {'chainId': 1337,
                                  'exchangeAddress': '0x...',
                                  'expirationTimeSeconds': '...',
                                  'feeRecipientAddress': '0x0000000000000000000000000000000000000000',
@@ -280,7 +280,7 @@ Select an order from the orderbook
 >>> order = jsdict_to_order(orderbook.bids.records[0].order)
 >>> from pprint import pprint
 >>> pprint(order)
-{'chainId': 50,
+{'chainId': 1337,
  'expirationTimeSeconds': ...,
  'feeRecipientAddress': '0x0000000000000000000000000000000000000000',
  'makerAddress': '0x...',

--- a/python-packages/sra_client/src/zero_ex/sra_client/__init__.py
+++ b/python-packages/sra_client/src/zero_ex/sra_client/__init__.py
@@ -38,9 +38,24 @@ To replicate this setup, one could run the following commands:
 
     docker run -d -p 8545:8545 0xorg/ganache-cli
 
+    docker run -d -p 60557:60557 --network host \
+        -e ETHEREUM_RPC_URL=http://localhost:8545 \
+        -e ETHEREUM_NETWORK_ID=50 \
+        -e ETHEREUM_CHAIN_ID=1337 \
+        -e USE_BOOTSTRAP_LIST=false \
+        -e VERBOSITY=3 \
+        -e PRIVATE_KEY_PATH= \
+        -e BLOCK_POLLING_INTERVAL=5s \
+        -e P2P_LISTEN_PORT=60557
+        0xorg/mesh:6.0.0-beta-0xv3
+
     docker run -d --network host \
         -e RPC_URL=http://localhost:8545 \
-        -e NETWORK_ID=50 \
+        -e CHAIN_ID=1337 \
+        -e FEE_RECIPIENT=0x0000000000000000000000000000000000000001 \
+        -e MAKER_FEE_UNIT_AMOUNT=0 \
+        -e TAKER_FEE_UNIT_AMOUNT=0
+        -e MESH_ENDPOINT=ws://localhost:60557
         -e WHITELIST_ALL_TOKENS=True \
         0xorg/launch-kit-ci
 

--- a/python-packages/sra_client/test/relayer/docker-compose.yml
+++ b/python-packages/sra_client/test/relayer/docker-compose.yml
@@ -35,7 +35,7 @@ services:
             - "3000:3000"
         network_mode: "host" # to connect to ganache
         environment:
-            - NETWORK_ID=50
+            - CHAIN_ID=1337
             - RPC_URL=http://localhost:8545
             - WHITELIST_ALL_TOKENS=True
             - FEE_RECIPIENT=0x0000000000000000000000000000000000000001


### PR DESCRIPTION
For CircleCI job `test-python`, change docker config for `launch-kit-backend` to set an environment variable for the chain ID, not for the network ID.  This was failing on all branches after a recent update to the `0xorg/launch-kit-backend:v3` tag.
