### PR TITLE
sra_client.py: Tweak Mesh block polling interval used in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,6 +203,7 @@ jobs:
                   VERBOSITY: 3
                   PRIVATE_KEY_PATH: ''
                   BLOCK_POLLING_INTERVAL: '50ms'
+                  ETHEREUM_RPC_MAX_REQUESTS_PER_24_HR_UTC: '1778000'
                   P2P_LISTEN_PORT: '60557'
               command: |
                   sh -c "waitForGanache () { until printf 'POST /\r\nContent-Length: 26\r\n\r\n{\"method\":\"net_listening\"}' | nc localhost 8545 | grep true; do continue; done }; waitForGanache && ./mesh"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,7 +202,7 @@ jobs:
                   USE_BOOTSTRAP_LIST: 'true'
                   VERBOSITY: 3
                   PRIVATE_KEY_PATH: ''
-                  BLOCK_POLLING_INTERVAL: '5s'
+                  BLOCK_POLLING_INTERVAL: '50ms'
                   P2P_LISTEN_PORT: '60557'
               command: |
                   sh -c "waitForGanache () { until printf 'POST /\r\nContent-Length: 26\r\n\r\n{\"method\":\"net_listening\"}' | nc localhost 8545 | grep true; do continue; done }; waitForGanache && ./mesh"


### PR DESCRIPTION
`test-python` is currently failing in development.

This is the relevant error: `{"code":100,"reason":"Validation Failed","validationErrors":[{"field":"signedOrder","code":1007,"reason":"OrderUnfunded: maker has insufficient balance or allowance for this order to be filled"}`.  This is in response to the Python SRA client doctest trying to post an order to `launch-kit-backend`+`mesh`+`ganache`.

The last time `test-python` ran successfully on `development` was at 2:52 PM PST yesterday.  The first time it failed on `development` was at 5:40 PM PST yesterday.

My first idea (and @jacob's too) was that something must have changed in the ganache snapshot, but that hasn't changed since Dec 3.

My next guess was that something changed in Mesh order validation (this runs unpinned, against the `:0xV3` tag), and indeed that tag was updated within the relevant time frame, at 3:36 PM PST.  But then @dekz tried to pin the Mesh tag used by the test, to (what we think is) the previous tag, `:7.2.1-beta-0xv3`, but it didn't change the behavior.

Digging more, i found that every time this has occurred, the mesh log has contained this error: `{"error_string":"Post http://localhost:8545: dial tcp 127.0.0.1:8545: connect: connection refused","level":"error","msg":"blockwatch.Watcher error encountered","myPeerID":"16Uiu2HAmHjhPfyyA7ci7pvAvBnCUUb6jQ8PjLDwX1yt92F8c5tae","time":"2019-12-20T03:47:55Z"}` ... can't connect to ganache?! other tests were running and hitting it just fine.  And i even have this super fancy command that i use to startup mesh in docker, that's specifically supposed to avoid this situation:  sh -c "waitForGanache () { until printf 'POST /\r\nContent-Length: 26\r\n\r\n{\"method\":\"net_listening\"}' | nc localhost 8545 | grep true; do continue; done }; waitForGanache && ./mesh".

@fabioberger was able to figure it out:
> it's a race condition
> In the latest version of Mesh, we now validate orders at the latest block known to the Mesh node.
> Before it always validated at the latest block known to Ganache
> So to fix, set BLOCK_POLLING_INTERVAL  to ~200ms, and sleep for ~400ms before posting the order to Mesh.
> This will give the Mesh node enough time to discover the latest block on Ganache, the one containing the balance/allowance txns

After I said I couldn't make the test sleep, because it's a documentation example, he suggested:
> you could set the polling interval to 50ms?
> Maybe give that a try...

But when I did that the mesh log said `{"error_string":"Given BLOCK_POLLING_INTERVAL (50ms), there are insufficient remaining ETH RPC requests in a 24hr period for Mesh to function properly. Increase ETHEREUM_RPC_MAX_REQUESTS_PER_24_HR_UTC to at least 1778000 (currently configured to: 200000)","level":"fatal","msg":"could not initialize app","myPeerID":"16Uiu2HAkuhE5XiCNxEr8Gn3rB5HRyyuRCjY6uURXX1EjpFbb8Zre","time":"2019-12-20T15:55:11Z"}`.  Following the instructions, I upped that RPC limit, and voila, tests passed!