### PR TITLE
Stop hardcoding contract addresses

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "4.0.2",
+        "changes": [
+            {
+                "note": "Allow contract addresses to be passed as optional constructor ags instead of hardcoding",
+                "pr": 2461
+            }
+        ]
+    },
+    {
         "version": "4.0.1",
         "changes": [
             {

--- a/packages/asset-swapper/src/index.ts
+++ b/packages/asset-swapper/src/index.ts
@@ -1,3 +1,4 @@
+export { ContractAddresses } from '@0x/contract-addresses';
 export { WSOpts } from '@0x/mesh-rpc-client';
 export {
     AcceptedRejectedOrders,

--- a/packages/asset-swapper/src/quote_consumers/swap_quote_consumer.ts
+++ b/packages/asset-swapper/src/quote_consumers/swap_quote_consumer.ts
@@ -42,7 +42,7 @@ export class SwapQuoteConsumer implements SwapQuoteConsumerBase {
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
         this.provider = provider;
         this.chainId = chainId;
-        this._contractAddresses = getContractAddressesForChainOrThrow(chainId);
+        this._contractAddresses = options.contractAddresses || getContractAddressesForChainOrThrow(chainId);
         this._exchangeConsumer = new ExchangeSwapQuoteConsumer(supportedProvider, this._contractAddresses, options);
         this._forwarderConsumer = new ForwarderSwapQuoteConsumer(supportedProvider, this._contractAddresses, options);
     }

--- a/packages/asset-swapper/src/swap_quoter.ts
+++ b/packages/asset-swapper/src/swap_quoter.ts
@@ -159,7 +159,7 @@ export class SwapQuoter {
         this.orderbook = orderbook;
         this.expiryBufferMs = expiryBufferMs;
         this.permittedOrderFeeTypes = permittedOrderFeeTypes;
-        this._contractAddresses = getContractAddressesForChainOrThrow(chainId);
+        this._contractAddresses = options.contractAddresses || getContractAddressesForChainOrThrow(chainId);
         this._devUtilsContract = new DevUtilsContract(this._contractAddresses.devUtils, provider);
         this._protocolFeeUtils = new ProtocolFeeUtils(constants.PROTOCOL_FEE_UTILS_POLLING_INTERVAL_IN_MS);
         this._orderStateUtils = new OrderStateUtils(this._devUtilsContract);

--- a/packages/asset-swapper/src/types.ts
+++ b/packages/asset-swapper/src/types.ts
@@ -1,3 +1,4 @@
+import { ContractAddresses } from '@0x/migrations';
 import { SignedOrder } from '@0x/types';
 import { BigNumber } from '@0x/utils';
 
@@ -87,6 +88,7 @@ export interface SwapQuoteConsumerBase {
  */
 export interface SwapQuoteConsumerOpts {
     chainId: number;
+    contractAddresses?: ContractAddresses;
 }
 
 /**
@@ -198,6 +200,7 @@ export interface SwapQuoterOpts extends OrderPrunerOpts {
     chainId: number;
     orderRefreshIntervalMs: number;
     expiryBufferMs: number;
+    contractAddresses?: ContractAddresses;
 }
 
 /**


### PR DESCRIPTION
## Description

In `@0x/asset-swapper`, some modules are instantiated by referring to addresses hardcoded in `@0x/contract-addresses`. This creates difficulty in testing because some contracts are not included on the Ganache snapshot or migration script e.g. ERC20BridgeSampler. 

This PR adds an optional `contractAddresses` param. If not provided, will fallback to previous behaviour of fetching from `@0x/contract-addresses`.

## Testing instructions

Tests should pass

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

 * Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
