### PR TITLE
Fuzz order matching

### DIFF
--- a/contracts/exchange-libs/CHANGELOG.json
+++ b/contracts/exchange-libs/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "4.1.0",
+        "changes": [
+            {
+                "note": "Reference functions for `matchOrders` and `matchOrdersWithMaximalFill`.",
+                "pr": 2437
+            }
+        ]
+    },
+    {
         "timestamp": 1578272714,
         "version": "4.0.3",
         "changes": [

--- a/contracts/exchange-libs/package.json
+++ b/contracts/exchange-libs/package.json
@@ -54,7 +54,6 @@
     "devDependencies": {
         "@0x/abi-gen": "^5.0.3",
         "@0x/contracts-gen": "^2.0.3",
-        "@0x/contracts-test-utils": "^5.1.0",
         "@0x/dev-utils": "^3.1.0",
         "@0x/sol-compiler": "^4.0.3",
         "@0x/subproviders": "^6.0.3",
@@ -82,6 +81,7 @@
     },
     "dependencies": {
         "@0x/base-contract": "^6.0.3",
+        "@0x/contracts-test-utils": "^5.1.0",
         "@0x/contracts-utils": "^4.0.3",
         "@0x/order-utils": "^10.1.0",
         "@0x/types": "^3.1.1",

--- a/contracts/integrations/CHANGELOG.json
+++ b/contracts/integrations/CHANGELOG.json
@@ -5,6 +5,10 @@
             {
                 "note": "Add mainnet contract wrapper `callAsync()` revert behavior tests.",
                 "pr": 2433
+            },
+            {
+                "note": "Fuzz tests for `matchOrders` and `matchOrdersWithMaximalFill`.",
+                "pr": 2437
             }
         ]
     },

--- a/contracts/integrations/test/framework/actors/maker.ts
+++ b/contracts/integrations/test/framework/actors/maker.ts
@@ -99,7 +99,7 @@ export function MakerMixin<TBase extends Constructor>(Base: TBase): TBase & Cons
             );
 
             // Maker and taker set balances/allowances to guarantee that the fill succeeds.
-            // Amounts are chosen to be within each actor's balance (divided by 2, in case
+            // Amounts are chosen to be within each actor's balance (divided by 8, in case
             // e.g. makerAsset = makerFeeAsset)
             const [makerAssetAmount, makerFee, takerAssetAmount, takerFee] = await Promise.all(
                 [

--- a/contracts/integrations/test/framework/actors/maker.ts
+++ b/contracts/integrations/test/framework/actors/maker.ts
@@ -20,6 +20,7 @@ export interface MakerInterface {
     cancelOrderAsync: (order: SignedOrder) => Promise<TransactionReceiptWithDecodedLogs>;
     joinStakingPoolAsync: (poolId: string) => Promise<TransactionReceiptWithDecodedLogs>;
     createFillableOrderAsync: (taker: Actor) => Promise<SignedOrder>;
+    createMatchableOrdersAsync(taker: Actor): Promise<[SignedOrder, SignedOrder]>;
 }
 
 /**
@@ -138,6 +139,92 @@ export function MakerMixin<TBase extends Constructor>(Base: TBase): TBase & Cons
             });
         }
 
+        public async createMatchableOrdersAsync(taker: Actor): Promise<[SignedOrder, SignedOrder]> {
+            const { actors, balanceStore } = this.actor.simulationEnvironment!;
+            await balanceStore.updateErc20BalancesAsync();
+
+            // Choose the assets for the orders
+            const [leftMakerToken, leftTakerToken, makerFeeToken, takerFeeToken] = Pseudorandom.sampleSize(
+                this.actor.deployment.tokens.erc20,
+                4, // tslint:disable-line:custom-no-magic-numbers
+            );
+            const rightMakerToken = leftTakerToken;
+            const rightTakerToken = leftMakerToken;
+
+            // Maker and taker set balances/allowances to guarantee that the fill succeeds.
+            // Amounts are chosen to be within each actor's balance (divided by 2, in case
+            // e.g. makerAsset = makerFeeAsset)
+            const [leftMakerAssetAmount, makerFee, leftTakerAssetAmount, takerFee] = await Promise.all(
+                [
+                    [this.actor, leftMakerToken],
+                    [this.actor, rightMakerToken],
+                    [this.actor, makerFeeToken],
+                    [taker, takerFeeToken],
+                ].map(async ([owner, token]) => {
+                    let balance = balanceStore.balances.erc20[owner.address][token.address];
+                    await (owner as Actor).configureERC20TokenAsync(token as DummyERC20TokenContract);
+                    balance = balanceStore.balances.erc20[owner.address][token.address] =
+                        constants.INITIAL_ERC20_BALANCE;
+                    return Pseudorandom.integer(0, balance.dividedToIntegerBy(8));
+                }),
+            );
+
+            // Select random amounts for the right order. The only constraint is that the slope
+            // of the left price curve is greater or equal to the inverse right price curve.
+            //   leftMakerAssetAmount/leftTakerAssetAmount >= rightTakerAssetAmount/rightMakerAssetAmount.
+            // We set the `rightMakerAssetAmount` equal to the `leftTakerAssetAmount` with probability 1/10,
+            // otherwise this scenario will never occur.
+            const shouldSetRightMakerEqualToLeftTakerAmount = Pseudorandom.integer(1, 10).eq(1);
+            const rightMakerAssetAmount = shouldSetRightMakerEqualToLeftTakerAmount
+                ? leftTakerAssetAmount
+                : Pseudorandom.integer(1, constants.INITIAL_ERC20_BALANCE.dividedToIntegerBy(8));
+            const rightTakerAssetAmount = Pseudorandom.integer(
+                1,
+                rightMakerAssetAmount.times(leftMakerAssetAmount).dividedToIntegerBy(leftTakerAssetAmount),
+            );
+
+            // Encode asset data
+            const [
+                leftMakerAssetData,
+                leftTakerAssetData,
+                rightMakerAssetData,
+                rightTakerAssetData,
+                makerFeeAssetData,
+                takerFeeAssetData,
+            ] = [leftMakerToken, leftTakerToken, rightMakerToken, rightTakerToken, makerFeeToken, takerFeeToken].map(
+                token =>
+                    this.actor.deployment.assetDataEncoder.ERC20Token(token.address).getABIEncodedTransactionData(),
+            );
+
+            // Construct and sign the left order
+            const leftOrder = await this.signOrderAsync({
+                makerAssetData: leftMakerAssetData,
+                takerAssetData: leftTakerAssetData,
+                makerFeeAssetData,
+                takerFeeAssetData,
+                makerAssetAmount: leftMakerAssetAmount,
+                takerAssetAmount: leftTakerAssetAmount,
+                makerFee,
+                takerFee,
+                feeRecipientAddress: Pseudorandom.sample(actors)!.address,
+            });
+
+            // Construct and sign the right order
+            const rightOrder = await this.signOrderAsync({
+                makerAssetData: rightMakerAssetData,
+                takerAssetData: rightTakerAssetData,
+                makerFeeAssetData,
+                takerFeeAssetData,
+                makerAssetAmount: rightMakerAssetAmount,
+                takerAssetAmount: rightTakerAssetAmount,
+                makerFee,
+                takerFee,
+                feeRecipientAddress: Pseudorandom.sample(actors)!.address,
+            });
+
+            return [leftOrder, rightOrder];
+        }
+
         private async *_validJoinStakingPool(): AsyncIterableIterator<AssertionResult | void> {
             const { stakingPools } = this.actor.simulationEnvironment!;
             const assertion = validJoinStakingPoolAssertion(this.actor.deployment);
@@ -146,6 +233,7 @@ export function MakerMixin<TBase extends Constructor>(Base: TBase): TBase & Cons
                 if (poolId === undefined) {
                     yield;
                 } else {
+                    this.makerPoolId = poolId;
                     yield assertion.executeAsync([poolId], { from: this.actor.address });
                 }
             }

--- a/contracts/integrations/test/framework/actors/taker.ts
+++ b/contracts/integrations/test/framework/actors/taker.ts
@@ -79,7 +79,6 @@ export function TakerMixin<TBase extends Constructor>(Base: TBase): TBase & Cons
                 .matchOrders(leftOrder, rightOrder, leftOrder.signature, rightOrder.signature)
                 .awaitTransactionSuccessAsync({
                     from: this.actor.address,
-                    gasPrice: DeploymentManager.gasPrice,
                     value: DeploymentManager.protocolFee,
                     ...txData,
                 });
@@ -97,7 +96,6 @@ export function TakerMixin<TBase extends Constructor>(Base: TBase): TBase & Cons
                 .matchOrdersWithMaximalFill(leftOrder, rightOrder, leftOrder.signature, rightOrder.signature)
                 .awaitTransactionSuccessAsync({
                     from: this.actor.address,
-                    gasPrice: DeploymentManager.gasPrice,
                     value: DeploymentManager.protocolFee,
                     ...txData,
                 });

--- a/contracts/integrations/test/framework/assertions/fillOrder.ts
+++ b/contracts/integrations/test/framework/assertions/fillOrder.ts
@@ -1,13 +1,7 @@
 import { ERC20TokenEvents, ERC20TokenTransferEventArgs } from '@0x/contracts-erc20';
 import { ExchangeEvents, ExchangeFillEventArgs } from '@0x/contracts-exchange';
 import { ReferenceFunctions } from '@0x/contracts-exchange-libs';
-import {
-    AggregatedStats,
-    constants as stakingConstants,
-    PoolStats,
-    StakingEvents,
-    StakingStakingPoolEarnedRewardsInEpochEventArgs,
-} from '@0x/contracts-staking';
+import { AggregatedStats, PoolStats } from '@0x/contracts-staking';
 import { expect, orderHashUtils, verifyEvents } from '@0x/contracts-test-utils';
 import { FillResults, Order } from '@0x/types';
 import { BigNumber } from '@0x/utils';
@@ -18,6 +12,7 @@ import { Maker } from '../actors/maker';
 import { filterActorsByRole } from '../actors/utils';
 import { DeploymentManager } from '../deployment_manager';
 import { SimulationEnvironment } from '../simulation';
+import { assertProtocolFeePaidAsync, getPoolInfoAsync } from '../utils/assert_protocol_fee';
 
 import { FunctionAssertion, FunctionResult } from './function_assertion';
 
@@ -109,8 +104,8 @@ export function validFillOrderAssertion(
     deployment: DeploymentManager,
     simulationEnvironment: SimulationEnvironment,
 ): FunctionAssertion<[Order, BigNumber, string], FillOrderBeforeInfo | void, FillResults> {
-    const { stakingWrapper } = deployment.staking;
     const { actors } = simulationEnvironment;
+    const expectedProtocolFee = DeploymentManager.protocolFee;
 
     return new FunctionAssertion<[Order, BigNumber, string], FillOrderBeforeInfo | void, FillResults>(
         deployment.exchange,
@@ -118,27 +113,9 @@ export function validFillOrderAssertion(
         {
             before: async (args: [Order, BigNumber, string]) => {
                 const [order] = args;
-                const { currentEpoch } = simulationEnvironment;
                 const maker = filterActorsByRole(actors, Maker).find(actor => actor.address === order.makerAddress);
-
-                const poolId = maker!.makerPoolId;
-                if (poolId === undefined) {
-                    return;
-                } else {
-                    const poolStats = PoolStats.fromArray(
-                        await stakingWrapper.poolStatsByEpoch(poolId, currentEpoch).callAsync(),
-                    );
-                    const aggregatedStats = AggregatedStats.fromArray(
-                        await stakingWrapper.aggregatedStatsByEpoch(currentEpoch).callAsync(),
-                    );
-                    const { currentEpochBalance: poolStake } = await stakingWrapper
-                        .getTotalStakeDelegatedToPool(poolId)
-                        .callAsync();
-                    const { currentEpochBalance: operatorStake } = await stakingWrapper
-                        .getStakeDelegatedToPoolByOwner(simulationEnvironment.stakingPools[poolId].operator, poolId)
-                        .callAsync();
-                    return { poolStats, aggregatedStats, poolStake, poolId, operatorStake };
-                }
+                const poolInfo = getPoolInfoAsync(maker!, simulationEnvironment, deployment);
+                return poolInfo;
             },
             after: async (
                 beforeInfo: FillOrderBeforeInfo | void,
@@ -150,69 +127,20 @@ export function validFillOrderAssertion(
                 expect(result.success, `Error: ${result.data}`).to.be.true();
 
                 const [order, fillAmount] = args;
-                const { currentEpoch } = simulationEnvironment;
 
                 // Ensure that the correct events were emitted.
                 verifyFillEvents(txData, order, result.receipt!, deployment, fillAmount);
 
-                // If the maker is not in a staking pool, there's nothing to check
-                if (beforeInfo === undefined) {
-                    return;
-                }
-
-                const expectedPoolStats = { ...beforeInfo.poolStats };
-                const expectedAggregatedStats = { ...beforeInfo.aggregatedStats };
-                const expectedEvents = [];
-
-                // Refer to `payProtocolFee`
-                if (beforeInfo.poolStake.isGreaterThanOrEqualTo(stakingConstants.DEFAULT_PARAMS.minimumPoolStake)) {
-                    if (beforeInfo.poolStats.feesCollected.isZero()) {
-                        const membersStakeInPool = beforeInfo.poolStake.minus(beforeInfo.operatorStake);
-                        const weightedStakeInPool = beforeInfo.operatorStake.plus(
-                            ReferenceFunctions.getPartialAmountFloor(
-                                stakingConstants.DEFAULT_PARAMS.rewardDelegatedStakeWeight,
-                                new BigNumber(stakingConstants.PPM),
-                                membersStakeInPool,
-                            ),
-                        );
-                        expectedPoolStats.membersStake = membersStakeInPool;
-                        expectedPoolStats.weightedStake = weightedStakeInPool;
-                        expectedAggregatedStats.totalWeightedStake = beforeInfo.aggregatedStats.totalWeightedStake.plus(
-                            weightedStakeInPool,
-                        );
-                        expectedAggregatedStats.numPoolsToFinalize = beforeInfo.aggregatedStats.numPoolsToFinalize.plus(
-                            1,
-                        );
-                        // StakingPoolEarnedRewardsInEpoch event emitted
-                        expectedEvents.push({
-                            epoch: currentEpoch,
-                            poolId: beforeInfo.poolId,
-                        });
-                    }
-                    // Credit a protocol fee to the maker's staking pool
-                    expectedPoolStats.feesCollected = beforeInfo.poolStats.feesCollected.plus(
-                        DeploymentManager.protocolFee,
-                    );
-                    // Update aggregated stats
-                    expectedAggregatedStats.totalFeesCollected = beforeInfo.aggregatedStats.totalFeesCollected.plus(
-                        DeploymentManager.protocolFee,
+                // If the maker is in a staking pool then validate the protocol fee.
+                if (beforeInfo !== undefined) {
+                    await assertProtocolFeePaidAsync(
+                        beforeInfo,
+                        result,
+                        simulationEnvironment,
+                        deployment,
+                        expectedProtocolFee,
                     );
                 }
-
-                // Check for updated stats and event
-                const poolStats = PoolStats.fromArray(
-                    await stakingWrapper.poolStatsByEpoch(beforeInfo.poolId, currentEpoch).callAsync(),
-                );
-                const aggregatedStats = AggregatedStats.fromArray(
-                    await stakingWrapper.aggregatedStatsByEpoch(currentEpoch).callAsync(),
-                );
-                expect(poolStats).to.deep.equal(expectedPoolStats);
-                expect(aggregatedStats).to.deep.equal(expectedAggregatedStats);
-                verifyEvents<StakingStakingPoolEarnedRewardsInEpochEventArgs>(
-                    result.receipt!,
-                    expectedEvents,
-                    StakingEvents.StakingPoolEarnedRewardsInEpoch,
-                );
             },
         },
     );

--- a/contracts/integrations/test/framework/assertions/matchOrders.ts
+++ b/contracts/integrations/test/framework/assertions/matchOrders.ts
@@ -1,0 +1,79 @@
+import { MatchedFillResults, Order } from '@0x/types';
+import { TxData } from 'ethereum-types';
+import * as _ from 'lodash';
+
+import { Maker } from '../actors/maker';
+import { filterActorsByRole } from '../actors/utils';
+import { DeploymentManager } from '../deployment_manager';
+import { SimulationEnvironment } from '../simulation';
+import { assertProtocolFeePaidAsync, getPoolInfoAsync, PoolInfo } from '../utils/assert_protocol_fee';
+import { verifyMatchEvents } from '../utils/verify_match_events';
+
+import { FunctionAssertion, FunctionResult } from './function_assertion';
+
+export const matchOrderRuntimeAssertion = (
+    deployment: DeploymentManager,
+    simulationEnvironment: SimulationEnvironment,
+    withMaximalFill: boolean,
+) => {
+    const { actors } = simulationEnvironment;
+    const expectedProtocolFee = DeploymentManager.protocolFee.times(2);
+
+    return {
+        before: async (args: [Order, Order, string, string]) => {
+            const [order] = args;
+            const maker = filterActorsByRole(actors, Maker).find(actor => actor.address === order.makerAddress);
+            // tslint:disable-next-line no-non-null-assertion
+            const poolInfo = getPoolInfoAsync(maker!, simulationEnvironment, deployment);
+            return poolInfo;
+        },
+        after: async (
+            beforeInfo: PoolInfo | void,
+            result: FunctionResult,
+            args: [Order, Order, string, string],
+            txData: Partial<TxData>,
+        ) => {
+            // Ensure that the correct events were emitted.
+            const [leftOrder, rightOrder] = args;
+
+            verifyMatchEvents(
+                txData,
+                leftOrder,
+                rightOrder,
+                // tslint:disable-next-line no-non-null-assertion no-unnecessary-type-assertion
+                result.receipt!,
+                deployment,
+                withMaximalFill,
+            );
+
+            // If the maker is in a staking pool then validate the protocol fee.
+            if (beforeInfo !== undefined) {
+                await assertProtocolFeePaidAsync(
+                    beforeInfo,
+                    result,
+                    simulationEnvironment,
+                    deployment,
+                    expectedProtocolFee,
+                );
+            }
+        },
+    };
+};
+
+/**
+ * A function assertion that verifies that a complete and valid `matchOrders` succeeded and emitted the correct logs.
+ */
+/* tslint:disable:no-unnecessary-type-assertion */
+/* tslint:disable:no-non-null-assertion */
+export function validMatchOrdersAssertion(
+    deployment: DeploymentManager,
+    simulationEnvironment: SimulationEnvironment,
+): FunctionAssertion<[Order, Order, string, string], PoolInfo | void, MatchedFillResults> {
+    return new FunctionAssertion<[Order, Order, string, string], PoolInfo | void, MatchedFillResults>(
+        deployment.exchange,
+        'matchOrders',
+        matchOrderRuntimeAssertion(deployment, simulationEnvironment, false),
+    );
+}
+/* tslint:enable:no-non-null-assertion */
+/* tslint:enable:no-unnecessary-type-assertion */

--- a/contracts/integrations/test/framework/assertions/matchOrders.ts
+++ b/contracts/integrations/test/framework/assertions/matchOrders.ts
@@ -3,7 +3,6 @@ import { TxData } from 'ethereum-types';
 import * as _ from 'lodash';
 
 import { Maker } from '../actors/maker';
-import { filterActorsByRole } from '../actors/utils';
 import { DeploymentManager } from '../deployment_manager';
 import { SimulationEnvironment } from '../simulation';
 import { assertProtocolFeePaidAsync, getPoolInfoAsync, PoolInfo } from '../utils/assert_protocol_fee';
@@ -11,7 +10,7 @@ import { verifyMatchEvents } from '../utils/verify_match_events';
 
 import { FunctionAssertion, FunctionResult } from './function_assertion';
 
-export const matchOrderRuntimeAssertion = (
+export const matchOrdersRuntimeAssertion = (
     deployment: DeploymentManager,
     simulationEnvironment: SimulationEnvironment,
     withMaximalFill: boolean,
@@ -22,9 +21,9 @@ export const matchOrderRuntimeAssertion = (
     return {
         before: async (args: [Order, Order, string, string]) => {
             const [order] = args;
-            const maker = filterActorsByRole(actors, Maker).find(actor => actor.address === order.makerAddress);
-            // tslint:disable-next-line no-non-null-assertion
-            const poolInfo = getPoolInfoAsync(maker!, simulationEnvironment, deployment);
+            // tslint:disable-next-line no-unnecessary-type-assertion
+            const maker = actors.find(actor => actor.address === order.makerAddress) as Maker;
+            const poolInfo = getPoolInfoAsync(maker, simulationEnvironment, deployment);
             return poolInfo;
         },
         after: async (
@@ -72,7 +71,7 @@ export function validMatchOrdersAssertion(
     return new FunctionAssertion<[Order, Order, string, string], PoolInfo | void, MatchedFillResults>(
         deployment.exchange,
         'matchOrders',
-        matchOrderRuntimeAssertion(deployment, simulationEnvironment, false),
+        matchOrdersRuntimeAssertion(deployment, simulationEnvironment, false),
     );
 }
 /* tslint:enable:no-non-null-assertion */

--- a/contracts/integrations/test/framework/assertions/matchOrdersWithMaximalFill.ts
+++ b/contracts/integrations/test/framework/assertions/matchOrdersWithMaximalFill.ts
@@ -6,7 +6,7 @@ import { SimulationEnvironment } from '../simulation';
 import { PoolInfo } from '../utils/assert_protocol_fee';
 
 import { FunctionAssertion } from './function_assertion';
-import { matchOrderRuntimeAssertion } from './matchOrders';
+import { matchOrdersRuntimeAssertion } from './matchOrders';
 
 /**
  * A function assertion that verifies that a complete and valid `matchOrdersWithMaximalFill` succeeded and emitted the correct logs.
@@ -20,7 +20,7 @@ export function validMatchOrdersWithMaximalFillAssertion(
     return new FunctionAssertion<[Order, Order, string, string], PoolInfo | void, MatchedFillResults>(
         deployment.exchange,
         'matchOrdersWithMaximalFill',
-        matchOrderRuntimeAssertion(deployment, simulationEnvironment, true),
+        matchOrdersRuntimeAssertion(deployment, simulationEnvironment, true),
     );
 }
 /* tslint:enable:no-non-null-assertion */

--- a/contracts/integrations/test/framework/assertions/matchOrdersWithMaximalFill.ts
+++ b/contracts/integrations/test/framework/assertions/matchOrdersWithMaximalFill.ts
@@ -1,0 +1,27 @@
+import { MatchedFillResults, Order } from '@0x/types';
+import * as _ from 'lodash';
+
+import { DeploymentManager } from '../deployment_manager';
+import { SimulationEnvironment } from '../simulation';
+import { PoolInfo } from '../utils/assert_protocol_fee';
+
+import { FunctionAssertion } from './function_assertion';
+import { matchOrderRuntimeAssertion } from './matchOrders';
+
+/**
+ * A function assertion that verifies that a complete and valid `matchOrdersWithMaximalFill` succeeded and emitted the correct logs.
+ */
+/* tslint:disable:no-unnecessary-type-assertion */
+/* tslint:disable:no-non-null-assertion */
+export function validMatchOrdersWithMaximalFillAssertion(
+    deployment: DeploymentManager,
+    simulationEnvironment: SimulationEnvironment,
+): FunctionAssertion<[Order, Order, string, string], PoolInfo | void, MatchedFillResults> {
+    return new FunctionAssertion<[Order, Order, string, string], PoolInfo | void, MatchedFillResults>(
+        deployment.exchange,
+        'matchOrdersWithMaximalFill',
+        matchOrderRuntimeAssertion(deployment, simulationEnvironment, true),
+    );
+}
+/* tslint:enable:no-non-null-assertion */
+/* tslint:enable:no-unnecessary-type-assertion */

--- a/contracts/integrations/test/framework/utils/assert_protocol_fee.ts
+++ b/contracts/integrations/test/framework/utils/assert_protocol_fee.ts
@@ -1,0 +1,118 @@
+import { ReferenceFunctions } from '@0x/contracts-exchange-libs';
+import {
+    AggregatedStats,
+    constants as stakingConstants,
+    PoolStats,
+    StakingEvents,
+    StakingStakingPoolEarnedRewardsInEpochEventArgs,
+} from '@0x/contracts-staking';
+import { expect, verifyEvents } from '@0x/contracts-test-utils';
+import { BigNumber } from '@0x/utils';
+import * as _ from 'lodash';
+
+import { Maker } from '../actors/maker';
+import { DeploymentManager } from '../deployment_manager';
+import { SimulationEnvironment } from '../simulation';
+
+import { FunctionResult } from '../assertions/function_assertion';
+
+export interface PoolInfo {
+    poolStats: PoolStats;
+    aggregatedStats: AggregatedStats;
+    poolStake: BigNumber;
+    operatorStake: BigNumber;
+    poolId: string;
+}
+
+/**
+ * Gets info for a given maker's pool.
+ */
+export async function getPoolInfoAsync(
+    maker: Maker,
+    simulationEnvironment: SimulationEnvironment,
+    deployment: DeploymentManager,
+): Promise<PoolInfo | undefined> {
+    const { stakingWrapper } = deployment.staking;
+    // tslint:disable-next-line no-non-null-assertion no-unnecessary-type-assertion
+    const poolId = maker!.makerPoolId;
+    const { currentEpoch } = simulationEnvironment;
+    if (poolId === undefined) {
+        return;
+    } else {
+        const poolStats = PoolStats.fromArray(await stakingWrapper.poolStatsByEpoch(poolId, currentEpoch).callAsync());
+        const aggregatedStats = AggregatedStats.fromArray(
+            await stakingWrapper.aggregatedStatsByEpoch(currentEpoch).callAsync(),
+        );
+        const { currentEpochBalance: poolStake } = await stakingWrapper
+            .getTotalStakeDelegatedToPool(poolId)
+            .callAsync();
+        const { currentEpochBalance: operatorStake } = await stakingWrapper
+            .getStakeDelegatedToPoolByOwner(simulationEnvironment.stakingPools[poolId].operator, poolId)
+            .callAsync();
+        return { poolStats, aggregatedStats, poolStake, poolId, operatorStake };
+    }
+}
+
+/**
+ * Asserts that a protocol fee was paid.
+ */
+export async function assertProtocolFeePaidAsync(
+    poolInfo: PoolInfo,
+    result: FunctionResult,
+    simulationEnvironment: SimulationEnvironment,
+    deployment: DeploymentManager,
+    expectedProtocolFee: BigNumber,
+): Promise<void> {
+    const { currentEpoch } = simulationEnvironment;
+    const { stakingWrapper } = deployment.staking;
+    const expectedPoolStats = { ...poolInfo.poolStats };
+    const expectedAggregatedStats = { ...poolInfo.aggregatedStats };
+    const expectedEvents = [];
+
+    // Refer to `payProtocolFee`
+    if (poolInfo.poolStake.isGreaterThanOrEqualTo(stakingConstants.DEFAULT_PARAMS.minimumPoolStake)) {
+        if (poolInfo.poolStats.feesCollected.isZero()) {
+            const membersStakeInPool = poolInfo.poolStake.minus(poolInfo.operatorStake);
+            const weightedStakeInPool = poolInfo.operatorStake.plus(
+                ReferenceFunctions.getPartialAmountFloor(
+                    stakingConstants.DEFAULT_PARAMS.rewardDelegatedStakeWeight,
+                    new BigNumber(stakingConstants.PPM),
+                    membersStakeInPool,
+                ),
+            );
+            expectedPoolStats.membersStake = membersStakeInPool;
+            expectedPoolStats.weightedStake = weightedStakeInPool;
+            expectedAggregatedStats.totalWeightedStake = poolInfo.aggregatedStats.totalWeightedStake.plus(
+                weightedStakeInPool,
+            );
+            expectedAggregatedStats.numPoolsToFinalize = poolInfo.aggregatedStats.numPoolsToFinalize.plus(1);
+            // StakingPoolEarnedRewardsInEpoch event emitted
+            expectedEvents.push({
+                epoch: currentEpoch,
+                poolId: poolInfo.poolId,
+            });
+        }
+        // Credit a protocol fee to the maker's staking pool
+        expectedPoolStats.feesCollected = poolInfo.poolStats.feesCollected.plus(expectedProtocolFee);
+        // Update aggregated stats
+        expectedAggregatedStats.totalFeesCollected = poolInfo.aggregatedStats.totalFeesCollected.plus(
+            expectedProtocolFee,
+        );
+    }
+
+    // Check for updated stats and event
+    const poolStats = PoolStats.fromArray(
+        await stakingWrapper.poolStatsByEpoch(poolInfo.poolId, currentEpoch).callAsync(),
+    );
+    const aggregatedStats = AggregatedStats.fromArray(
+        await stakingWrapper.aggregatedStatsByEpoch(currentEpoch).callAsync(),
+    );
+    expect(poolStats).to.deep.equal(expectedPoolStats);
+    expect(aggregatedStats).to.deep.equal(expectedAggregatedStats);
+    verifyEvents<StakingStakingPoolEarnedRewardsInEpochEventArgs>(
+        // tslint:disable-next-line no-non-null-assertion no-unnecessary-type-assertion
+        result.receipt!,
+        expectedEvents,
+        StakingEvents.StakingPoolEarnedRewardsInEpoch,
+    );
+}

--- a/contracts/integrations/test/framework/utils/assert_protocol_fee.ts
+++ b/contracts/integrations/test/framework/utils/assert_protocol_fee.ts
@@ -34,7 +34,7 @@ export async function getPoolInfoAsync(
 ): Promise<PoolInfo | undefined> {
     const { stakingWrapper } = deployment.staking;
     // tslint:disable-next-line no-non-null-assertion no-unnecessary-type-assertion
-    const poolId = maker!.makerPoolId;
+    const poolId = maker.makerPoolId;
     const { currentEpoch } = simulationEnvironment;
     if (poolId === undefined) {
         return;

--- a/contracts/integrations/test/framework/utils/verify_match_events.ts
+++ b/contracts/integrations/test/framework/utils/verify_match_events.ts
@@ -1,0 +1,151 @@
+import { ERC20TokenEvents, ERC20TokenTransferEventArgs } from '@0x/contracts-erc20';
+import { ExchangeEvents, ExchangeFillEventArgs } from '@0x/contracts-exchange';
+import { ReferenceFunctions } from '@0x/contracts-exchange-libs';
+import { orderHashUtils, verifyEvents } from '@0x/contracts-test-utils';
+import { MatchedFillResults, Order } from '@0x/types';
+import { BigNumber } from '@0x/utils';
+import { TransactionReceiptWithDecodedLogs, TxData } from 'ethereum-types';
+import * as _ from 'lodash';
+
+import { DeploymentManager } from '../deployment_manager';
+
+/**
+ * Verifies `Fill` and `Transfer` events emitted by `matchOrders` or `matchOrdersWithMaximalFill`.
+ */
+export function verifyMatchEvents(
+    txData: Partial<TxData>,
+    leftOrder: Order,
+    rightOrder: Order,
+    receipt: TransactionReceiptWithDecodedLogs,
+    deployment: DeploymentManager,
+    withMaximalFill: boolean,
+): void {
+    const matchResults = ReferenceFunctions.calculateMatchResults(
+        leftOrder,
+        rightOrder,
+        DeploymentManager.protocolFeeMultiplier,
+        DeploymentManager.gasPrice,
+        withMaximalFill,
+    );
+    const takerAddress = txData.from as string;
+    const value = new BigNumber(txData.value || 0);
+
+    verifyMatchFilledEvents(leftOrder, rightOrder, receipt, matchResults, takerAddress);
+    verifyMatchTransferEvents(leftOrder, rightOrder, receipt, matchResults, takerAddress, value, deployment);
+}
+
+/**
+ * Verifies `Fill` events emitted by `matchOrders` or `matchOrdersWithMaximalFill`.
+ */
+const verifyMatchFilledEvents = (
+    leftOrder: Order,
+    rightOrder: Order,
+    receipt: TransactionReceiptWithDecodedLogs,
+    matchResults: MatchedFillResults,
+    takerAddress: string,
+) => {
+    const expectedFillEvents = [
+        {
+            makerAddress: leftOrder.makerAddress,
+            feeRecipientAddress: leftOrder.feeRecipientAddress,
+            makerAssetData: leftOrder.makerAssetData,
+            takerAssetData: leftOrder.takerAssetData,
+            makerFeeAssetData: leftOrder.makerFeeAssetData,
+            takerFeeAssetData: leftOrder.takerFeeAssetData,
+            orderHash: orderHashUtils.getOrderHashHex(leftOrder),
+            takerAddress,
+            senderAddress: takerAddress,
+            ...matchResults.left,
+        },
+        {
+            makerAddress: rightOrder.makerAddress,
+            feeRecipientAddress: rightOrder.feeRecipientAddress,
+            makerAssetData: rightOrder.makerAssetData,
+            takerAssetData: rightOrder.takerAssetData,
+            makerFeeAssetData: rightOrder.makerFeeAssetData,
+            takerFeeAssetData: rightOrder.takerFeeAssetData,
+            orderHash: orderHashUtils.getOrderHashHex(rightOrder),
+            takerAddress,
+            senderAddress: takerAddress,
+            ...matchResults.right,
+        },
+    ];
+
+    verifyEvents<ExchangeFillEventArgs>(receipt, expectedFillEvents, ExchangeEvents.Fill);
+};
+
+/**
+ * Verifies `Transfer` events emitted by `matchOrders` or `matchOrdersWithMaximalFill`.
+ */
+const verifyMatchTransferEvents = (
+    leftOrder: Order,
+    rightOrder: Order,
+    receipt: TransactionReceiptWithDecodedLogs,
+    matchResults: MatchedFillResults,
+    takerAddress: string,
+    value: BigNumber,
+    deployment: DeploymentManager,
+) => {
+    const expectedTransferEvents = [
+        {
+            _from: rightOrder.makerAddress,
+            _to: leftOrder.makerAddress,
+            _value: matchResults.left.takerAssetFilledAmount,
+        },
+        {
+            _from: leftOrder.makerAddress,
+            _to: rightOrder.makerAddress,
+            _value: matchResults.right.takerAssetFilledAmount,
+        },
+        {
+            _from: rightOrder.makerAddress,
+            _to: rightOrder.feeRecipientAddress,
+            _value: matchResults.right.makerFeePaid,
+        },
+        {
+            _from: leftOrder.makerAddress,
+            _to: leftOrder.feeRecipientAddress,
+            _value: matchResults.left.makerFeePaid,
+        },
+        {
+            _from: leftOrder.makerAddress,
+            _to: takerAddress,
+            _value: matchResults.left.makerAssetFilledAmount.minus(matchResults.right.takerAssetFilledAmount),
+        },
+        {
+            _from: rightOrder.makerAddress,
+            _to: takerAddress,
+            _value: matchResults.right.makerAssetFilledAmount.minus(matchResults.left.takerAssetFilledAmount),
+        },
+        {
+            _from: takerAddress,
+            _to: deployment.staking.stakingProxy.address,
+            _value: value.isLessThan(DeploymentManager.protocolFee.times(2))
+                ? DeploymentManager.protocolFee
+                : new BigNumber(0),
+        },
+        {
+            _from: takerAddress,
+            _to: deployment.staking.stakingProxy.address,
+            _value: value.isLessThan(DeploymentManager.protocolFee) ? DeploymentManager.protocolFee : new BigNumber(0),
+        },
+        {
+            _from: takerAddress,
+            _to: rightOrder.feeRecipientAddress,
+            _value:
+                leftOrder.feeRecipientAddress === rightOrder.feeRecipientAddress
+                    ? new BigNumber(0)
+                    : matchResults.right.takerFeePaid,
+        },
+        {
+            _from: takerAddress,
+            _to: leftOrder.feeRecipientAddress,
+            _value:
+                leftOrder.feeRecipientAddress === rightOrder.feeRecipientAddress
+                    ? matchResults.left.takerFeePaid.plus(matchResults.right.takerFeePaid)
+                    : matchResults.left.takerFeePaid,
+        },
+    ].filter(event => event._value.isGreaterThan(0));
+
+    verifyEvents<ERC20TokenTransferEventArgs>(receipt, expectedTransferEvents, ERC20TokenEvents.Transfer);
+};

--- a/contracts/integrations/test/framework/utils/verify_match_events.ts
+++ b/contracts/integrations/test/framework/utils/verify_match_events.ts
@@ -1,7 +1,7 @@
 import { ERC20TokenEvents, ERC20TokenTransferEventArgs } from '@0x/contracts-erc20';
 import { ExchangeEvents, ExchangeFillEventArgs } from '@0x/contracts-exchange';
 import { ReferenceFunctions } from '@0x/contracts-exchange-libs';
-import { orderHashUtils, verifyEvents } from '@0x/contracts-test-utils';
+import { constants, orderHashUtils, verifyEvents } from '@0x/contracts-test-utils';
 import { MatchedFillResults, Order } from '@0x/types';
 import { BigNumber } from '@0x/utils';
 import { TransactionReceiptWithDecodedLogs, TxData } from 'ethereum-types';
@@ -122,7 +122,7 @@ const verifyMatchTransferEvents = (
             _to: deployment.staking.stakingProxy.address,
             _value: value.isLessThan(DeploymentManager.protocolFee.times(2))
                 ? DeploymentManager.protocolFee
-                : new BigNumber(0),
+                : constants.ZERO_AMOUNT,
         },
         {
             _from: takerAddress,
@@ -134,7 +134,7 @@ const verifyMatchTransferEvents = (
             _to: rightOrder.feeRecipientAddress,
             _value:
                 leftOrder.feeRecipientAddress === rightOrder.feeRecipientAddress
-                    ? new BigNumber(0)
+                    ? constants.ZERO_AMOUNT
                     : matchResults.right.takerFeePaid,
         },
         {

--- a/contracts/integrations/test/fuzz_tests/match_orders_test.ts
+++ b/contracts/integrations/test/fuzz_tests/match_orders_test.ts
@@ -1,0 +1,83 @@
+import { blockchainTests } from '@0x/contracts-test-utils';
+import * as _ from 'lodash';
+
+import { Actor } from '../framework/actors/base';
+import { Maker } from '../framework/actors/maker';
+import { PoolOperator } from '../framework/actors/pool_operator';
+import { Taker } from '../framework/actors/taker';
+import { filterActorsByRole } from '../framework/actors/utils';
+import { AssertionResult } from '../framework/assertions/function_assertion';
+import { BlockchainBalanceStore } from '../framework/balances/blockchain_balance_store';
+import { DeploymentManager } from '../framework/deployment_manager';
+import { Simulation, SimulationEnvironment } from '../framework/simulation';
+import { Pseudorandom } from '../framework/utils/pseudorandom';
+
+import { PoolManagementSimulation } from './pool_management_test';
+
+export class MatchOrdersSimulation extends Simulation {
+    protected async *_assertionGenerator(): AsyncIterableIterator<AssertionResult | void> {
+        const { actors } = this.environment;
+        const makers = filterActorsByRole(actors, Maker);
+        const takers = filterActorsByRole(actors, Taker);
+
+        const poolManagement = new PoolManagementSimulation(this.environment);
+
+        const [actions, weights] = _.unzip([
+            // 20% chance of executing validJoinStakingPool for a random maker
+            ...makers.map(maker => [maker.simulationActions.validJoinStakingPool, 0.2 / makers.length]),
+            // 30% chance of executing matchOrders for a random taker
+            ...takers.map(taker => [taker.simulationActions.validMatchOrders, 0.3]),
+            // 30% chance of executing matchOrders for a random taker
+            ...takers.map(taker => [taker.simulationActions.validMatchOrdersWithMaximalFill, 0.3]),
+            // 20% chance of executing an assertion generated from the pool management simulation
+            [poolManagement.generator, 0.2],
+        ]) as [Array<AsyncIterableIterator<AssertionResult | void>>, number[]];
+        while (true) {
+            const action = Pseudorandom.sample(actions, weights);
+            yield (await action!.next()).value; // tslint:disable-line:no-non-null-assertion
+        }
+    }
+}
+
+blockchainTests('Match Orders fuzz test', env => {
+    before(function(): void {
+        if (process.env.FUZZ_TEST !== 'match_orders') {
+            this.skip();
+        }
+    });
+    after(async () => {
+        Actor.reset();
+    });
+
+    it('fuzz', async () => {
+        // Deploy contracts
+        const deployment = await DeploymentManager.deployAsync(env, {
+            numErc20TokensToDeploy: 4,
+            numErc721TokensToDeploy: 0,
+            numErc1155TokensToDeploy: 0,
+        });
+
+        // Set up balance store
+        const balanceStore = new BlockchainBalanceStore({}, {});
+
+        // Spin up actors
+        const actors = [
+            new Maker({ deployment, name: 'Maker 1' }),
+            new Taker({ deployment, name: 'Taker 1' }),
+            new PoolOperator({ deployment, name: 'PoolOperator 1' }),
+        ];
+
+        // Set up simulation environment
+        const simulationEnvironment = new SimulationEnvironment(deployment, balanceStore, actors);
+
+        // Takers need to set a WETH allowance for the staking proxy in case they pay the protocol fee in WETH
+        const takers = filterActorsByRole(actors, Taker);
+        for (const taker of takers) {
+            await taker.configureERC20TokenAsync(deployment.tokens.weth, deployment.staking.stakingProxy.address);
+        }
+
+        // Run simulation
+        const simulation = new MatchOrdersSimulation(simulationEnvironment);
+        return simulation.fuzzAsync();
+    });
+});


### PR DESCRIPTION
## Description

This PR implements fuzz testing for `matchOrders` and `matchOrdersWithMaximalFill`. 

Included in this PR:
1. Maker actor can now generate matchable orders.
2. Taker actor can now match orders.
3. Reference functions for `matchOrders` and `matchOrdersWithMaximalFill`. 
4. Fuzz tests for `matchOrders` and `matchOrdersWithMaximalFill`. 
5. Fixed a bug in the fill order fuzz tests: `_validJoinStakingPool` was not recording the `poolId` after joining, so protocol fees were not getting validated by the `fillOrder` assertion.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
