### PR TITLE
ERC20BridgeSampler: Catch DevUtils reverts

### DIFF
--- a/contracts/erc20-bridge-sampler/CHANGELOG.json
+++ b/contracts/erc20-bridge-sampler/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "1.3.0",
+        "changes": [
+            {
+                "note": "Catch reverts to `DevUtils` calls",
+                "pr": 2476
+            }
+        ]
+    },
+    {
         "timestamp": 1580988106,
         "version": "1.2.1",
         "changes": [

--- a/packages/contract-addresses/CHANGELOG.json
+++ b/packages/contract-addresses/CHANGELOG.json
@@ -5,6 +5,10 @@
             {
                 "note": "Update `ERC20BridgeSampler` and `Eth2Dai` on mainnet and kovan.",
                 "pr": 2474
+            },
+            {
+                "note": "Update `ERC20BridgeSampler` address on mainnet and kovan.",
+                "pr": 2476
             }
         ]
     },

--- a/packages/contract-addresses/addresses.json
+++ b/packages/contract-addresses/addresses.json
@@ -23,7 +23,7 @@
         "devUtils": "0x161793cdca4ff9e766a706c2c49c36ac1340bbcd",
         "erc20BridgeProxy": "0x8ed95d1746bf1e4dab58d8ed4724f1ef95b20db0",
         "uniswapBridge": "0x533344cfdf2a3e911e2cf4c6f5ed08e791f5355f",
-        "erc20BridgeSampler": "0x45d41caec1cd893517e6e4e8222717d3d7a3bcb0",
+        "erc20BridgeSampler": "0x38b55fb7b13cbfbf8781e0f11a77b6199ae10a11",
         "kyberBridge": "0xf342f3a80fdc9b48713d58fe97e17f5cc764ee62",
         "eth2DaiBridge": "0xe3379a1956f4a79f39eb2e87bb441419e167538e",
         "chaiBridge": "0x77c31eba23043b9a72d13470f3a3a311344d7438",
@@ -114,7 +114,7 @@
         "erc20BridgeProxy": "0xfb2dd2a1366de37f7241c83d47da58fd503e2c64",
         "uniswapBridge": "0x8224aa8fe5c9f07d5a59c735386ff6cc6aaeb568",
         "eth2DaiBridge": "0x9485d65c6a2fae0d519cced5bd830e57c41998a9",
-        "erc20BridgeSampler": "0x5ad1553c2e60db118d2c01c0b73ac71e6c586b84",
+        "erc20BridgeSampler": "0x76a3d21fc9c16afd29eb12a5bdcedd5ddbf24357",
         "kyberBridge": "0xde7b2747624a647600fdb349184d0448ab954929",
         "chaiBridge": "0x0000000000000000000000000000000000000000",
         "dydxBridge": "0x0000000000000000000000000000000000000000"


### PR DESCRIPTION
## Description

Puts `getOrderRelevantState()` behind a `staticcall()` to catch reverts. Redeployed the sampler contract.

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
