### PR TITLE
Fix 0xorg/ganache-cli docker image not supporting re-runs

### DIFF
--- a/packages/migrations/CHANGELOG.json
+++ b/packages/migrations/CHANGELOG.json
@@ -5,6 +5,10 @@
             {
                 "note": "Added DydxBridge Contract to ContractAddresses",
                 "pr": 2401
+            },
+            {
+                "note": "Changed docker image command to overwrite any existing snapshot when unzipping the image downloaded from S3.",
+                "pr": 2420
             }
         ]
     },

--- a/packages/migrations/Dockerfile
+++ b/packages/migrations/Dockerfile
@@ -11,5 +11,5 @@ ENV SNAPSHOT_HOST "http://ganache-snapshots.0x.org.s3-website.us-east-2.amazonaw
 ENV SNAPSHOT_NAME "0x_ganache_snapshot"
 EXPOSE 8545
 
-CMD [ "sh", "-c", "echo downloading snapshot version: $VERSION; wget $SNAPSHOT_HOST/$SNAPSHOT_NAME-$VERSION.zip -O snapshot.zip && unzip snapshot.zip && ganache-cli --gasLimit 10000000 --db $SNAPSHOT_NAME --noVMErrorsOnRPCResponse -p 8545 --keepAliveTimeout=40000 --networkId \"$NETWORK_ID\" -m \"$MNEMONIC\" -h 0.0.0.0"]
+CMD [ "sh", "-c", "echo downloading snapshot version: $VERSION; wget $SNAPSHOT_HOST/$SNAPSHOT_NAME-$VERSION.zip -O snapshot.zip && unzip -o snapshot.zip && ganache-cli --gasLimit 10000000 --db $SNAPSHOT_NAME --noVMErrorsOnRPCResponse -p 8545 --keepAliveTimeout=40000 --networkId \"$NETWORK_ID\" -m \"$MNEMONIC\" -h 0.0.0.0"]
 

--- a/packages/migrations/Dockerfile
+++ b/packages/migrations/Dockerfile
@@ -11,5 +11,5 @@ ENV SNAPSHOT_HOST "http://ganache-snapshots.0x.org.s3-website.us-east-2.amazonaw
 ENV SNAPSHOT_NAME "0x_ganache_snapshot"
 EXPOSE 8545
 
-CMD [ "sh", "-c", "echo downloading snapshot version: $VERSION; wget $SNAPSHOT_HOST/$SNAPSHOT_NAME-$VERSION.zip -O snapshot.zip && unzip -o snapshot.zip && ganache-cli --gasLimit 10000000 --db $SNAPSHOT_NAME --noVMErrorsOnRPCResponse -p 8545 --keepAliveTimeout=40000 --networkId \"$NETWORK_ID\" -m \"$MNEMONIC\" -h 0.0.0.0"]
+CMD [ "sh", "-c", "echo downloading snapshot version: $VERSION; wget --timestamping $SNAPSHOT_HOST/$SNAPSHOT_NAME-$VERSION.zip -O snapshot.zip && unzip -o snapshot.zip && ganache-cli --gasLimit 10000000 --db $SNAPSHOT_NAME --noVMErrorsOnRPCResponse -p 8545 --keepAliveTimeout=40000 --networkId \"$NETWORK_ID\" -m \"$MNEMONIC\" -h 0.0.0.0"]
 


### PR DESCRIPTION
## Description

In using `0xorg/ganache-cli` for Neptune, we have a docker-compose file that includes an image for the `maker_keeper` service, which is dependent on another image for `ganache-cli`.  In attempting to re-run the `maker_keeper` image, docker-compose was bringing up the existing `ganache-cli` container, and hitting a prompt like:

```
Archive:  snapshot.zip
replace 0x_ganache_snapshot/!trie_db!0xdcd9cdbeca6483199e490e6fd0f1faf52bc1470d6e045421f0e86461b4c84578? [y]es, [n]o, [A]ll, [N]one, [r]ename: downloading snapshot version: 5.0.0
```

This was precluding us from re-running `maker_keeper` tests.

With this change, restarting an existing container will not hang on the prompt shown above, and will start up fully.

## Testing instructions

```bash
$ docker run -d -p 8545:8545 --name ganache 0xorg/ganache-cli
$ docker stop ganache
$ docker start ganache
```

If you execute the above commands with a docker image tag for an existing version of the image, you'll find that the final `start` command will not leave the container running, and if you look at `docker logs ganache` you'll see that `rename?` prompt at the end.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Add new entries to the relevant CHANGELOG.jsons.
