### PR TITLE
Fix/python latest ganache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,7 +193,7 @@ jobs:
         working_directory: ~/repo
         docker:
             - image: nikolaik/python-nodejs:python3.7-nodejs8
-            - image: 0xorg/ganache-cli
+            - image: 0xorg/ganache-cli:6.0.0
             - image: 0xorg/mesh:0xV3
               environment:
                   ETHEREUM_RPC_URL: 'http://localhost:8545'

--- a/python-packages/contract_wrappers/src/zero_ex/contract_wrappers/__init__.py
+++ b/python-packages/contract_wrappers/src/zero_ex/contract_wrappers/__init__.py
@@ -380,7 +380,7 @@ will be consumed.
 ...     ),
 ...     tx_params=TxParams(from_=maker_address),
 ... )
-74...
+71...
 """
 
 from .tx_params import TxParams

--- a/python-packages/sra_client/test/relayer/docker-compose.yml
+++ b/python-packages/sra_client/test/relayer/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3'
 services:
     ganache:
-        image: "0xorg/ganache-cli"
+        image: "0xorg/ganache-cli:6.0.0"
         ports:
             - "8545:8545"
     mesh:


### PR DESCRIPTION
Bump `test-python` to use `6.0.0` 0xorg/ganache-cli image with istanbul support.