### PR TITLE
Include bin in npm publish

### DIFF
--- a/packages/abi-gen/CHANGELOG.json
+++ b/packages/abi-gen/CHANGELOG.json
@@ -1,5 +1,13 @@
 [
     {
+        "version": "5.2.2",
+        "changes": [
+            {
+                "note": "Include `bin` files"
+            }
+        ]
+    },
+    {
         "timestamp": 1582623685,
         "version": "5.2.1",
         "changes": [

--- a/packages/abi-gen/package.json
+++ b/packages/abi-gen/package.json
@@ -113,6 +113,7 @@
         "access": "public"
     },
     "files": [
+        "bin/*",
         "templates/*",
         "*.js",
         "*.ts",

--- a/packages/sol-compiler/CHANGELOG.json
+++ b/packages/sol-compiler/CHANGELOG.json
@@ -1,13 +1,5 @@
 [
     {
-        "version": "4.0.9",
-        "changes": [
-            {
-                "note": "Include `bin` files"
-            }
-        ]
-    },
-    {
         "timestamp": 1582623685,
         "version": "4.0.8",
         "changes": [

--- a/packages/sol-compiler/CHANGELOG.json
+++ b/packages/sol-compiler/CHANGELOG.json
@@ -1,5 +1,13 @@
 [
     {
+        "version": "4.0.9",
+        "changes": [
+            {
+                "note": "Include `bin` files"
+            }
+        ]
+    },
+    {
         "timestamp": 1582623685,
         "version": "4.0.8",
         "changes": [

--- a/packages/sol-doc/.npmignore
+++ b/packages/sol-doc/.npmignore
@@ -8,3 +8,5 @@
 /lib/monorepo_scripts/
 # Package specific ignore
 /docs
+# Whitelist bin
+!bin/**/*

--- a/packages/sol-doc/CHANGELOG.json
+++ b/packages/sol-doc/CHANGELOG.json
@@ -1,5 +1,13 @@
 [
     {
+        "version": "3.1.6",
+        "changes": [
+            {
+                "note": "Include `bin` files"
+            }
+        ]
+    },
+    {
         "timestamp": 1582623685,
         "version": "3.1.5",
         "changes": [


### PR DESCRIPTION
## Description

`bin/*` was not present in the publish.

https://unpkg.com/browse/@0x/sol-doc@3.1.5/


```
(env) abi-gen λ npm publish --dry-run                                       fix/sol-doc/publish
npm notice
npm notice 📦  @0x/abi-gen@5.2.1
npm notice === Tarball Contents ===
npm notice 5.9kB  package.json
npm notice 23.8kB CHANGELOG.json
npm notice 11.1kB CHANGELOG.md
npm notice 6.8kB  README.md
npm notice 52B    bin/abi-gen.js
npm notice 66B    lib/src/index.d.ts
npm notice 107B   lib/src/index.d.ts.map
```

```
npm notice
npm notice 📦  @0x/sol-compiler@4.0.8
npm notice === Tarball Contents ===
npm notice 4.0kB  package.json
npm notice 18.5kB CHANGELOG.json
npm notice 7.5kB  CHANGELOG.md
npm notice 2.1kB  README.md
npm notice 49B    bin/sol-compiler.js
npm notice 91B    lib/src/cli.d.ts
npm notice 125B   lib/src/cli.d.ts.map
```