### PR TITLE
chore: add package.json to suppress warning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 jobs:
     build:
-        resource_class: medium+
+        resource_class: medium
         docker:
             - image: nikolaik/python-nodejs:python3.7-nodejs8
         environment:

--- a/packages/devnet/CHANGELOG.json
+++ b/packages/devnet/CHANGELOG.json
@@ -1,0 +1,9 @@
+{
+    "version": "1.0.0",
+    "changes": [
+        {
+            "note": "Added package.json to suppress warnings.",
+            "PR": 2429
+        }
+    ]
+}

--- a/packages/devnet/package.json
+++ b/packages/devnet/package.json
@@ -1,0 +1,5 @@
+{
+    "private": true,
+    "comment": "Used to suppress yarn build warnings",
+    "name": "devnet"
+}

--- a/packages/verdaccio/CHANGELOG.json
+++ b/packages/verdaccio/CHANGELOG.json
@@ -1,0 +1,9 @@
+{
+    "version": "1.0.0",
+    "changes": [
+        {
+            "note": "Added package.json to suppress warnings.",
+            "PR": 2429
+        }
+    ]
+}

--- a/packages/verdaccio/package.json
+++ b/packages/verdaccio/package.json
@@ -1,0 +1,5 @@
+{
+    "private": true,
+    "comment": "Used to suppress yarn build warnings",
+    "name": "verdaccio"
+}


### PR DESCRIPTION
## Description

Yarn build gets warnings from devnet and verdaccio directories about lack of .json on a mac.

## Testing instructions

yarn build

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

* Added 2 package.json to suppress yarn warnings 

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ x] Prefix PR title with `[WIP]` if necessary.
-   [x ] Add new entries to the relevant CHANGELOG.jsons.
