### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,8 +14,8 @@ packages/abi-gen/ @feuGeneA
 packages/base-contract/ @xianny
 packages/connect/ @fragosti 
 packages/abi-gen-templates/ @feuGeneA @xianny
-packages/contract-addresses/ @albrow
-packages/contract-artifacts/ @albrow
+packages/contract-addresses/ @abandeali1
+packages/contract-artifacts/ @abandeali1
 packages/dev-utils/ @LogvinovLeon @fabioberger
 packages/devnet/ @albrow
 packages/ethereum-types/ @LogvinovLeon


### PR DESCRIPTION
Remove `@albrow` as code owner for the `contract-addresses` and `contract-artifacts` packages. It's been a long time since I've worked on these packages and I am no longer the best person to review changes to them.