### PR TITLE
Fix extra space in `provider.send` signature from fabio. Fixes #2285.

### DIFF
--- a/packages/utils/CHANGELOG.json
+++ b/packages/utils/CHANGELOG.json
@@ -1,5 +1,15 @@
 [
     {
+        "timestamp": 1578468911,
+        "version": "5.1.3",
+        "changes": [
+            {
+                "note": "Fix extra space in `provider.send` signature",
+                "pr": 2428
+            }
+        ]
+    },
+    {
         "timestamp": 1578272714,
         "version": "5.1.2",
         "changes": [

--- a/packages/utils/CHANGELOG.json
+++ b/packages/utils/CHANGELOG.json
@@ -1,6 +1,5 @@
 [
     {
-        "timestamp": 1578468911,
         "version": "5.1.3",
         "changes": [
             {

--- a/packages/utils/src/provider_utils.ts
+++ b/packages/utils/src/provider_utils.ts
@@ -74,7 +74,7 @@ export const providerUtils = {
         } else if ((supportedProvider as any).send !== undefined) {
             // HACK(fabio): Detect if the `send` method has the old interface `send(payload, cb)` such
             // as in versions < Web3.js@1.0.0-beta.37. If so, do a simple re-mapping
-            if (_.includes((supportedProvider as any).send.toString(), 'function (payload, callback)')) {
+            if (_.includes((supportedProvider as any).send.toString().replace(" ", ""), 'function(payload,callback)')) {
                 provider.sendAsync = (supportedProvider as any).send.bind(supportedProvider);
                 return provider;
             } else {

--- a/packages/utils/src/provider_utils.ts
+++ b/packages/utils/src/provider_utils.ts
@@ -74,7 +74,7 @@ export const providerUtils = {
         } else if ((supportedProvider as any).send !== undefined) {
             // HACK(fabio): Detect if the `send` method has the old interface `send(payload, cb)` such
             // as in versions < Web3.js@1.0.0-beta.37. If so, do a simple re-mapping
-            if (_.includes((supportedProvider as any).send.toString().replace(" ", ""), 'function(payload,callback)')) {
+            if (_.includes((supportedProvider as any).send.toString().replace(' ', ''), 'function(payload,callback)')) {
                 provider.sendAsync = (supportedProvider as any).send.bind(supportedProvider);
                 return provider;
             } else {


### PR DESCRIPTION
## Description

The bug is explained in https://github.com/0xProject/0x-monorepo/issues/2285

I'm also affected and this PR is implementing my proposed fix - remove spaces from function signature to guarantee the match. There could be better fix for this "hack", but I'm just ensuring that the bug don't affect my workflow anymore.

## Types of changes

* Bug fix (non-breaking change which fixes an issue)
