### PR TITLE
[DNM][erc20-bridge-sampler] gas stipend for DevUtils

### DIFF
--- a/contracts/erc20-bridge-sampler/contracts/src/ERC20BridgeSampler.sol
+++ b/contracts/erc20-bridge-sampler/contracts/src/ERC20BridgeSampler.sol
@@ -40,6 +40,7 @@ contract ERC20BridgeSampler is
     uint256 constant internal KYBER_SAMPLE_CALL_GAS = 1500e3;
     uint256 constant internal UNISWAP_SAMPLE_CALL_GAS = 150e3;
     uint256 constant internal ETH2DAI_SAMPLE_CALL_GAS = 1000e3;
+    uint256 constant internal DEV_UTILS_SAMPLE_CALL_GAS = 500e3;
     address constant private UNISWAP_SOURCE = 0xc0a47dFe034B400B47bDaD5FecDa2621de6c4d95;
     address constant private ETH2DAI_SOURCE = 0x39755357759cE0d7f32dC8dC45414CCa409AE24e;
     address constant private KYBER_SOURCE = 0x818E6FECD516Ecc3849DAf6845e3EC868087B755;
@@ -208,7 +209,7 @@ contract ERC20BridgeSampler is
                 LibOrder.OrderInfo memory orderInfo,
                 uint256 fillableTakerAssetAmount,
                 bool isValidSignature
-            ) = IDevUtils(_getDevUtilsAddress()).getOrderRelevantState(
+            ) = IDevUtils(_getDevUtilsAddress()).getOrderRelevantState.gas(DEV_UTILS_SAMPLE_CALL_GAS)(
                 orders[i],
                 orderSignatures[i]
             );


### PR DESCRIPTION
Gives a 500e3 gas stipend to DevUtils to prevent any Invalid Opcode from consuming all gas and failing the `eth_call`

Deployed to Kovan only at `0x39f2a0dba5e6ea855369e2f09967169032173470`.

Applied into https://github.com/0xProject/0x-monorepo/pull/2474