### PR TITLE
[asset-swapper] Bump sampler gas limit and allow for override

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -3,7 +3,12 @@
         "version": "4.1.1",
         "changes": [
             {
-                "note": "Prune orders before creating a dummy order for the Sampler"
+                "note": "Prune orders before creating a dummy order for the Sampler",
+                "pr": 2470
+            },
+            {
+                "note": "Bump sampler gas limit to 60e6",
+                "pr": 2471
             }
         ]
     },

--- a/packages/asset-swapper/src/constants.ts
+++ b/packages/asset-swapper/src/constants.ts
@@ -42,7 +42,7 @@ const DEFAULT_SWAP_QUOTER_OPTS: SwapQuoterOpts = {
         orderRefreshIntervalMs: 10000, // 10 seconds
     },
     ...DEFAULT_ORDER_PRUNER_OPTS,
-    samplerGasLimit: 60e6,
+    samplerGasLimit: 36e6,
 };
 
 const DEFAULT_FORWARDER_EXTENSION_CONTRACT_OPTS: ForwarderExtensionContractOpts = {

--- a/packages/asset-swapper/src/constants.ts
+++ b/packages/asset-swapper/src/constants.ts
@@ -42,6 +42,7 @@ const DEFAULT_SWAP_QUOTER_OPTS: SwapQuoterOpts = {
         orderRefreshIntervalMs: 10000, // 10 seconds
     },
     ...DEFAULT_ORDER_PRUNER_OPTS,
+    samplerGasLimit: 60e6,
 };
 
 const DEFAULT_FORWARDER_EXTENSION_CONTRACT_OPTS: ForwarderExtensionContractOpts = {

--- a/packages/asset-swapper/src/swap_quoter.ts
+++ b/packages/asset-swapper/src/swap_quoter.ts
@@ -145,7 +145,7 @@ export class SwapQuoter {
      * @return  An instance of SwapQuoter
      */
     constructor(supportedProvider: SupportedProvider, orderbook: Orderbook, options: Partial<SwapQuoterOpts> = {}) {
-        const { chainId, expiryBufferMs, permittedOrderFeeTypes } = _.merge(
+        const { chainId, expiryBufferMs, permittedOrderFeeTypes, samplerGasLimit } = _.merge(
             {},
             constants.DEFAULT_SWAP_QUOTER_OPTS,
             options,
@@ -166,7 +166,7 @@ export class SwapQuoter {
         const samplerContract = new IERC20BridgeSamplerContract(
             this._contractAddresses.erc20BridgeSampler,
             this.provider,
-            { gas: marketOperationConstants.SAMPLER_CONTRACT_GAS_LIMIT },
+            { gas: samplerGasLimit },
         );
         this._marketOperationUtils = new MarketOperationUtils(samplerContract, this._contractAddresses, {
             chainId,

--- a/packages/asset-swapper/src/swap_quoter.ts
+++ b/packages/asset-swapper/src/swap_quoter.ts
@@ -22,7 +22,6 @@ import {
 import { assert } from './utils/assert';
 import { calculateLiquidity } from './utils/calculate_liquidity';
 import { MarketOperationUtils } from './utils/market_operation_utils';
-import { constants as marketOperationConstants } from './utils/market_operation_utils/constants';
 import { dummyOrderUtils } from './utils/market_operation_utils/dummy_order_utils';
 import { orderPrunerUtils } from './utils/order_prune_utils';
 import { OrderStateUtils } from './utils/order_state_utils';

--- a/packages/asset-swapper/src/types.ts
+++ b/packages/asset-swapper/src/types.ts
@@ -204,7 +204,7 @@ export interface CalculateSwapQuoteOpts extends GetMarketOrdersOpts {}
  * orderRefreshIntervalMs: The interval in ms that getBuyQuoteAsync should trigger an refresh of orders and order states. Defaults to 10000ms (10s).
  * expiryBufferMs: The number of seconds to add when calculating whether an order is expired or not. Defaults to 300s (5m).
  * contractAddresses: Optionally override the contract addresses used for the chain
- * samplerGasLimit: The gas limit used when querying the sampler contract. Defaults to 60e6
+ * samplerGasLimit: The gas limit used when querying the sampler contract. Defaults to 36e6
  */
 export interface SwapQuoterOpts extends OrderPrunerOpts {
     chainId: number;

--- a/packages/asset-swapper/src/types.ts
+++ b/packages/asset-swapper/src/types.ts
@@ -203,12 +203,15 @@ export interface CalculateSwapQuoteOpts extends GetMarketOrdersOpts {}
  * chainId: The ethereum chain id. Defaults to 1 (mainnet).
  * orderRefreshIntervalMs: The interval in ms that getBuyQuoteAsync should trigger an refresh of orders and order states. Defaults to 10000ms (10s).
  * expiryBufferMs: The number of seconds to add when calculating whether an order is expired or not. Defaults to 300s (5m).
+ * contractAddresses: Optionally override the contract addresses used for the chain
+ * samplerGasLimit: The gas limit used when querying the sampler contract. Defaults to 60e6
  */
 export interface SwapQuoterOpts extends OrderPrunerOpts {
     chainId: number;
     orderRefreshIntervalMs: number;
     expiryBufferMs: number;
     contractAddresses?: ContractAddresses;
+    samplerGasLimit?: number;
 }
 
 /**

--- a/packages/asset-swapper/src/utils/market_operation_utils/constants.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/constants.ts
@@ -42,5 +42,4 @@ export const constants = {
     DEFAULT_GET_MARKET_ORDERS_OPTS,
     ERC20_PROXY_ID: '0xf47261b0',
     WALLET_SIGNATURE: '0x04',
-    SAMPLER_CONTRACT_GAS_LIMIT: 16e6,
 };


### PR DESCRIPTION
## Description

Sometimes sampling can be over `16e6` gas. On Kovan we had disabled Kyber as sampling can sometimes be `55,883,366` from `estimateGas`. It's a crazy amount. If we go over the set gas limit it results in an OOG exception. If unset it uses the current block limit.

I've exposed the option so it can be modified in a pinch rather than being a fixed constant. 

Perhaps in the future we calculate this based on the numSamples and sources involved (plus some buffer for 0x Native orders)

We do restrict gas limits for Kyber (1.5mil), Eth2Dai (1mil), Uniswap (150k)
`34.5e6 = 1.5e6 * 13 + 1e6 * 13 + .15e6 * 13`. So assuming 0 Native orders and `13` samples, we need a limit in the worst case of `34.5e6`. Setting it to `36e6` to accounts for 0x native orders.