### PR TITLE
Fix Kyber and Uniswap ERC20Bridges

### DIFF
--- a/contracts/asset-proxy/CHANGELOG.json
+++ b/contracts/asset-proxy/CHANGELOG.json
@@ -5,6 +5,10 @@
             {
                 "note": "Integration tests for DydxBridge with ERC20BridgeProxy.",
                 "pr": 2401
+            },
+            {
+                "note": "Fix `UniswapBridge` token -> token transfer call.",
+                "pr": "TODO"
             }
         ]
     },

--- a/contracts/asset-proxy/CHANGELOG.json
+++ b/contracts/asset-proxy/CHANGELOG.json
@@ -9,6 +9,10 @@
             {
                 "note": "Fix `UniswapBridge` token -> token transfer call.",
                 "pr": "TODO"
+            },
+            {
+                "note": "Fix `KyberBridge` incorrect `minConversionRate` calculation.",
+                "pr": "TODO"
             }
         ]
     },

--- a/contracts/asset-proxy/CHANGELOG.json
+++ b/contracts/asset-proxy/CHANGELOG.json
@@ -8,11 +8,11 @@
             },
             {
                 "note": "Fix `UniswapBridge` token -> token transfer call.",
-                "pr": "TODO"
+                "pr": 2412
             },
             {
                 "note": "Fix `KyberBridge` incorrect `minConversionRate` calculation.",
-                "pr": "TODO"
+                "pr": 2412
             }
         ]
     },

--- a/contracts/asset-proxy/contracts/src/bridges/UniswapBridge.sol
+++ b/contracts/asset-proxy/contracts/src/bridges/UniswapBridge.sol
@@ -134,8 +134,8 @@ contract UniswapBridge is
                 state.fromTokenBalance,
                 // Minimum buy amount.
                 amount,
-                // No minimum intermediate ETH buy amount.
-                0,
+                // Must buy at least 1 intermediate ETH.
+                1,
                 // Expires after this block.
                 block.timestamp,
                 // Recipient is `to`.

--- a/contracts/asset-proxy/contracts/test/TestKyberBridge.sol
+++ b/contracts/asset-proxy/contracts/test/TestKyberBridge.sol
@@ -67,9 +67,11 @@ interface ITestContract {
 /// @dev A minimalist ERC20/WETH token.
 contract TestToken {
 
+    uint8 public decimals;
     ITestContract private _testContract;
 
-    constructor() public {
+    constructor(uint8 decimals_) public {
+        decimals = decimals_;
         _testContract = ITestContract(msg.sender);
     }
 
@@ -165,7 +167,7 @@ contract TestKyberBridge is
     uint256 private _nextFillAmount;
 
     constructor() public {
-        weth = IEtherToken(address(new TestToken()));
+        weth = IEtherToken(address(new TestToken(18)));
     }
 
     /// @dev Implementation of `IKyberNetworkProxy.trade()`
@@ -195,11 +197,11 @@ contract TestKyberBridge is
         return _nextFillAmount;
     }
 
-    function createToken()
+    function createToken(uint8 decimals)
         external
         returns (address tokenAddress)
     {
-        return address(new TestToken());
+        return address(new TestToken(decimals));
     }
 
     function setNextFillAmount(uint256 amount)

--- a/contracts/asset-proxy/test/uniswap_bridge.ts
+++ b/contracts/asset-proxy/test/uniswap_bridge.ts
@@ -176,7 +176,7 @@ blockchainTests.resets('UniswapBridge unit tests', env => {
                 expect(calls[0].exchange).to.eq(exchangeAddress);
                 expect(calls[0].tokensSold).to.bignumber.eq(opts.fromTokenBalance);
                 expect(calls[0].minTokensBought).to.bignumber.eq(opts.amount);
-                expect(calls[0].minEthBought).to.bignumber.eq(0);
+                expect(calls[0].minEthBought).to.bignumber.eq(1);
                 expect(calls[0].deadline).to.bignumber.eq(blockTime);
                 expect(calls[0].recipient).to.eq(opts.toAddress);
                 expect(calls[0].toTokenAddress).to.eq(opts.toTokenAddress);

--- a/packages/contract-addresses/CHANGELOG.json
+++ b/packages/contract-addresses/CHANGELOG.json
@@ -13,6 +13,10 @@
             {
                 "note": "Added DydxBridge Contract to contract-addresses",
                 "pr": 2401
+            },
+            {
+                "note": "Update Uniswap mainnet address.",
+                "pr": "TODO"
             }
         ]
     },

--- a/packages/contract-addresses/CHANGELOG.json
+++ b/packages/contract-addresses/CHANGELOG.json
@@ -15,8 +15,12 @@
                 "pr": 2401
             },
             {
-                "note": "Update Uniswap mainnet address.",
-                "pr": "TODO"
+                "note": "Update `UniswapBridge` mainnet address.",
+                "pr": 2412
+            },
+            {
+                "note": "Update `KyberBridge` mainnet address.",
+                "pr": 2412
             }
         ]
     },

--- a/packages/contract-addresses/addresses.json
+++ b/packages/contract-addresses/addresses.json
@@ -24,7 +24,7 @@
         "uniswapBridge": "0xb0dc61047847732a013ce27341228228a38655a0",
         "eth2DaiBridge": "0x0ac2d6f5f5afc669d3ca38f830dad2b4f238ad3f",
         "erc20BridgeSampler": "0x1b402fdb5ee87f989c11e3963557e89cc313b6c0",
-        "kyberBridge": "0xe64660275c40c16c491c2dabf50afaded20f858f",
+        "kyberBridge": "0x7253a80c1d3a3175283bad9ed04b2cecad0fe0d3",
         "dydxBridge": "0x96ddba19b69d6ea2549f6a12d005595167414744"
     },
     "3": {

--- a/packages/contract-addresses/addresses.json
+++ b/packages/contract-addresses/addresses.json
@@ -21,7 +21,7 @@
         "stakingProxy": "0xa26e80e7dea86279c6d778d702cc413e6cffa777",
         "devUtils": "0xc7612135356ba8f75dbf517b55d88a91977492dc",
         "erc20BridgeProxy": "0x8ed95d1746bf1e4dab58d8ed4724f1ef95b20db0",
-        "uniswapBridge": "0xa6baaed2053058a3c8f11e0c7a9716304454b09e",
+        "uniswapBridge": "0xb0dc61047847732a013ce27341228228a38655a0",
         "eth2DaiBridge": "0x0ac2d6f5f5afc669d3ca38f830dad2b4f238ad3f",
         "erc20BridgeSampler": "0x1b402fdb5ee87f989c11e3963557e89cc313b6c0",
         "kyberBridge": "0xe64660275c40c16c491c2dabf50afaded20f858f",


### PR DESCRIPTION
## Description

- Uniswap `tokenToTokenTransferInput()` was being called wrongly (minimum eth buy must be at least `1`).
- Kyber's `minConversionRate` parameter for `trade()` was being computed all wrong by not normalizing for token decimals. :tired_face: 

Both contracts have been redeployed and addresses updated in `contract-addresses`.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
