### PR TITLE
RevertError: Decode Parity revert errors

### DIFF
--- a/packages/utils/CHANGELOG.json
+++ b/packages/utils/CHANGELOG.json
@@ -5,6 +5,10 @@
             {
                 "note": "Removed exports AuthorizableRevertErrors, LibAddressArrayRevertErrors, LibBytesRevertErrors, OwnableRevertErrors, ReentrancyGuardRevertErrors and SafeMathRevertErrors",
                 "pr": 2321
+            },
+            {
+                "note": "Decode `Parity` revert errors",
+                "pr": 2341
             }
         ]
     },

--- a/packages/utils/test/revert_error_test.ts
+++ b/packages/utils/test/revert_error_test.ts
@@ -1,7 +1,13 @@
 import * as chai from 'chai';
 import * as _ from 'lodash';
 
-import { AnyRevertError, RawRevertError, RevertError, StringRevertError } from '../src/revert_error';
+import {
+    AnyRevertError,
+    getThrownErrorRevertErrorBytes,
+    RawRevertError,
+    RevertError,
+    StringRevertError,
+} from '../src/revert_error';
 
 import { chaiSetup } from './utils/chai_setup';
 
@@ -152,6 +158,14 @@ describe('RevertError', () => {
             const _encoded = encoded.substr(0, encoded.length - 1);
             const decode = () => RevertError.decode(_encoded);
             expect(decode).to.throw();
+        });
+    });
+    describe('getThrownErrorRevertErrorBytes', () => {
+        it('should decode Parity revert errors', () => {
+            const revertAbi = '0x1234';
+            const parityError = { code: 1234, message: 'VM execution error.', data: `Reverted ${revertAbi}`, name: '' };
+            const revertError = getThrownErrorRevertErrorBytes(parityError);
+            expect(revertError).to.be.eq(revertAbi);
         });
     });
     describe('encoding', () => {


### PR DESCRIPTION
## Description

Parity nodes have a different response than Ganache/Geth nodes in the event of an `eth_call` error. This lead to the errors not being decoded and just throwing ABI encoded strings.

Parity
```
Error Thrown
{ code: -32015,
  data:
   'Reverted 0xa6bcde47000000000000000000000000000000000000000000000000000000005dcf4184000000000000000000000000000000000000000000000000000000005dce5fec',
  message: 'VM execution error.' }
```

Geth
```
RESPONSE
"0xa6bcde47000000000000000000000000000000000000000000000000000000005dcf798c000000000000000000000000000000000000000000000000000000005dce5fe9"

{ BlockTimestampTooLowError: BlockTimestampTooLowError()
...
  abi:
   { type: 'error',
     name: 'BlockTimestampTooLowError',
     arguments: [ [Object], [Object] ] },
  _raw: undefined }
```
