### PR TITLE
[asset-swapper] Add latest BUSD Curve

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -9,6 +9,14 @@
             {
                 "note": "Add destroy for gas heartbeat",
                 "pr": 2492
+            },
+            {
+                "note": "Added `BUSD` Curve",
+                "pr": 2506
+            },
+            {
+                "note": "Updated `Compound` Curve address",
+                "pr": 2506
             }
         ]
     },

--- a/packages/asset-swapper/src/constants.ts
+++ b/packages/asset-swapper/src/constants.ts
@@ -68,8 +68,8 @@ const DEFAULT_SWAP_QUOTE_REQUEST_OPTS: SwapQuoteRequestOpts = {
 // Mainnet Curve configuration
 const DEFAULT_CURVE_OPTS: { [source: string]: { version: number; curveAddress: string; tokens: string[] } } = {
     [ERC20BridgeSource.CurveUsdcDai]: {
-        version: 0,
-        curveAddress: '0x2e60cf74d81ac34eb21eeff58db4d385920ef419',
+        version: 1,
+        curveAddress: '0xa2b47e3d5c44877cca798226b7b8118f9bfb7a56',
         tokens: ['0x6b175474e89094c44da98b954eedeac495271d0f', '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'],
     },
     [ERC20BridgeSource.CurveUsdcDaiUsdt]: {

--- a/packages/asset-swapper/src/constants.ts
+++ b/packages/asset-swapper/src/constants.ts
@@ -91,6 +91,16 @@ const DEFAULT_CURVE_OPTS: { [source: string]: { version: number; curveAddress: s
             '0x0000000000085d4780b73119b644ae5ecd22b376',
         ],
     },
+    [ERC20BridgeSource.CurveUsdcDaiUsdtBusd]: {
+        version: 1,
+        curveAddress: '0x79a8c46dea5ada233abaffd40f3a0a2b1e5a4f27',
+        tokens: [
+            '0x6b175474e89094c44da98b954eedeac495271d0f',
+            '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            '0xdac17f958d2ee523a2206206994597c13d831ec7',
+            '0x4fabb145d64652a948d72533023f6e7a623c7c53',
+        ],
+    },
 };
 
 export const constants = {

--- a/packages/asset-swapper/src/utils/market_operation_utils/constants.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/constants.ts
@@ -11,9 +11,11 @@ export const SELL_SOURCES = [
     ERC20BridgeSource.Uniswap,
     ERC20BridgeSource.Eth2Dai,
     ERC20BridgeSource.Kyber,
+    // All Curve Sources
     ERC20BridgeSource.CurveUsdcDai,
     ERC20BridgeSource.CurveUsdcDaiUsdt,
     ERC20BridgeSource.CurveUsdcDaiUsdtTusd,
+    ERC20BridgeSource.CurveUsdcDaiUsdtBusd,
 ];
 
 /**

--- a/packages/asset-swapper/src/utils/market_operation_utils/create_order.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/create_order.ts
@@ -109,6 +109,7 @@ export class CreateOrderUtils {
             case ERC20BridgeSource.CurveUsdcDai:
             case ERC20BridgeSource.CurveUsdcDaiUsdt:
             case ERC20BridgeSource.CurveUsdcDaiUsdtTusd:
+            case ERC20BridgeSource.CurveUsdcDaiUsdtBusd:
                 return this._contractAddress.curveBridge;
             default:
                 break;
@@ -127,11 +128,7 @@ function createBridgeOrder(
     isBuy: boolean = false,
 ): OptimizedMarketOrder {
     let makerAssetData;
-    if (
-        fill.source === ERC20BridgeSource.CurveUsdcDai ||
-        fill.source === ERC20BridgeSource.CurveUsdcDaiUsdt ||
-        fill.source === ERC20BridgeSource.CurveUsdcDaiUsdtTusd
-    ) {
+    if (Object.keys(constants.DEFAULT_CURVE_OPTS).includes(fill.source)) {
         const { curveAddress, tokens, version } = constants.DEFAULT_CURVE_OPTS[fill.source];
         const fromTokenIdx = tokens.indexOf(takerToken);
         const toTokenIdx = tokens.indexOf(makerToken);

--- a/packages/asset-swapper/src/utils/market_operation_utils/sampler.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/sampler.ts
@@ -199,11 +199,7 @@ const samplerOperations = {
                     batchedOperation = samplerOperations.getUniswapSellQuotes(makerToken, takerToken, takerFillAmounts);
                 } else if (source === ERC20BridgeSource.Kyber) {
                     batchedOperation = samplerOperations.getKyberSellQuotes(makerToken, takerToken, takerFillAmounts);
-                } else if (
-                    source === ERC20BridgeSource.CurveUsdcDai ||
-                    source === ERC20BridgeSource.CurveUsdcDaiUsdt ||
-                    source === ERC20BridgeSource.CurveUsdcDaiUsdtTusd
-                ) {
+                } else if (Object.keys(constants.DEFAULT_CURVE_OPTS).includes(source)) {
                     const { curveAddress, tokens } = constants.DEFAULT_CURVE_OPTS[source];
                     const fromTokenIdx = tokens.indexOf(takerToken);
                     const toTokenIdx = tokens.indexOf(makerToken);

--- a/packages/asset-swapper/src/utils/market_operation_utils/types.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/types.ts
@@ -31,6 +31,7 @@ export enum ERC20BridgeSource {
     CurveUsdcDai = 'Curve_USDC_DAI',
     CurveUsdcDaiUsdt = 'Curve_USDC_DAI_USDT',
     CurveUsdcDaiUsdtTusd = 'Curve_USDC_DAI_USDT_TUSD',
+    CurveUsdcDaiUsdtBusd = 'Curve_USDC_DAI_USDT_BUSD',
 }
 
 // Internal `fillData` field for `Fill` objects.

--- a/packages/asset-swapper/test/market_operation_utils_test.ts
+++ b/packages/asset-swapper/test/market_operation_utils_test.ts
@@ -204,6 +204,7 @@ describe('MarketOperationUtils tests', () => {
         [ERC20BridgeSource.CurveUsdcDai]: _.times(NUM_SAMPLES, () => 0),
         [ERC20BridgeSource.CurveUsdcDaiUsdt]: _.times(NUM_SAMPLES, () => 0),
         [ERC20BridgeSource.CurveUsdcDaiUsdtTusd]: _.times(NUM_SAMPLES, () => 0),
+        [ERC20BridgeSource.CurveUsdcDaiUsdtBusd]: _.times(NUM_SAMPLES, () => 0),
     };
 
     function findSourceWithMaxOutput(rates: RatesBySource): ERC20BridgeSource {
@@ -274,11 +275,7 @@ describe('MarketOperationUtils tests', () => {
                 runLimit: 0,
                 sampleDistributionBase: 1,
                 bridgeSlippage: 0,
-                excludedSources: [
-                    ERC20BridgeSource.CurveUsdcDai,
-                    ERC20BridgeSource.CurveUsdcDaiUsdt,
-                    ERC20BridgeSource.CurveUsdcDaiUsdtTusd,
-                ],
+                excludedSources: Object.keys(assetSwapperConstants.DEFAULT_CURVE_OPTS) as ERC20BridgeSource[],
             };
 
             beforeEach(() => {
@@ -545,11 +542,7 @@ describe('MarketOperationUtils tests', () => {
                 numSamples: NUM_SAMPLES,
                 runLimit: 0,
                 sampleDistributionBase: 1,
-                excludedSources: [
-                    ERC20BridgeSource.CurveUsdcDai,
-                    ERC20BridgeSource.CurveUsdcDaiUsdt,
-                    ERC20BridgeSource.CurveUsdcDaiUsdtTusd,
-                ],
+                excludedSources: Object.keys(assetSwapperConstants.DEFAULT_CURVE_OPTS) as ERC20BridgeSource[],
             };
 
             beforeEach(() => {


### PR DESCRIPTION
## Description

Adds latest Curve (BUSD) 

https://github.com/curvefi/curve-contract/blob/pool_busd/deployed/2020-02-28_busd/mainnet.log

https://explore.duneanalytics.com/public/dashboards/ZaUkVovIfv5jm3OMqRochs3vTlc7PPUD4OjBOfrq

Migrates to latest Compound Curve (version 1)
https://github.com/curvefi/curve-contract/blob/pool_compound/deployed/2020-02-25_compound/mainnet.log


```json
{
  "price": "1.0012382004075",
  "to": "0x61935cbdd02287b511119ddb11aeb42f1593b7ef",
  "data": "...",
  "value": "3150000000000000",
  "gas": "4065253",
  "from": "REDACTED",
  "gasPrice": "7000000000",
  "protocolFee": "3150000000000000",
  "buyTokenAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
  "sellTokenAddress": "0x6b175474e89094c44da98b954eedeac495271d0f",
  "buyAmount": "400495280163",
  "sellAmount": "400000000000000000000000",
  "sources": [
    {
      "name": "Curve_USDC_DAI_USDT_TUSD",
      "proportion": "0.5189"
    },
    {
      "name": "Curve_USDC_DAI_USDT_BUSD",
      "proportion": "0.3696"
    },
    {
      "name": "Curve_USDC_DAI",
      "proportion": "0.1114"
    }
  ],
```

Follow up:
- [ ] retire version in Curve bridge (everyone is on v1)?