### PR TITLE
`@0x/contracts-integrations`: Better input generation for fuzzing

### DIFF
--- a/contracts/integrations/test/framework/actors/maker.ts
+++ b/contracts/integrations/test/framework/actors/maker.ts
@@ -111,7 +111,7 @@ export function MakerMixin<TBase extends Constructor>(Base: TBase): TBase & Cons
                     await (owner as Actor).configureERC20TokenAsync(token as DummyERC20TokenContract);
                     balance = balanceStore.balances.erc20[owner.address][token.address] =
                         constants.INITIAL_ERC20_BALANCE;
-                    return Pseudorandom.integer(balance.dividedToIntegerBy(2));
+                    return Pseudorandom.integer(0, balance.dividedToIntegerBy(2));
                 }),
             );
             // Encode asset data

--- a/contracts/integrations/test/framework/actors/pool_operator.ts
+++ b/contracts/integrations/test/framework/actors/pool_operator.ts
@@ -6,7 +6,7 @@ import * as _ from 'lodash';
 import { validCreateStakingPoolAssertion } from '../assertions/createStakingPool';
 import { validDecreaseStakingPoolOperatorShareAssertion } from '../assertions/decreaseStakingPoolOperatorShare';
 import { AssertionResult } from '../assertions/function_assertion';
-import { Pseudorandom } from '../utils/pseudorandom';
+import { Distributions, Pseudorandom } from '../utils/pseudorandom';
 
 import { Actor, Constructor } from './base';
 
@@ -83,7 +83,11 @@ export function PoolOperatorMixin<TBase extends Constructor>(Base: TBase): TBase
         private async *_validCreateStakingPool(): AsyncIterableIterator<AssertionResult> {
             const assertion = validCreateStakingPoolAssertion(this.actor.deployment, this.actor.simulationEnvironment!);
             while (true) {
-                const operatorShare = Pseudorandom.integer(constants.PPM).toNumber();
+                const operatorShare = Pseudorandom.integer(
+                    0,
+                    constants.PPM,
+                    Distributions.Kumaraswamy(0.2, 0.2),
+                ).toNumber();
                 yield assertion.executeAsync([operatorShare, false], { from: this.actor.address });
             }
         }
@@ -96,7 +100,11 @@ export function PoolOperatorMixin<TBase extends Constructor>(Base: TBase): TBase
                 if (poolId === undefined) {
                     yield undefined;
                 } else {
-                    const operatorShare = Pseudorandom.integer(stakingPools[poolId].operatorShare).toNumber();
+                    const operatorShare = Pseudorandom.integer(
+                        0,
+                        stakingPools[poolId].operatorShare,
+                        Distributions.Kumaraswamy(0.2, 0.2),
+                    ).toNumber();
                     yield assertion.executeAsync([poolId, operatorShare], { from: this.actor.address });
                 }
             }

--- a/contracts/integrations/test/framework/actors/staker.ts
+++ b/contracts/integrations/test/framework/actors/staker.ts
@@ -118,7 +118,10 @@ export function StakerMixin<TBase extends Constructor>(Base: TBase): TBase & Con
                 const fromStatus =
                     fromPoolId === undefined || stakingPools[fromPoolId].lastFinalized.isLessThan(currentEpoch.minus(1))
                         ? StakeStatus.Undelegated
-                        : (Pseudorandom.sample([StakeStatus.Undelegated, StakeStatus.Delegated]) as StakeStatus);
+                        : (Pseudorandom.sample(
+                              [StakeStatus.Undelegated, StakeStatus.Delegated],
+                              [0.2, 0.8],
+                          ) as StakeStatus);
                 const from = new StakeInfo(fromStatus, fromPoolId);
 
                 // Pick a random pool to move the stake to
@@ -128,7 +131,10 @@ export function StakerMixin<TBase extends Constructor>(Base: TBase): TBase & Con
                 const toStatus =
                     toPoolId === undefined || stakingPools[toPoolId].lastFinalized.isLessThan(currentEpoch.minus(1))
                         ? StakeStatus.Undelegated
-                        : (Pseudorandom.sample([StakeStatus.Undelegated, StakeStatus.Delegated]) as StakeStatus);
+                        : (Pseudorandom.sample(
+                              [StakeStatus.Undelegated, StakeStatus.Delegated],
+                              [0.2, 0.8],
+                          ) as StakeStatus);
                 const to = new StakeInfo(toStatus, toPoolId);
 
                 // The next epoch balance of the `from` stake is the amount that can be moved

--- a/contracts/integrations/test/framework/actors/staker.ts
+++ b/contracts/integrations/test/framework/actors/staker.ts
@@ -79,7 +79,7 @@ export function StakerMixin<TBase extends Constructor>(Base: TBase): TBase & Con
             while (true) {
                 await balanceStore.updateErc20BalancesAsync();
                 const zrxBalance = balanceStore.balances.erc20[this.actor.address][zrx.address];
-                const amount = Pseudorandom.integer(zrxBalance);
+                const amount = Pseudorandom.integer(0, zrxBalance);
                 yield assertion.executeAsync([amount], { from: this.actor.address });
             }
         }
@@ -98,7 +98,7 @@ export function StakerMixin<TBase extends Constructor>(Base: TBase): TBase & Con
                     undelegatedStake.currentEpochBalance,
                     undelegatedStake.nextEpochBalance,
                 );
-                const amount = Pseudorandom.integer(withdrawableStake);
+                const amount = Pseudorandom.integer(0, withdrawableStake);
                 yield assertion.executeAsync([amount], { from: this.actor.address });
             }
         }
@@ -136,7 +136,7 @@ export function StakerMixin<TBase extends Constructor>(Base: TBase): TBase & Con
                     from.status === StakeStatus.Undelegated
                         ? this.stake[StakeStatus.Undelegated].nextEpochBalance
                         : this.stake[StakeStatus.Delegated][from.poolId].nextEpochBalance;
-                const amount = Pseudorandom.integer(moveableStake);
+                const amount = Pseudorandom.integer(0, moveableStake);
 
                 yield assertion.executeAsync([from, to, amount], { from: this.actor.address });
             }

--- a/contracts/integrations/test/framework/actors/staker.ts
+++ b/contracts/integrations/test/framework/actors/staker.ts
@@ -120,7 +120,7 @@ export function StakerMixin<TBase extends Constructor>(Base: TBase): TBase & Con
                         ? StakeStatus.Undelegated
                         : (Pseudorandom.sample(
                               [StakeStatus.Undelegated, StakeStatus.Delegated],
-                              [0.2, 0.8],
+                              [0.2, 0.8], // 20% chance of `Undelegated`, 80% chance of `Delegated`
                           ) as StakeStatus);
                 const from = new StakeInfo(fromStatus, fromPoolId);
 
@@ -133,7 +133,7 @@ export function StakerMixin<TBase extends Constructor>(Base: TBase): TBase & Con
                         ? StakeStatus.Undelegated
                         : (Pseudorandom.sample(
                               [StakeStatus.Undelegated, StakeStatus.Delegated],
-                              [0.2, 0.8],
+                              [0.2, 0.8], // 20% chance of `Undelegated`, 80% chance of `Delegated`
                           ) as StakeStatus);
                 const to = new StakeInfo(toStatus, toPoolId);
 

--- a/contracts/integrations/test/framework/actors/taker.ts
+++ b/contracts/integrations/test/framework/actors/taker.ts
@@ -75,12 +75,12 @@ export function TakerMixin<TBase extends Constructor>(Base: TBase): TBase & Cons
                     // Maker creates and signs a fillable order
                     const order = await maker.createFillableOrderAsync(this.actor);
                     // Taker fills the order by a random amount (up to the order's takerAssetAmount)
-                    const fillAmount = Pseudorandom.integer(order.takerAssetAmount);
+                    const fillAmount = Pseudorandom.integer(0, order.takerAssetAmount);
                     // Taker executes the fill with a random msg.value, so that sometimes the
                     // protocol fee is paid in ETH and other times it's paid in WETH.
                     yield assertion.executeAsync([order, fillAmount, order.signature], {
                         from: this.actor.address,
-                        value: Pseudorandom.integer(DeploymentManager.protocolFee.times(2)),
+                        value: Pseudorandom.integer(0, DeploymentManager.protocolFee.times(2)),
                     });
                 }
             }

--- a/contracts/integrations/test/framework/actors/tslint.json
+++ b/contracts/integrations/test/framework/actors/tslint.json
@@ -2,6 +2,7 @@
     "extends": ["@0x/tslint-config"],
     "rules": {
         "max-classes-per-file": false,
-        "no-non-null-assertion": false
+        "no-non-null-assertion": false,
+        "custom-no-magic-numbers": false
     }
 }

--- a/contracts/integrations/test/framework/assertions/decreaseStakingPoolOperatorShare.ts
+++ b/contracts/integrations/test/framework/assertions/decreaseStakingPoolOperatorShare.ts
@@ -13,11 +13,11 @@ import { FunctionAssertion, FunctionResult } from './function_assertion';
 export function validDecreaseStakingPoolOperatorShareAssertion(
     deployment: DeploymentManager,
     pools: StakingPoolById,
-): FunctionAssertion<[string, number], {}, void> {
+): FunctionAssertion<[string, number], void, void> {
     const { stakingWrapper } = deployment.staking;
 
-    return new FunctionAssertion<[string, number], {}, void>(stakingWrapper, 'decreaseStakingPoolOperatorShare', {
-        after: async (_beforeInfo, result: FunctionResult, args: [string, number], _txData: Partial<TxData>) => {
+    return new FunctionAssertion<[string, number], void, void>(stakingWrapper, 'decreaseStakingPoolOperatorShare', {
+        after: async (_beforeInfo: void, result: FunctionResult, args: [string, number], _txData: Partial<TxData>) => {
             // Ensure that the tx succeeded.
             expect(result.success, `Error: ${result.data}`).to.be.true();
 

--- a/contracts/integrations/test/framework/utils/pseudorandom.ts
+++ b/contracts/integrations/test/framework/utils/pseudorandom.ts
@@ -8,8 +8,10 @@ class PRNGWrapper {
     public readonly rng = seedrandom(this.seed);
 
     /*
-     * Pseudorandom version of _.sample. Picks an element of the given array with uniform probability.
-     * Return undefined if the array is empty.
+     * Pseudorandom version of _.sample. Picks an element of the given array. If an array of weights
+     * is provided, elements of `arr` are weighted according to the value in the corresponding index
+     * of `weights`. Otherwise, the samples are chosen uniformly at random. Return undefined if the
+     * array is empty.
      */
     public sample<T>(arr: T[], weights?: number[]): T | undefined {
         if (arr.length === 0) {
@@ -29,7 +31,9 @@ class PRNGWrapper {
 
     /*
      * Pseudorandom version of _.sampleSize. Returns an array of `n` samples from the given array
-     * (with replacement), chosen with uniform probability. Return undefined if the array is empty.
+     * (with replacement). If an array of weights is provided, elements of `arr` are weighted
+     * according to the value in the corresponding index of `weights`. Otherwise, the samples are
+     * chosen uniformly at random. Return undefined if the array is empty.
      */
     public sampleSize<T>(arr: T[], n: number, weights?: number[]): T[] | undefined {
         if (arr.length === 0) {
@@ -59,11 +63,14 @@ class PRNGWrapper {
     /*
      * Returns a function that produces samples from the Kumaraswamy distribution parameterized by
      * the given alpha and beta. The Kumaraswamy distribution is like the beta distribution, but
-     * with a nice closed form.
+     * with a nice closed form. More info:
      * https://en.wikipedia.org/wiki/Kumaraswamy_distribution
      * https://www.johndcook.com/blog/2009/11/24/kumaraswamy-distribution/
+     * Alpha and beta default to 0.2, so that the distribution favors the extremes of the domain.
+     * The PDF for alpha=0.2, beta=0.2:
+     * https://www.wolframalpha.com/input/?i=0.2*0.2*x%5E%280.2-1%29*%281-x%5E0.2%29%5E%280.2-1%29+from+0+to+1
      */
-    public kumaraswamy(this: PRNGWrapper, alpha: Numberish, beta: Numberish): () => BigNumber {
+    public kumaraswamy(this: PRNGWrapper, alpha: Numberish = 0.2, beta: Numberish = 0.2): () => BigNumber {
         const ONE = new BigNumber(1);
         return () => {
             const u = new BigNumber(this.rng()).modulo(ONE); // u ~ Uniform(0, 1)

--- a/contracts/integrations/test/fuzz_tests/pool_management_test.ts
+++ b/contracts/integrations/test/fuzz_tests/pool_management_test.ts
@@ -16,7 +16,9 @@ export class PoolManagementSimulation extends Simulation {
         const operators = filterActorsByRole(actors, PoolOperator);
 
         const [actions, weights] = _.unzip([
+            // 40% chance of executing validCreateStakingPool assertion for a random operator
             ...operators.map(operator => [operator.simulationActions.validCreateStakingPool, 0.4]),
+            // 60% chance of executing validDecreaseStakingPoolOperatorShare for a random operator
             ...operators.map(operator => [operator.simulationActions.validDecreaseStakingPoolOperatorShare, 0.6]),
         ]) as [Array<AsyncIterableIterator<AssertionResult | void>>, number[]];
         while (true) {

--- a/contracts/integrations/test/fuzz_tests/pool_management_test.ts
+++ b/contracts/integrations/test/fuzz_tests/pool_management_test.ts
@@ -18,7 +18,7 @@ export class PoolManagementSimulation extends Simulation {
         const [actions, weights] = _.unzip([
             ...operators.map(operator => [operator.simulationActions.validCreateStakingPool, 0.4]),
             ...operators.map(operator => [operator.simulationActions.validDecreaseStakingPoolOperatorShare, 0.6]),
-        ]) as [AsyncIterableIterator<AssertionResult | void>[], number[]];
+        ]) as [Array<AsyncIterableIterator<AssertionResult | void>>, number[]];
         while (true) {
             const action = Pseudorandom.sample(actions, weights);
             yield (await action!.next()).value; // tslint:disable-line:no-non-null-assertion

--- a/contracts/integrations/test/fuzz_tests/pool_management_test.ts
+++ b/contracts/integrations/test/fuzz_tests/pool_management_test.ts
@@ -1,4 +1,5 @@
 import { blockchainTests } from '@0x/contracts-test-utils';
+import * as _ from 'lodash';
 
 import { Actor } from '../framework/actors/base';
 import { PoolOperator } from '../framework/actors/pool_operator';
@@ -14,12 +15,12 @@ export class PoolManagementSimulation extends Simulation {
         const { actors } = this.environment;
         const operators = filterActorsByRole(actors, PoolOperator);
 
-        const actions = [
-            ...operators.map(operator => operator.simulationActions.validCreateStakingPool),
-            ...operators.map(operator => operator.simulationActions.validDecreaseStakingPoolOperatorShare),
-        ];
+        const [actions, weights] = _.unzip([
+            ...operators.map(operator => [operator.simulationActions.validCreateStakingPool, 0.4]),
+            ...operators.map(operator => [operator.simulationActions.validDecreaseStakingPoolOperatorShare, 0.6]),
+        ]) as [AsyncIterableIterator<AssertionResult | void>[], number[]];
         while (true) {
-            const action = Pseudorandom.sample(actions);
+            const action = Pseudorandom.sample(actions, weights);
             yield (await action!.next()).value; // tslint:disable-line:no-non-null-assertion
         }
     }

--- a/contracts/integrations/test/fuzz_tests/pool_membership_test.ts
+++ b/contracts/integrations/test/fuzz_tests/pool_membership_test.ts
@@ -24,8 +24,11 @@ export class PoolMembershipSimulation extends Simulation {
         const poolManagement = new PoolManagementSimulation(this.environment);
 
         const [actions, weights] = _.unzip([
+            // 20% chance of executing validJoinStakingPool for a random maker
             ...makers.map(maker => [maker.simulationActions.validJoinStakingPool, 0.2 / makers.length]),
+            // 60% chance of executing validFillOrder for a random taker
             ...takers.map(taker => [taker.simulationActions.validFillOrder, 0.6 / takers.length]),
+            // 20% chance of executing an assertion generated from the pool management simulation
             [poolManagement.generator, 0.2],
         ]) as [Array<AsyncIterableIterator<AssertionResult | void>>, number[]];
 

--- a/contracts/integrations/test/fuzz_tests/pool_membership_test.ts
+++ b/contracts/integrations/test/fuzz_tests/pool_membership_test.ts
@@ -27,7 +27,7 @@ export class PoolMembershipSimulation extends Simulation {
             ...makers.map(maker => [maker.simulationActions.validJoinStakingPool, 0.2 / makers.length]),
             ...takers.map(taker => [taker.simulationActions.validFillOrder, 0.6 / takers.length]),
             [poolManagement.generator, 0.2],
-        ]) as [AsyncIterableIterator<AssertionResult | void>[], number[]];
+        ]) as [Array<AsyncIterableIterator<AssertionResult | void>>, number[]];
 
         while (true) {
             const action = Pseudorandom.sample(actions, weights);

--- a/contracts/integrations/test/fuzz_tests/stake_management_test.ts
+++ b/contracts/integrations/test/fuzz_tests/stake_management_test.ts
@@ -22,9 +22,13 @@ export class StakeManagementSimulation extends Simulation {
         const poolManagement = new PoolManagementSimulation(this.environment);
 
         const [actions, weights] = _.unzip([
+            // 30% chance of executing validStake for a random staker
             ...stakers.map(staker => [staker.simulationActions.validStake, 0.3 / stakers.length]),
+            // 20% chance of executing validUnstake for a random staker
             ...stakers.map(staker => [staker.simulationActions.validUnstake, 0.2 / stakers.length]),
+            // 30% chance of executing validMoveStake for a random staker
             ...stakers.map(staker => [staker.simulationActions.validMoveStake, 0.3 / stakers.length]),
+            // 20% chance of executing an assertion generated from the pool management simulation
             [poolManagement.generator, 0.2],
         ]) as [Array<AsyncIterableIterator<AssertionResult | void>>, number[]];
 

--- a/contracts/integrations/test/fuzz_tests/stake_management_test.ts
+++ b/contracts/integrations/test/fuzz_tests/stake_management_test.ts
@@ -22,11 +22,11 @@ export class StakeManagementSimulation extends Simulation {
         const poolManagement = new PoolManagementSimulation(this.environment);
 
         const [actions, weights] = _.unzip([
-            ...stakers.map(staker => [staker.simulationActions.validStake, 0.3]),
-            ...stakers.map(staker => [staker.simulationActions.validUnstake, 0.2]),
-            ...stakers.map(staker => [staker.simulationActions.validMoveStake, 0.3]),
+            ...stakers.map(staker => [staker.simulationActions.validStake, 0.3 / stakers.length]),
+            ...stakers.map(staker => [staker.simulationActions.validUnstake, 0.2 / stakers.length]),
+            ...stakers.map(staker => [staker.simulationActions.validMoveStake, 0.3 / stakers.length]),
             [poolManagement.generator, 0.2],
-        ]) as [AsyncIterableIterator<AssertionResult | void>[], number[]];
+        ]) as [Array<AsyncIterableIterator<AssertionResult | void>>, number[]];
 
         while (true) {
             const action = Pseudorandom.sample(actions, weights);

--- a/contracts/integrations/test/fuzz_tests/staking_rewards_test.ts
+++ b/contracts/integrations/test/fuzz_tests/staking_rewards_test.ts
@@ -34,10 +34,15 @@ export class StakingRewardsSimulation extends Simulation {
         const stakeManagement = new StakeManagementSimulation(this.environment);
 
         const [actions, weights] = _.unzip([
+            // 10% chance of executing validWithdrawDelegatorRewards for a random staker
             ...stakers.map(staker => [staker.simulationActions.validWithdrawDelegatorRewards, 0.1 / stakers.length]),
+            // 10% chance of executing validFinalizePool for a random keeper
             ...keepers.map(keeper => [keeper.simulationActions.validFinalizePool, 0.1 / keepers.length]),
+            // 10% chance of executing validEndEpoch for a random keeper
             ...keepers.map(keeper => [keeper.simulationActions.validEndEpoch, 0.1 / keepers.length]),
+            // 50% chance of executing an assertion generated from the pool membership simulation
             [poolMembership.generator, 0.5],
+            // 20% chance of executing an assertion generated from the stake management simulation
             [stakeManagement.generator, 0.2],
         ]) as [Array<AsyncIterableIterator<AssertionResult | void>>, number[]];
         while (true) {

--- a/contracts/integrations/test/fuzz_tests/staking_rewards_test.ts
+++ b/contracts/integrations/test/fuzz_tests/staking_rewards_test.ts
@@ -39,7 +39,7 @@ export class StakingRewardsSimulation extends Simulation {
             ...keepers.map(keeper => [keeper.simulationActions.validEndEpoch, 0.1 / keepers.length]),
             [poolMembership.generator, 0.5],
             [stakeManagement.generator, 0.2],
-        ]) as [AsyncIterableIterator<AssertionResult | void>[], number[]];
+        ]) as [Array<AsyncIterableIterator<AssertionResult | void>>, number[]];
         while (true) {
             const action = Pseudorandom.sample(actions, weights);
             yield (await action!.next()).value; // tslint:disable-line:no-non-null-assertion

--- a/contracts/integrations/test/fuzz_tests/tslint.json
+++ b/contracts/integrations/test/fuzz_tests/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": ["@0x/tslint-config"],
     "rules": {
-        "no-invalid-this": false
+        "no-invalid-this": false,
+        "custom-no-magic-numbers": false
     }
 }

--- a/contracts/staking/src/types.ts
+++ b/contracts/staking/src/types.ts
@@ -83,9 +83,10 @@ export function loadCurrentBalance(balance: StoredBalance, epoch: BigNumber): St
  * Simulates _increaseNextBalance
  */
 export function increaseNextBalance(balance: StoredBalance, amount: Numberish, epoch: BigNumber): StoredBalance {
+    const newBalance = loadCurrentBalance(balance, epoch);
     return {
-        ...loadCurrentBalance(balance, epoch),
-        nextEpochBalance: balance.nextEpochBalance.plus(amount),
+        ...newBalance,
+        nextEpochBalance: newBalance.nextEpochBalance.plus(amount),
     };
 }
 
@@ -93,9 +94,10 @@ export function increaseNextBalance(balance: StoredBalance, amount: Numberish, e
  * Simulates _decreaseNextBalance
  */
 export function decreaseNextBalance(balance: StoredBalance, amount: Numberish, epoch: BigNumber): StoredBalance {
+    const newBalance = loadCurrentBalance(balance, epoch);
     return {
-        ...loadCurrentBalance(balance, epoch),
-        nextEpochBalance: balance.nextEpochBalance.minus(amount),
+        ...newBalance,
+        nextEpochBalance: newBalance.nextEpochBalance.minus(amount),
     };
 }
 
@@ -107,10 +109,11 @@ export function increaseCurrentAndNextBalance(
     amount: Numberish,
     epoch: BigNumber,
 ): StoredBalance {
+    const newBalance = loadCurrentBalance(balance, epoch);
     return {
-        ...loadCurrentBalance(balance, epoch),
-        currentEpochBalance: balance.currentEpochBalance.plus(amount),
-        nextEpochBalance: balance.nextEpochBalance.plus(amount),
+        ...newBalance,
+        currentEpochBalance: newBalance.currentEpochBalance.plus(amount),
+        nextEpochBalance: newBalance.nextEpochBalance.plus(amount),
     };
 }
 
@@ -122,10 +125,11 @@ export function decreaseCurrentAndNextBalance(
     amount: Numberish,
     epoch: BigNumber,
 ): StoredBalance {
+    const newBalance = loadCurrentBalance(balance, epoch);
     return {
-        ...loadCurrentBalance(balance, epoch),
-        currentEpochBalance: balance.currentEpochBalance.minus(amount),
-        nextEpochBalance: balance.nextEpochBalance.minus(amount),
+        ...newBalance,
+        currentEpochBalance: newBalance.currentEpochBalance.minus(amount),
+        nextEpochBalance: newBalance.nextEpochBalance.minus(amount),
     };
 }
 


### PR DESCRIPTION
## Description
Adds some functionality to `Pseudorandom` for more sophisticated input generation. In particular, you can now pass in an array of weights alongside the array of inputs to `Pseudorandom.sample` and `sampleSize`. For `Pseudorandom.integer`, you can pass in a custom probability distribution alongside the min and max values. I implemented the [Kumaraswamy distribution](https://www.johndcook.com/blog/2009/11/24/kumaraswamy-distribution/), a beta-like distribution which allows to weigh the extreme ends of an input distribution more heavily: 
![Screen Shot 2019-12-13 at 13 17 52](https://user-images.githubusercontent.com/8365992/70832852-02189500-1dab-11ea-9637-4cf7f56fa64f.png)
I want to get some feedback on what sort of weights/distributions we want. I've chosen some values that are intended to be either more realistic or hit more corner cases than uniformly random samples, but they're still p arbitrary. 

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
