### PR TITLE
asset-swapper: Fix understimated protocol fee in worst case quote.

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "4.0.1",
+        "changes": [
+            {
+                "note": "Fix underestimated protocol fee in worst case quote.",
+                "pr": 2452
+            }
+        ]
+    },
+    {
         "version": "4.0.0",
         "changes": [
             {

--- a/packages/asset-swapper/src/utils/swap_quote_calculator.ts
+++ b/packages/asset-swapper/src/utils/swap_quote_calculator.ts
@@ -298,7 +298,7 @@ export class SwapQuoteCalculator {
             filledOrders.push(order);
         }
         const protocolFeeInWeiAmount = await this._protocolFeeUtils.calculateWorstCaseProtocolFeeAsync(
-            filledOrders,
+            !worstCase ? filledOrders : orders,
             gasPrice,
         );
         return {
@@ -387,7 +387,7 @@ export class SwapQuoteCalculator {
             filledOrders.push(order);
         }
         const protocolFeeInWeiAmount = await this._protocolFeeUtils.calculateWorstCaseProtocolFeeAsync(
-            filledOrders,
+            !worstCase ? filledOrders : orders,
             gasPrice,
         );
         return {

--- a/packages/asset-swapper/test/swap_quote_calculator_test.ts
+++ b/packages/asset-swapper/test/swap_quote_calculator_test.ts
@@ -312,7 +312,7 @@ describe('swapQuoteCalculator', () => {
                 takerAssetAmount: assetSellAmount,
                 totalTakerAssetAmount: assetSellAmount,
                 makerAssetAmount: baseUnitAmount(1.6),
-                protocolFeeInWeiAmount: baseUnitAmount(15, 4),
+                protocolFeeInWeiAmount: baseUnitAmount(45, 4),
             });
         });
         it('calculates a correct swapQuote with no slippage (takerAsset denominated fee orders)', async () => {
@@ -391,7 +391,7 @@ describe('swapQuoteCalculator', () => {
                 takerAssetAmount: assetSellAmount.minus(baseUnitAmount(1.2)),
                 totalTakerAssetAmount: assetSellAmount,
                 makerAssetAmount: baseUnitAmount(1.8),
-                protocolFeeInWeiAmount: baseUnitAmount(15, 4),
+                protocolFeeInWeiAmount: baseUnitAmount(30, 4),
             });
         });
         it('calculates a correct swapQuote with no slippage (makerAsset denominated fee orders)', async () => {
@@ -472,7 +472,7 @@ describe('swapQuoteCalculator', () => {
                 takerAssetAmount: assetSellAmount.minus(baseUnitAmount(2)),
                 totalTakerAssetAmount: assetSellAmount,
                 makerAssetAmount: baseUnitAmount(0.8),
-                protocolFeeInWeiAmount: baseUnitAmount(15, 4),
+                protocolFeeInWeiAmount: baseUnitAmount(45, 4),
             });
         });
     });


### PR DESCRIPTION
## Description

There are scenarios where the protocol fee is actually *lower* when calculating the worst case fill order vs the best case. Because 0x-api uses the worst case protocol fees to compute the final quote `value`, we can end up underpaying gas at fill time.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
