### PR TITLE
Update resolver errors to include parent filename

### DIFF
--- a/packages/sol-compiler/src/utils/compiler.ts
+++ b/packages/sol-compiler/src/utils/compiler.ts
@@ -232,9 +232,13 @@ export function getSourceTreeHash(resolver: Resolver, importPath: string): Buffe
     if (dependencies.length === 0) {
         return sourceHash;
     } else {
-        const dependencySourceTreeHashes = _.map(dependencies, (dependency: string) =>
-            getSourceTreeHash(resolver, dependency),
-        );
+        const dependencySourceTreeHashes = _.map(dependencies, (dependency: string) => {
+            try {
+                return getSourceTreeHash(resolver, dependency);
+            } catch (e) {
+                throw Error(`Error when trying to resolve dependencies for ${importPath}: ${(e as Error).message}`);
+            }
+        });
         const sourceTreeHashesBuffer = Buffer.concat([sourceHash, ...dependencySourceTreeHashes]);
         const sourceTreeHash = ethUtil.sha3(sourceTreeHashesBuffer);
         return sourceTreeHash;


### PR DESCRIPTION
## Description

Add parent filename when resolving on the parents dependencies fails. This makes it so that it's easy to figure out which file has invalid import when multiple contracts has the same failing imports. Commonly happens during sweeping refactors.

## Testing instructions

Run compiler on a smart contract that has an incorrect import path for a dependency, inspect that the error message now reports the smart contract file within the error description.

## Types of changes

<!-- * New feature (non-breaking change which adds functionality) -->
- Add parent filename when resolving on the parents dependencies fails.

I didnt modify the changelog since I dont know if 0x wants to include extra features in the next release.
