### PR TITLE
Feature/erc20 bridge sampler/query multiple buys sells tweaks

### DIFF
--- a/contracts/erc20-bridge-sampler/CHANGELOG.json
+++ b/contracts/erc20-bridge-sampler/CHANGELOG.json
@@ -5,6 +5,10 @@
             {
                 "note": "Add batch functions to query quotes",
                 "pr": 2427
+            },
+            {
+                "note": "Early exit if a DEX sample fails",
+                "pr": 2427
             }
         ]
     },

--- a/contracts/erc20-bridge-sampler/contracts/src/ERC20BridgeSampler.sol
+++ b/contracts/erc20-bridge-sampler/contracts/src/ERC20BridgeSampler.sol
@@ -37,9 +37,9 @@ contract ERC20BridgeSampler is
     DeploymentConstants
 {
     bytes4 constant internal ERC20_PROXY_ID = 0xf47261b0; // bytes4(keccak256("ERC20Token(address)"));
-    uint256 constant internal KYBER_SAMPLE_CALL_GAS = 600e3;
+    uint256 constant internal KYBER_SAMPLE_CALL_GAS = 1500e3;
     uint256 constant internal UNISWAP_SAMPLE_CALL_GAS = 150e3;
-    uint256 constant internal ETH2DAI_SAMPLE_CALL_GAS = 250e3;
+    uint256 constant internal ETH2DAI_SAMPLE_CALL_GAS = 1000e3;
 
     /// @dev Query batches of native orders and sample sell quotes on multiple DEXes at once.
     /// @param orders Batches of Native orders to query.
@@ -104,7 +104,6 @@ contract ERC20BridgeSampler is
             ordersAndSamples[i].tokenAmountsBySource = tokenAmountsBySource;
         }
     }
-
 
     /// @dev Query native orders and sample sell quotes on multiple DEXes at once.
     /// @param orders Native orders to query.
@@ -346,6 +345,8 @@ contract ERC20BridgeSampler is
             uint256 rate = 0;
             if (didSucceed) {
                 rate = abi.decode(resultData, (uint256));
+            } else {
+                break;
             }
             makerTokenAmounts[i] =
                 rate *
@@ -386,6 +387,8 @@ contract ERC20BridgeSampler is
             uint256 buyAmount = 0;
             if (didSucceed) {
                 buyAmount = abi.decode(resultData, (uint256));
+            } else{
+                break;
             }
             makerTokenAmounts[i] = buyAmount;
         }
@@ -421,6 +424,8 @@ contract ERC20BridgeSampler is
             uint256 sellAmount = 0;
             if (didSucceed) {
                 sellAmount = abi.decode(resultData, (uint256));
+            } else {
+                break;
             }
             takerTokenAmounts[i] = sellAmount;
         }
@@ -449,26 +454,28 @@ contract ERC20BridgeSampler is
         IUniswapExchangeQuotes makerTokenExchange = makerToken == _getWethAddress() ?
             IUniswapExchangeQuotes(0) : _getUniswapExchange(makerToken);
         for (uint256 i = 0; i < numSamples; i++) {
+            bool didSucceed = true;
             if (makerToken == _getWethAddress()) {
-                makerTokenAmounts[i] = _callUniswapExchangePriceFunction(
+                (makerTokenAmounts[i], didSucceed) = _callUniswapExchangePriceFunction(
                     address(takerTokenExchange),
                     takerTokenExchange.getTokenToEthInputPrice.selector,
                     takerTokenAmounts[i]
                 );
             } else if (takerToken == _getWethAddress()) {
-                makerTokenAmounts[i] = _callUniswapExchangePriceFunction(
+                (makerTokenAmounts[i], didSucceed) = _callUniswapExchangePriceFunction(
                     address(makerTokenExchange),
                     makerTokenExchange.getEthToTokenInputPrice.selector,
                     takerTokenAmounts[i]
                 );
             } else {
-                uint256 ethBought = _callUniswapExchangePriceFunction(
+                uint256 ethBought;
+                (ethBought, didSucceed) = _callUniswapExchangePriceFunction(
                     address(takerTokenExchange),
                     takerTokenExchange.getTokenToEthInputPrice.selector,
                     takerTokenAmounts[i]
                 );
                 if (ethBought != 0) {
-                    makerTokenAmounts[i] = _callUniswapExchangePriceFunction(
+                    (makerTokenAmounts[i], didSucceed) = _callUniswapExchangePriceFunction(
                         address(makerTokenExchange),
                         makerTokenExchange.getEthToTokenInputPrice.selector,
                         ethBought
@@ -476,6 +483,9 @@ contract ERC20BridgeSampler is
                 } else {
                     makerTokenAmounts[i] = 0;
                 }
+            }
+            if (!didSucceed) {
+                break;
             }
         }
     }
@@ -503,26 +513,28 @@ contract ERC20BridgeSampler is
         IUniswapExchangeQuotes makerTokenExchange = makerToken == _getWethAddress() ?
             IUniswapExchangeQuotes(0) : _getUniswapExchange(makerToken);
         for (uint256 i = 0; i < numSamples; i++) {
+            bool didSucceed = true;
             if (makerToken == _getWethAddress()) {
-                takerTokenAmounts[i] = _callUniswapExchangePriceFunction(
+                (takerTokenAmounts[i], didSucceed) = _callUniswapExchangePriceFunction(
                     address(takerTokenExchange),
                     takerTokenExchange.getTokenToEthOutputPrice.selector,
                     makerTokenAmounts[i]
                 );
             } else if (takerToken == _getWethAddress()) {
-                takerTokenAmounts[i] = _callUniswapExchangePriceFunction(
+                (takerTokenAmounts[i], didSucceed) = _callUniswapExchangePriceFunction(
                     address(makerTokenExchange),
                     makerTokenExchange.getEthToTokenOutputPrice.selector,
                     makerTokenAmounts[i]
                 );
             } else {
-                uint256 ethSold = _callUniswapExchangePriceFunction(
+                uint256 ethSold;
+                (ethSold, didSucceed) = _callUniswapExchangePriceFunction(
                     address(makerTokenExchange),
                     makerTokenExchange.getEthToTokenOutputPrice.selector,
                     makerTokenAmounts[i]
                 );
                 if (ethSold != 0) {
-                    takerTokenAmounts[i] = _callUniswapExchangePriceFunction(
+                    (takerTokenAmounts[i], didSucceed) = _callUniswapExchangePriceFunction(
                         address(takerTokenExchange),
                         takerTokenExchange.getTokenToEthOutputPrice.selector,
                         ethSold
@@ -530,6 +542,9 @@ contract ERC20BridgeSampler is
                 } else {
                     takerTokenAmounts[i] = 0;
                 }
+            }
+            if (!didSucceed) {
+                break;
             }
         }
     }
@@ -558,12 +573,13 @@ contract ERC20BridgeSampler is
     )
         private
         view
-        returns (uint256 outputAmount)
+        returns (uint256 outputAmount, bool didSucceed)
     {
         if (uniswapExchangeAddress == address(0)) {
-            return 0;
+            return (outputAmount, didSucceed);
         }
-        (bool didSucceed, bytes memory resultData) =
+        bytes memory resultData;
+        (didSucceed, resultData) =
             uniswapExchangeAddress.staticcall.gas(UNISWAP_SAMPLE_CALL_GAS)(
                 abi.encodeWithSelector(
                     functionSelector,

--- a/contracts/erc20-bridge-sampler/contracts/test/TestERC20BridgeSampler.sol
+++ b/contracts/erc20-bridge-sampler/contracts/test/TestERC20BridgeSampler.sol
@@ -338,7 +338,11 @@ contract TestERC20BridgeSampler is
         bytes32 orderHash = keccak256(abi.encode(order.salt));
         // Everything else is derived from the hash.
         orderInfo.orderHash = orderHash;
-        orderInfo.orderStatus = LibOrder.OrderStatus(uint256(orderHash) % MAX_ORDER_STATUS);
+        if (uint256(orderHash) % 100 > 90) {
+            orderInfo.orderStatus = LibOrder.OrderStatus.FULLY_FILLED;
+        } else {
+            orderInfo.orderStatus = LibOrder.OrderStatus.FILLABLE;
+        }
         orderInfo.orderTakerAssetFilledAmount = uint256(orderHash) % order.takerAssetAmount;
         fillableTakerAssetAmount =
             order.takerAssetAmount - orderInfo.orderTakerAssetFilledAmount;

--- a/contracts/erc20-bridge-sampler/test/erc20-bridge-sampler.ts
+++ b/contracts/erc20-bridge-sampler/test/erc20-bridge-sampler.ts
@@ -195,7 +195,7 @@ blockchainTests('erc20-bridge-sampler', env => {
 
     function getDeterministicFillableTakerAssetAmount(order: Order): BigNumber {
         const hash = getPackedHash(hexUtils.toHex(order.salt, 32));
-        const orderStatus = new BigNumber(hash).mod(255).toNumber();
+        const orderStatus = new BigNumber(hash).mod(100).toNumber() > 90 ? 5 : 3;
         const isValidSignature = !!new BigNumber(hash).mod(2).toNumber();
         if (orderStatus !== 3 || !isValidSignature) {
             return constants.ZERO_AMOUNT;
@@ -208,7 +208,7 @@ blockchainTests('erc20-bridge-sampler', env => {
         return order.makerAssetAmount
             .times(takerAmount)
             .div(order.takerAssetAmount)
-            .integerValue(BigNumber.ROUND_DOWN);
+            .integerValue(BigNumber.ROUND_UP);
     }
 
     function getERC20AssetData(tokenAddress: string): string {
@@ -255,7 +255,7 @@ blockchainTests('erc20-bridge-sampler', env => {
     describe('getOrderFillableTakerAssetAmounts()', () => {
         it('returns the expected amount for each order', async () => {
             const orders = createOrders(MAKER_TOKEN, TAKER_TOKEN);
-            const signatures: string[] = _.times(orders.length, hexUtils.random);
+            const signatures: string[] = _.times(orders.length, i => hexUtils.random());
             const expected = orders.map(getDeterministicFillableTakerAssetAmount);
             const actual = await testContract.getOrderFillableTakerAssetAmounts(orders, signatures).callAsync();
             expect(actual).to.deep.eq(expected);
@@ -269,7 +269,7 @@ blockchainTests('erc20-bridge-sampler', env => {
         it('returns zero for an order with zero maker asset amount', async () => {
             const orders = createOrders(MAKER_TOKEN, TAKER_TOKEN, 1);
             orders[0].makerAssetAmount = constants.ZERO_AMOUNT;
-            const signatures: string[] = _.times(orders.length, hexUtils.random);
+            const signatures: string[] = _.times(orders.length, i => hexUtils.random());
             const actual = await testContract.getOrderFillableTakerAssetAmounts(orders, signatures).callAsync();
             expect(actual).to.deep.eq([constants.ZERO_AMOUNT]);
         });
@@ -277,7 +277,7 @@ blockchainTests('erc20-bridge-sampler', env => {
         it('returns zero for an order with zero taker asset amount', async () => {
             const orders = createOrders(MAKER_TOKEN, TAKER_TOKEN, 1);
             orders[0].takerAssetAmount = constants.ZERO_AMOUNT;
-            const signatures: string[] = _.times(orders.length, hexUtils.random);
+            const signatures: string[] = _.times(orders.length, i => hexUtils.random());
             const actual = await testContract.getOrderFillableTakerAssetAmounts(orders, signatures).callAsync();
             expect(actual).to.deep.eq([constants.ZERO_AMOUNT]);
         });
@@ -293,7 +293,7 @@ blockchainTests('erc20-bridge-sampler', env => {
     describe('getOrderFillableMakerAssetAmounts()', () => {
         it('returns the expected amount for each order', async () => {
             const orders = createOrders(MAKER_TOKEN, TAKER_TOKEN);
-            const signatures: string[] = _.times(orders.length, hexUtils.random);
+            const signatures: string[] = _.times(orders.length, i => hexUtils.random());
             const expected = orders.map(getDeterministicFillableMakerAssetAmount);
             const actual = await testContract.getOrderFillableMakerAssetAmounts(orders, signatures).callAsync();
             expect(actual).to.deep.eq(expected);
@@ -307,7 +307,7 @@ blockchainTests('erc20-bridge-sampler', env => {
         it('returns zero for an order with zero maker asset amount', async () => {
             const orders = createOrders(MAKER_TOKEN, TAKER_TOKEN, 1);
             orders[0].makerAssetAmount = constants.ZERO_AMOUNT;
-            const signatures: string[] = _.times(orders.length, hexUtils.random);
+            const signatures: string[] = _.times(orders.length, i => hexUtils.random());
             const actual = await testContract.getOrderFillableMakerAssetAmounts(orders, signatures).callAsync();
             expect(actual).to.deep.eq([constants.ZERO_AMOUNT]);
         });
@@ -315,7 +315,7 @@ blockchainTests('erc20-bridge-sampler', env => {
         it('returns zero for an order with zero taker asset amount', async () => {
             const orders = createOrders(MAKER_TOKEN, TAKER_TOKEN, 1);
             orders[0].takerAssetAmount = constants.ZERO_AMOUNT;
-            const signatures: string[] = _.times(orders.length, hexUtils.random);
+            const signatures: string[] = _.times(orders.length, i => hexUtils.random());
             const actual = await testContract.getOrderFillableMakerAssetAmounts(orders, signatures).callAsync();
             expect(actual).to.deep.eq([constants.ZERO_AMOUNT]);
         });
@@ -330,7 +330,7 @@ blockchainTests('erc20-bridge-sampler', env => {
 
     describe('queryOrdersAndSampleSells()', () => {
         const ORDERS = createOrders(MAKER_TOKEN, TAKER_TOKEN);
-        const SIGNATURES: string[] = _.times(ORDERS.length, hexUtils.random);
+        const SIGNATURES: string[] = _.times(ORDERS.length, i => hexUtils.random());
 
         before(async () => {
             await testContract.createTokenExchanges([MAKER_TOKEN, TAKER_TOKEN]).awaitTransactionSuccessAsync();
@@ -436,7 +436,7 @@ blockchainTests('erc20-bridge-sampler', env => {
 
     describe('queryOrdersAndSampleBuys()', () => {
         const ORDERS = createOrders(MAKER_TOKEN, TAKER_TOKEN);
-        const SIGNATURES: string[] = _.times(ORDERS.length, hexUtils.random);
+        const SIGNATURES: string[] = _.times(ORDERS.length, i => hexUtils.random());
 
         before(async () => {
             await testContract.createTokenExchanges([MAKER_TOKEN, TAKER_TOKEN]).awaitTransactionSuccessAsync();

--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -13,6 +13,10 @@
             {
                 "note": "Added `getBatchMarketBuySwapQuoteForAssetDataAsync` on `SwapQuoter`",
                 "pr": 2427
+            },
+            {
+                "note": "Add exponential sampling distribution and `sampleDistributionBase` option to `SwapQuoter`",
+                "pr": 2427
             }
         ]
     },

--- a/packages/asset-swapper/src/utils/market_operation_utils/constants.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/constants.ts
@@ -24,12 +24,14 @@ export const SELL_SOURCES = [ERC20BridgeSource.Uniswap, ERC20BridgeSource.Eth2Da
 export const BUY_SOURCES = [ERC20BridgeSource.Uniswap, ERC20BridgeSource.Eth2Dai];
 
 export const DEFAULT_GET_MARKET_ORDERS_OPTS: GetMarketOrdersOpts = {
-    runLimit: 4096,
+    // tslint:disable-next-line: custom-no-magic-numbers
+    runLimit: 2 ** 15,
     excludedSources: [],
     bridgeSlippage: 0.0005,
-    dustFractionThreshold: 0.01,
-    numSamples: 10,
+    dustFractionThreshold: 0.0025,
+    numSamples: 12,
     noConflicts: true,
+    sampleDistributionBase: 1.25,
 };
 
 export const constants = {
@@ -40,5 +42,5 @@ export const constants = {
     DEFAULT_GET_MARKET_ORDERS_OPTS,
     ERC20_PROXY_ID: '0xf47261b0',
     WALLET_SIGNATURE: '0x04',
-    SAMPLER_CONTRACT_GAS_LIMIT: 10e6,
+    SAMPLER_CONTRACT_GAS_LIMIT: 16e6,
 };

--- a/packages/asset-swapper/src/utils/market_operation_utils/index.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/index.ts
@@ -63,7 +63,7 @@ export class MarketOperationUtils {
         };
         const [fillableAmounts, dexQuotes] = await this._dexSampler.getFillableAmountsAndSampleMarketSellAsync(
             nativeOrders,
-            DexOrderSampler.getSampleAmounts(takerAmount, _opts.numSamples),
+            DexOrderSampler.getSampleAmounts(takerAmount, _opts.numSamples, _opts.sampleDistributionBase),
             difference(SELL_SOURCES, _opts.excludedSources),
         );
         const nativeOrdersWithFillableAmounts = createSignedOrdersWithFillableAmounts(
@@ -78,7 +78,6 @@ export class MarketOperationUtils {
             _opts.dustFractionThreshold,
         );
         const clippedNativePath = clipPathToInput(prunedNativePath, takerAmount);
-
         const dexPaths = createPathsFromDexQuotes(dexQuotes, _opts.noConflicts);
         const allPaths = [...dexPaths];
         const allFills = flattenDexPaths(dexPaths);
@@ -134,7 +133,7 @@ export class MarketOperationUtils {
 
         const [fillableAmounts, dexQuotes] = await this._dexSampler.getFillableAmountsAndSampleMarketBuyAsync(
             nativeOrders,
-            DexOrderSampler.getSampleAmounts(makerAmount, _opts.numSamples),
+            DexOrderSampler.getSampleAmounts(makerAmount, _opts.numSamples, _opts.sampleDistributionBase),
             difference(BUY_SOURCES, _opts.excludedSources),
         );
         const signedOrderWithFillableAmounts = this._createBuyOrdersPathFromSamplerResultIfExists(

--- a/packages/asset-swapper/src/utils/market_operation_utils/sampler.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/sampler.ts
@@ -13,16 +13,14 @@ export class DexOrderSampler {
     /**
      * Generate sample amounts up to `maxFillAmount`.
      */
-    public static getSampleAmounts(maxFillAmount: BigNumber, numSamples: number): BigNumber[] {
-        const amounts = [];
-        for (let i = 0; i < numSamples; i++) {
-            amounts.push(
-                maxFillAmount
-                    .times(i + 1)
-                    .div(numSamples)
-                    .integerValue(BigNumber.ROUND_UP),
-            );
-        }
+    public static getSampleAmounts(maxFillAmount: BigNumber, numSamples: number, expBase: number = 1): BigNumber[] {
+        const distribution = [...Array<BigNumber>(numSamples)].map((v, i) => new BigNumber(expBase).pow(i));
+        const stepSizes = distribution.map(d => d.div(BigNumber.sum(...distribution)));
+        const amounts = stepSizes.map((s, i) => {
+            return maxFillAmount
+                .times(BigNumber.sum(...[0, ...stepSizes.slice(0, i + 1)]))
+                .integerValue(BigNumber.ROUND_UP);
+        });
         return amounts;
     }
 

--- a/packages/asset-swapper/src/utils/market_operation_utils/types.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/types.ts
@@ -114,4 +114,12 @@ export interface GetMarketOrdersOpts {
      * Default is 0.01 (100 basis points).
      */
     dustFractionThreshold: number;
+    /**
+     * The exponential sampling distribution base.
+     * A value of 1 will result in evenly spaced samples.
+     * > 1 will result in more samples at lower sizes.
+     * < 1 will result in more samples at higher sizes.
+     * Default: 1.25.
+     */
+    sampleDistributionBase: number;
 }

--- a/packages/asset-swapper/src/utils/protocol_fee_utils.ts
+++ b/packages/asset-swapper/src/utils/protocol_fee_utils.ts
@@ -9,9 +9,9 @@ export class ProtocolFeeUtils {
     public gasPriceEstimation: BigNumber;
     private readonly _gasPriceHeart: any;
 
-    constructor(gasPricePollingIntervalInMs: number) {
+    constructor(gasPricePollingIntervalInMs: number, initialGasPrice: BigNumber = constants.ZERO_AMOUNT) {
         this._gasPriceHeart = heartbeats.createHeart(gasPricePollingIntervalInMs);
-        this.gasPriceEstimation = constants.ZERO_AMOUNT;
+        this.gasPriceEstimation = initialGasPrice;
         this._initializeHeartBeat();
     }
 

--- a/packages/asset-swapper/test/exchange_swap_quote_consumer_test.ts
+++ b/packages/asset-swapper/test/exchange_swap_quote_consumer_test.ts
@@ -123,7 +123,7 @@ describe('ExchangeSwapQuoteConsumer', () => {
         };
         const privateKey = devConstants.TESTRPC_PRIVATE_KEYS[userAddresses.indexOf(makerAddress)];
         orderFactory = new OrderFactory(privateKey, defaultOrderParams);
-        protocolFeeUtils = new ProtocolFeeUtils(constants.PROTOCOL_FEE_UTILS_POLLING_INTERVAL_IN_MS);
+        protocolFeeUtils = new ProtocolFeeUtils(constants.PROTOCOL_FEE_UTILS_POLLING_INTERVAL_IN_MS, new BigNumber(1));
         expectMakerAndTakerBalancesForTakerAssetAsync = expectMakerAndTakerBalancesAsyncFactory(
             erc20TakerTokenContract,
             makerAddress,

--- a/packages/asset-swapper/test/forwarder_swap_quote_consumer_test.ts
+++ b/packages/asset-swapper/test/forwarder_swap_quote_consumer_test.ts
@@ -126,7 +126,7 @@ describe('ForwarderSwapQuoteConsumer', () => {
         };
         const privateKey = devConstants.TESTRPC_PRIVATE_KEYS[userAddresses.indexOf(makerAddress)];
         orderFactory = new OrderFactory(privateKey, defaultOrderParams);
-        protocolFeeUtils = new ProtocolFeeUtils(constants.PROTOCOL_FEE_UTILS_POLLING_INTERVAL_IN_MS);
+        protocolFeeUtils = new ProtocolFeeUtils(constants.PROTOCOL_FEE_UTILS_POLLING_INTERVAL_IN_MS, new BigNumber(1));
         expectMakerAndTakerBalancesAsync = expectMakerAndTakerBalancesAsyncFactory(
             erc20TokenContract,
             makerAddress,

--- a/packages/asset-swapper/test/market_operation_utils_test.ts
+++ b/packages/asset-swapper/test/market_operation_utils_test.ts
@@ -306,7 +306,7 @@ describe('MarketOperationUtils tests', () => {
                 _.times(3, () => SOURCE_RATES[ERC20BridgeSource.Native][0]),
             );
             const DEFAULT_SAMPLER = createSamplerFromSellRates(SOURCE_RATES);
-            const DEFAULT_OPTS = { numSamples: 3, runLimit: 0 };
+            const DEFAULT_OPTS = { numSamples: 3, runLimit: 0, sampleDistributionBase: 1 };
             const defaultMarketOperationUtils = new MarketOperationUtils(
                 DEFAULT_SAMPLER,
                 contractAddresses,
@@ -552,7 +552,7 @@ describe('MarketOperationUtils tests', () => {
                 _.times(3, () => SOURCE_RATES[ERC20BridgeSource.Native][0]),
             );
             const DEFAULT_SAMPLER = createSamplerFromBuyRates(SOURCE_RATES);
-            const DEFAULT_OPTS = { numSamples: 3, runLimit: 0 };
+            const DEFAULT_OPTS = { numSamples: 3, runLimit: 0, sampleDistributionBase: 1 };
             const defaultMarketOperationUtils = new MarketOperationUtils(
                 DEFAULT_SAMPLER,
                 contractAddresses,

--- a/packages/asset-swapper/test/swap_quote_consumer_utils_test.ts
+++ b/packages/asset-swapper/test/swap_quote_consumer_utils_test.ts
@@ -119,7 +119,7 @@ describe('swapQuoteConsumerUtils', () => {
         };
         const privateKey = devConstants.TESTRPC_PRIVATE_KEYS[userAddresses.indexOf(makerAddress)];
         orderFactory = new OrderFactory(privateKey, defaultOrderParams);
-        protocolFeeUtils = new ProtocolFeeUtils(constants.PROTOCOL_FEE_UTILS_POLLING_INTERVAL_IN_MS);
+        protocolFeeUtils = new ProtocolFeeUtils(constants.PROTOCOL_FEE_UTILS_POLLING_INTERVAL_IN_MS, new BigNumber(1));
         forwarderOrderFactory = new OrderFactory(privateKey, defaultForwarderOrderParams);
 
         swapQuoteConsumer = new SwapQuoteConsumer(provider, {

--- a/packages/contract-artifacts/CHANGELOG.json
+++ b/packages/contract-artifacts/CHANGELOG.json
@@ -5,6 +5,10 @@
             {
                 "note": "Update all artifacts.",
                 "pr": 2432
+            },
+            {
+                "note": "Update `IERC20BridgeSampler artifact",
+                "pr": 2427
             }
         ]
     },

--- a/packages/contract-artifacts/artifacts/IERC20BridgeSampler.json
+++ b/packages/contract-artifacts/artifacts/IERC20BridgeSampler.json
@@ -284,6 +284,26 @@
                     },
                     "return": "orderFillableTakerAssetAmounts How much taker asset can be filled         by each order in `orders`."
                 },
+                "queryBatchOrdersAndSampleBuys((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes,bytes,bytes)[][],bytes[][],address[],uint256[][])": {
+                    "details": "Query batches of native orders and sample buy quotes on multiple DEXes at once.",
+                    "params": {
+                        "makerTokenAmounts": "Batches of Maker token sell amount for each sample.",
+                        "orderSignatures": "Batches of Signatures for each respective order in `orders`.",
+                        "orders": "Batches of Native orders to query.",
+                        "sources": "Address of each DEX. Passing in an unsupported DEX will throw."
+                    },
+                    "return": "ordersAndSamples How much taker asset can be filled         by each order in `orders`. Taker amounts sold for each source at         each maker token amount. First indexed by source index, then sample         index"
+                },
+                "queryBatchOrdersAndSampleSells((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes,bytes,bytes)[][],bytes[][],address[],uint256[][])": {
+                    "details": "Query batches of native orders and sample sell quotes on multiple DEXes at once.",
+                    "params": {
+                        "orderSignatures": "Batches of Signatures for each respective order in `orders`.",
+                        "orders": "Batches of Native orders to query.",
+                        "sources": "Address of each DEX. Passing in an unsupported DEX will throw.",
+                        "takerTokenAmounts": "Batches of Taker token sell amount for each sample."
+                    },
+                    "return": "ordersAndSamples How much taker asset can be filled         by each order in `orders`. Maker amounts bought for each source at         each taker token amount. First indexed by source index, then sample         index."
+                },
                 "queryOrdersAndSampleBuys((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes,bytes,bytes)[],bytes[],address[],uint256[])": {
                     "details": "Query native orders and sample buy quotes on multiple DEXes at once.",
                     "params": {

--- a/packages/contract-wrappers/src/generated-wrappers/i_erc20_bridge_sampler.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/i_erc20_bridge_sampler.ts
@@ -797,6 +797,7 @@ export class IERC20BridgeSamplerContract extends BaseContract {
                     defaultBlock,
                 );
                 const abiEncoder = self._lookupAbiEncoder(functionSignature);
+                BaseContract._throwIfUnexpectedEmptyCallResult(rawCallResult, abiEncoder);
                 return abiEncoder.strictDecodeReturnValue<BigNumber[]>(rawCallResult);
             },
             getABIEncodedTransactionData(): string {
@@ -843,6 +844,7 @@ export class IERC20BridgeSamplerContract extends BaseContract {
                     defaultBlock,
                 );
                 const abiEncoder = self._lookupAbiEncoder(functionSignature);
+                BaseContract._throwIfUnexpectedEmptyCallResult(rawCallResult, abiEncoder);
                 return abiEncoder.strictDecodeReturnValue<BigNumber[]>(rawCallResult);
             },
             getABIEncodedTransactionData(): string {
@@ -861,6 +863,7 @@ export class IERC20BridgeSamplerContract extends BaseContract {
      * @returns ordersAndSamples How much taker asset can be filled         by each order in &#x60;orders&#x60;. Taker amounts sold for each source at         each maker token amount. First indexed by source index, then sample         index
      */
     public queryBatchOrdersAndSampleBuys(
+        // tslint:disable-next-line: array-type
         orders: Array<{
             makerAddress: string;
             takerAddress: string;
@@ -925,6 +928,7 @@ export class IERC20BridgeSamplerContract extends BaseContract {
      * @returns ordersAndSamples How much taker asset can be filled         by each order in &#x60;orders&#x60;. Maker amounts bought for each source at         each taker token amount. First indexed by source index, then sample         index.
      */
     public queryBatchOrdersAndSampleSells(
+        // tslint:disable-next-line: array-type
         orders: Array<{
             makerAddress: string;
             takerAddress: string;
@@ -1027,6 +1031,7 @@ export class IERC20BridgeSamplerContract extends BaseContract {
                     defaultBlock,
                 );
                 const abiEncoder = self._lookupAbiEncoder(functionSignature);
+                BaseContract._throwIfUnexpectedEmptyCallResult(rawCallResult, abiEncoder);
                 return abiEncoder.strictDecodeReturnValue<[BigNumber[], BigNumber[][]]>(rawCallResult);
             },
             getABIEncodedTransactionData(): string {
@@ -1088,6 +1093,7 @@ export class IERC20BridgeSamplerContract extends BaseContract {
                     defaultBlock,
                 );
                 const abiEncoder = self._lookupAbiEncoder(functionSignature);
+                BaseContract._throwIfUnexpectedEmptyCallResult(rawCallResult, abiEncoder);
                 return abiEncoder.strictDecodeReturnValue<[BigNumber[], BigNumber[][]]>(rawCallResult);
             },
             getABIEncodedTransactionData(): string {
@@ -1130,6 +1136,7 @@ export class IERC20BridgeSamplerContract extends BaseContract {
                     defaultBlock,
                 );
                 const abiEncoder = self._lookupAbiEncoder(functionSignature);
+                BaseContract._throwIfUnexpectedEmptyCallResult(rawCallResult, abiEncoder);
                 return abiEncoder.strictDecodeReturnValue<BigNumber[][]>(rawCallResult);
             },
             getABIEncodedTransactionData(): string {
@@ -1172,6 +1179,7 @@ export class IERC20BridgeSamplerContract extends BaseContract {
                     defaultBlock,
                 );
                 const abiEncoder = self._lookupAbiEncoder(functionSignature);
+                BaseContract._throwIfUnexpectedEmptyCallResult(rawCallResult, abiEncoder);
                 return abiEncoder.strictDecodeReturnValue<BigNumber[][]>(rawCallResult);
             },
             getABIEncodedTransactionData(): string {

--- a/packages/contract-wrappers/src/generated-wrappers/i_erc20_bridge_sampler.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/i_erc20_bridge_sampler.ts
@@ -850,8 +850,18 @@ export class IERC20BridgeSamplerContract extends BaseContract {
             },
         };
     }
+    /**
+     * Query batches of native orders and sample buy quotes on multiple DEXes at once.
+     * @param orders Batches of Native orders to query.
+     * @param orderSignatures Batches of Signatures for each respective order in
+     *     `orders`.
+     * @param sources Address of each DEX. Passing in an unsupported DEX will
+     *     throw.
+     * @param makerTokenAmounts Batches of Maker token sell amount for each sample.
+     * @returns ordersAndSamples How much taker asset can be filled         by each order in &#x60;orders&#x60;. Taker amounts sold for each source at         each maker token amount. First indexed by source index, then sample         index
+     */
     public queryBatchOrdersAndSampleBuys(
-        orders: Array<Array<{
+        orders: Array<{
             makerAddress: string;
             takerAddress: string;
             feeRecipientAddress: string;
@@ -866,7 +876,7 @@ export class IERC20BridgeSamplerContract extends BaseContract {
             takerAssetData: string;
             makerFeeAssetData: string;
             takerFeeAssetData: string;
-        }>>,
+        }>[],
         orderSignatures: string[][],
         sources: string[],
         makerTokenAmounts: BigNumber[][],
@@ -904,8 +914,18 @@ export class IERC20BridgeSamplerContract extends BaseContract {
             },
         };
     }
+    /**
+     * Query batches of native orders and sample sell quotes on multiple DEXes at once.
+     * @param orders Batches of Native orders to query.
+     * @param orderSignatures Batches of Signatures for each respective order in
+     *     `orders`.
+     * @param sources Address of each DEX. Passing in an unsupported DEX will
+     *     throw.
+     * @param takerTokenAmounts Batches of Taker token sell amount for each sample.
+     * @returns ordersAndSamples How much taker asset can be filled         by each order in &#x60;orders&#x60;. Maker amounts bought for each source at         each taker token amount. First indexed by source index, then sample         index.
+     */
     public queryBatchOrdersAndSampleSells(
-        orders: Array<Array<{
+        orders: Array<{
             makerAddress: string;
             takerAddress: string;
             feeRecipientAddress: string;
@@ -920,7 +940,7 @@ export class IERC20BridgeSamplerContract extends BaseContract {
             takerAssetData: string;
             makerFeeAssetData: string;
             takerFeeAssetData: string;
-        }>>,
+        }>[],
         orderSignatures: string[][],
         sources: string[],
         takerTokenAmounts: BigNumber[][],


### PR DESCRIPTION
## Description
- Sampler contract now forwards more gas to kyber and eth2dai, to make up for large fills.
- Sampler now bails if any DEX sample reverts.
- Add exponential sampling distribution to `SwapQuoter`, exposed via option `sampleDistributionBase`.
- Tweak other default `SwapQuoter` options to be friendlier to big fills.
- Disable ethgasstation requests in `asset-swapper` tests because they can fail on CI.

**TODO**: Deploy thew new `ERC20BridgeSampler` contract and update `contract-addresses`. 

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
