### PR TITLE
[asset-swapper] Change Exchange sell to marketSellOrdersFillOrKill

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -24,6 +24,7 @@
             },
             {
                 "note": "Change Exchange sell function from `marketSellOrdersNoThrow` to `marketSellOrdersFillOrKill`",
+                "pr": 2450
             }
         ]
     },

--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -21,6 +21,9 @@
             {
                 "note": "Compute more accurate best quote price",
                 "pr": 2427
+            },
+            {
+                "note": "Change Exchange sell function from `marketSellOrdersNoThrow` to `marketSellOrdersFillOrKill`",
             }
         ]
     },

--- a/packages/asset-swapper/src/quote_consumers/exchange_swap_quote_consumer.ts
+++ b/packages/asset-swapper/src/quote_consumers/exchange_swap_quote_consumer.ts
@@ -51,7 +51,7 @@ export class ExchangeSwapQuoteConsumer implements SwapQuoteConsumerBase {
                 .getABIEncodedTransactionData();
         } else {
             calldataHexString = this._exchangeContract
-                .marketSellOrdersNoThrow(orders, quote.takerAssetFillAmount, signatures)
+                .marketSellOrdersFillOrKill(orders, quote.takerAssetFillAmount, signatures)
                 .getABIEncodedTransactionData();
         }
 


### PR DESCRIPTION
## Description

Inconsistency with `getCallData` and `execute` and with buy versus sell. In execute we use [`marketSellOrdersFillOrKill`](https://github.com/0xProject/0x-monorepo/pull/2450/files#diff-d9a13f38d79f128b4e2775a4f283d1e3R101)