### PR TITLE
`@0x/contracts-integrations`: Negative assertions for fuzzing

### DIFF
--- a/contracts/integrations/CHANGELOG.json
+++ b/contracts/integrations/CHANGELOG.json
@@ -9,6 +9,10 @@
             {
                 "note": "Fuzz tests for `matchOrders` and `matchOrdersWithMaximalFill`.",
                 "pr": 2437
+            },
+            {
+                "note": "Add various negative assertions for fuzz tests",
+                "pr": 2431
             }
         ]
     },

--- a/contracts/integrations/test/framework/actors/pool_operator.ts
+++ b/contracts/integrations/test/framework/actors/pool_operator.ts
@@ -92,7 +92,7 @@ export function PoolOperatorMixin<TBase extends Constructor>(Base: TBase): TBase
                 const operatorShare = Pseudorandom.integer(
                     0,
                     stakingConstants.PPM,
-                    Distributions.Kumaraswamy(0.2, 0.2),
+                    Distributions.Kumaraswamy(),
                 ).toNumber();
                 yield assertion.executeAsync([operatorShare, false], { from: this.actor.address });
             }
@@ -104,7 +104,7 @@ export function PoolOperatorMixin<TBase extends Constructor>(Base: TBase): TBase
                 const operatorShare = Pseudorandom.integer(
                     (stakingConstants.PPM as number) + 1,
                     constants.MAX_UINT32,
-                    Distributions.Kumaraswamy(0.2, 0.2),
+                    Distributions.Kumaraswamy(),
                 ).toNumber();
                 yield assertion.executeAsync([operatorShare, false], { from: this.actor.address });
             }
@@ -121,7 +121,7 @@ export function PoolOperatorMixin<TBase extends Constructor>(Base: TBase): TBase
                     const operatorShare = Pseudorandom.integer(
                         0,
                         stakingPools[poolId].operatorShare,
-                        Distributions.Kumaraswamy(0.2, 0.2),
+                        Distributions.Kumaraswamy(),
                     ).toNumber();
                     yield assertion.executeAsync([poolId, operatorShare], { from: this.actor.address });
                 }
@@ -139,7 +139,7 @@ export function PoolOperatorMixin<TBase extends Constructor>(Base: TBase): TBase
                     const operatorShare = Pseudorandom.integer(
                         (stakingPools[poolId].operatorShare as number) + 1,
                         constants.MAX_UINT32,
-                        Distributions.Kumaraswamy(0.2, 0.2),
+                        Distributions.Kumaraswamy(),
                     ).toNumber();
                     yield assertion.executeAsync([poolId, operatorShare], { from: this.actor.address });
                 }

--- a/contracts/integrations/test/framework/actors/pool_operator.ts
+++ b/contracts/integrations/test/framework/actors/pool_operator.ts
@@ -102,7 +102,7 @@ export function PoolOperatorMixin<TBase extends Constructor>(Base: TBase): TBase
             const assertion = invalidCreateStakingPoolAssertion(this.actor.deployment);
             while (true) {
                 const operatorShare = Pseudorandom.integer(
-                    stakingConstants.PPM + 1,
+                    (stakingConstants.PPM as number) + 1,
                     constants.MAX_UINT32,
                     Distributions.Kumaraswamy(0.2, 0.2),
                 ).toNumber();
@@ -137,7 +137,7 @@ export function PoolOperatorMixin<TBase extends Constructor>(Base: TBase): TBase
                     yield undefined;
                 } else {
                     const operatorShare = Pseudorandom.integer(
-                        stakingPools[poolId].operatorShare + 1,
+                        (stakingPools[poolId].operatorShare as number) + 1,
                         constants.MAX_UINT32,
                         Distributions.Kumaraswamy(0.2, 0.2),
                     ).toNumber();

--- a/contracts/integrations/test/framework/assertions/createStakingPool.ts
+++ b/contracts/integrations/test/framework/assertions/createStakingPool.ts
@@ -1,6 +1,6 @@
 import { StakingRevertErrors, StoredBalance } from '@0x/contracts-staking';
 import { expect } from '@0x/contracts-test-utils';
-import { BigNumber } from '@0x/utils';
+import { BigNumber, hexUtils } from '@0x/utils';
 import { TxData } from 'ethereum-types';
 
 import { DeploymentManager } from '../deployment_manager';
@@ -26,10 +26,7 @@ export function validCreateStakingPoolAssertion(
         before: async () => {
             const lastPoolId = await stakingWrapper.lastPoolId().callAsync();
             // Effectively the last poolId + 1, but as a bytestring
-            return `0x${new BigNumber(lastPoolId)
-                .plus(1)
-                .toString(16)
-                .padStart(64, '0')}`;
+            return hexUtils.leftPad(new BigNumber(lastPoolId).plus(1));
         },
         after: async (
             expectedPoolId: string,
@@ -73,10 +70,7 @@ export function invalidCreateStakingPoolAssertion(
         before: async () => {
             const lastPoolId = await stakingWrapper.lastPoolId().callAsync();
             // Effectively the last poolId + 1, but as a bytestring
-            return `0x${new BigNumber(lastPoolId)
-                .plus(1)
-                .toString(16)
-                .padStart(64, '0')}`;
+            return hexUtils.leftPad(new BigNumber(lastPoolId).plus(1));
         },
         after: async (expectedPoolId: string, result: FunctionResult, args: [number, boolean]) => {
             // Ensure that the tx reverted.

--- a/contracts/integrations/test/framework/assertions/createStakingPool.ts
+++ b/contracts/integrations/test/framework/assertions/createStakingPool.ts
@@ -1,4 +1,4 @@
-import { StoredBalance } from '@0x/contracts-staking';
+import { StakingRevertErrors, StoredBalance } from '@0x/contracts-staking';
 import { expect } from '@0x/contracts-test-utils';
 import { BigNumber } from '@0x/utils';
 import { TxData } from 'ethereum-types';
@@ -22,7 +22,7 @@ export function validCreateStakingPoolAssertion(
     const { stakingWrapper } = deployment.staking;
 
     return new FunctionAssertion<[number, boolean], string, string>(stakingWrapper, 'createStakingPool', {
-        // Returns the expected ID of th created pool
+        // Returns the expected ID of the created pool
         before: async () => {
             const lastPoolId = await stakingWrapper.lastPoolId().callAsync();
             // Effectively the last poolId + 1, but as a bytestring
@@ -54,6 +54,43 @@ export function validCreateStakingPoolAssertion(
                 delegatedStake: new StoredBalance(),
                 lastFinalized: simulationEnvironment.currentEpoch,
             };
+        },
+    });
+}
+
+/**
+ * Returns a FunctionAssertion for `createStakingPool` which assumes an invalid operator share (i.e.
+ * greater than 1,000,000) is provided. The FunctionAssertion checks that the transaction reverts
+ * with the expected OperatorShareError.
+ */
+export function invalidCreateStakingPoolAssertion(
+    deployment: DeploymentManager,
+): FunctionAssertion<[number, boolean], string, string> {
+    const { stakingWrapper } = deployment.staking;
+
+    return new FunctionAssertion<[number, boolean], string, string>(stakingWrapper, 'createStakingPool', {
+        // Returns the poolId we are expecting to revert with
+        before: async () => {
+            const lastPoolId = await stakingWrapper.lastPoolId().callAsync();
+            // Effectively the last poolId + 1, but as a bytestring
+            return `0x${new BigNumber(lastPoolId)
+                .plus(1)
+                .toString(16)
+                .padStart(64, '0')}`;
+        },
+        after: async (expectedPoolId: string, result: FunctionResult, args: [number, boolean]) => {
+            // Ensure that the tx reverted.
+            expect(result.success).to.be.false();
+
+            // Check revert error
+            const [operatorShare] = args;
+            expect(result.data).to.equal(
+                new StakingRevertErrors.OperatorShareError(
+                    StakingRevertErrors.OperatorShareErrorCodes.OperatorShareTooLarge,
+                    expectedPoolId,
+                    operatorShare,
+                ),
+            );
         },
     });
 }

--- a/contracts/integrations/test/framework/assertions/decreaseStakingPoolOperatorShare.ts
+++ b/contracts/integrations/test/framework/assertions/decreaseStakingPoolOperatorShare.ts
@@ -1,4 +1,4 @@
-import { StakingPoolById } from '@0x/contracts-staking';
+import { constants, StakingPoolById, StakingRevertErrors } from '@0x/contracts-staking';
 import { expect } from '@0x/contracts-test-utils';
 import { TxData } from 'ethereum-types';
 
@@ -29,6 +29,40 @@ export function validDecreaseStakingPoolOperatorShareAssertion(
 
             // Updates the pool in local state.
             pools[poolId].operatorShare = operatorShare;
+        },
+    });
+}
+
+/**
+ * Returns a FunctionAssertion for `decreaseStakingPoolOperatorShare` which assumes the given
+ * operator share is larger than the current operator share for the pool. The FunctionAssertion
+ * checks that the transaction reverts with the correct error in this scenario.
+ */
+export function invalidDecreaseStakingPoolOperatorShareAssertion(
+    deployment: DeploymentManager,
+): FunctionAssertion<[string, number], void, void> {
+    const { stakingWrapper } = deployment.staking;
+
+    return new FunctionAssertion<[string, number], void, void>(stakingWrapper, 'decreaseStakingPoolOperatorShare', {
+        after: async (_beforeInfo: void, result: FunctionResult, args: [string, number], _txData: Partial<TxData>) => {
+            // Ensure that the tx reverted.
+            expect(result.success).to.be.false();
+
+            // Check revert error
+            const [poolId, operatorShare] = args;
+            const expectedError =
+                operatorShare > constants.PPM
+                    ? new StakingRevertErrors.OperatorShareError(
+                          StakingRevertErrors.OperatorShareErrorCodes.OperatorShareTooLarge,
+                          poolId,
+                          operatorShare,
+                      )
+                    : new StakingRevertErrors.OperatorShareError(
+                          StakingRevertErrors.OperatorShareErrorCodes.CanOnlyDecreaseOperatorShare,
+                          poolId,
+                          operatorShare,
+                      );
+            expect(result.data).to.equal(expectedError);
         },
     });
 }

--- a/contracts/integrations/test/framework/assertions/finalizePool.ts
+++ b/contracts/integrations/test/framework/assertions/finalizePool.ts
@@ -166,20 +166,24 @@ export function validFinalizePoolAssertion(
             // Check that pool rewards have increased.
             const poolRewards = await stakingWrapper.rewardsByPoolId(poolId).callAsync();
             expect(poolRewards).to.bignumber.equal(beforeInfo.poolRewards.plus(membersReward));
-            // Check that cumulative rewards have increased.
-            const [
-                mostRecentCumulativeRewards,
-                cumulativeRewardsLastStored,
-            ] = await stakingWrapper.getMostRecentCumulativeReward(poolId).callAsync();
-            expect(cumulativeRewardsLastStored).to.bignumber.equal(currentEpoch);
-            let [numerator, denominator] = ReferenceFunctions.LibFractions.add(
-                beforeInfo.mostRecentCumulativeRewards.numerator,
-                beforeInfo.mostRecentCumulativeRewards.denominator,
-                membersReward,
-                beforeInfo.poolStats.membersStake,
-            );
-            [numerator, denominator] = ReferenceFunctions.LibFractions.normalize(numerator, denominator);
-            expect(mostRecentCumulativeRewards).to.deep.equal({ numerator, denominator });
+
+            if (membersReward.isGreaterThan(0)) {
+                // Check that cumulative rewards have increased.
+                const [
+                    mostRecentCumulativeRewards,
+                    cumulativeRewardsLastStored,
+                ] = await stakingWrapper.getMostRecentCumulativeReward(poolId).callAsync();
+                expect(cumulativeRewardsLastStored).to.bignumber.equal(currentEpoch);
+
+                let [numerator, denominator] = ReferenceFunctions.LibFractions.add(
+                    beforeInfo.mostRecentCumulativeRewards.numerator,
+                    beforeInfo.mostRecentCumulativeRewards.denominator,
+                    membersReward,
+                    beforeInfo.poolStats.membersStake,
+                );
+                [numerator, denominator] = ReferenceFunctions.LibFractions.normalize(numerator, denominator);
+                expect(mostRecentCumulativeRewards).to.deep.equal({ numerator, denominator });
+            }
 
             // Check that aggregated stats have been updated
             const aggregatedStats = AggregatedStats.fromArray(

--- a/contracts/integrations/test/framework/assertions/generic_assertions.ts
+++ b/contracts/integrations/test/framework/assertions/generic_assertions.ts
@@ -1,0 +1,24 @@
+import { BaseContract } from '@0x/base-contract';
+import { expect } from '@0x/contracts-test-utils';
+import { RevertReason } from '@0x/types';
+import { StringRevertError } from '@0x/utils';
+
+import { FunctionAssertion, FunctionResult } from './function_assertion';
+
+/**
+ * Returns a generic FunctionAssertion for the given contract function, asserting that the
+ * function call reverts in an asset proxy contract with TRANSFER_FAILED.
+ */
+export function assetProxyTransferFailedAssertion<TArgs extends any[]>(
+    contract: BaseContract,
+    functionName: string,
+): FunctionAssertion<TArgs, void, void> {
+    return new FunctionAssertion(contract, functionName, {
+        after: async (_beforeInfo: void, result: FunctionResult) => {
+            // Ensure that the tx reverted.
+            expect(result.success).to.be.false();
+            // Check revert error
+            expect(result.data).to.equal(new StringRevertError(RevertReason.TransferFailed));
+        },
+    });
+}

--- a/contracts/integrations/test/framework/assertions/moveStake.ts
+++ b/contracts/integrations/test/framework/assertions/moveStake.ts
@@ -9,7 +9,6 @@ import {
     StoredBalance,
 } from '@0x/contracts-staking';
 import { expect } from '@0x/contracts-test-utils';
-import { SafeMathRevertErrors } from '@0x/contracts-utils';
 import { BigNumber } from '@0x/utils';
 import { TxData } from 'ethereum-types';
 import * as _ from 'lodash';
@@ -217,33 +216,6 @@ export function moveStakeNonexistentPoolAssertion(
 
                 // Check revert error
                 expect(result.data).to.equal(new StakingRevertErrors.PoolExistenceError(nonExistentPoolId, false));
-            },
-        },
-    );
-}
-
-/**
- * Returns a FunctionAssertion for `moveStake` which assumes the input amount exceeds the moveable
- * amount of stake. Checks that the transaction reverts.
- */
-export function moveStakeInvalidAmountAssertion(
-    deployment: DeploymentManager,
-): FunctionAssertion<[StakeInfo, StakeInfo, BigNumber], void, void> {
-    return new FunctionAssertion<[StakeInfo, StakeInfo, BigNumber], void, void>(
-        deployment.staking.stakingWrapper,
-        'moveStake',
-        {
-            after: async (_beforeInfo: void, result: FunctionResult) => {
-                // Ensure that the tx reverted.
-                expect(result.success).to.be.false();
-
-                // This isn't ideal but unfortunately there are several different revert errors that
-                // can be triggered by trying to move more stake than possible.
-                expect(
-                    result.data instanceof SafeMathRevertErrors.Uint256BinOpError ||
-                        result.data instanceof SafeMathRevertErrors.Uint256DowncastError ||
-                        result.data instanceof StakingRevertErrors.InsufficientBalanceError,
-                ).to.be.true();
             },
         },
     );

--- a/contracts/integrations/test/fuzz_tests/pool_management_test.ts
+++ b/contracts/integrations/test/fuzz_tests/pool_management_test.ts
@@ -20,8 +20,10 @@ export class PoolManagementSimulation extends Simulation {
             ...operators.map(operator => [operator.simulationActions.validCreateStakingPool, 0.38]),
             // 2% chance of executing invalidCreateStakingPool assertion for a random operator
             ...operators.map(operator => [operator.simulationActions.invalidCreateStakingPool, 0.02]),
-            // 60% chance of executing validDecreaseStakingPoolOperatorShare for a random operator
-            ...operators.map(operator => [operator.simulationActions.validDecreaseStakingPoolOperatorShare, 0.6]),
+            // 58% chance of executing validDecreaseStakingPoolOperatorShare for a random operator
+            ...operators.map(operator => [operator.simulationActions.validDecreaseStakingPoolOperatorShare, 0.58]),
+            // 2% chance of executing invalidDecreaseStakingPoolOperatorShare for a random operator
+            ...operators.map(operator => [operator.simulationActions.invalidDecreaseStakingPoolOperatorShare, 0.02]),
         ]) as [Array<AsyncIterableIterator<AssertionResult | void>>, number[]];
         while (true) {
             const action = Pseudorandom.sample(actions, weights);

--- a/contracts/integrations/test/fuzz_tests/pool_management_test.ts
+++ b/contracts/integrations/test/fuzz_tests/pool_management_test.ts
@@ -16,8 +16,10 @@ export class PoolManagementSimulation extends Simulation {
         const operators = filterActorsByRole(actors, PoolOperator);
 
         const [actions, weights] = _.unzip([
-            // 40% chance of executing validCreateStakingPool assertion for a random operator
-            ...operators.map(operator => [operator.simulationActions.validCreateStakingPool, 0.4]),
+            // 38% chance of executing validCreateStakingPool assertion for a random operator
+            ...operators.map(operator => [operator.simulationActions.validCreateStakingPool, 0.38]),
+            // 2% chance of executing invalidCreateStakingPool assertion for a random operator
+            ...operators.map(operator => [operator.simulationActions.invalidCreateStakingPool, 0.02]),
             // 60% chance of executing validDecreaseStakingPoolOperatorShare for a random operator
             ...operators.map(operator => [operator.simulationActions.validDecreaseStakingPoolOperatorShare, 0.6]),
         ]) as [Array<AsyncIterableIterator<AssertionResult | void>>, number[]];

--- a/contracts/integrations/test/fuzz_tests/stake_management_test.ts
+++ b/contracts/integrations/test/fuzz_tests/stake_management_test.ts
@@ -30,12 +30,10 @@ export class StakeManagementSimulation extends Simulation {
             ...stakers.map(staker => [staker.simulationActions.validStake, 0.28 / stakers.length]),
             // 2% chance of executing invalidUnstake for a random staker
             ...stakers.map(staker => [staker.simulationActions.validUnstake, 0.02 / stakers.length]),
-            // 26% chance of executing validMoveStake for a random staker
-            ...stakers.map(staker => [staker.simulationActions.validMoveStake, 0.26 / stakers.length]),
+            // 28% chance of executing validMoveStake for a random staker
+            ...stakers.map(staker => [staker.simulationActions.validMoveStake, 0.28 / stakers.length]),
             // 2% chance of executing moveStakeNonexistentPool for a random staker
             ...stakers.map(staker => [staker.simulationActions.moveStakeNonexistentPool, 0.02 / stakers.length]),
-            // 2% chance of executing moveStakeInvalidAmount for a random staker
-            ...stakers.map(staker => [staker.simulationActions.moveStakeInvalidAmount, 0.02 / stakers.length]),
             // 20% chance of executing an assertion generated from the pool management simulation
             [poolManagement.generator, 0.2],
         ]) as [Array<AsyncIterableIterator<AssertionResult | void>>, number[]];

--- a/contracts/integrations/test/fuzz_tests/stake_management_test.ts
+++ b/contracts/integrations/test/fuzz_tests/stake_management_test.ts
@@ -22,12 +22,20 @@ export class StakeManagementSimulation extends Simulation {
         const poolManagement = new PoolManagementSimulation(this.environment);
 
         const [actions, weights] = _.unzip([
-            // 30% chance of executing validStake for a random staker
-            ...stakers.map(staker => [staker.simulationActions.validStake, 0.3 / stakers.length]),
-            // 20% chance of executing validUnstake for a random staker
-            ...stakers.map(staker => [staker.simulationActions.validUnstake, 0.2 / stakers.length]),
-            // 30% chance of executing validMoveStake for a random staker
-            ...stakers.map(staker => [staker.simulationActions.validMoveStake, 0.3 / stakers.length]),
+            // 28% chance of executing validStake for a random staker
+            ...stakers.map(staker => [staker.simulationActions.validStake, 0.28 / stakers.length]),
+            // 2% chance of executing invalidUnstake for a random staker
+            ...stakers.map(staker => [staker.simulationActions.invalidStake, 0.02 / stakers.length]),
+            // 28% chance of executing validUnstake for a random staker
+            ...stakers.map(staker => [staker.simulationActions.validStake, 0.28 / stakers.length]),
+            // 2% chance of executing invalidUnstake for a random staker
+            ...stakers.map(staker => [staker.simulationActions.validUnstake, 0.02 / stakers.length]),
+            // 26% chance of executing validMoveStake for a random staker
+            ...stakers.map(staker => [staker.simulationActions.validMoveStake, 0.26 / stakers.length]),
+            // 2% chance of executing moveStakeNonexistentPool for a random staker
+            ...stakers.map(staker => [staker.simulationActions.moveStakeNonexistentPool, 0.02 / stakers.length]),
+            // 2% chance of executing moveStakeInvalidAmount for a random staker
+            ...stakers.map(staker => [staker.simulationActions.moveStakeInvalidAmount, 0.02 / stakers.length]),
             // 20% chance of executing an assertion generated from the pool management simulation
             [poolManagement.generator, 0.2],
         ]) as [Array<AsyncIterableIterator<AssertionResult | void>>, number[]];

--- a/contracts/integrations/test/fuzz_tests/staking_rewards_test.ts
+++ b/contracts/integrations/test/fuzz_tests/staking_rewards_test.ts
@@ -38,8 +38,10 @@ export class StakingRewardsSimulation extends Simulation {
             ...stakers.map(staker => [staker.simulationActions.validWithdrawDelegatorRewards, 0.1 / stakers.length]),
             // 10% chance of executing validFinalizePool for a random keeper
             ...keepers.map(keeper => [keeper.simulationActions.validFinalizePool, 0.1 / keepers.length]),
-            // 10% chance of executing validEndEpoch for a random keeper
-            ...keepers.map(keeper => [keeper.simulationActions.validEndEpoch, 0.1 / keepers.length]),
+            // 7% chance of executing validEndEpoch for a random keeper
+            ...keepers.map(keeper => [keeper.simulationActions.validEndEpoch, 0.07 / keepers.length]),
+            // 3% chance of executing invalidEndEpoch for a random keeper
+            ...keepers.map(keeper => [keeper.simulationActions.invalidEndEpoch, 0.03 / keepers.length]),
             // 50% chance of executing an assertion generated from the pool membership simulation
             [poolMembership.generator, 0.5],
             // 20% chance of executing an assertion generated from the stake management simulation

--- a/contracts/test-utils/src/constants.ts
+++ b/contracts/test-utils/src/constants.ts
@@ -60,6 +60,7 @@ export const constants = {
     NULL_BYTES32: '0x0000000000000000000000000000000000000000000000000000000000000000',
     UNLIMITED_ALLOWANCE_IN_BASE_UNITS: MAX_UINT256,
     MAX_UINT256,
+    MAX_UINT32: new BigNumber(2).pow(32).minus(1),
     TESTRPC_PRIVATE_KEYS: _.map(TESTRPC_PRIVATE_KEYS_STRINGS, privateKeyString => ethUtil.toBuffer(privateKeyString)),
     INITIAL_ERC20_BALANCE: Web3Wrapper.toBaseUnitAmount(new BigNumber(10000), 18),
     INITIAL_ERC20_ALLOWANCE: Web3Wrapper.toBaseUnitAmount(new BigNumber(10000), 18),


### PR DESCRIPTION
## Description
Adds "negative assertions" for `endEpoch`, `createStakingPool`, `decreaseStakingPoolOperatorShare`, `stake`, `unstake`, `moveStake`, and `withdrawDelegatorRewards` –– i.e. `FunctionAssertion`s that check revert conditions. 
Adds these new assertions to the fuzz tests, giving them lower weight than their valid counterparts. 

One notable omission is `fillOrder` –– imo it's already very thoroughly tested, and there are so many different ways it can revert that it's not as valuable to add negative assertions for. `fillOrder` is mostly important for the fuzz tests insofar as it generates protocol fees. 

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
