### PR TITLE
[base-contract] throw string revert error

### DIFF
--- a/packages/base-contract/CHANGELOG.json
+++ b/packages/base-contract/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "6.1.1",
+        "changes": [
+            {
+                "note": "Throw Error when revert is StringRevertError",
+                "pr": 2453
+            }
+        ]
+    },
+    {
         "version": "6.1.0",
         "changes": [
             {

--- a/packages/base-contract/src/index.ts
+++ b/packages/base-contract/src/index.ts
@@ -142,13 +142,13 @@ export class BaseContract {
         let revertError: RevertError;
         try {
             revertError = decodeThrownErrorAsRevertError(error);
-            // Re-cast StringRevertErrors as plain Errors for backwards-compatibility.
-            if (revertError instanceof StringRevertError) {
-                throw new Error(revertError.values.message as string);
-            }
         } catch (err) {
             // Can't decode it.
             return;
+        }
+        // Re-cast StringRevertErrors as plain Errors for backwards-compatibility.
+        if (revertError instanceof StringRevertError) {
+            throw new Error(revertError.values.message as string);
         }
         throw revertError;
     }


### PR DESCRIPTION
Was throwing inside a try/catch and immediately getting caught. Exception was then re-thrown as:
```js
{
  message: 'VM execution error.',
  data:
   'Reverted 0x08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000025455243323042726964676553616d706c65722f494e56414c49445f544f4b454e5f50414952000000000000000000000000000000000000000000000000000000' 
}
```