### PR TITLE
`@0x/contracts-exchange-forwarder`: StaticCall support, MultiAsset buy support

### DIFF
--- a/contracts/exchange-forwarder/contracts/src/MixinAssets.sol
+++ b/contracts/exchange-forwarder/contracts/src/MixinAssets.sol
@@ -146,6 +146,9 @@ contract MixinAssets is
         );
     }
 
+    /// @dev Decodes MultiAsset assetData and recursively transfers assets to sender.
+    /// @param assetData Byte array encoded for the respective asset proxy.
+    /// @param amount Amount of asset to transfer to sender.
     function _transferMultiAsset(
         bytes memory assetData,
         uint256 amount

--- a/contracts/exchange-forwarder/contracts/src/MixinExchangeWrapper.sol
+++ b/contracts/exchange-forwarder/contracts/src/MixinExchangeWrapper.sol
@@ -513,7 +513,10 @@ contract MixinExchangeWrapper is
     {
         return (
             takerFee == 0 ||
-            takerFeeAssetData.readBytes4(0) == IAssetData(address(0)).StaticCall.selector
+            (
+                takerFeeAssetData.length > 3 &&
+                takerFeeAssetData.readBytes4(0) == IAssetData(address(0)).StaticCall.selector
+            )
         );
     }
 }

--- a/contracts/exchange-forwarder/contracts/test/TestForwarder.sol
+++ b/contracts/exchange-forwarder/contracts/test/TestForwarder.sol
@@ -61,17 +61,4 @@ contract TestForwarder is
             amount
         );
     }
-
-    function noTakerFee(
-        uint256 takerFee,
-        bytes memory takerFeeAssetData
-    )
-        public
-        returns (bool)
-    {
-        return _noTakerFee(
-            takerFee,
-            takerFeeAssetData
-        );
-    }
 }

--- a/contracts/exchange-forwarder/contracts/test/TestForwarder.sol
+++ b/contracts/exchange-forwarder/contracts/test/TestForwarder.sol
@@ -61,4 +61,17 @@ contract TestForwarder is
             amount
         );
     }
+
+    function noTakerFee(
+        uint256 takerFee,
+        bytes memory takerFeeAssetData
+    )
+        public
+        returns (bool)
+    {
+        return _noTakerFee(
+            takerFee,
+            takerFeeAssetData
+        );
+    }
 }

--- a/contracts/exchange-forwarder/test/asset_test.ts
+++ b/contracts/exchange-forwarder/test/asset_test.ts
@@ -292,27 +292,4 @@ blockchainTests.resets('Supported asset type unit tests', env => {
             return expect(tx).to.revertWith(expectedError);
         });
     });
-
-    describe('_noTakerFee', () => {
-        it('returns true if takerFee == 0 and takerFeeAssetData != StaticCall', async () => {
-            const result = await forwarder.noTakerFee(constants.ZERO_AMOUNT, erc20AssetData).callAsync();
-            expect(result).to.be.true();
-        });
-        it('returns false if takerFee != 0 and takerFeeAssetData != StaticCall', async () => {
-            const result = await forwarder
-                .noTakerFee(getRandomInteger(1, constants.MAX_UINT256), erc20AssetData)
-                .callAsync();
-            expect(result).to.be.false();
-        });
-        it('returns true if takerFee == 0 and takerFeeAssetData == StaticCall', async () => {
-            const result = await forwarder.noTakerFee(constants.ZERO_AMOUNT, staticCallAssetData).callAsync();
-            expect(result).to.be.true();
-        });
-        it('returns true if takerFee != 0 and takerFeeAssetData == StaticCall', async () => {
-            const result = await forwarder
-                .noTakerFee(getRandomInteger(1, constants.MAX_UINT256), staticCallAssetData)
-                .callAsync();
-            expect(result).to.be.true();
-        });
-    });
 });

--- a/contracts/exchange-forwarder/test/asset_test.ts
+++ b/contracts/exchange-forwarder/test/asset_test.ts
@@ -158,8 +158,18 @@ blockchainTests.resets('Supported asset type unit tests', env => {
             const result = await forwarder.areUnderlyingAssetsEqual(erc20AssetData, multiAssetData).callAsync();
             expect(result).to.be.false();
         });
-        it('returns true if assetData1 == assetData2 are MultiAsset', async () => {
+        it('returns true if assetData1 == assetData2 are MultiAsset (single nested asset)', async () => {
             const result = await forwarder.areUnderlyingAssetsEqual(multiAssetData, multiAssetData).callAsync();
+            expect(result).to.be.true();
+        });
+        it('returns true if assetData1 == assetData2 are MultiAsset (multiple nested assets)', async () => {
+            const assetData = assetDataEncoder
+                .MultiAsset(
+                    [getRandomInteger(0, constants.MAX_UINT256), new BigNumber(1)],
+                    [erc20AssetData, erc721AssetData],
+                )
+                .getABIEncodedTransactionData();
+            const result = await forwarder.areUnderlyingAssetsEqual(assetData, assetData).callAsync();
             expect(result).to.be.true();
         });
         it('returns false if assetData1 != assetData2 are MultiAsset', async () => {

--- a/contracts/exchange-forwarder/test/asset_test.ts
+++ b/contracts/exchange-forwarder/test/asset_test.ts
@@ -234,8 +234,10 @@ blockchainTests.resets('Supported asset type unit tests', env => {
                 .transferAssetToSender(assortedMultiAssetData, TRANSFER_AMOUNT)
                 .awaitTransactionSuccessAsync({ from: receiver });
             expect(txReceipt.logs.length).to.equal(2);
+            // tslint:disable:no-unnecessary-type-assertion
             const erc20TransferEvent = (txReceipt.logs[0] as LogWithDecodedArgs<ERC20TokenTransferEventArgs>).args;
             const erc721TransferEvent = (txReceipt.logs[1] as LogWithDecodedArgs<ERC721TokenTransferEventArgs>).args;
+            // tslint:enable:no-unnecessary-type-assertion
             expect(erc20TransferEvent).to.deep.equal({
                 _from: forwarder.address,
                 _to: receiver,
@@ -252,8 +254,10 @@ blockchainTests.resets('Supported asset type unit tests', env => {
                 .transferAssetToSender(assortedMultiAssetData, TRANSFER_AMOUNT)
                 .awaitTransactionSuccessAsync({ from: receiver });
             expect(txReceipt.logs.length).to.equal(2);
+            // tslint:disable:no-unnecessary-type-assertion
             const erc20TransferEvent = (txReceipt.logs[0] as LogWithDecodedArgs<ERC20TokenTransferEventArgs>).args;
             const erc721TransferEvent = (txReceipt.logs[1] as LogWithDecodedArgs<ERC721TokenTransferEventArgs>).args;
+            // tslint:enable:no-unnecessary-type-assertion
             expect(erc20TransferEvent).to.deep.equal({
                 _from: forwarder.address,
                 _to: receiver,

--- a/contracts/integrations/test/forwarder/forwarder_test.ts
+++ b/contracts/integrations/test/forwarder/forwarder_test.ts
@@ -319,7 +319,7 @@ blockchainTests('Forwarder integration tests', env => {
             const fillableOrder = await maker.signOrderAsync();
             await testFactory.marketSellTestAsync([cancelledOrder, fillableOrder], 1.5, { noopOrders: [0] });
         });
-        for (const orderAssetData of ['makerAssetData', 'makerFeeAssetData', 'takerFeeAssetData']) {
+        for (const orderAssetData of ['makerAssetData', 'makerFeeAssetData']) {
             it(`should fill an order with StaticCall ${orderAssetData} if the StaticCall succeeds`, async () => {
                 const staticCallOrder = await maker.signOrderAsync({
                     [orderAssetData]: staticCallSuccessAssetData,

--- a/contracts/integrations/test/forwarder/forwarder_test_factory.ts
+++ b/contracts/integrations/test/forwarder/forwarder_test_factory.ts
@@ -22,6 +22,7 @@ interface MarketSellOptions {
     forwarderFeeRecipientAddresses: string[];
     revertError: RevertError;
     bridgeExcessBuyAmount: BigNumber;
+    noopOrders: number[]; // Indices of orders expected to noop on _fillOrderNoThrow (e.g. cancelled orders)
 }
 
 interface MarketBuyOptions extends MarketSellOptions {
@@ -71,7 +72,7 @@ export class ForwarderTestFactory {
             orders.map(order => this._deployment.exchange.getOrderInfo(order).callAsync()),
         );
         const expectedOrderStatuses = orderInfoBefore.map((orderInfo, i) =>
-            fractionalNumberOfOrdersToFill >= i + 1 && orderInfo.orderStatus === OrderStatus.Fillable
+            fractionalNumberOfOrdersToFill >= i + 1 && !(options.noopOrders || []).includes(i)
                 ? OrderStatus.FullyFilled
                 : orderInfo.orderStatus,
         );
@@ -112,7 +113,7 @@ export class ForwarderTestFactory {
             orders.map(order => this._deployment.exchange.getOrderInfo(order).callAsync()),
         );
         const expectedOrderStatuses = orderInfoBefore.map((orderInfo, i) =>
-            fractionalNumberOfOrdersToFill >= i + 1 && orderInfo.orderStatus === OrderStatus.Fillable
+            fractionalNumberOfOrdersToFill >= i + 1 && !(options.noopOrders || []).includes(i)
                 ? OrderStatus.FullyFilled
                 : orderInfo.orderStatus,
         );
@@ -198,8 +199,8 @@ export class ForwarderTestFactory {
         for (const [i, order] of orders.entries()) {
             if (remainingOrdersToFill === 0) {
                 break;
-            } else if (ordersInfoBefore[i].orderStatus !== OrderStatus.Fillable) {
-                // If the order is not fillable, skip over it but still count it towards fractionalNumberOfOrdersToFill
+            } else if ((options.noopOrders || []).includes(i)) {
+                // If the order won't be filled, skip over it but still count it towards fractionalNumberOfOrdersToFill
                 remainingOrdersToFill = Math.max(remainingOrdersToFill - 1, 0);
                 continue;
             }
@@ -245,7 +246,10 @@ export class ForwarderTestFactory {
         const makerFeeFilled = takerAssetFilled.times(order.makerFee).dividedToIntegerBy(order.takerAssetAmount);
         makerFee = BigNumber.max(makerFee.minus(makerFeeFilled), 0);
         const takerFeeFilled = takerAssetFilled.times(order.takerFee).dividedToIntegerBy(order.takerAssetAmount);
-        takerFee = BigNumber.max(takerFee.minus(takerFeeFilled), 0);
+        takerFee =
+            hexUtils.slice(order.takerFeeAssetData, 0, 4) === AssetProxyId.StaticCall
+                ? constants.ZERO_AMOUNT
+                : BigNumber.max(takerFee.minus(takerFeeFilled), 0);
 
         makerAssetAmount = makerAssetAmount.plus(bridgeExcessBuyAmount);
         let wethSpentAmount = takerAssetAmount.plus(DeploymentManager.protocolFee);

--- a/contracts/integrations/test/forwarder/forwarder_test_factory.ts
+++ b/contracts/integrations/test/forwarder/forwarder_test_factory.ts
@@ -246,10 +246,7 @@ export class ForwarderTestFactory {
         const makerFeeFilled = takerAssetFilled.times(order.makerFee).dividedToIntegerBy(order.takerAssetAmount);
         makerFee = BigNumber.max(makerFee.minus(makerFeeFilled), 0);
         const takerFeeFilled = takerAssetFilled.times(order.takerFee).dividedToIntegerBy(order.takerAssetAmount);
-        takerFee =
-            hexUtils.slice(order.takerFeeAssetData, 0, 4) === AssetProxyId.StaticCall
-                ? constants.ZERO_AMOUNT
-                : BigNumber.max(takerFee.minus(takerFeeFilled), 0);
+        takerFee = BigNumber.max(takerFee.minus(takerFeeFilled), 0);
 
         makerAssetAmount = makerAssetAmount.plus(bridgeExcessBuyAmount);
         let wethSpentAmount = takerAssetAmount.plus(DeploymentManager.protocolFee);


### PR DESCRIPTION
## Description
Adds for MultiAsset `makerAssetData` and StaticCall `makerAssetData`/`makerFeeAssetData`/`takerFeeAssetData` in the Forwarder.
MultiAsset buy support is straightforward enough, but StaticCall `takerFeeAssetData` introduces some corner cases wrt how the Forwarder computes how much WETH has been spent. 
We could simplify the code a bit by restricting the user from providing StaticCall `takerFeeAssetData`, but one could plausibly have some weird use case where you'd want that due to for settlement order reasons 🤷‍♂
Edit: No longer supports StaticCall `takerFeeAssetData` for cleanliness' sake

## Testing instructions
Unit tests: `PKG=@0x/contracts-exchange-forwarder yarn test`
Integration tests: `PKG=@0x/contracts-integrations yarn test`

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
