### PR TITLE
Instant - Added should_remove_files_in_s3 flag in discharge configuration

### DIFF
--- a/packages/instant/.dogfood.discharge.json
+++ b/packages/instant/.dogfood.discharge.json
@@ -10,5 +10,5 @@
     "aws_region": "us-east-1",
     "cdn": false,
     "dns_configured": true,
-    "should_keep_files_in_s3": true 
+    "should_keep_files_in_s3": true
 }

--- a/packages/instant/.dogfood.discharge.json
+++ b/packages/instant/.dogfood.discharge.json
@@ -10,5 +10,5 @@
     "aws_region": "us-east-1",
     "cdn": false,
     "dns_configured": true,
-    "should_remove_files_in_s3": false
+    "should_keep_files_in_s3": true 
 }

--- a/packages/instant/.dogfood.discharge.json
+++ b/packages/instant/.dogfood.discharge.json
@@ -9,5 +9,6 @@
     "aws_profile": "0xproject",
     "aws_region": "us-east-1",
     "cdn": false,
-    "dns_configured": true
+    "dns_configured": true,
+    "should_remove_files_in_s3": false
 }

--- a/packages/instant/.production.discharge.json
+++ b/packages/instant/.production.discharge.json
@@ -10,5 +10,5 @@
     "aws_region": "us-east-1",
     "cdn": true,
     "dns_configured": true,
-    "should_remove_files_in_s3": false
+    "should_keep_files_in_s3": true
 }

--- a/packages/instant/.production.discharge.json
+++ b/packages/instant/.production.discharge.json
@@ -9,5 +9,6 @@
     "aws_profile": "0xproject",
     "aws_region": "us-east-1",
     "cdn": true,
-    "dns_configured": true
+    "dns_configured": true,
+    "should_remove_files_in_s3": false
 }

--- a/packages/instant/.staging.discharge.json
+++ b/packages/instant/.staging.discharge.json
@@ -9,5 +9,6 @@
     "aws_profile": "0xproject",
     "aws_region": "us-east-1",
     "cdn": false,
-    "dns_configured": true
+    "dns_configured": true,
+    "should_remove_files_in_s3": false
 }

--- a/packages/instant/.staging.discharge.json
+++ b/packages/instant/.staging.discharge.json
@@ -10,5 +10,5 @@
     "aws_region": "us-east-1",
     "cdn": false,
     "dns_configured": true,
-    "should_remove_files_in_s3": false
+    "should_keep_files_in_s3": true
 }


### PR DESCRIPTION
## Description

Adding in flag to keep v2.1 in s3 without a later upload of `umd/v3*` deleting the 2.1 build.

Related: https://github.com/0xProject/discharge/pull/1

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
