### PR TITLE
Add more token support for instant v3 with bridge orders

### DIFF
--- a/packages/instant/src/data/asset_data_network_mapping.ts
+++ b/packages/instant/src/data/asset_data_network_mapping.ts
@@ -65,7 +65,6 @@ export const assetDataNetworkMapping: AssetDataByNetwork[] = [
     },
     // USDC
     {
-        [Network.Kovan]: '',
         [Network.Mainnet]: '0xf47261b0000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
     },
 ];

--- a/packages/instant/src/redux/async_data.ts
+++ b/packages/instant/src/redux/async_data.ts
@@ -35,7 +35,20 @@ export const asyncData = {
             const wethAssetData = await swapQuoter.getEtherTokenAssetDataOrThrowAsync();
             const assetDatas = await swapQuoter.getAvailableMakerAssetDatasAsync(wethAssetData);
             const deduplicatedAssetDatas = _.uniq(assetDatas);
-            const assets = assetUtils.createAssetsFromAssetDatas(deduplicatedAssetDatas, assetMetaDataMap, network);
+            const assetsWithNativeOrders = assetUtils.createAssetsFromAssetDatas(
+                deduplicatedAssetDatas,
+                assetMetaDataMap,
+                network,
+            );
+            const assetsWithOnlyBridgeOrders = await assetUtils.createAssetsFromAssetMetadataMapsAvailableWithBridgeOrdersAsync(
+                swapQuoter,
+                assetMetaDataMap,
+                network,
+            );
+            const assets = _.uniqBy(
+                _.concat(assetsWithNativeOrders, assetsWithOnlyBridgeOrders),
+                asset => asset.assetData,
+            );
             dispatch(actions.setAvailableAssets(assets));
         } catch (e) {
             const errorMessage = 'Could not find any assets';

--- a/packages/instant/src/util/swap_quoter_utils.ts
+++ b/packages/instant/src/util/swap_quoter_utils.ts
@@ -1,0 +1,35 @@
+import { ERC20BridgeSource, SwapQuoter } from '@0x/asset-swapper';
+import { AssetProxyId } from '@0x/types';
+import { BigNumber } from '@0x/utils';
+import { Web3Wrapper } from '@0x/web3-wrapper';
+
+import { DEFAULT_GAS_PRICE } from '../constants';
+import { Asset } from '../types';
+
+// TODO(dave4506) rather arbitrarily chosen
+const ASSET_UNIT_TEST_AMOUNT = new BigNumber(100);
+
+export const swapQuoterUtils = {
+    isAssetLiquiditySupportedWithBridgeOrdersAsync: async (swapQuoter: SwapQuoter, asset: Asset): Promise<boolean> => {
+        const baseUnitValue =
+            asset.metaData.assetProxyId === AssetProxyId.ERC20
+                ? Web3Wrapper.toBaseUnitAmount(ASSET_UNIT_TEST_AMOUNT, asset.metaData.decimals)
+                : ASSET_UNIT_TEST_AMOUNT;
+
+        const wethAssetData = await swapQuoter.getEtherTokenAssetDataOrThrowAsync();
+        try {
+            const quote = await swapQuoter.getMarketBuySwapQuoteForAssetDataAsync(
+                asset.assetData,
+                wethAssetData,
+                baseUnitValue,
+                {
+                    gasPrice: DEFAULT_GAS_PRICE,
+                    excludedSources: [ERC20BridgeSource.Native],
+                },
+            );
+            return Promise.resolve(quote.orders.length !== 0);
+        } catch (error) {
+            return Promise.resolve(false);
+        }
+    },
+};


### PR DESCRIPTION
## Description

A Proof of Concept to reenable aggregator liquidity into instant. Problem is how we check if there is `bridge order` liquidity is rather *stupid*. (not performant).

Moving forward the best two paths may be:
- simply assume liquidity is there and don't check
- leverage a 0x api call that checks the bridge order liquidity on our behalf. 

But nice to see instant bridge orders works.

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
