### PR TITLE
Fix 100% operator share

### DIFF
--- a/contracts/staking/contracts/src/staking_pools/MixinStakingPool.sol
+++ b/contracts/staking/contracts/src/staking_pools/MixinStakingPool.sol
@@ -164,8 +164,8 @@ contract MixinStakingPool is
                 poolId,
                 newOperatorShare
             ));
-        } else if (newOperatorShare >= currentOperatorShare) {
-            // new share must be less than the current share
+        } else if (newOperatorShare > currentOperatorShare) {
+            // new share must be less than or equal to the current share
             LibRichErrors.rrevert(LibStakingRichErrors.OperatorShareError(
                 LibStakingRichErrors.OperatorShareErrorCodes.CanOnlyDecreaseOperatorShare,
                 poolId,

--- a/contracts/staking/test/pools_test.ts
+++ b/contracts/staking/test/pools_test.ts
@@ -174,7 +174,7 @@ blockchainTests('Staking Pool Management', env => {
             // decrease operator share
             await poolOperator.decreaseStakingPoolOperatorShareAsync(poolId, increasedOperatorShare, revertError);
         });
-        it('Should fail if operator calls decreaseStakingPoolOperatorShare but newOperatorShare == oldOperatorShare', async () => {
+        it('Should be successful if operator calls decreaseStakingPoolOperatorShare and newOperatorShare == oldOperatorShare', async () => {
             // test parameters
             const operatorAddress = users[0];
             const operatorShare = (39 / 100) * PPM_DENOMINATOR;
@@ -184,13 +184,8 @@ blockchainTests('Staking Pool Management', env => {
             const poolId = await poolOperator.createStakingPoolAsync(operatorShare, false);
             expect(poolId).to.be.equal(stakingConstants.INITIAL_POOL_ID);
 
-            const revertError = new StakingRevertErrors.OperatorShareError(
-                StakingRevertErrors.OperatorShareErrorCodes.CanOnlyDecreaseOperatorShare,
-                poolId,
-                operatorShare,
-            );
             // decrease operator share
-            await poolOperator.decreaseStakingPoolOperatorShareAsync(poolId, operatorShare, revertError);
+            await poolOperator.decreaseStakingPoolOperatorShareAsync(poolId, operatorShare);
         });
         it('should fail to decrease operator share if not called by operator', async () => {
             // test parameters

--- a/contracts/staking/test/unit_tests/staking_pool_test.ts
+++ b/contracts/staking/test/unit_tests/staking_pool_test.ts
@@ -170,6 +170,13 @@ blockchainTests.resets('MixinStakingPool unit tests', env => {
             expect(pool.operator).to.eq(operator);
             expect(pool.operatorShare).to.bignumber.eq(operatorShare);
         });
+        it('records pool details when operator share is 100%', async () => {
+            const operatorShare = constants.PPM_100_PERCENT;
+            await testContract.createStakingPool.awaitTransactionSuccessAsync(operatorShare, false, { from: operator });
+            const pool = await testContract.getStakingPool.callAsync(nextPoolId);
+            expect(pool.operator).to.eq(operator);
+            expect(pool.operatorShare).to.bignumber.eq(operatorShare);
+        });
         it('returns the next pool ID', async () => {
             const poolId = await testContract.createStakingPool.callAsync(randomOperatorShare(), false, {
                 from: operator,
@@ -239,20 +246,6 @@ blockchainTests.resets('MixinStakingPool unit tests', env => {
             const expectedError = new StakingRevertErrors.OnlyCallableByPoolOperatorError(maker, poolId);
             return expect(tx).to.revertWith(expectedError);
         });
-        it('fails if operator share is equal to current', async () => {
-            const { poolId, operatorShare } = await createPoolAsync();
-            const tx = testContract.decreaseStakingPoolOperatorShare.awaitTransactionSuccessAsync(
-                poolId,
-                operatorShare,
-                { from: operator },
-            );
-            const expectedError = new StakingRevertErrors.OperatorShareError(
-                StakingRevertErrors.OperatorShareErrorCodes.CanOnlyDecreaseOperatorShare,
-                poolId,
-                operatorShare,
-            );
-            return expect(tx).to.revertWith(expectedError);
-        });
         it('fails if operator share is greater than current', async () => {
             const { poolId, operatorShare } = await createPoolAsync();
             const tx = testContract.decreaseStakingPoolOperatorShare.awaitTransactionSuccessAsync(
@@ -290,6 +283,14 @@ blockchainTests.resets('MixinStakingPool unit tests', env => {
             );
             const pool = await testContract.getStakingPool.callAsync(poolId);
             expect(pool.operatorShare).to.bignumber.eq(operatorShare - 1);
+        });
+        it('does not modify operator share if equal to current', async () => {
+            const { poolId, operatorShare } = await createPoolAsync();
+            await testContract.decreaseStakingPoolOperatorShare.awaitTransactionSuccessAsync(poolId, operatorShare, {
+                from: operator,
+            });
+            const pool = await testContract.getStakingPool.callAsync(poolId);
+            expect(pool.operatorShare).to.bignumber.eq(operatorShare);
         });
         it('does not modify operator', async () => {
             const { poolId, operatorShare } = await createPoolAsync();

--- a/contracts/staking/test/unit_tests/staking_pool_test.ts
+++ b/contracts/staking/test/unit_tests/staking_pool_test.ts
@@ -177,6 +177,13 @@ blockchainTests.resets('MixinStakingPool unit tests', env => {
             expect(pool.operator).to.eq(operator);
             expect(pool.operatorShare).to.bignumber.eq(operatorShare);
         });
+        it('records pool details when operator share is 0%', async () => {
+            const operatorShare = constants.ZERO_AMOUNT;
+            await testContract.createStakingPool.awaitTransactionSuccessAsync(operatorShare, false, { from: operator });
+            const pool = await testContract.getStakingPool.callAsync(nextPoolId);
+            expect(pool.operator).to.eq(operator);
+            expect(pool.operatorShare).to.bignumber.eq(operatorShare);
+        });
         it('returns the next pool ID', async () => {
             const poolId = await testContract.createStakingPool.callAsync(randomOperatorShare(), false, {
                 from: operator,

--- a/packages/migrations/src/test_contract_configs.ts
+++ b/packages/migrations/src/test_contract_configs.ts
@@ -265,9 +265,6 @@ async function testContractConfigsAsync(provider: SupportedProvider): Promise<vo
         const stakingProxyOwner = await stakingProxy.owner.callAsync();
         warnIfMismatch(stakingProxyOwner, addresses.zeroExGovernor, 'Unexpected StakingProxy owner');
 
-        const zrxVaultOwner = await zrxVault.owner.callAsync();
-        warnIfMismatch(zrxVaultOwner, addresses.zeroExGovernor, 'Unexpected ZrxVault owner');
-
         const stakingProxyAuthorizedAddresses = await stakingProxy.getAuthorizedAddresses.callAsync();
         warnIfMismatch(
             stakingProxyAuthorizedAddresses.length,
@@ -277,10 +274,20 @@ async function testContractConfigsAsync(provider: SupportedProvider): Promise<vo
         const isGovernorAuthorizedInStakingProxy = await stakingProxy.authorized.callAsync(addresses.zeroExGovernor);
         warnIfMismatch(isGovernorAuthorizedInStakingProxy, true, 'ZeroExGovernor not authorized in StakingProxy');
 
+        const zrxVaultOwner = await zrxVault.owner.callAsync();
+        warnIfMismatch(zrxVaultOwner, addresses.zeroExGovernor, 'Unexpected ZrxVault owner');
+
         const zrxVaultAuthorizedAddresses = await zrxVault.getAuthorizedAddresses.callAsync();
         warnIfMismatch(zrxVaultAuthorizedAddresses.length, 1, 'Unexpected number of authorized addresses in ZrxVault');
+
         const isGovernorAuthorizedInZrxVault = await zrxVault.authorized.callAsync(addresses.zeroExGovernor);
         warnIfMismatch(isGovernorAuthorizedInZrxVault, true, 'ZeroExGovernor not authorized in ZrxVault');
+
+        const zrxAssetProxy = await zrxVault.zrxAssetProxy.callAsync();
+        warnIfMismatch(zrxAssetProxy, addresses.erc20Proxy, 'Unexpected ERC20Proxy set in ZrxVault');
+
+        const zrxVaultStakingProxy = await zrxVault.stakingProxyAddress.callAsync();
+        warnIfMismatch(zrxVaultStakingProxy, addresses.stakingProxy, 'Unexpected StakingProxy set in ZrxVault');
 
         const params = await stakingContract.getParams.callAsync();
         warnIfMismatch(


### PR DESCRIPTION
## Description

An operator currently cannot open up a pool with a 100% `operatorShare` because of an off by 1 error. Pretty simple fix.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
