### PR TITLE
Pare down Mesh env vars in Py test env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,14 +197,10 @@ jobs:
             - image: 0xorg/mesh:0xV3
               environment:
                   ETHEREUM_RPC_URL: 'http://localhost:8545'
-                  ETHEREUM_NETWORK_ID: '50'
                   ETHEREUM_CHAIN_ID: '1337'
-                  USE_BOOTSTRAP_LIST: 'true'
-                  VERBOSITY: 3
-                  PRIVATE_KEY_PATH: ''
+                  VERBOSITY: 5
                   BLOCK_POLLING_INTERVAL: '50ms'
                   ETHEREUM_RPC_MAX_REQUESTS_PER_24_HR_UTC: '1778000'
-                  P2P_LISTEN_PORT: '60557'
               command: |
                   sh -c "waitForGanache () { until printf 'POST /\r\nContent-Length: 26\r\n\r\n{\"method\":\"net_listening\"}' | nc localhost 8545 | grep true; do continue; done }; waitForGanache && ./mesh"
             - image: 0xorg/launch-kit-backend:v3

--- a/python-packages/sra_client/test/relayer/docker-compose.yml
+++ b/python-packages/sra_client/test/relayer/docker-compose.yml
@@ -11,13 +11,9 @@ services:
             - ganache
         environment:
             ETHEREUM_RPC_URL: 'http://localhost:8545'
-            ETHEREUM_NETWORK_ID: '50'
             ETHEREUM_CHAIN_ID: '1337'
-            USE_BOOTSTRAP_LIST: 'true'
-            VERBOSITY: 3
-            PRIVATE_KEY_PATH: ''
+            VERBOSITY: 5
             BLOCK_POLLING_INTERVAL: '5s'
-            P2P_LISTEN_PORT: '60557'
         ports:
             - '60557:60557'
         network_mode: "host" # to connect to ganache


### PR DESCRIPTION
Remove unnecessary environment variables from the Mesh environment used by Python SRA client tests.