### PR TITLE
Fix unbound method in provider standardizer

### DIFF
--- a/packages/utils/src/provider_utils.ts
+++ b/packages/utils/src/provider_utils.ts
@@ -42,6 +42,10 @@ export const providerUtils = {
             enable: (supportedProvider as any).enable,
             sendAsync: _.noop.bind(_), // Will be replaced
         };
+        if (provider.enable) {
+            // Need to bind, metamask can lose reference to function without binding as of 7.7.0
+            provider.enable.bind(supportedProvider);
+        }
         // Case 1: We've already converted to our ZeroExProvider so noop.
         if ((supportedProvider as any).isStandardizedProvider) {
             // tslint:disable-next-line:no-unnecessary-type-assertion


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.


Yesterday, Metamask (as of 7.7.0 https://github.com/MetaMask/metamask-extension/releases/tag/v7.7.0) changed the internals of their provider (using prototypes) [see 
 [https://github.com/MetaMask/metamask-inpage-provider/blob/master/index.js#L285-L301](https://github.com/MetaMask/metamask-inpage-provider/blob/master/index.js#L285-L301) ] and the way we pull off the methods of the provider object when standardizing the providing make JavaScript lose the `this` context without binding, which breaks our implementation. This PR fixes that.