### PR TITLE
Add JSON RPC ID namespace options  to web3wrapper + other packages

### DIFF
--- a/packages/abi-gen/CHANGELOG.json
+++ b/packages/abi-gen/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "5.3.0",
+        "changes": [
+            {
+                "note": "Add support for jsonRpcIdNameSpace",
+                "pr": 2508
+            }
+        ]
+    },
+    {
         "version": "5.2.2",
         "changes": [
             {

--- a/packages/abi-gen/templates/TypeScript/contract.handlebars
+++ b/packages/abi-gen/templates/TypeScript/contract.handlebars
@@ -392,8 +392,9 @@ export class {{contractName}}Contract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = {{contractName}}Contract.deployedBytecode,
+        jsonRpcIdNameSpace?: string,
     ) {
-        super('{{contractName}}', {{contractName}}Contract.ABI(), address, supportedProvider, txDefaults, logDecodeDependencies, deployedBytecode);
+        super('{{contractName}}', {{contractName}}Contract.ABI(), address, supportedProvider, txDefaults, logDecodeDependencies, deployedBytecode, jsonRpcIdNameSpace);
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         {{#if events~}}
         this._subscriptionManager = new SubscriptionManager<{{contractName}}EventArgs, {{contractName}}Events>(

--- a/packages/abi-gen/test-cli/output/typescript/abi_gen_dummy.ts
+++ b/packages/abi-gen/test-cli/output/typescript/abi_gen_dummy.ts
@@ -2111,6 +2111,7 @@ export class AbiGenDummyContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = AbiGenDummyContract.deployedBytecode,
+        jsonRpcIdNameSpace?: string,
     ) {
         super(
             'AbiGenDummy',
@@ -2120,6 +2121,7 @@ export class AbiGenDummyContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
+            jsonRpcIdNameSpace,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         this._subscriptionManager = new SubscriptionManager<AbiGenDummyEventArgs, AbiGenDummyEvents>(

--- a/packages/abi-gen/test-cli/output/typescript/lib_dummy.ts
+++ b/packages/abi-gen/test-cli/output/typescript/lib_dummy.ts
@@ -233,6 +233,7 @@ export class LibDummyContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = LibDummyContract.deployedBytecode,
+        jsonRpcIdNameSpace?: string,
     ) {
         super(
             'LibDummy',
@@ -242,6 +243,7 @@ export class LibDummyContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
+            jsonRpcIdNameSpace,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         LibDummyContract.ABI().forEach((item, index) => {

--- a/packages/abi-gen/test-cli/output/typescript/test_lib_dummy.ts
+++ b/packages/abi-gen/test-cli/output/typescript/test_lib_dummy.ts
@@ -326,6 +326,7 @@ export class TestLibDummyContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = TestLibDummyContract.deployedBytecode,
+        jsonRpcIdNameSpace?: string,
     ) {
         super(
             'TestLibDummy',
@@ -335,6 +336,7 @@ export class TestLibDummyContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
+            jsonRpcIdNameSpace,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         TestLibDummyContract.ABI().forEach((item, index) => {

--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -9,6 +9,10 @@
             {
                 "note": "Add destroy for gas heartbeat",
                 "pr": 2492
+            },
+            {
+                "note": "Add support for jsonRpcIdNameSpace",
+                "pr": 2508
             }
         ]
     },

--- a/packages/asset-swapper/docs/reference.mdx
+++ b/packages/asset-swapper/docs/reference.mdx
@@ -1,51 +1,11 @@
-# Interface: Web3JsV1Provider
 
-Web3.js version 1 provider interface
-This provider interface was implemented in the pre-1.0Beta releases for Web3.js.
-This interface allowed sending synchonous requests, support for which was later dropped.
-
-
-##   Methods
-
-###  send
-
-▸ **send**(`payload`: [JSONRPCRequestPayload](_ethereum_types_src_index_.jsonrpcrequestpayload.md)): *[JSONRPCResponsePayload](#class-jsonrpcresponsepayload)*
-
-*Defined in [ethereum-types/src/index.ts:45](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L45)*
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`payload` | [JSONRPCRequestPayload](#class-jsonrpcrequestpayload) |
-
-**Returns:** *[JSONRPCResponsePayload](#class-jsonrpcresponsepayload)*
-
-___
-
-###  sendAsync
-
-▸ **sendAsync**(`payload`: [JSONRPCRequestPayload](_ethereum_types_src_index_.jsonrpcrequestpayload.md), `callback`: [JSONRPCErrorCallback](#jsonrpcerrorcallback)): *void*
-
-*Defined in [ethereum-types/src/index.ts:44](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L44)*
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`payload` | [JSONRPCRequestPayload](#class-jsonrpcrequestpayload) |
-`callback` | [JSONRPCErrorCallback](#jsonrpcerrorcallback) |
-
-**Returns:** *void*
-
-<hr />
 
 # Class: SwapQuoteConsumer
 
 
 ##  Implements
 
-* [SwapQuoteConsumerBase](#interface-swapquoteconsumerbase)‹*[SmartContractParams](#smartcontractparams)*›
+* [SwapQuoteConsumerBase](#interface-swapquoteconsumerbase)
 
 
 ##  Constructors
@@ -54,7 +14,7 @@ Name | Type |
 
 \+ **new SwapQuoteConsumer**(`supportedProvider`: [SupportedProvider](#supportedprovider), `options`: `Partial<SwapQuoteConsumerOpts>`): *[SwapQuoteConsumer](#class-swapquoteconsumer)*
 
-*Defined in [asset-swapper/src/quote_consumers/swap_quote_consumer.ts:39](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/quote_consumers/swap_quote_consumer.ts#L39)*
+*Defined in [asset-swapper/src/quote_consumers/swap_quote_consumer.ts:37](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/quote_consumers/swap_quote_consumer.ts#L37)*
 
 **Parameters:**
 
@@ -71,7 +31,7 @@ Name | Type | Default |
 
 • **chainId**: *number*
 
-*Defined in [asset-swapper/src/quote_consumers/swap_quote_consumer.ts:28](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/quote_consumers/swap_quote_consumer.ts#L28)*
+*Defined in [asset-swapper/src/quote_consumers/swap_quote_consumer.ts:25](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/quote_consumers/swap_quote_consumer.ts#L25)*
 
 ___
 
@@ -79,17 +39,17 @@ ___
 
 • **provider**: *`ZeroExProvider`*
 
-*Defined in [asset-swapper/src/quote_consumers/swap_quote_consumer.ts:27](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/quote_consumers/swap_quote_consumer.ts#L27)*
+*Defined in [asset-swapper/src/quote_consumers/swap_quote_consumer.ts:24](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/quote_consumers/swap_quote_consumer.ts#L24)*
 
 ## Methods
 
 ###  executeSwapQuoteOrThrowAsync
 
-▸ **executeSwapQuoteOrThrowAsync**(`quote`: [SwapQuote](#swapquote), `opts`: `Partial<SwapQuoteExecutionOpts & SwapQuoteConsumingOpts>`): *`Promise<string>`*
+▸ **executeSwapQuoteOrThrowAsync**(`quote`: [SwapQuote](#swapquote), `opts`: `Partial<SwapQuoteExecutionOpts>`): *`Promise<string>`*
 
 *Implementation of [SwapQuoteConsumerBase](#interface-swapquoteconsumerbase)*
 
-*Defined in [asset-swapper/src/quote_consumers/swap_quote_consumer.ts:89](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/quote_consumers/swap_quote_consumer.ts#L89)*
+*Defined in [asset-swapper/src/quote_consumers/swap_quote_consumer.ts:71](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/quote_consumers/swap_quote_consumer.ts#L71)*
 
 Given a SwapQuote and desired rate (in takerAsset), attempt to execute the swap with 0x extension or exchange contract.
 
@@ -98,7 +58,7 @@ Given a SwapQuote and desired rate (in takerAsset), attempt to execute the swap 
 Name | Type | Default | Description |
 ------ | ------ | ------ | ------ |
 `quote` | [SwapQuote](#swapquote) | - | An object that conforms to SwapQuote. See type definition for more information. |
-`opts` | `Partial<SwapQuoteExecutionOpts & SwapQuoteConsumingOpts>` |  {} | Options for getting CalldataInfo. See type definition for more information.  |
+`opts` | `Partial<SwapQuoteExecutionOpts>` |  {} | Options for getting CalldataInfo. See type definition for more information.  |
 
 **Returns:** *`Promise<string>`*
 
@@ -106,11 +66,11 @@ ___
 
 ###  getCalldataOrThrowAsync
 
-▸ **getCalldataOrThrowAsync**(`quote`: [SwapQuote](#swapquote), `opts`: `Partial<SwapQuoteGetOutputOpts & SwapQuoteConsumingOpts>`): *`Promise<CalldataInfo>`*
+▸ **getCalldataOrThrowAsync**(`quote`: [SwapQuote](#swapquote), `opts`: `Partial<SwapQuoteGetOutputOpts>`): *`Promise<CalldataInfo>`*
 
 *Implementation of [SwapQuoteConsumerBase](#interface-swapquoteconsumerbase)*
 
-*Defined in [asset-swapper/src/quote_consumers/swap_quote_consumer.ts:61](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/quote_consumers/swap_quote_consumer.ts#L61)*
+*Defined in [asset-swapper/src/quote_consumers/swap_quote_consumer.ts:57](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/quote_consumers/swap_quote_consumer.ts#L57)*
 
 Given a SwapQuote, returns 'CalldataInfo' for a 0x extesion or exchange call. See type definition of CalldataInfo for more information.
 
@@ -119,7 +79,7 @@ Given a SwapQuote, returns 'CalldataInfo' for a 0x extesion or exchange call. Se
 Name | Type | Default | Description |
 ------ | ------ | ------ | ------ |
 `quote` | [SwapQuote](#swapquote) | - | An object that conforms to SwapQuote. See type definition for more information. |
-`opts` | `Partial<SwapQuoteGetOutputOpts & SwapQuoteConsumingOpts>` |  {} | Options for getting SmartContractParams. See type definition for more information.  |
+`opts` | `Partial<SwapQuoteGetOutputOpts>` |  {} | Options for getting SmartContractParams. See type definition for more information.  |
 
 **Returns:** *`Promise<CalldataInfo>`*
 
@@ -129,7 +89,7 @@ ___
 
 ▸ **getOptimalExtensionContractTypeAsync**(`quote`: [SwapQuote](#swapquote), `opts`: `Partial<GetExtensionContractTypeOpts>`): *`Promise<ExtensionContractType>`*
 
-*Defined in [asset-swapper/src/quote_consumers/swap_quote_consumer.ts:103](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/quote_consumers/swap_quote_consumer.ts#L103)*
+*Defined in [asset-swapper/src/quote_consumers/swap_quote_consumer.ts:85](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/quote_consumers/swap_quote_consumer.ts#L85)*
 
 Given a SwapQuote, returns optimal 0x protocol interface (extension or no extension) to perform the swap.
 
@@ -144,32 +104,11 @@ Name | Type | Default | Description |
 
 ___
 
-###  getSmartContractParamsOrThrowAsync
-
-▸ **getSmartContractParamsOrThrowAsync**(`quote`: [SwapQuote](#swapquote), `opts`: `Partial<SwapQuoteGetOutputOpts & SwapQuoteConsumingOpts>`): *`Promise<SmartContractParamsInfo<SmartContractParams>>`*
-
-*Implementation of [SwapQuoteConsumerBase](#interface-swapquoteconsumerbase)*
-
-*Defined in [asset-swapper/src/quote_consumers/swap_quote_consumer.ts:75](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/quote_consumers/swap_quote_consumer.ts#L75)*
-
-Given a SwapQuote, returns 'SmartContractParamsInfo' for a 0x extension or exchange call. See type definition of SmartContractParamsInfo for more information.
-
-**Parameters:**
-
-Name | Type | Default | Description |
------- | ------ | ------ | ------ |
-`quote` | [SwapQuote](#swapquote) | - | An object that conforms to SwapQuote. See type definition for more information. |
-`opts` | `Partial<SwapQuoteGetOutputOpts & SwapQuoteConsumingOpts>` |  {} | Options for getting SmartContractParams. See type definition for more information.  |
-
-**Returns:** *`Promise<SmartContractParamsInfo<SmartContractParams>>`*
-
-___
-
 ### `Static` getSwapQuoteConsumer
 
 ▸ **getSwapQuoteConsumer**(`supportedProvider`: [SupportedProvider](#supportedprovider), `options`: `Partial<SwapQuoteConsumerOpts>`): *[SwapQuoteConsumer](#class-swapquoteconsumer)*
 
-*Defined in [asset-swapper/src/quote_consumers/swap_quote_consumer.ts:34](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/quote_consumers/swap_quote_consumer.ts#L34)*
+*Defined in [asset-swapper/src/quote_consumers/swap_quote_consumer.ts:32](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/quote_consumers/swap_quote_consumer.ts#L32)*
 
 **Parameters:**
 
@@ -191,7 +130,7 @@ Name | Type | Default |
 
 \+ **new SwapQuoter**(`supportedProvider`: [SupportedProvider](#supportedprovider), `orderbook`: `Orderbook`, `options`: `Partial<SwapQuoterOpts>`): *[SwapQuoter](#class-swapquoter)*
 
-*Defined in [asset-swapper/src/swap_quoter.ts:129](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/swap_quoter.ts#L129)*
+*Defined in [asset-swapper/src/swap_quoter.ts:136](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/swap_quoter.ts#L136)*
 
 Instantiates a new SwapQuoter instance
 
@@ -209,11 +148,19 @@ An instance of SwapQuoter
 
 ## Properties
 
+###  chainId
+
+• **chainId**: *number*
+
+*Defined in [asset-swapper/src/swap_quoter.ts:36](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/swap_quoter.ts#L36)*
+
+___
+
 ###  expiryBufferMs
 
 • **expiryBufferMs**: *number*
 
-*Defined in [asset-swapper/src/swap_quoter.ts:32](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/swap_quoter.ts#L32)*
+*Defined in [asset-swapper/src/swap_quoter.ts:35](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/swap_quoter.ts#L35)*
 
 ___
 
@@ -221,7 +168,7 @@ ___
 
 • **orderbook**: *`Orderbook`*
 
-*Defined in [asset-swapper/src/swap_quoter.ts:31](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/swap_quoter.ts#L31)*
+*Defined in [asset-swapper/src/swap_quoter.ts:34](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/swap_quoter.ts#L34)*
 
 ___
 
@@ -229,7 +176,7 @@ ___
 
 • **permittedOrderFeeTypes**: *`Set<OrderPrunerPermittedFeeTypes>`*
 
-*Defined in [asset-swapper/src/swap_quoter.ts:33](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/swap_quoter.ts#L33)*
+*Defined in [asset-swapper/src/swap_quoter.ts:37](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/swap_quoter.ts#L37)*
 
 ___
 
@@ -237,7 +184,7 @@ ___
 
 • **provider**: *`ZeroExProvider`*
 
-*Defined in [asset-swapper/src/swap_quoter.ts:30](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/swap_quoter.ts#L30)*
+*Defined in [asset-swapper/src/swap_quoter.ts:33](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/swap_quoter.ts#L33)*
 
 ## Methods
 
@@ -245,7 +192,7 @@ ___
 
 ▸ **destroyAsync**(): *`Promise<void>`*
 
-*Defined in [asset-swapper/src/swap_quoter.ts:393](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/swap_quoter.ts#L393)*
+*Defined in [asset-swapper/src/swap_quoter.ts:482](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/swap_quoter.ts#L482)*
 
 Destroys any subscriptions or connections.
 
@@ -257,7 +204,7 @@ ___
 
 ▸ **getAvailableMakerAssetDatasAsync**(`takerAssetData`: string): *`Promise<string[]>`*
 
-*Defined in [asset-swapper/src/swap_quoter.ts:321](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/swap_quoter.ts#L321)*
+*Defined in [asset-swapper/src/swap_quoter.ts:404](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/swap_quoter.ts#L404)*
 
 Get the asset data of all assets that are purchaseable with takerAssetData in the order provider passed in at init.
 
@@ -277,7 +224,7 @@ ___
 
 ▸ **getAvailableTakerAssetDatasAsync**(`makerAssetData`: string): *`Promise<string[]>`*
 
-*Defined in [asset-swapper/src/swap_quoter.ts:306](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/swap_quoter.ts#L306)*
+*Defined in [asset-swapper/src/swap_quoter.ts:389](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/swap_quoter.ts#L389)*
 
 Get the asset data of all assets that can be used to purchase makerAssetData in the order provider passed in at init.
 
@@ -293,11 +240,30 @@ An array of asset data strings that can purchase makerAssetData.
 
 ___
 
+###  getBatchMarketBuySwapQuoteForAssetDataAsync
+
+▸ **getBatchMarketBuySwapQuoteForAssetDataAsync**(`makerAssetDatas`: string[], `takerAssetData`: string, `makerAssetBuyAmount`: `BigNumber`[], `options`: `Partial<SwapQuoteRequestOpts>`): *`Promise<Array<MarketBuySwapQuote | undefined>>`*
+
+*Defined in [asset-swapper/src/swap_quoter.ts:243](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/swap_quoter.ts#L243)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`makerAssetDatas` | string[] | - |
+`takerAssetData` | string | - |
+`makerAssetBuyAmount` | `BigNumber`[] | - |
+`options` | `Partial<SwapQuoteRequestOpts>` |  {} |
+
+**Returns:** *`Promise<Array<MarketBuySwapQuote | undefined>>`*
+
+___
+
 ###  getEtherTokenAssetDataOrThrowAsync
 
 ▸ **getEtherTokenAssetDataOrThrowAsync**(): *`Promise<string>`*
 
-*Defined in [asset-swapper/src/swap_quoter.ts:400](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/swap_quoter.ts#L400)*
+*Defined in [asset-swapper/src/swap_quoter.ts:490](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/swap_quoter.ts#L490)*
 
 Utility function to get assetData for Ether token.
 
@@ -309,7 +275,7 @@ ___
 
 ▸ **getLiquidityForMakerTakerAssetDataPairAsync**(`makerAssetData`: string, `takerAssetData`: string): *`Promise<LiquidityForTakerMakerAssetDataPair>`*
 
-*Defined in [asset-swapper/src/swap_quoter.ts:281](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/swap_quoter.ts#L281)*
+*Defined in [asset-swapper/src/swap_quoter.ts:361](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/swap_quoter.ts#L361)*
 
 Returns information about available liquidity for an asset
 Does not factor in slippage or fees
@@ -329,9 +295,9 @@ ___
 
 ###  getMarketBuySwapQuoteAsync
 
-▸ **getMarketBuySwapQuoteAsync**(`makerTokenAddress`: string, `takerTokenAddress`: string, `makerAssetBuyAmount`: `BigNumber`, `options`: `Partial<SwapQuoteRequestOpts>`): *`Promise<SwapQuote>`*
+▸ **getMarketBuySwapQuoteAsync**(`makerTokenAddress`: string, `takerTokenAddress`: string, `makerAssetBuyAmount`: `BigNumber`, `options`: `Partial<SwapQuoteRequestOpts>`): *`Promise<MarketBuySwapQuote>`*
 
-*Defined in [asset-swapper/src/swap_quoter.ts:223](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/swap_quoter.ts#L223)*
+*Defined in [asset-swapper/src/swap_quoter.ts:303](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/swap_quoter.ts#L303)*
 
 Get a `SwapQuote` containing all information relevant to fulfilling a swap between a desired ERC20 token address and ERC20 owned by a provided address.
 You can then pass the `SwapQuote` to a `SwapQuoteConsumer` to execute a buy, or process SwapQuote for on-chain consumption.
@@ -345,7 +311,7 @@ Name | Type | Default | Description |
 `makerAssetBuyAmount` | `BigNumber` | - | The amount of maker asset to swap for. |
 `options` | `Partial<SwapQuoteRequestOpts>` |  {} | Options for the request. See type definition for more information.  |
 
-**Returns:** *`Promise<SwapQuote>`*
+**Returns:** *`Promise<MarketBuySwapQuote>`*
 
 An object that conforms to SwapQuote that satisfies the request. See type definition for more information.
 
@@ -355,7 +321,7 @@ ___
 
 ▸ **getMarketBuySwapQuoteForAssetDataAsync**(`makerAssetData`: string, `takerAssetData`: string, `makerAssetBuyAmount`: `BigNumber`, `options`: `Partial<SwapQuoteRequestOpts>`): *`Promise<MarketBuySwapQuote>`*
 
-*Defined in [asset-swapper/src/swap_quoter.ts:198](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/swap_quoter.ts#L198)*
+*Defined in [asset-swapper/src/swap_quoter.ts:227](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/swap_quoter.ts#L227)*
 
 Get a `SwapQuote` containing all information relevant to fulfilling a swap between a desired ERC20 token address and ERC20 owned by a provided address.
 You can then pass the `SwapQuote` to a `SwapQuoteConsumer` to execute a buy, or process SwapQuote for on-chain consumption.
@@ -377,9 +343,9 @@ ___
 
 ###  getMarketSellSwapQuoteAsync
 
-▸ **getMarketSellSwapQuoteAsync**(`makerTokenAddress`: string, `takerTokenAddress`: string, `takerAssetSellAmount`: `BigNumber`, `options`: `Partial<SwapQuoteRequestOpts>`): *`Promise<SwapQuote>`*
+▸ **getMarketSellSwapQuoteAsync**(`makerTokenAddress`: string, `takerTokenAddress`: string, `takerAssetSellAmount`: `BigNumber`, `options`: `Partial<SwapQuoteRequestOpts>`): *`Promise<MarketSellSwapQuote>`*
 
-*Defined in [asset-swapper/src/swap_quoter.ts:253](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/swap_quoter.ts#L253)*
+*Defined in [asset-swapper/src/swap_quoter.ts:333](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/swap_quoter.ts#L333)*
 
 Get a `SwapQuote` containing all information relevant to fulfilling a swap between a desired ERC20 token address and ERC20 owned by a provided address.
 You can then pass the `SwapQuote` to a `SwapQuoteConsumer` to execute a buy, or process SwapQuote for on-chain consumption.
@@ -393,7 +359,7 @@ Name | Type | Default | Description |
 `takerAssetSellAmount` | `BigNumber` | - | The amount of taker asset to sell. |
 `options` | `Partial<SwapQuoteRequestOpts>` |  {} | Options for the request. See type definition for more information.  |
 
-**Returns:** *`Promise<SwapQuote>`*
+**Returns:** *`Promise<MarketSellSwapQuote>`*
 
 An object that conforms to SwapQuote that satisfies the request. See type definition for more information.
 
@@ -403,7 +369,7 @@ ___
 
 ▸ **getMarketSellSwapQuoteForAssetDataAsync**(`makerAssetData`: string, `takerAssetData`: string, `takerAssetSellAmount`: `BigNumber`, `options`: `Partial<SwapQuoteRequestOpts>`): *`Promise<MarketSellSwapQuote>`*
 
-*Defined in [asset-swapper/src/swap_quoter.ts:172](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/swap_quoter.ts#L172)*
+*Defined in [asset-swapper/src/swap_quoter.ts:201](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/swap_quoter.ts#L201)*
 
 Get a `SwapQuote` containing all information relevant to fulfilling a swap between a desired ERC20 token address and ERC20 owned by a provided address.
 You can then pass the `SwapQuote` to a `SwapQuoteConsumer` to execute a buy, or process SwapQuote for on-chain consumption.
@@ -423,11 +389,11 @@ An object that conforms to SwapQuote that satisfies the request. See type defini
 
 ___
 
-###  getPrunedSignedOrdersAsync
+###  getSignedOrdersWithFillableAmountsAsync
 
-▸ **getPrunedSignedOrdersAsync**(`makerAssetData`: string, `takerAssetData`: string): *`Promise<PrunedSignedOrder[]>`*
+▸ **getSignedOrdersWithFillableAmountsAsync**(`makerAssetData`: string, `takerAssetData`: string): *`Promise<SignedOrderWithFillableAmounts[]>`*
 
-*Defined in [asset-swapper/src/swap_quoter.ts:355](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/swap_quoter.ts#L355)*
+*Defined in [asset-swapper/src/swap_quoter.ts:438](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/swap_quoter.ts#L438)*
 
 Grab orders from the order provider, prunes for valid orders with provided OrderPruner options
 
@@ -438,7 +404,7 @@ Name | Type | Description |
 `makerAssetData` | string | The makerAssetData of the desired asset to swap for (for more info: https://github.com/0xProject/0x-protocol-specification/blob/master/v2/v2-specification.md). |
 `takerAssetData` | string | The takerAssetData of the asset to swap makerAssetData for (for more info: https://github.com/0xProject/0x-protocol-specification/blob/master/v2/v2-specification.md).  |
 
-**Returns:** *`Promise<PrunedSignedOrder[]>`*
+**Returns:** *`Promise<SignedOrderWithFillableAmounts[]>`*
 
 ___
 
@@ -446,7 +412,7 @@ ___
 
 ▸ **isSwapQuoteFillableByTakerAddressAsync**(`swapQuote`: [SwapQuote](#swapquote), `takerAddress`: string): *`Promise<[boolean, boolean]>`*
 
-*Defined in [asset-swapper/src/swap_quoter.ts:376](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/swap_quoter.ts#L376)*
+*Defined in [asset-swapper/src/swap_quoter.ts:466](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/swap_quoter.ts#L466)*
 
 Util function to check if takerAddress's allowance is enough for 0x exchange contracts to conduct the swap specified by the swapQuote.
 
@@ -465,7 +431,7 @@ ___
 
 ▸ **isTakerMakerAssetDataPairAvailableAsync**(`makerAssetData`: string, `takerAssetData`: string): *`Promise<boolean>`*
 
-*Defined in [asset-swapper/src/swap_quoter.ts:338](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/swap_quoter.ts#L338)*
+*Defined in [asset-swapper/src/swap_quoter.ts:421](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/swap_quoter.ts#L421)*
 
 Validates the taker + maker asset pair is available from the order provider provided to `SwapQuote`.
 
@@ -486,7 +452,7 @@ ___
 
 ▸ **getSwapQuoterForMeshEndpoint**(`supportedProvider`: [SupportedProvider](#supportedprovider), `meshEndpoint`: string, `options`: `Partial<SwapQuoterOpts & MeshOrderProviderOpts>`): *[SwapQuoter](#class-swapquoter)*
 
-*Defined in [asset-swapper/src/swap_quoter.ts:116](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/swap_quoter.ts#L116)*
+*Defined in [asset-swapper/src/swap_quoter.ts:123](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/swap_quoter.ts#L123)*
 
 Instantiates a new SwapQuoter instance given a 0x Mesh endpoint. This pulls all available liquidity stored in Mesh
 
@@ -508,7 +474,7 @@ ___
 
 ▸ **getSwapQuoterForProvidedOrders**(`supportedProvider`: [SupportedProvider](#supportedprovider), `orders`: `SignedOrder`[], `options`: `Partial<SwapQuoterOpts>`): *[SwapQuoter](#class-swapquoter)*
 
-*Defined in [asset-swapper/src/swap_quoter.ts:44](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/swap_quoter.ts#L44)*
+*Defined in [asset-swapper/src/swap_quoter.ts:53](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/swap_quoter.ts#L53)*
 
 Instantiates a new SwapQuoter instance given existing liquidity in the form of orders and feeOrders.
 
@@ -530,7 +496,7 @@ ___
 
 ▸ **getSwapQuoterForStandardRelayerAPIUrl**(`supportedProvider`: [SupportedProvider](#supportedprovider), `sraApiUrl`: string, `options`: `Partial<SwapQuoterOpts & SRAPollingOrderProviderOpts>`): *[SwapQuoter](#class-swapquoter)*
 
-*Defined in [asset-swapper/src/swap_quoter.ts:64](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/swap_quoter.ts#L64)*
+*Defined in [asset-swapper/src/swap_quoter.ts:73](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/swap_quoter.ts#L73)*
 
 Instantiates a new SwapQuoter instance given a [Standard Relayer API](https://github.com/0xProject/standard-relayer-api) endpoint
 
@@ -552,7 +518,7 @@ ___
 
 ▸ **getSwapQuoterForStandardRelayerAPIWebsocket**(`supportedProvider`: [SupportedProvider](#supportedprovider), `sraApiUrl`: string, `sraWebsocketAPIUrl`: string, `options`: `Partial<SwapQuoterOpts>`): *[SwapQuoter](#class-swapquoter)*
 
-*Defined in [asset-swapper/src/swap_quoter.ts:91](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/swap_quoter.ts#L91)*
+*Defined in [asset-swapper/src/swap_quoter.ts:99](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/swap_quoter.ts#L99)*
 
 Instantiates a new SwapQuoter instance given a [Standard Relayer API](https://github.com/0xProject/standard-relayer-api) endpoint
 and a websocket endpoint. This is more effecient than `getSwapQuoterForStandardRelayerAPIUrl` when requesting multiple quotes.
@@ -572,6 +538,97 @@ An instance of SwapQuoter
 
 <hr />
 
+# Class: ProtocolFeeUtils
+
+
+##   Constructors
+
+
+
+\+ **new ProtocolFeeUtils**(`gasPricePollingIntervalInMs`: number, `initialGasPrice`: `BigNumber`): *[ProtocolFeeUtils](#class-protocolfeeutils)*
+
+*Defined in [asset-swapper/src/utils/protocol_fee_utils.ts:10](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/protocol_fee_utils.ts#L10)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`gasPricePollingIntervalInMs` | number | - |
+`initialGasPrice` | `BigNumber` |  constants.ZERO_AMOUNT |
+
+**Returns:** *[ProtocolFeeUtils](#class-protocolfeeutils)*
+
+## Properties
+
+###  gasPriceEstimation
+
+• **gasPriceEstimation**: *`BigNumber`*
+
+*Defined in [asset-swapper/src/utils/protocol_fee_utils.ts:9](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/protocol_fee_utils.ts#L9)*
+
+## Methods
+
+###  calculateWorstCaseProtocolFeeAsync
+
+▸ **calculateWorstCaseProtocolFeeAsync**<**T**>(`orders`: `T`[], `gasPrice`: `BigNumber`): *`Promise<BigNumber>`*
+
+*Defined in [asset-swapper/src/utils/protocol_fee_utils.ts:45](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/protocol_fee_utils.ts#L45)*
+
+Calculates protocol fee with protofol fee multiplier for each fill.
+
+**Type parameters:**
+
+▪ **T**: *`Order`*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`orders` | `T`[] |
+`gasPrice` | `BigNumber` |
+
+**Returns:** *`Promise<BigNumber>`*
+
+___
+
+###  destroyAsync
+
+▸ **destroyAsync**(): *`Promise<void>`*
+
+*Defined in [asset-swapper/src/utils/protocol_fee_utils.ts:38](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/protocol_fee_utils.ts#L38)*
+
+Destroys any subscriptions or connections.
+
+**Returns:** *`Promise<void>`*
+
+___
+
+###  getGasPriceEstimationOrThrowAsync
+
+▸ **getGasPriceEstimationOrThrowAsync**(`shouldHardRefresh?`: undefined | false | true): *`Promise<BigNumber>`*
+
+*Defined in [asset-swapper/src/utils/protocol_fee_utils.ts:24](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/protocol_fee_utils.ts#L24)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`shouldHardRefresh?` | undefined \| false \| true |
+
+**Returns:** *`Promise<BigNumber>`*
+
+___
+
+###  getProtocolFeeMultiplierAsync
+
+▸ **getProtocolFeeMultiplierAsync**(): *`Promise<BigNumber>`*
+
+*Defined in [asset-swapper/src/utils/protocol_fee_utils.ts:20](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/protocol_fee_utils.ts#L20)*
+
+**Returns:** *`Promise<BigNumber>`*
+
+<hr />
+
 # Class: BaseOrderProvider
 
 
@@ -581,7 +638,7 @@ An instance of SwapQuoter
 
 \+ **new BaseOrderProvider**(`orderStore`: [OrderStore](_orderbook_src_order_store_.orderstore.md)): *[BaseOrderProvider](#class-baseorderprovider)*
 
-*Defined in [orderbook/src/order_provider/base_order_provider.ts:12](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/order_provider/base_order_provider.ts#L12)*
+*Defined in [orderbook/src/order_provider/base_order_provider.ts:12](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/order_provider/base_order_provider.ts#L12)*
 
 **Parameters:**
 
@@ -597,7 +654,7 @@ Name | Type |
 
 • **_orderStore**: *[OrderStore](#class-orderstore)*
 
-*Defined in [orderbook/src/order_provider/base_order_provider.ts:12](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/order_provider/base_order_provider.ts#L12)*
+*Defined in [orderbook/src/order_provider/base_order_provider.ts:12](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/order_provider/base_order_provider.ts#L12)*
 
 ## Methods
 
@@ -605,7 +662,7 @@ Name | Type |
 
 ▸ **addOrdersAsync**(`orders`: `SignedOrder`[]): *`Promise<AcceptedRejectedOrders>`*
 
-*Defined in [orderbook/src/order_provider/base_order_provider.ts:27](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/order_provider/base_order_provider.ts#L27)*
+*Defined in [orderbook/src/order_provider/base_order_provider.ts:27](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/order_provider/base_order_provider.ts#L27)*
 
 **Parameters:**
 
@@ -621,7 +678,7 @@ ___
 
 ▸ **createSubscriptionForAssetPairAsync**(`makerAssetData`: string, `takerAssetData`: string): *`Promise<void>`*
 
-*Defined in [orderbook/src/order_provider/base_order_provider.ts:18](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/order_provider/base_order_provider.ts#L18)*
+*Defined in [orderbook/src/order_provider/base_order_provider.ts:18](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/order_provider/base_order_provider.ts#L18)*
 
 **Parameters:**
 
@@ -638,7 +695,7 @@ ___
 
 ▸ **destroyAsync**(): *`Promise<void>`*
 
-*Defined in [orderbook/src/order_provider/base_order_provider.ts:25](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/order_provider/base_order_provider.ts#L25)*
+*Defined in [orderbook/src/order_provider/base_order_provider.ts:25](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/order_provider/base_order_provider.ts#L25)*
 
 **Returns:** *`Promise<void>`*
 
@@ -648,7 +705,7 @@ ___
 
 ▸ **getAvailableAssetDatasAsync**(): *`Promise<AssetPairsItem[]>`*
 
-*Defined in [orderbook/src/order_provider/base_order_provider.ts:23](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/order_provider/base_order_provider.ts#L23)*
+*Defined in [orderbook/src/order_provider/base_order_provider.ts:23](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/order_provider/base_order_provider.ts#L23)*
 
 **Returns:** *`Promise<AssetPairsItem[]>`*
 
@@ -661,57 +718,19 @@ ___
 
 
 
-\+ **new OrderSet**(`orders`: `APIOrder`[]): *[OrderSet](#class-orderset)*
+\+ **new OrderSet**(): *[OrderSet](#class-orderset)*
 
-*Defined in [orderbook/src/order_set.ts:6](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/order_set.ts#L6)*
-
-**Parameters:**
-
-Name | Type | Default |
------- | ------ | ------ |
-`orders` | `APIOrder`[] |  [] |
+*Defined in [orderbook/src/order_set.ts:6](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/order_set.ts#L6)*
 
 **Returns:** *[OrderSet](#class-orderset)*
 
 ## Methods
 
-###  add
+###  addAsync
 
-▸ **add**(`item`: `APIOrder`): *void*
+▸ **addAsync**(`item`: `APIOrder`): *`Promise<void>`*
 
-*Defined in [orderbook/src/order_set.ts:19](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/order_set.ts#L19)*
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`item` | `APIOrder` |
-
-**Returns:** *void*
-
-___
-
-###  addMany
-
-▸ **addMany**(`items`: `APIOrder`[]): *void*
-
-*Defined in [orderbook/src/order_set.ts:25](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/order_set.ts#L25)*
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`items` | `APIOrder`[] |
-
-**Returns:** *void*
-
-___
-
-###  delete
-
-▸ **delete**(`item`: `APIOrder`): *boolean*
-
-*Defined in [orderbook/src/order_set.ts:57](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/order_set.ts#L57)*
+*Defined in [orderbook/src/order_set.ts:16](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/order_set.ts#L16)*
 
 **Parameters:**
 
@@ -719,15 +738,15 @@ Name | Type |
 ------ | ------ |
 `item` | `APIOrder` |
 
-**Returns:** *boolean*
+**Returns:** *`Promise<void>`*
 
 ___
 
-###  deleteMany
+###  addManyAsync
 
-▸ **deleteMany**(`items`: `APIOrder`[]): *void*
+▸ **addManyAsync**(`items`: `APIOrder`[]): *`Promise<void>`*
 
-*Defined in [orderbook/src/order_set.ts:61](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/order_set.ts#L61)*
+*Defined in [orderbook/src/order_set.ts:22](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/order_set.ts#L22)*
 
 **Parameters:**
 
@@ -735,15 +754,47 @@ Name | Type |
 ------ | ------ |
 `items` | `APIOrder`[] |
 
-**Returns:** *void*
+**Returns:** *`Promise<void>`*
 
 ___
 
-###  diff
+###  deleteAsync
 
-▸ **diff**(`other`: [OrderSet](#class-orderset)): *object*
+▸ **deleteAsync**(`item`: `APIOrder`): *`Promise<boolean>`*
 
-*Defined in [orderbook/src/order_set.ts:35](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/order_set.ts#L35)*
+*Defined in [orderbook/src/order_set.ts:54](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/order_set.ts#L54)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`item` | `APIOrder` |
+
+**Returns:** *`Promise<boolean>`*
+
+___
+
+###  deleteManyAsync
+
+▸ **deleteManyAsync**(`items`: `APIOrder`[]): *`Promise<void>`*
+
+*Defined in [orderbook/src/order_set.ts:58](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/order_set.ts#L58)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`items` | `APIOrder`[] |
+
+**Returns:** *`Promise<void>`*
+
+___
+
+###  diffAsync
+
+▸ **diffAsync**(`other`: [OrderSet](#class-orderset)): *`Promise<object>`*
+
+*Defined in [orderbook/src/order_set.ts:32](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/order_set.ts#L32)*
 
 **Parameters:**
 
@@ -751,15 +802,15 @@ Name | Type |
 ------ | ------ |
 `other` | [OrderSet](#class-orderset) |
 
-**Returns:** *object*
+**Returns:** *`Promise<object>`*
 
 ___
 
-###  has
+###  hasAsync
 
-▸ **has**(`order`: `APIOrder`): *boolean*
+▸ **hasAsync**(`order`: `APIOrder`): *`Promise<boolean>`*
 
-*Defined in [orderbook/src/order_set.ts:31](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/order_set.ts#L31)*
+*Defined in [orderbook/src/order_set.ts:28](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/order_set.ts#L28)*
 
 **Parameters:**
 
@@ -767,7 +818,7 @@ Name | Type |
 ------ | ------ |
 `order` | `APIOrder` |
 
-**Returns:** *boolean*
+**Returns:** *`Promise<boolean>`*
 
 ___
 
@@ -775,7 +826,7 @@ ___
 
 ▸ **size**(): *number*
 
-*Defined in [orderbook/src/order_set.ts:15](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/order_set.ts#L15)*
+*Defined in [orderbook/src/order_set.ts:12](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/order_set.ts#L12)*
 
 **Returns:** *number*
 
@@ -785,7 +836,7 @@ ___
 
 ▸ **values**(): *`IterableIterator<APIOrder>`*
 
-*Defined in [orderbook/src/order_set.ts:53](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/order_set.ts#L53)*
+*Defined in [orderbook/src/order_set.ts:50](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/order_set.ts#L50)*
 
 **Returns:** *`IterableIterator<APIOrder>`*
 
@@ -796,11 +847,28 @@ ___
 
 ##   Methods
 
-###  getOrderSetForAssetPair
+###  getBatchOrderSetsForAssetsAsync
 
-▸ **getOrderSetForAssetPair**(`assetPairKey`: string): *[OrderSet](#class-orderset)*
+▸ **getBatchOrderSetsForAssetsAsync**(`makerAssetDatas`: string[], `takerAssetDatas`: string[]): *`Promise<OrderSet[]>`*
 
-*Defined in [orderbook/src/order_store.ts:19](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/order_store.ts#L19)*
+*Defined in [orderbook/src/order_store.ts:28](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/order_store.ts#L28)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`makerAssetDatas` | string[] |
+`takerAssetDatas` | string[] |
+
+**Returns:** *`Promise<OrderSet[]>`*
+
+___
+
+###  getOrderSetForAssetPairAsync
+
+▸ **getOrderSetForAssetPairAsync**(`assetPairKey`: string): *`Promise<OrderSet>`*
+
+*Defined in [orderbook/src/order_store.ts:19](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/order_store.ts#L19)*
 
 **Parameters:**
 
@@ -808,15 +876,15 @@ Name | Type |
 ------ | ------ |
 `assetPairKey` | string |
 
-**Returns:** *[OrderSet](#class-orderset)*
+**Returns:** *`Promise<OrderSet>`*
 
 ___
 
-###  getOrderSetForAssets
+###  getOrderSetForAssetsAsync
 
-▸ **getOrderSetForAssets**(`makerAssetData`: string, `takerAssetData`: string): *[OrderSet](#class-orderset)*
+▸ **getOrderSetForAssetsAsync**(`makerAssetData`: string, `takerAssetData`: string): *`Promise<OrderSet>`*
 
-*Defined in [orderbook/src/order_store.ts:15](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/order_store.ts#L15)*
+*Defined in [orderbook/src/order_store.ts:15](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/order_store.ts#L15)*
 
 **Parameters:**
 
@@ -825,15 +893,15 @@ Name | Type |
 `makerAssetData` | string |
 `takerAssetData` | string |
 
-**Returns:** *[OrderSet](#class-orderset)*
+**Returns:** *`Promise<OrderSet>`*
 
 ___
 
-###  has
+###  hasAsync
 
-▸ **has**(`assetPairKey`: string): *boolean*
+▸ **hasAsync**(`assetPairKey`: string): *`Promise<boolean>`*
 
-*Defined in [orderbook/src/order_store.ts:34](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/order_store.ts#L34)*
+*Defined in [orderbook/src/order_store.ts:47](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/order_store.ts#L47)*
 
 **Parameters:**
 
@@ -841,25 +909,25 @@ Name | Type |
 ------ | ------ |
 `assetPairKey` | string |
 
-**Returns:** *boolean*
+**Returns:** *`Promise<boolean>`*
 
 ___
 
-###  keys
+###  keysAsync
 
-▸ **keys**(): *`IterableIterator<string>`*
+▸ **keysAsync**(): *`Promise<IterableIterator<string>>`*
 
-*Defined in [orderbook/src/order_store.ts:40](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/order_store.ts#L40)*
+*Defined in [orderbook/src/order_store.ts:53](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/order_store.ts#L53)*
 
-**Returns:** *`IterableIterator<string>`*
+**Returns:** *`Promise<IterableIterator<string>>`*
 
 ___
 
-###  update
+###  updateAsync
 
-▸ **update**(`addedRemoved`: [AddedRemovedOrders](#interface-addedremovedorders)): *void*
+▸ **updateAsync**(`addedRemoved`: [AddedRemovedOrders](#interface-addedremovedorders)): *`Promise<void>`*
 
-*Defined in [orderbook/src/order_store.ts:28](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/order_store.ts#L28)*
+*Defined in [orderbook/src/order_store.ts:41](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/order_store.ts#L41)*
 
 **Parameters:**
 
@@ -867,15 +935,15 @@ Name | Type |
 ------ | ------ |
 `addedRemoved` | [AddedRemovedOrders](#interface-addedremovedorders) |
 
-**Returns:** *void*
+**Returns:** *`Promise<void>`*
 
 ___
 
-###  values
+###  valuesAsync
 
-▸ **values**(`assetPairKey`: string): *`APIOrder`[]*
+▸ **valuesAsync**(`assetPairKey`: string): *`Promise<APIOrder[]>`*
 
-*Defined in [orderbook/src/order_store.ts:37](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/order_store.ts#L37)*
+*Defined in [orderbook/src/order_store.ts:50](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/order_store.ts#L50)*
 
 **Parameters:**
 
@@ -883,7 +951,7 @@ Name | Type |
 ------ | ------ |
 `assetPairKey` | string |
 
-**Returns:** *`APIOrder`[]*
+**Returns:** *`Promise<APIOrder[]>`*
 
 ___
 
@@ -891,7 +959,7 @@ ___
 
 ▸ **assetPairKeyToAssets**(`assetPairKey`: string): *string[]*
 
-*Defined in [orderbook/src/order_store.ts:12](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/order_store.ts#L12)*
+*Defined in [orderbook/src/order_store.ts:12](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/order_store.ts#L12)*
 
 **Parameters:**
 
@@ -907,7 +975,7 @@ ___
 
 ▸ **getKeyForAssetPair**(`makerAssetData`: string, `takerAssetData`: string): *string*
 
-*Defined in [orderbook/src/order_store.ts:9](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/order_store.ts#L9)*
+*Defined in [orderbook/src/order_store.ts:9](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/order_store.ts#L9)*
 
 **Parameters:**
 
@@ -929,7 +997,7 @@ Name | Type |
 
 \+ **new Orderbook**(`orderProvider`: [BaseOrderProvider](_orderbook_src_order_provider_base_order_provider_.baseorderprovider.md), `orderStore`: [OrderStore](_orderbook_src_order_store_.orderstore.md)): *[Orderbook](#class-orderbook)*
 
-*Defined in [orderbook/src/orderbook.ts:55](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/orderbook.ts#L55)*
+*Defined in [orderbook/src/orderbook.ts:55](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/orderbook.ts#L55)*
 
 Creates an Orderbook with the order provider. All order updates are stored
 in the `OrderStore`.
@@ -949,7 +1017,7 @@ Name | Type | Description |
 
 ▸ **addOrdersAsync**(`orders`: `SignedOrder`[]): *`Promise<AcceptedRejectedOrders>`*
 
-*Defined in [orderbook/src/orderbook.ts:98](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/orderbook.ts#L98)*
+*Defined in [orderbook/src/orderbook.ts:118](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/orderbook.ts#L118)*
 
 Adds the orders to the Order Provider. All accepted orders will be returned
 and rejected orders will be returned with an message indicating a reason for its rejection
@@ -968,7 +1036,7 @@ ___
 
 ▸ **destroyAsync**(): *`Promise<void>`*
 
-*Defined in [orderbook/src/orderbook.ts:104](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/orderbook.ts#L104)*
+*Defined in [orderbook/src/orderbook.ts:124](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/orderbook.ts#L124)*
 
 Destroys any subscriptions or connections.
 
@@ -980,7 +1048,7 @@ ___
 
 ▸ **getAvailableAssetDatasAsync**(): *`Promise<AssetPairsItem[]>`*
 
-*Defined in [orderbook/src/orderbook.ts:90](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/orderbook.ts#L90)*
+*Defined in [orderbook/src/orderbook.ts:110](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/orderbook.ts#L110)*
 
 Returns all of the Available Asset Pairs for the provided Order Provider.
 
@@ -988,11 +1056,28 @@ Returns all of the Available Asset Pairs for the provided Order Provider.
 
 ___
 
+###  getBatchOrdersAsync
+
+▸ **getBatchOrdersAsync**(`makerAssetDatas`: string[], `takerAssetDatas`: string[]): *`Promise<APIOrder[][]>`*
+
+*Defined in [orderbook/src/orderbook.ts:87](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/orderbook.ts#L87)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`makerAssetDatas` | string[] |
+`takerAssetDatas` | string[] |
+
+**Returns:** *`Promise<APIOrder[][]>`*
+
+___
+
 ###  getOrdersAsync
 
 ▸ **getOrdersAsync**(`makerAssetData`: string, `takerAssetData`: string): *`Promise<APIOrder[]>`*
 
-*Defined in [orderbook/src/orderbook.ts:75](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/orderbook.ts#L75)*
+*Defined in [orderbook/src/orderbook.ts:75](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/orderbook.ts#L75)*
 
 Returns all orders where the order.makerAssetData == makerAssetData and
 order.takerAssetData == takerAssetData. This pair is then subscribed to
@@ -1015,7 +1100,7 @@ ___
 
 ▸ **getOrderbookForMeshProvider**(`opts`: [MeshOrderProviderOpts](#interface-meshorderprovideropts)): *[Orderbook](#class-orderbook)*
 
-*Defined in [orderbook/src/orderbook.ts:52](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/orderbook.ts#L52)*
+*Defined in [orderbook/src/orderbook.ts:52](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/orderbook.ts#L52)*
 
 Creates an Orderbook with a Mesh Order Provider. This Provider fetches ALL orders
 and subscribes to updates on ALL orders.
@@ -1034,7 +1119,7 @@ ___
 
 ▸ **getOrderbookForPollingProvider**(`opts`: [SRAPollingOrderProviderOpts](#interface-srapollingorderprovideropts)): *[Orderbook](#class-orderbook)*
 
-*Defined in [orderbook/src/orderbook.ts:43](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/orderbook.ts#L43)*
+*Defined in [orderbook/src/orderbook.ts:43](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/orderbook.ts#L43)*
 
 Creates an Orderbook with SRA Polling Provider. This Provider simply polls every interval.
 
@@ -1052,7 +1137,7 @@ ___
 
 ▸ **getOrderbookForProvidedOrders**(`orders`: `SignedOrder`[]): *[Orderbook](#class-orderbook)*
 
-*Defined in [orderbook/src/orderbook.ts:26](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/orderbook.ts#L26)*
+*Defined in [orderbook/src/orderbook.ts:26](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/orderbook.ts#L26)*
 
 Creates an Orderbook with the provided orders. This provider simply stores the
 orders and allows querying. No validation or subscriptions occur.
@@ -1071,7 +1156,7 @@ ___
 
 ▸ **getOrderbookForWebsocketProvider**(`opts`: [SRAWebsocketOrderProviderOpts](#interface-srawebsocketorderprovideropts)): *[Orderbook](#class-orderbook)*
 
-*Defined in [orderbook/src/orderbook.ts:35](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/orderbook.ts#L35)*
+*Defined in [orderbook/src/orderbook.ts:35](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/orderbook.ts#L35)*
 
 Creates an Orderbook with the SRA Websocket Provider. This Provider fetches orders via
 the SRA http endpoint and then subscribes to the asset pair for future updates.
@@ -1097,7 +1182,7 @@ Represents the varying smart contracts that can consume a valid swap quote
 
 • **Forwarder**: = "FORWARDER"
 
-*Defined in [asset-swapper/src/types.ts:106](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L106)*
+*Defined in [asset-swapper/src/types.ts:63](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L63)*
 
 ___
 
@@ -1105,7 +1190,7 @@ ___
 
 • **None**: = "NONE"
 
-*Defined in [asset-swapper/src/types.ts:107](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L107)*
+*Defined in [asset-swapper/src/types.ts:64](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L64)*
 
 <hr />
 
@@ -1113,7 +1198,52 @@ ___
 
 
 
+# Enumeration: SwapQuoteConsumerError
 
+Possible error messages thrown by an SwapQuoterConsumer instance or associated static methods.
+
+
+##  Enumeration members
+
+###  InvalidForwarderSwapQuote
+
+• **InvalidForwarderSwapQuote**: = "INVALID_FORWARDER_SWAP_QUOTE_PROVIDED"
+
+*Defined in [asset-swapper/src/types.ts:224](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L224)*
+
+___
+
+###  InvalidMarketSellOrMarketBuySwapQuote
+
+• **InvalidMarketSellOrMarketBuySwapQuote**: = "INVALID_MARKET_BUY_SELL_SWAP_QUOTE"
+
+*Defined in [asset-swapper/src/types.ts:223](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L223)*
+
+___
+
+###  NoAddressAvailable
+
+• **NoAddressAvailable**: = "NO_ADDRESS_AVAILABLE"
+
+*Defined in [asset-swapper/src/types.ts:225](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L225)*
+
+___
+
+###  SignatureRequestDenied
+
+• **SignatureRequestDenied**: = "SIGNATURE_REQUEST_DENIED"
+
+*Defined in [asset-swapper/src/types.ts:226](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L226)*
+
+___
+
+###  TransactionValueTooLow
+
+• **TransactionValueTooLow**: = "TRANSACTION_VALUE_TOO_LOW"
+
+*Defined in [asset-swapper/src/types.ts:227](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L227)*
+
+<hr />
 
 # Enumeration: SwapQuoterError
 
@@ -1122,11 +1252,13 @@ Possible error messages thrown by an SwapQuoter instance or associated static me
 
 ##  Enumeration members
 
+
+
 ###  AssetUnavailable
 
 • **AssetUnavailable**: = "ASSET_UNAVAILABLE"
 
-*Defined in [asset-swapper/src/types.ts:298](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L298)*
+*Defined in [asset-swapper/src/types.ts:237](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L237)*
 
 ___
 
@@ -1134,7 +1266,7 @@ ___
 
 • **InsufficientAssetLiquidity**: = "INSUFFICIENT_ASSET_LIQUIDITY"
 
-*Defined in [asset-swapper/src/types.ts:297](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L297)*
+*Defined in [asset-swapper/src/types.ts:236](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L236)*
 
 ___
 
@@ -1142,7 +1274,7 @@ ___
 
 • **NoEtherTokenContractFound**: = "NO_ETHER_TOKEN_CONTRACT_FOUND"
 
-*Defined in [asset-swapper/src/types.ts:295](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L295)*
+*Defined in [asset-swapper/src/types.ts:234](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L234)*
 
 ___
 
@@ -1150,7 +1282,7 @@ ___
 
 • **NoGasPriceProvidedOrEstimated**: = "NO_GAS_PRICE_PROVIDED_OR_ESTIMATED"
 
-*Defined in [asset-swapper/src/types.ts:299](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L299)*
+*Defined in [asset-swapper/src/types.ts:238](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L238)*
 
 ___
 
@@ -1158,7 +1290,72 @@ ___
 
 • **StandardRelayerApiError**: = "STANDARD_RELAYER_API_ERROR"
 
-*Defined in [asset-swapper/src/types.ts:296](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L296)*
+*Defined in [asset-swapper/src/types.ts:235](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L235)*
+
+<hr />
+
+
+
+# Enumeration: ERC20BridgeSource
+
+DEX sources to aggregate.
+
+
+##  Enumeration members
+
+###  CurveUsdcDai
+
+• **CurveUsdcDai**: = "Curve_USDC_DAI"
+
+*Defined in [asset-swapper/src/utils/market_operation_utils/types.ts:31](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/market_operation_utils/types.ts#L31)*
+
+___
+
+###  CurveUsdcDaiUsdt
+
+• **CurveUsdcDaiUsdt**: = "Curve_USDC_DAI_USDT"
+
+*Defined in [asset-swapper/src/utils/market_operation_utils/types.ts:32](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/market_operation_utils/types.ts#L32)*
+
+___
+
+###  CurveUsdcDaiUsdtTusd
+
+• **CurveUsdcDaiUsdtTusd**: = "Curve_USDC_DAI_USDT_TUSD"
+
+*Defined in [asset-swapper/src/utils/market_operation_utils/types.ts:33](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/market_operation_utils/types.ts#L33)*
+
+___
+
+###  Eth2Dai
+
+• **Eth2Dai**: = "Eth2Dai"
+
+*Defined in [asset-swapper/src/utils/market_operation_utils/types.ts:29](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/market_operation_utils/types.ts#L29)*
+
+___
+
+###  Kyber
+
+• **Kyber**: = "Kyber"
+
+*Defined in [asset-swapper/src/utils/market_operation_utils/types.ts:30](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/market_operation_utils/types.ts#L30)*
+
+___
+
+###  Native
+
+• **Native**: = "Native"
+
+*Defined in [asset-swapper/src/utils/market_operation_utils/types.ts:27](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/market_operation_utils/types.ts#L27)*
+
+___
+
+###  Uniswap
+
+• **Uniswap**: = "Uniswap"
+
+*Defined in [asset-swapper/src/utils/market_operation_utils/types.ts:28](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/market_operation_utils/types.ts#L28)*
 
 <hr />
 
@@ -1194,13 +1391,20 @@ ___
 
 
 
+
+
+
+
+
+
 <hr />
+
+
 
 # Interface: CalldataInfo
 
 Represents the metadata to call a smart contract with calldata.
 calldataHexString: The hexstring of the calldata.
-methodAbi: The ABI of the smart contract method to call.
 toAddress: The contract address to call.
 ethAmount: The eth amount in wei to send with the smart contract call.
 
@@ -1211,7 +1415,7 @@ ethAmount: The eth amount in wei to send with the smart contract call.
 
 • **calldataHexString**: *string*
 
-*Defined in [asset-swapper/src/types.ts:55](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L55)*
+*Defined in [asset-swapper/src/types.ts:54](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L54)*
 
 ___
 
@@ -1219,15 +1423,7 @@ ___
 
 • **ethAmount**: *`BigNumber`*
 
-*Defined in [asset-swapper/src/types.ts:58](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L58)*
-
-___
-
-###  methodAbi
-
-• **methodAbi**: *`MethodAbi`*
-
-*Defined in [asset-swapper/src/types.ts:56](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L56)*
+*Defined in [asset-swapper/src/types.ts:56](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L56)*
 
 ___
 
@@ -1235,19 +1431,34 @@ ___
 
 • **toAddress**: *string*
 
-*Defined in [asset-swapper/src/types.ts:57](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L57)*
+*Defined in [asset-swapper/src/types.ts:55](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L55)*
 
 <hr />
 
+# Interface: ForwarderExtensionContractOpts
+
+ethAmount: The amount of eth (in Wei) sent to the forwarder contract.
+feePercentage: percentage (up to 5%) of the taker asset paid to feeRecipient
+feeRecipient: address of the receiver of the feePercentage of taker asset
 
 
+##   Properties
 
+###  feePercentage
 
+• **feePercentage**: *number*
 
+*Defined in [asset-swapper/src/types.ts:120](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L120)*
 
+___
 
+###  feeRecipient
 
+• **feeRecipient**: *string*
 
+*Defined in [asset-swapper/src/types.ts:121](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L121)*
+
+<hr />
 
 
 
@@ -1260,7 +1471,7 @@ ___
 
 • **ethAmount**? : *`BigNumber`*
 
-*Defined in [asset-swapper/src/types.ts:209](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L209)*
+*Defined in [asset-swapper/src/types.ts:128](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L128)*
 
 ___
 
@@ -1268,7 +1479,7 @@ ___
 
 • **takerAddress**? : *undefined | string*
 
-*Defined in [asset-swapper/src/types.ts:208](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L208)*
+*Defined in [asset-swapper/src/types.ts:127](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L127)*
 
 <hr />
 
@@ -1283,7 +1494,7 @@ Represents available liquidity for a given assetData.
 
 • **makerAssetAvailableInBaseUnits**: *`BigNumber`*
 
-*Defined in [asset-swapper/src/types.ts:306](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L306)*
+*Defined in [asset-swapper/src/types.ts:246](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L246)*
 
 ___
 
@@ -1291,7 +1502,7 @@ ___
 
 • **takerAssetAvailableInBaseUnits**: *`BigNumber`*
 
-*Defined in [asset-swapper/src/types.ts:307](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L307)*
+*Defined in [asset-swapper/src/types.ts:247](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L247)*
 
 <hr />
 
@@ -1309,7 +1520,17 @@ type: Specified MarketOperation the SwapQuote is provided for
 
 *Inherited from [SwapQuoteBase](#interface-swapquotebase).[bestCaseQuoteInfo](#bestcasequoteinfo)*
 
-*Defined in [asset-swapper/src/types.ts:223](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L223)*
+*Defined in [asset-swapper/src/types.ts:144](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L144)*
+
+___
+
+###  gasPrice
+
+• **gasPrice**: *`BigNumber`*
+
+*Inherited from [SwapQuoteBase](#interface-swapquotebase).[gasPrice](#gasprice)*
+
+*Defined in [asset-swapper/src/types.ts:142](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L142)*
 
 ___
 
@@ -1319,7 +1540,7 @@ ___
 
 *Inherited from [SwapQuoteBase](#interface-swapquotebase).[makerAssetData](#makerassetdata)*
 
-*Defined in [asset-swapper/src/types.ts:221](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L221)*
+*Defined in [asset-swapper/src/types.ts:141](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L141)*
 
 ___
 
@@ -1327,7 +1548,7 @@ ___
 
 • **makerAssetFillAmount**: *`BigNumber`*
 
-*Defined in [asset-swapper/src/types.ts:241](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L241)*
+*Defined in [asset-swapper/src/types.ts:163](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L163)*
 
 ___
 
@@ -1337,7 +1558,17 @@ ___
 
 *Inherited from [SwapQuoteBase](#interface-swapquotebase).[orders](#orders)*
 
-*Defined in [asset-swapper/src/types.ts:222](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L222)*
+*Defined in [asset-swapper/src/types.ts:143](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L143)*
+
+___
+
+###  sourceBreakdown
+
+• **sourceBreakdown**: *[SwapQuoteOrdersBreakdown](#class-swapquoteordersbreakdown)*
+
+*Inherited from [SwapQuoteBase](#interface-swapquotebase).[sourceBreakdown](#sourcebreakdown)*
+
+*Defined in [asset-swapper/src/types.ts:146](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L146)*
 
 ___
 
@@ -1347,7 +1578,7 @@ ___
 
 *Inherited from [SwapQuoteBase](#interface-swapquotebase).[takerAssetData](#takerassetdata)*
 
-*Defined in [asset-swapper/src/types.ts:220](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L220)*
+*Defined in [asset-swapper/src/types.ts:140](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L140)*
 
 ___
 
@@ -1355,7 +1586,7 @@ ___
 
 • **type**: *[Buy](#buy)*
 
-*Defined in [asset-swapper/src/types.ts:242](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L242)*
+*Defined in [asset-swapper/src/types.ts:164](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L164)*
 
 ___
 
@@ -1365,7 +1596,7 @@ ___
 
 *Inherited from [SwapQuoteBase](#interface-swapquotebase).[worstCaseQuoteInfo](#worstcasequoteinfo)*
 
-*Defined in [asset-swapper/src/types.ts:224](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L224)*
+*Defined in [asset-swapper/src/types.ts:145](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L145)*
 
 <hr />
 
@@ -1383,7 +1614,17 @@ type: Specified MarketOperation the SwapQuote is provided for
 
 *Inherited from [SwapQuoteBase](#interface-swapquotebase).[bestCaseQuoteInfo](#bestcasequoteinfo)*
 
-*Defined in [asset-swapper/src/types.ts:223](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L223)*
+*Defined in [asset-swapper/src/types.ts:144](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L144)*
+
+___
+
+###  gasPrice
+
+• **gasPrice**: *`BigNumber`*
+
+*Inherited from [SwapQuoteBase](#interface-swapquotebase).[gasPrice](#gasprice)*
+
+*Defined in [asset-swapper/src/types.ts:142](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L142)*
 
 ___
 
@@ -1393,7 +1634,7 @@ ___
 
 *Inherited from [SwapQuoteBase](#interface-swapquotebase).[makerAssetData](#makerassetdata)*
 
-*Defined in [asset-swapper/src/types.ts:221](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L221)*
+*Defined in [asset-swapper/src/types.ts:141](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L141)*
 
 ___
 
@@ -1403,7 +1644,17 @@ ___
 
 *Inherited from [SwapQuoteBase](#interface-swapquotebase).[orders](#orders)*
 
-*Defined in [asset-swapper/src/types.ts:222](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L222)*
+*Defined in [asset-swapper/src/types.ts:143](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L143)*
+
+___
+
+###  sourceBreakdown
+
+• **sourceBreakdown**: *[SwapQuoteOrdersBreakdown](#class-swapquoteordersbreakdown)*
+
+*Inherited from [SwapQuoteBase](#interface-swapquotebase).[sourceBreakdown](#sourcebreakdown)*
+
+*Defined in [asset-swapper/src/types.ts:146](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L146)*
 
 ___
 
@@ -1413,7 +1664,7 @@ ___
 
 *Inherited from [SwapQuoteBase](#interface-swapquotebase).[takerAssetData](#takerassetdata)*
 
-*Defined in [asset-swapper/src/types.ts:220](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L220)*
+*Defined in [asset-swapper/src/types.ts:140](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L140)*
 
 ___
 
@@ -1421,7 +1672,7 @@ ___
 
 • **takerAssetFillAmount**: *`BigNumber`*
 
-*Defined in [asset-swapper/src/types.ts:232](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L232)*
+*Defined in [asset-swapper/src/types.ts:154](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L154)*
 
 ___
 
@@ -1429,7 +1680,7 @@ ___
 
 • **type**: *[Sell](#sell)*
 
-*Defined in [asset-swapper/src/types.ts:233](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L233)*
+*Defined in [asset-swapper/src/types.ts:155](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L155)*
 
 ___
 
@@ -1439,7 +1690,7 @@ ___
 
 *Inherited from [SwapQuoteBase](#interface-swapquotebase).[worstCaseQuoteInfo](#worstcasequoteinfo)*
 
-*Defined in [asset-swapper/src/types.ts:224](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L224)*
+*Defined in [asset-swapper/src/types.ts:145](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L145)*
 
 <hr />
 
@@ -1449,7 +1700,7 @@ ___
 
 
 
-# Interface: PrunedSignedOrder
+# Interface: SignedOrderWithFillableAmounts
 
 fillableMakerAssetAmount: Amount of makerAsset that is fillable
 fillableTakerAssetAmount: Amount of takerAsset that is fillable
@@ -1502,7 +1753,7 @@ ___
 
 • **fillableMakerAssetAmount**: *`BigNumber`*
 
-*Defined in [asset-swapper/src/types.ts:42](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L42)*
+*Defined in [asset-swapper/src/types.ts:42](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L42)*
 
 ___
 
@@ -1510,7 +1761,7 @@ ___
 
 • **fillableTakerAssetAmount**: *`BigNumber`*
 
-*Defined in [asset-swapper/src/types.ts:43](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L43)*
+*Defined in [asset-swapper/src/types.ts:43](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L43)*
 
 ___
 
@@ -1518,7 +1769,7 @@ ___
 
 • **fillableTakerFeeAmount**: *`BigNumber`*
 
-*Defined in [asset-swapper/src/types.ts:44](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L44)*
+*Defined in [asset-swapper/src/types.ts:44](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L44)*
 
 ___
 
@@ -1654,65 +1905,11 @@ Defined in types/lib/index.d.ts:19
 
 
 
-# Interface: SmartContractParamsInfo <**T**>
-
-Represents the metadata to call a smart contract with parameters.
-params: The metadata object containing all the input parameters of a smart contract call.
-toAddress: The contract address to call.
-ethAmount: If provided, the eth amount in wei to send with the smart contract call.
-methodAbi: The ABI of the smart contract method to call with params.
-
-## Type parameters
-
-▪ **T**
-
-
-##   Properties
-
-###  ethAmount
-
-• **ethAmount**: *`BigNumber`*
-
-*Defined in [asset-swapper/src/types.ts:71](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L71)*
-
-___
-
-###  methodAbi
-
-• **methodAbi**: *`MethodAbi`*
-
-*Defined in [asset-swapper/src/types.ts:72](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L72)*
-
-___
-
-###  params
-
-• **params**: *`T`*
-
-*Defined in [asset-swapper/src/types.ts:69](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L69)*
-
-___
-
-###  toAddress
-
-• **toAddress**: *string*
-
-*Defined in [asset-swapper/src/types.ts:70](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L70)*
-
-<hr />
-
-
-
-# Interface: SwapQuoteConsumerBase <**T**>
+# Interface: SwapQuoteConsumerBase
 
 Interface that varying SwapQuoteConsumers adhere to (exchange consumer, router consumer, forwarder consumer, coordinator consumer)
 getCalldataOrThrow: Get CalldataInfo to swap for tokens with provided SwapQuote. Throws if invalid SwapQuote is provided.
-getSmartContractParamsOrThrow: Get SmartContractParamsInfo to swap for tokens with provided SwapQuote. Throws if invalid SwapQuote is provided.
 executeSwapQuoteOrThrowAsync: Executes a web3 transaction to swap for tokens with provided SwapQuote. Throws if invalid SwapQuote is provided.
-
-## Type parameters
-
-▪ **T**
 
 
 ##  Implemented by
@@ -1726,7 +1923,7 @@ executeSwapQuoteOrThrowAsync: Executes a web3 transaction to swap for tokens wit
 
 ▸ **executeSwapQuoteOrThrowAsync**(`quote`: [SwapQuote](#swapquote), `opts`: `Partial<SwapQuoteExecutionOpts>`): *`Promise<string>`*
 
-*Defined in [asset-swapper/src/types.ts:159](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L159)*
+*Defined in [asset-swapper/src/types.ts:83](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L83)*
 
 **Parameters:**
 
@@ -1743,7 +1940,7 @@ ___
 
 ▸ **getCalldataOrThrowAsync**(`quote`: [SwapQuote](#swapquote), `opts`: `Partial<SwapQuoteGetOutputOpts>`): *`Promise<CalldataInfo>`*
 
-*Defined in [asset-swapper/src/types.ts:154](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L154)*
+*Defined in [asset-swapper/src/types.ts:82](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L82)*
 
 **Parameters:**
 
@@ -1753,23 +1950,6 @@ Name | Type |
 `opts` | `Partial<SwapQuoteGetOutputOpts>` |
 
 **Returns:** *`Promise<CalldataInfo>`*
-
-___
-
-###  getSmartContractParamsOrThrowAsync
-
-▸ **getSmartContractParamsOrThrowAsync**(`quote`: [SwapQuote](#swapquote), `opts`: `Partial<SwapQuoteGetOutputOpts>`): *`Promise<SmartContractParamsInfo<T>>`*
-
-*Defined in [asset-swapper/src/types.ts:155](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L155)*
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`quote` | [SwapQuote](#swapquote) |
-`opts` | `Partial<SwapQuoteGetOutputOpts>` |
-
-**Returns:** *`Promise<SmartContractParamsInfo<T>>`*
 
 <hr />
 
@@ -1784,29 +1964,31 @@ chainId: The chainId that the desired orders should be for.
 
 • **chainId**: *number*
 
-*Defined in [asset-swapper/src/types.ts:166](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L166)*
+*Defined in [asset-swapper/src/types.ts:90](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L90)*
 
-<hr />
+___
 
-# Interface: SwapQuoteConsumingOpts
+### `Optional` contractAddresses
 
+• **contractAddresses**? : *[ContractAddresses](#class-contractaddresses)*
 
-##   Properties
+*Defined in [asset-swapper/src/types.ts:91](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L91)*
 
-###  useExtensionContract
+___
 
-• **useExtensionContract**: *[ExtensionContractType](#enumeration-extensioncontracttype)*
+### `Optional` jsonRpcIdNameSpace
 
-*Defined in [asset-swapper/src/types.ts:202](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L202)*
+• **jsonRpcIdNameSpace**? : *undefined | string*
+
+*Defined in [asset-swapper/src/types.ts:92](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L92)*
 
 <hr />
 
 # Interface: SwapQuoteExecutionOpts
 
+ethAmount: The amount of eth sent with the execution of a swap.
 takerAddress: The address to perform the buy. Defaults to the first available address from the provider.
 gasLimit: The amount of gas to send with a transaction (in Gwei). Defaults to an eth_estimateGas rpc call.
-gasPrice: Gas price in Wei to use for a transaction
-ethAmount: The amount of eth sent with the execution of a swap
 
 
 ##   Properties
@@ -1815,7 +1997,17 @@ ethAmount: The amount of eth sent with the execution of a swap
 
 • **ethAmount**? : *`BigNumber`*
 
-*Defined in [asset-swapper/src/types.ts:184](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L184)*
+*Defined in [asset-swapper/src/types.ts:109](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L109)*
+
+___
+
+### `Optional` extensionContractOpts
+
+• **extensionContractOpts**? : *[ForwarderExtensionContractOpts](#class-forwarderextensioncontractopts) | any*
+
+*Inherited from [SwapQuoteGetOutputOpts](#interface-swapquotegetoutputopts).[extensionContractOpts](#optional-extensioncontractopts)*
+
+*Defined in [asset-swapper/src/types.ts:100](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L100)*
 
 ___
 
@@ -1823,15 +2015,7 @@ ___
 
 • **gasLimit**? : *undefined | number*
 
-*Defined in [asset-swapper/src/types.ts:182](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L182)*
-
-___
-
-### `Optional` gasPrice
-
-• **gasPrice**? : *`BigNumber`*
-
-*Defined in [asset-swapper/src/types.ts:183](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L183)*
+*Defined in [asset-swapper/src/types.ts:111](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L111)*
 
 ___
 
@@ -1839,7 +2023,17 @@ ___
 
 • **takerAddress**? : *undefined | string*
 
-*Defined in [asset-swapper/src/types.ts:181](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L181)*
+*Defined in [asset-swapper/src/types.ts:110](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L110)*
+
+___
+
+###  useExtensionContract
+
+• **useExtensionContract**: *[ExtensionContractType](#enumeration-extensioncontracttype)*
+
+*Inherited from [SwapQuoteGetOutputOpts](#interface-swapquotegetoutputopts).[useExtensionContract](#useextensioncontract)*
+
+*Defined in [asset-swapper/src/types.ts:99](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L99)*
 
 <hr />
 
@@ -1848,18 +2042,40 @@ ___
 Represents the options provided to a generic SwapQuoteConsumer
 
 
-##  Hierarchy
+##   Properties
 
-* **SwapQuoteInfo**
+### `Optional` extensionContractOpts
+
+• **extensionContractOpts**? : *[ForwarderExtensionContractOpts](#class-forwarderextensioncontractopts) | any*
+
+*Defined in [asset-swapper/src/types.ts:100](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L100)*
+
+___
+
+###  useExtensionContract
+
+• **useExtensionContract**: *[ExtensionContractType](#enumeration-extensioncontracttype)*
+
+*Defined in [asset-swapper/src/types.ts:99](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L99)*
+
+<hr />
+
+# Interface: SwapQuoteInfo
+
+feeTakerAssetAmount: The amount of takerAsset reserved for paying takerFees when swapping for desired assets.
+takerAssetAmount: The amount of takerAsset swapped for desired makerAsset.
+totalTakerAssetAmount: The total amount of takerAsset required to complete the swap (filling orders, and paying takerFees).
+makerAssetAmount: The amount of makerAsset that will be acquired through the swap.
+protocolFeeInWeiAmount: The amount of ETH to pay (in WEI) as protocol fee to perform the swap for desired asset.
 
 
-##  Properties
+##   Properties
 
 ###  feeTakerAssetAmount
 
 • **feeTakerAssetAmount**: *`BigNumber`*
 
-*Defined in [asset-swapper/src/types.ts:253](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L253)*
+*Defined in [asset-swapper/src/types.ts:175](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L175)*
 
 ___
 
@@ -1867,15 +2083,15 @@ ___
 
 • **makerAssetAmount**: *`BigNumber`*
 
-*Defined in [asset-swapper/src/types.ts:256](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L256)*
+*Defined in [asset-swapper/src/types.ts:178](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L178)*
 
 ___
 
-###  protocolFeeInEthAmount
+###  protocolFeeInWeiAmount
 
-• **protocolFeeInEthAmount**: *`BigNumber`*
+• **protocolFeeInWeiAmount**: *`BigNumber`*
 
-*Defined in [asset-swapper/src/types.ts:257](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L257)*
+*Defined in [asset-swapper/src/types.ts:179](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L179)*
 
 ___
 
@@ -1883,7 +2099,7 @@ ___
 
 • **takerAssetAmount**: *`BigNumber`*
 
-*Defined in [asset-swapper/src/types.ts:254](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L254)*
+*Defined in [asset-swapper/src/types.ts:176](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L176)*
 
 ___
 
@@ -1891,23 +2107,140 @@ ___
 
 • **totalTakerAssetAmount**: *`BigNumber`*
 
-*Defined in [asset-swapper/src/types.ts:255](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L255)*
+*Defined in [asset-swapper/src/types.ts:177](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L177)*
 
 <hr />
 
-# Interface: SwapQuoteRequestOpts
+# Interface: SwapQuoteOrdersBreakdown
 
-slippagePercentage: The percentage buffer to add to account for slippage. Affects max ETH price estimates. Defaults to 0.2 (20%).
-gasPrice: gas price to determine protocolFee amount, default to ethGasStation fast amount
+percentage breakdown of each liquidity source used in quote
 
 
-##   Properties
+##  Hierarchy
+
+  * [CalculateSwapQuoteOpts](#class-calculateswapquoteopts)
+
+  * **SwapQuoteRequestOpts**
+
+
+##  Properties
+
+###  bridgeSlippage
+
+• **bridgeSlippage**: *number*
+
+*Inherited from [GetMarketOrdersOpts](#interface-getmarketordersopts).[bridgeSlippage](#bridgeslippage)*
+
+*Defined in [asset-swapper/src/utils/market_operation_utils/types.ts:154](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/market_operation_utils/types.ts#L154)*
+
+When generating bridge orders, we use
+sampled rate * (1 - bridgeSlippage)
+as the rate for calculating maker/taker asset amounts.
+This should be a small positive number (e.g., 0.0005) to make up for
+small discrepancies between samples and truth.
+Default is 0.0005 (5 basis points).
+
+___
+
+###  dustFractionThreshold
+
+• **dustFractionThreshold**: *number*
+
+*Inherited from [GetMarketOrdersOpts](#interface-getmarketordersopts).[dustFractionThreshold](#dustfractionthreshold)*
+
+*Defined in [asset-swapper/src/utils/market_operation_utils/types.ts:163](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/market_operation_utils/types.ts#L163)*
+
+Dust amount, as a fraction of the fill amount.
+Default is 0.01 (100 basis points).
+
+___
+
+###  excludedSources
+
+• **excludedSources**: *[ERC20BridgeSource](#enumeration-erc20bridgesource)[]*
+
+*Inherited from [GetMarketOrdersOpts](#interface-getmarketordersopts).[excludedSources](#excludedsources)*
+
+*Defined in [asset-swapper/src/utils/market_operation_utils/types.ts:136](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/market_operation_utils/types.ts#L136)*
+
+Liquidity sources to exclude. Default is none.
+
+___
+
+###  fees
+
+• **fees**: *object*
+
+*Inherited from [GetMarketOrdersOpts](#interface-getmarketordersopts).[fees](#fees)*
+
+*Defined in [asset-swapper/src/utils/market_operation_utils/types.ts:175](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/market_operation_utils/types.ts#L175)*
+
+Fees for each liquidity source, expressed in gas.
+
+#### Type declaration:
+
+● \[▪ **source**: *string*\]: `BigNumber`
+
+___
 
 ### `Optional` gasPrice
 
 • **gasPrice**? : *`BigNumber`*
 
-*Defined in [asset-swapper/src/types.ts:266](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L266)*
+*Defined in [asset-swapper/src/types.ts:195](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L195)*
+
+___
+
+###  noConflicts
+
+• **noConflicts**: *boolean*
+
+*Inherited from [GetMarketOrdersOpts](#interface-getmarketordersopts).[noConflicts](#noconflicts)*
+
+*Defined in [asset-swapper/src/utils/market_operation_utils/types.ts:140](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/market_operation_utils/types.ts#L140)*
+
+Whether to prevent mixing Kyber orders with Uniswap and Eth2Dai orders.
+
+___
+
+###  numSamples
+
+• **numSamples**: *number*
+
+*Inherited from [GetMarketOrdersOpts](#interface-getmarketordersopts).[numSamples](#numsamples)*
+
+*Defined in [asset-swapper/src/utils/market_operation_utils/types.ts:158](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/market_operation_utils/types.ts#L158)*
+
+Number of samples to take for each DEX quote.
+
+___
+
+###  runLimit
+
+• **runLimit**: *number*
+
+*Inherited from [GetMarketOrdersOpts](#interface-getmarketordersopts).[runLimit](#runlimit)*
+
+*Defined in [asset-swapper/src/utils/market_operation_utils/types.ts:145](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/market_operation_utils/types.ts#L145)*
+
+Complexity limit on the search algorithm, i.e., maximum number of
+nodes to visit. Default is 1024.
+
+___
+
+###  sampleDistributionBase
+
+• **sampleDistributionBase**: *number*
+
+*Inherited from [GetMarketOrdersOpts](#interface-getmarketordersopts).[sampleDistributionBase](#sampledistributionbase)*
+
+*Defined in [asset-swapper/src/utils/market_operation_utils/types.ts:171](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/market_operation_utils/types.ts#L171)*
+
+The exponential sampling distribution base.
+A value of 1 will result in evenly spaced samples.
+> 1 will result in more samples at lower sizes.
+< 1 will result in more samples at higher sizes.
+Default: 1.25.
 
 ___
 
@@ -1915,7 +2248,7 @@ ___
 
 • **slippagePercentage**: *number*
 
-*Defined in [asset-swapper/src/types.ts:265](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L265)*
+*Defined in [asset-swapper/src/types.ts:194](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L194)*
 
 <hr />
 
@@ -1924,6 +2257,8 @@ ___
 chainId: The ethereum chain id. Defaults to 1 (mainnet).
 orderRefreshIntervalMs: The interval in ms that getBuyQuoteAsync should trigger an refresh of orders and order states. Defaults to 10000ms (10s).
 expiryBufferMs: The number of seconds to add when calculating whether an order is expired or not. Defaults to 300s (5m).
+contractAddresses: Optionally override the contract addresses used for the chain
+samplerGasLimit: The gas limit used when querying the sampler contract. Defaults to 36e6
 
 
 ##   Properties
@@ -1932,7 +2267,15 @@ expiryBufferMs: The number of seconds to add when calculating whether an order i
 
 • **chainId**: *number*
 
-*Defined in [asset-swapper/src/types.ts:275](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L275)*
+*Defined in [asset-swapper/src/types.ts:211](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L211)*
+
+___
+
+### `Optional` contractAddresses
+
+• **contractAddresses**? : *[ContractAddresses](#class-contractaddresses)*
+
+*Defined in [asset-swapper/src/types.ts:214](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L214)*
 
 ___
 
@@ -1942,7 +2285,15 @@ ___
 
 *Overrides [OrderPrunerOpts](_asset_swapper_src_types_.orderpruneropts.md).[expiryBufferMs](#expirybufferms)*
 
-*Defined in [asset-swapper/src/types.ts:277](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L277)*
+*Defined in [asset-swapper/src/types.ts:213](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L213)*
+
+___
+
+### `Optional` jsonRpcIdNameSpace
+
+• **jsonRpcIdNameSpace**? : *undefined | string*
+
+*Defined in [asset-swapper/src/types.ts:216](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L216)*
 
 ___
 
@@ -1950,7 +2301,7 @@ ___
 
 • **orderRefreshIntervalMs**: *number*
 
-*Defined in [asset-swapper/src/types.ts:276](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L276)*
+*Defined in [asset-swapper/src/types.ts:212](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L212)*
 
 ___
 
@@ -1960,7 +2311,591 @@ ___
 
 *Inherited from [OrderPrunerOpts](#interface-orderpruneropts).[permittedOrderFeeTypes](#permittedorderfeetypes)*
 
-*Defined in [asset-swapper/src/types.ts:11](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L11)*
+*Defined in [asset-swapper/src/types.ts:13](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L13)*
+
+___
+
+### `Optional` samplerGasLimit
+
+• **samplerGasLimit**? : *undefined | number*
+
+*Defined in [asset-swapper/src/types.ts:215](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L215)*
+
+<hr />
+
+# Interface: CollapsedFill
+
+Represents continguous fills on a path that have been merged together.
+
+
+##   Properties
+
+###  source
+
+• **source**: *[ERC20BridgeSource](#enumeration-erc20bridgesource)*
+
+*Defined in [asset-swapper/src/utils/market_operation_utils/types.ts:94](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/market_operation_utils/types.ts#L94)*
+
+The source DEX.
+
+___
+
+###  subFills
+
+• **subFills**: *`Array<object>`*
+
+*Defined in [asset-swapper/src/utils/market_operation_utils/types.ts:106](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/market_operation_utils/types.ts#L106)*
+
+All the fill asset amounts that were collapsed into this node.
+
+___
+
+###  totalMakerAssetAmount
+
+• **totalMakerAssetAmount**: *`BigNumber`*
+
+*Defined in [asset-swapper/src/utils/market_operation_utils/types.ts:98](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/market_operation_utils/types.ts#L98)*
+
+Total maker asset amount.
+
+___
+
+###  totalTakerAssetAmount
+
+• **totalTakerAssetAmount**: *`BigNumber`*
+
+*Defined in [asset-swapper/src/utils/market_operation_utils/types.ts:102](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/market_operation_utils/types.ts#L102)*
+
+Total taker asset amount.
+
+<hr />
+
+
+
+
+
+
+
+
+
+# Interface: NativeCollapsedFill
+
+A `CollapsedFill` wrapping a native order.
+
+
+##   Properties
+
+###  nativeOrder
+
+• **nativeOrder**: *[SignedOrderWithFillableAmounts](#class-signedorderwithfillableamounts)*
+
+*Defined in [asset-swapper/src/utils/market_operation_utils/types.ts:116](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/market_operation_utils/types.ts#L116)*
+
+___
+
+###  source
+
+• **source**: *[ERC20BridgeSource](#enumeration-erc20bridgesource)*
+
+*Inherited from [CollapsedFill](#interface-collapsedfill).[source](#source)*
+
+*Defined in [asset-swapper/src/utils/market_operation_utils/types.ts:94](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/market_operation_utils/types.ts#L94)*
+
+The source DEX.
+
+___
+
+###  subFills
+
+• **subFills**: *`Array<object>`*
+
+*Inherited from [CollapsedFill](#interface-collapsedfill).[subFills](#subfills)*
+
+*Defined in [asset-swapper/src/utils/market_operation_utils/types.ts:106](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/market_operation_utils/types.ts#L106)*
+
+All the fill asset amounts that were collapsed into this node.
+
+___
+
+###  totalMakerAssetAmount
+
+• **totalMakerAssetAmount**: *`BigNumber`*
+
+*Inherited from [CollapsedFill](#interface-collapsedfill).[totalMakerAssetAmount](#totalmakerassetamount)*
+
+*Defined in [asset-swapper/src/utils/market_operation_utils/types.ts:98](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/market_operation_utils/types.ts#L98)*
+
+Total maker asset amount.
+
+___
+
+###  totalTakerAssetAmount
+
+• **totalTakerAssetAmount**: *`BigNumber`*
+
+*Inherited from [CollapsedFill](#interface-collapsedfill).[totalTakerAssetAmount](#totaltakerassetamount)*
+
+*Defined in [asset-swapper/src/utils/market_operation_utils/types.ts:102](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/market_operation_utils/types.ts#L102)*
+
+Total taker asset amount.
+
+<hr />
+
+
+
+# Interface: OptimizedMarketOrder
+
+Optimized orders to fill.
+
+
+##   Properties
+
+###  chainId
+
+• **chainId**: *number*
+
+
+
+Defined in types/lib/index.d.ts:4
+
+___
+
+###  exchangeAddress
+
+• **exchangeAddress**: *string*
+
+
+
+Defined in types/lib/index.d.ts:5
+
+___
+
+###  expirationTimeSeconds
+
+• **expirationTimeSeconds**: *`BigNumber`*
+
+
+
+Defined in types/lib/index.d.ts:14
+
+___
+
+###  feeRecipientAddress
+
+• **feeRecipientAddress**: *string*
+
+
+
+Defined in types/lib/index.d.ts:8
+
+___
+
+###  fill
+
+• **fill**: *[CollapsedFill](#class-collapsedfill)*
+
+*Defined in [asset-swapper/src/utils/market_operation_utils/types.ts:126](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/market_operation_utils/types.ts#L126)*
+
+The optimized fills that generated this order.
+
+___
+
+###  fillableMakerAssetAmount
+
+• **fillableMakerAssetAmount**: *`BigNumber`*
+
+*Inherited from [SignedOrderWithFillableAmounts](#interface-signedorderwithfillableamounts).[fillableMakerAssetAmount](#fillablemakerassetamount)*
+
+*Defined in [asset-swapper/src/types.ts:42](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L42)*
+
+___
+
+###  fillableTakerAssetAmount
+
+• **fillableTakerAssetAmount**: *`BigNumber`*
+
+*Inherited from [SignedOrderWithFillableAmounts](#interface-signedorderwithfillableamounts).[fillableTakerAssetAmount](#fillabletakerassetamount)*
+
+*Defined in [asset-swapper/src/types.ts:43](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L43)*
+
+___
+
+###  fillableTakerFeeAmount
+
+• **fillableTakerFeeAmount**: *`BigNumber`*
+
+*Inherited from [SignedOrderWithFillableAmounts](#interface-signedorderwithfillableamounts).[fillableTakerFeeAmount](#fillabletakerfeeamount)*
+
+*Defined in [asset-swapper/src/types.ts:44](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L44)*
+
+___
+
+###  makerAddress
+
+• **makerAddress**: *string*
+
+
+
+Defined in types/lib/index.d.ts:6
+
+___
+
+###  makerAssetAmount
+
+• **makerAssetAmount**: *`BigNumber`*
+
+
+
+Defined in types/lib/index.d.ts:10
+
+___
+
+###  makerAssetData
+
+• **makerAssetData**: *string*
+
+
+
+Defined in types/lib/index.d.ts:16
+
+___
+
+###  makerFee
+
+• **makerFee**: *`BigNumber`*
+
+
+
+Defined in types/lib/index.d.ts:12
+
+___
+
+###  makerFeeAssetData
+
+• **makerFeeAssetData**: *string*
+
+
+
+Defined in types/lib/index.d.ts:18
+
+___
+
+###  salt
+
+• **salt**: *`BigNumber`*
+
+
+
+Defined in types/lib/index.d.ts:15
+
+___
+
+###  senderAddress
+
+• **senderAddress**: *string*
+
+
+
+Defined in types/lib/index.d.ts:9
+
+___
+
+###  signature
+
+• **signature**: *string*
+
+
+
+Defined in types/lib/index.d.ts:22
+
+___
+
+###  takerAddress
+
+• **takerAddress**: *string*
+
+
+
+Defined in types/lib/index.d.ts:7
+
+___
+
+###  takerAssetAmount
+
+• **takerAssetAmount**: *`BigNumber`*
+
+
+
+Defined in types/lib/index.d.ts:11
+
+___
+
+###  takerAssetData
+
+• **takerAssetData**: *string*
+
+
+
+Defined in types/lib/index.d.ts:17
+
+___
+
+###  takerFee
+
+• **takerFee**: *`BigNumber`*
+
+
+
+Defined in types/lib/index.d.ts:13
+
+___
+
+###  takerFeeAssetData
+
+• **takerFeeAssetData**: *string*
+
+
+
+Defined in types/lib/index.d.ts:19
+
+<hr />
+
+
+
+# Interface: ContractAddresses
+
+
+##   Properties
+
+###  assetProxyOwner
+
+• **assetProxyOwner**: *string*
+
+*Defined in [contract-addresses/src/index.ts:10](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/contract-addresses/src/index.ts#L10)*
+
+___
+
+###  broker
+
+• **broker**: *string*
+
+*Defined in [contract-addresses/src/index.ts:31](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/contract-addresses/src/index.ts#L31)*
+
+___
+
+###  chaiBridge
+
+• **chaiBridge**: *string*
+
+*Defined in [contract-addresses/src/index.ts:27](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/contract-addresses/src/index.ts#L27)*
+
+___
+
+###  chainlinkStopLimit
+
+• **chainlinkStopLimit**: *string*
+
+*Defined in [contract-addresses/src/index.ts:32](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/contract-addresses/src/index.ts#L32)*
+
+___
+
+###  coordinator
+
+• **coordinator**: *string*
+
+*Defined in [contract-addresses/src/index.ts:14](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/contract-addresses/src/index.ts#L14)*
+
+___
+
+###  coordinatorRegistry
+
+• **coordinatorRegistry**: *string*
+
+*Defined in [contract-addresses/src/index.ts:13](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/contract-addresses/src/index.ts#L13)*
+
+___
+
+###  curveBridge
+
+• **curveBridge**: *string*
+
+*Defined in [contract-addresses/src/index.ts:29](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/contract-addresses/src/index.ts#L29)*
+
+___
+
+###  devUtils
+
+• **devUtils**: *string*
+
+*Defined in [contract-addresses/src/index.ts:18](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/contract-addresses/src/index.ts#L18)*
+
+___
+
+###  dydxBridge
+
+• **dydxBridge**: *string*
+
+*Defined in [contract-addresses/src/index.ts:28](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/contract-addresses/src/index.ts#L28)*
+
+___
+
+###  erc1155Proxy
+
+• **erc1155Proxy**: *string*
+
+*Defined in [contract-addresses/src/index.ts:17](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/contract-addresses/src/index.ts#L17)*
+
+___
+
+###  erc20BridgeProxy
+
+• **erc20BridgeProxy**: *string*
+
+*Defined in [contract-addresses/src/index.ts:22](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/contract-addresses/src/index.ts#L22)*
+
+___
+
+###  erc20BridgeSampler
+
+• **erc20BridgeSampler**: *string*
+
+*Defined in [contract-addresses/src/index.ts:23](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/contract-addresses/src/index.ts#L23)*
+
+___
+
+###  erc20Proxy
+
+• **erc20Proxy**: *string*
+
+*Defined in [contract-addresses/src/index.ts:4](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/contract-addresses/src/index.ts#L4)*
+
+___
+
+###  erc721Proxy
+
+• **erc721Proxy**: *string*
+
+*Defined in [contract-addresses/src/index.ts:5](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/contract-addresses/src/index.ts#L5)*
+
+___
+
+###  eth2DaiBridge
+
+• **eth2DaiBridge**: *string*
+
+*Defined in [contract-addresses/src/index.ts:25](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/contract-addresses/src/index.ts#L25)*
+
+___
+
+###  etherToken
+
+• **etherToken**: *string*
+
+*Defined in [contract-addresses/src/index.ts:7](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/contract-addresses/src/index.ts#L7)*
+
+___
+
+###  exchange
+
+• **exchange**: *string*
+
+*Defined in [contract-addresses/src/index.ts:9](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/contract-addresses/src/index.ts#L9)*
+
+___
+
+###  exchangeV2
+
+• **exchangeV2**: *string*
+
+*Defined in [contract-addresses/src/index.ts:8](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/contract-addresses/src/index.ts#L8)*
+
+___
+
+###  forwarder
+
+• **forwarder**: *string*
+
+*Defined in [contract-addresses/src/index.ts:12](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/contract-addresses/src/index.ts#L12)*
+
+___
+
+###  godsUnchainedValidator
+
+• **godsUnchainedValidator**: *string*
+
+*Defined in [contract-addresses/src/index.ts:30](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/contract-addresses/src/index.ts#L30)*
+
+___
+
+###  kyberBridge
+
+• **kyberBridge**: *string*
+
+*Defined in [contract-addresses/src/index.ts:26](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/contract-addresses/src/index.ts#L26)*
+
+___
+
+###  multiAssetProxy
+
+• **multiAssetProxy**: *string*
+
+*Defined in [contract-addresses/src/index.ts:15](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/contract-addresses/src/index.ts#L15)*
+
+___
+
+###  staking
+
+• **staking**: *string*
+
+*Defined in [contract-addresses/src/index.ts:20](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/contract-addresses/src/index.ts#L20)*
+
+___
+
+###  stakingProxy
+
+• **stakingProxy**: *string*
+
+*Defined in [contract-addresses/src/index.ts:21](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/contract-addresses/src/index.ts#L21)*
+
+___
+
+###  staticCallProxy
+
+• **staticCallProxy**: *string*
+
+*Defined in [contract-addresses/src/index.ts:16](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/contract-addresses/src/index.ts#L16)*
+
+___
+
+###  uniswapBridge
+
+• **uniswapBridge**: *string*
+
+*Defined in [contract-addresses/src/index.ts:24](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/contract-addresses/src/index.ts#L24)*
+
+___
+
+###  zeroExGovernor
+
+• **zeroExGovernor**: *string*
+
+*Defined in [contract-addresses/src/index.ts:11](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/contract-addresses/src/index.ts#L11)*
+
+___
+
+###  zrxToken
+
+• **zrxToken**: *string*
+
+*Defined in [contract-addresses/src/index.ts:6](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/contract-addresses/src/index.ts#L6)*
+
+___
+
+###  zrxVault
+
+• **zrxVault**: *string*
+
+*Defined in [contract-addresses/src/index.ts:19](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/contract-addresses/src/index.ts#L19)*
 
 <hr />
 
@@ -2001,7 +2936,15 @@ ___
 
 • **components**? : *[DataItem](#class-dataitem)[]*
 
-*Defined in [ethereum-types/src/index.ts:137](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L137)*
+*Defined in [ethereum-types/src/index.ts:138](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L138)*
+
+___
+
+### `Optional` internalType
+
+• **internalType**? : *undefined | string*
+
+*Defined in [ethereum-types/src/index.ts:137](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L137)*
 
 ___
 
@@ -2009,7 +2952,7 @@ ___
 
 • **name**: *string*
 
-*Defined in [ethereum-types/src/index.ts:135](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L135)*
+*Defined in [ethereum-types/src/index.ts:135](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L135)*
 
 ___
 
@@ -2017,7 +2960,7 @@ ___
 
 • **type**: *string*
 
-*Defined in [ethereum-types/src/index.ts:136](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L136)*
+*Defined in [ethereum-types/src/index.ts:136](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L136)*
 
 <hr />
 
@@ -2036,7 +2979,7 @@ ___
 
 • **isEIP1193**: *boolean*
 
-*Defined in [ethereum-types/src/index.ts:73](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L73)*
+*Defined in [ethereum-types/src/index.ts:73](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L73)*
 
 ## Methods
 
@@ -2044,7 +2987,7 @@ ___
 
 ▸ **on**(`event`: [EIP1193Event](#eip1193event), `listener`: function): *this*
 
-*Defined in [ethereum-types/src/index.ts:75](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L75)*
+*Defined in [ethereum-types/src/index.ts:75](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L75)*
 
 **Parameters:**
 
@@ -2068,7 +3011,7 @@ ___
 
 ▸ **send**(`method`: string, `params?`: any[]): *`Promise<any>`*
 
-*Defined in [ethereum-types/src/index.ts:74](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L74)*
+*Defined in [ethereum-types/src/index.ts:74](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L74)*
 
 **Parameters:**
 
@@ -2102,7 +3045,7 @@ Name | Type |
 
 ▸ **sendAsync**(`payload`: [JSONRPCRequestPayload](_ethereum_types_src_index_.jsonrpcrequestpayload.md), `callback`: [JSONRPCErrorCallback](#jsonrpcerrorcallback)): *void*
 
-*Defined in [ethereum-types/src/index.ts:14](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L14)*
+*Defined in [ethereum-types/src/index.ts:14](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L14)*
 
 **Parameters:**
 
@@ -2126,7 +3069,7 @@ Name | Type |
 
 • **id**: *number*
 
-*Defined in [ethereum-types/src/index.ts:330](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L330)*
+*Defined in [ethereum-types/src/index.ts:331](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L331)*
 
 ___
 
@@ -2134,7 +3077,7 @@ ___
 
 • **jsonrpc**: *string*
 
-*Defined in [ethereum-types/src/index.ts:331](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L331)*
+*Defined in [ethereum-types/src/index.ts:332](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L332)*
 
 ___
 
@@ -2142,7 +3085,7 @@ ___
 
 • **method**: *string*
 
-*Defined in [ethereum-types/src/index.ts:329](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L329)*
+*Defined in [ethereum-types/src/index.ts:330](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L330)*
 
 ___
 
@@ -2150,7 +3093,7 @@ ___
 
 • **params**: *any[]*
 
-*Defined in [ethereum-types/src/index.ts:328](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L328)*
+*Defined in [ethereum-types/src/index.ts:329](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L329)*
 
 <hr />
 
@@ -2163,7 +3106,7 @@ ___
 
 • **code**: *number*
 
-*Defined in [ethereum-types/src/index.ts:336](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L336)*
+*Defined in [ethereum-types/src/index.ts:337](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L337)*
 
 ___
 
@@ -2171,7 +3114,7 @@ ___
 
 • **message**: *string*
 
-*Defined in [ethereum-types/src/index.ts:335](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L335)*
+*Defined in [ethereum-types/src/index.ts:336](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L336)*
 
 <hr />
 
@@ -2184,7 +3127,7 @@ ___
 
 • **error**? : *[JSONRPCResponseError](#class-jsonrpcresponseerror)*
 
-*Defined in [ethereum-types/src/index.ts:343](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L343)*
+*Defined in [ethereum-types/src/index.ts:344](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L344)*
 
 ___
 
@@ -2192,7 +3135,7 @@ ___
 
 • **id**: *number*
 
-*Defined in [ethereum-types/src/index.ts:341](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L341)*
+*Defined in [ethereum-types/src/index.ts:342](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L342)*
 
 ___
 
@@ -2200,7 +3143,7 @@ ___
 
 • **jsonrpc**: *string*
 
-*Defined in [ethereum-types/src/index.ts:342](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L342)*
+*Defined in [ethereum-types/src/index.ts:343](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L343)*
 
 ___
 
@@ -2208,74 +3151,7 @@ ___
 
 • **result**: *any*
 
-*Defined in [ethereum-types/src/index.ts:340](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L340)*
-
-<hr />
-
-
-
-
-
-
-
-# Interface: MethodAbi
-
-
-##   Properties
-
-###  constant
-
-• **constant**: *boolean*
-
-*Defined in [ethereum-types/src/index.ts:94](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L94)*
-
-___
-
-###  inputs
-
-• **inputs**: *[DataItem](#class-dataitem)[]*
-
-*Defined in [ethereum-types/src/index.ts:92](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L92)*
-
-___
-
-###  name
-
-• **name**: *string*
-
-*Defined in [ethereum-types/src/index.ts:91](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L91)*
-
-___
-
-###  outputs
-
-• **outputs**: *[DataItem](#class-dataitem)[]*
-
-*Defined in [ethereum-types/src/index.ts:93](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L93)*
-
-___
-
-###  payable
-
-• **payable**: *boolean*
-
-*Defined in [ethereum-types/src/index.ts:96](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L96)*
-
-___
-
-###  stateMutability
-
-• **stateMutability**: *[StateMutability](#statemutability)*
-
-*Defined in [ethereum-types/src/index.ts:95](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L95)*
-
-___
-
-###  type
-
-• **type**: *string*
-
-*Defined in [ethereum-types/src/index.ts:90](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L90)*
+*Defined in [ethereum-types/src/index.ts:341](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L341)*
 
 <hr />
 
@@ -2308,41 +3184,6 @@ ___
 
 
 
-
-# Interface: TupleDataItem
-
-
-##   Properties
-
-###  components
-
-• **components**: *[DataItem](#class-dataitem)[]*
-
-*Overrides [DataItem](_ethereum_types_src_index_.dataitem.md).[components](#optional-components)*
-
-*Defined in [ethereum-types/src/index.ts:141](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L141)*
-
-___
-
-###  name
-
-• **name**: *string*
-
-*Inherited from [DataItem](#interface-dataitem).[name](#name)*
-
-*Defined in [ethereum-types/src/index.ts:135](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L135)*
-
-___
-
-###  type
-
-• **type**: *string*
-
-*Inherited from [DataItem](#interface-dataitem).[type](#type)*
-
-*Defined in [ethereum-types/src/index.ts:136](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L136)*
-
-<hr />
 
 
 
@@ -2359,7 +3200,7 @@ Error class representing insufficient asset liquidity
 
 \+ **new InsufficientAssetLiquidityError**(`amountAvailableToFill`: `BigNumber`): *[InsufficientAssetLiquidityError](#class-insufficientassetliquidityerror)*
 
-*Defined in [asset-swapper/src/errors.ts:12](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/errors.ts#L12)*
+*Defined in [asset-swapper/src/errors.ts:12](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/errors.ts#L12)*
 
 **Parameters:**
 
@@ -2375,7 +3216,7 @@ Name | Type | Description |
 
 • **amountAvailableToFill**: *`BigNumber`*
 
-*Defined in [asset-swapper/src/errors.ts:12](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/errors.ts#L12)*
+*Defined in [asset-swapper/src/errors.ts:12](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/errors.ts#L12)*
 
 The amount availabe to fill (in base units) factoring in slippage.
 
@@ -2421,6 +3262,99 @@ ___
 
 <hr />
 
+
+
+# Interface: TupleDataItem
+
+
+##   Properties
+
+###  components
+
+• **components**: *[DataItem](#class-dataitem)[]*
+
+*Overrides [DataItem](_ethereum_types_src_index_.dataitem.md).[components](#optional-components)*
+
+*Defined in [ethereum-types/src/index.ts:142](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L142)*
+
+___
+
+### `Optional` internalType
+
+• **internalType**? : *undefined | string*
+
+*Inherited from [DataItem](#interface-dataitem).[internalType](#optional-internaltype)*
+
+*Defined in [ethereum-types/src/index.ts:137](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L137)*
+
+___
+
+###  name
+
+• **name**: *string*
+
+*Inherited from [DataItem](#interface-dataitem).[name](#name)*
+
+*Defined in [ethereum-types/src/index.ts:135](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L135)*
+
+___
+
+###  type
+
+• **type**: *string*
+
+*Inherited from [DataItem](#interface-dataitem).[type](#type)*
+
+*Defined in [ethereum-types/src/index.ts:136](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L136)*
+
+<hr />
+
+
+
+
+
+# Interface: Web3JsV1Provider
+
+Web3.js version 1 provider interface
+This provider interface was implemented in the pre-1.0Beta releases for Web3.js.
+This interface allowed sending synchonous requests, support for which was later dropped.
+
+
+##   Methods
+
+###  send
+
+▸ **send**(`payload`: [JSONRPCRequestPayload](_ethereum_types_src_index_.jsonrpcrequestpayload.md)): *[JSONRPCResponsePayload](#class-jsonrpcresponsepayload)*
+
+*Defined in [ethereum-types/src/index.ts:45](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L45)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`payload` | [JSONRPCRequestPayload](#class-jsonrpcrequestpayload) |
+
+**Returns:** *[JSONRPCResponsePayload](#class-jsonrpcresponsepayload)*
+
+___
+
+###  sendAsync
+
+▸ **sendAsync**(`payload`: [JSONRPCRequestPayload](_ethereum_types_src_index_.jsonrpcrequestpayload.md), `callback`: [JSONRPCErrorCallback](#jsonrpcerrorcallback)): *void*
+
+*Defined in [ethereum-types/src/index.ts:44](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L44)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`payload` | [JSONRPCRequestPayload](#class-jsonrpcrequestpayload) |
+`callback` | [JSONRPCErrorCallback](#jsonrpcerrorcallback) |
+
+**Returns:** *void*
+
+<hr />
+
 # Interface: Web3JsV2Provider
 
 Web3.js version 2 provider interface
@@ -2434,7 +3368,7 @@ before the first attempts to conform to EIP1193
 
 ▸ **send**(`payload`: [JSONRPCRequestPayload](_ethereum_types_src_index_.jsonrpcrequestpayload.md), `callback`: [JSONRPCErrorCallback](#jsonrpcerrorcallback)): *void*
 
-*Defined in [ethereum-types/src/index.ts:54](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L54)*
+*Defined in [ethereum-types/src/index.ts:54](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L54)*
 
 **Parameters:**
 
@@ -2460,7 +3394,7 @@ however it does not conform entirely.
 
 ▸ **send**(`method`: string, `params?`: any[]): *`Promise<any>`*
 
-*Defined in [ethereum-types/src/index.ts:63](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L63)*
+*Defined in [ethereum-types/src/index.ts:63](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L63)*
 
 **Parameters:**
 
@@ -2486,7 +3420,7 @@ add here
 
 • **isMetaMask**? : *undefined | false | true*
 
-*Defined in [ethereum-types/src/index.ts:31](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L31)*
+*Defined in [ethereum-types/src/index.ts:31](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L31)*
 
 ___
 
@@ -2494,7 +3428,7 @@ ___
 
 • **isParity**? : *undefined | false | true*
 
-*Defined in [ethereum-types/src/index.ts:32](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L32)*
+*Defined in [ethereum-types/src/index.ts:32](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L32)*
 
 ___
 
@@ -2502,7 +3436,7 @@ ___
 
 • **isZeroExProvider**? : *undefined | false | true*
 
-*Defined in [ethereum-types/src/index.ts:30](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L30)*
+*Defined in [ethereum-types/src/index.ts:30](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L30)*
 
 ## Methods
 
@@ -2510,7 +3444,7 @@ ___
 
 ▸ **enable**(): *`Promise<void>`*
 
-*Defined in [ethereum-types/src/index.ts:34](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L34)*
+*Defined in [ethereum-types/src/index.ts:34](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L34)*
 
 **Returns:** *`Promise<void>`*
 
@@ -2520,7 +3454,7 @@ ___
 
 ▸ **sendAsync**(`payload`: [JSONRPCRequestPayload](_ethereum_types_src_index_.jsonrpcrequestpayload.md), `callback`: [JSONRPCErrorCallback](#jsonrpcerrorcallback)): *void*
 
-*Defined in [ethereum-types/src/index.ts:35](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L35)*
+*Defined in [ethereum-types/src/index.ts:35](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L35)*
 
 **Parameters:**
 
@@ -2537,7 +3471,7 @@ ___
 
 ▸ **stop**(): *void*
 
-*Defined in [ethereum-types/src/index.ts:33](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L33)*
+*Defined in [ethereum-types/src/index.ts:33](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L33)*
 
 **Returns:** *void*
 
@@ -2552,7 +3486,7 @@ ___
 
 • **accepted**: *`SignedOrder`[]*
 
-*Defined in [orderbook/src/types.ts:15](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/types.ts#L15)*
+*Defined in [orderbook/src/types.ts:15](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/types.ts#L15)*
 
 ___
 
@@ -2560,7 +3494,7 @@ ___
 
 • **rejected**: *[RejectedOrder](#class-rejectedorder)[]*
 
-*Defined in [orderbook/src/types.ts:16](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/types.ts#L16)*
+*Defined in [orderbook/src/types.ts:16](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/types.ts#L16)*
 
 <hr />
 
@@ -2573,7 +3507,7 @@ ___
 
 • **added**: *`APIOrder`[]*
 
-*Defined in [orderbook/src/types.ts:6](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/types.ts#L6)*
+*Defined in [orderbook/src/types.ts:6](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/types.ts#L6)*
 
 ___
 
@@ -2581,7 +3515,7 @@ ___
 
 • **assetPairKey**: *string*
 
-*Defined in [orderbook/src/types.ts:5](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/types.ts#L5)*
+*Defined in [orderbook/src/types.ts:5](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/types.ts#L5)*
 
 ___
 
@@ -2589,7 +3523,7 @@ ___
 
 • **removed**: *`APIOrder`[]*
 
-*Defined in [orderbook/src/types.ts:7](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/types.ts#L7)*
+*Defined in [orderbook/src/types.ts:7](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/types.ts#L7)*
 
 <hr />
 
@@ -2604,7 +3538,7 @@ Constructor options for a Mesh Order Provider
 
 • **websocketEndpoint**: *string*
 
-*Defined in [orderbook/src/types.ts:52](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/types.ts#L52)*
+*Defined in [orderbook/src/types.ts:50](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/types.ts#L50)*
 
 ___
 
@@ -2612,7 +3546,7 @@ ___
 
 • **wsOpts**? : *`WSOpts`*
 
-*Defined in [orderbook/src/types.ts:54](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/types.ts#L54)*
+*Defined in [orderbook/src/types.ts:52](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/types.ts#L52)*
 
 <hr />
 
@@ -2625,7 +3559,7 @@ ___
 
 • **message**: *string*
 
-*Defined in [orderbook/src/types.ts:11](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/types.ts#L11)*
+*Defined in [orderbook/src/types.ts:11](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/types.ts#L11)*
 
 ___
 
@@ -2633,7 +3567,7 @@ ___
 
 • **order**: *`SignedOrder`*
 
-*Defined in [orderbook/src/types.ts:12](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/types.ts#L12)*
+*Defined in [orderbook/src/types.ts:12](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/types.ts#L12)*
 
 <hr />
 
@@ -2648,7 +3582,7 @@ Constructor options for a SRA Polling Order Provider
 
 • **chainId**? : *undefined | number*
 
-*Defined in [orderbook/src/types.ts:44](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/types.ts#L44)*
+*Defined in [orderbook/src/types.ts:42](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/types.ts#L42)*
 
 ___
 
@@ -2656,7 +3590,7 @@ ___
 
 • **httpEndpoint**: *string*
 
-*Defined in [orderbook/src/types.ts:38](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/types.ts#L38)*
+*Defined in [orderbook/src/types.ts:36](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/types.ts#L36)*
 
 ___
 
@@ -2664,7 +3598,7 @@ ___
 
 • **perPage**? : *undefined | number*
 
-*Defined in [orderbook/src/types.ts:42](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/types.ts#L42)*
+*Defined in [orderbook/src/types.ts:40](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/types.ts#L40)*
 
 ___
 
@@ -2672,7 +3606,7 @@ ___
 
 • **pollingIntervalMs**: *number*
 
-*Defined in [orderbook/src/types.ts:40](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/types.ts#L40)*
+*Defined in [orderbook/src/types.ts:38](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/types.ts#L38)*
 
 <hr />
 
@@ -2683,19 +3617,11 @@ Constructor options for a SRA Websocket Order Provider
 
 ##   Properties
 
-### `Optional` chainId
-
-• **chainId**? : *undefined | number*
-
-*Defined in [orderbook/src/types.ts:30](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/types.ts#L30)*
-
-___
-
 ###  httpEndpoint
 
 • **httpEndpoint**: *string*
 
-*Defined in [orderbook/src/types.ts:26](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/types.ts#L26)*
+*Defined in [orderbook/src/types.ts:26](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/types.ts#L26)*
 
 ___
 
@@ -2703,7 +3629,7 @@ ___
 
 • **websocketEndpoint**: *string*
 
-*Defined in [orderbook/src/types.ts:28](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/types.ts#L28)*
+*Defined in [orderbook/src/types.ts:28](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/types.ts#L28)*
 
 <hr />
 
@@ -2716,7 +3642,7 @@ ___
 
 • **metaData**: *object*
 
-*Defined in [types/src/index.ts:403](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/types/src/index.ts#L403)*
+*Defined in [types/src/index.ts:424](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/types/src/index.ts#L424)*
 
 ___
 
@@ -2724,7 +3650,7 @@ ___
 
 • **order**: *[SignedOrder](#class-signedorder)*
 
-*Defined in [types/src/index.ts:402](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/types/src/index.ts#L402)*
+*Defined in [types/src/index.ts:423](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/types/src/index.ts#L423)*
 
 <hr />
 
@@ -2739,7 +3665,7 @@ ___
 
 • **assetData**: *string*
 
-*Defined in [types/src/index.ts:419](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/types/src/index.ts#L419)*
+*Defined in [types/src/index.ts:440](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/types/src/index.ts#L440)*
 
 ___
 
@@ -2747,7 +3673,7 @@ ___
 
 • **maxAmount**: *`BigNumber`*
 
-*Defined in [types/src/index.ts:421](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/types/src/index.ts#L421)*
+*Defined in [types/src/index.ts:442](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/types/src/index.ts#L442)*
 
 ___
 
@@ -2755,7 +3681,7 @@ ___
 
 • **minAmount**: *`BigNumber`*
 
-*Defined in [types/src/index.ts:420](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/types/src/index.ts#L420)*
+*Defined in [types/src/index.ts:441](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/types/src/index.ts#L441)*
 
 ___
 
@@ -2763,7 +3689,7 @@ ___
 
 • **precision**: *number*
 
-*Defined in [types/src/index.ts:422](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/types/src/index.ts#L422)*
+*Defined in [types/src/index.ts:443](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/types/src/index.ts#L443)*
 
 <hr />
 
@@ -2776,7 +3702,7 @@ ___
 
 • **assetDataA**: *[Asset](#class-asset)*
 
-*Defined in [types/src/index.ts:414](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/types/src/index.ts#L414)*
+*Defined in [types/src/index.ts:435](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/types/src/index.ts#L435)*
 
 ___
 
@@ -2784,7 +3710,7 @@ ___
 
 • **assetDataB**: *[Asset](#class-asset)*
 
-*Defined in [types/src/index.ts:415](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/types/src/index.ts#L415)*
+*Defined in [types/src/index.ts:436](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/types/src/index.ts#L436)*
 
 <hr />
 
@@ -2884,8 +3810,6 @@ ___
 
 
 
-
-
 # Interface: SignedOrder
 
 
@@ -2897,7 +3821,7 @@ ___
 
 *Inherited from [Order](#interface-order).[chainId](#chainid)*
 
-*Defined in [types/src/index.ts:14](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/types/src/index.ts#L14)*
+*Defined in [types/src/index.ts:14](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/types/src/index.ts#L14)*
 
 ___
 
@@ -2907,7 +3831,7 @@ ___
 
 *Inherited from [Order](#interface-order).[exchangeAddress](#exchangeaddress)*
 
-*Defined in [types/src/index.ts:15](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/types/src/index.ts#L15)*
+*Defined in [types/src/index.ts:15](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/types/src/index.ts#L15)*
 
 ___
 
@@ -2917,7 +3841,7 @@ ___
 
 *Inherited from [Order](#interface-order).[expirationTimeSeconds](#expirationtimeseconds)*
 
-*Defined in [types/src/index.ts:24](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/types/src/index.ts#L24)*
+*Defined in [types/src/index.ts:24](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/types/src/index.ts#L24)*
 
 ___
 
@@ -2927,7 +3851,7 @@ ___
 
 *Inherited from [Order](#interface-order).[feeRecipientAddress](#feerecipientaddress)*
 
-*Defined in [types/src/index.ts:18](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/types/src/index.ts#L18)*
+*Defined in [types/src/index.ts:18](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/types/src/index.ts#L18)*
 
 ___
 
@@ -2937,7 +3861,7 @@ ___
 
 *Inherited from [Order](#interface-order).[makerAddress](#makeraddress)*
 
-*Defined in [types/src/index.ts:16](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/types/src/index.ts#L16)*
+*Defined in [types/src/index.ts:16](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/types/src/index.ts#L16)*
 
 ___
 
@@ -2947,7 +3871,7 @@ ___
 
 *Inherited from [Order](#interface-order).[makerAssetAmount](#makerassetamount)*
 
-*Defined in [types/src/index.ts:20](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/types/src/index.ts#L20)*
+*Defined in [types/src/index.ts:20](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/types/src/index.ts#L20)*
 
 ___
 
@@ -2957,7 +3881,7 @@ ___
 
 *Inherited from [Order](#interface-order).[makerAssetData](#makerassetdata)*
 
-*Defined in [types/src/index.ts:26](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/types/src/index.ts#L26)*
+*Defined in [types/src/index.ts:26](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/types/src/index.ts#L26)*
 
 ___
 
@@ -2967,7 +3891,7 @@ ___
 
 *Inherited from [Order](#interface-order).[makerFee](#makerfee)*
 
-*Defined in [types/src/index.ts:22](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/types/src/index.ts#L22)*
+*Defined in [types/src/index.ts:22](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/types/src/index.ts#L22)*
 
 ___
 
@@ -2977,7 +3901,7 @@ ___
 
 *Inherited from [Order](#interface-order).[makerFeeAssetData](#makerfeeassetdata)*
 
-*Defined in [types/src/index.ts:28](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/types/src/index.ts#L28)*
+*Defined in [types/src/index.ts:28](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/types/src/index.ts#L28)*
 
 ___
 
@@ -2987,7 +3911,7 @@ ___
 
 *Inherited from [Order](#interface-order).[salt](#salt)*
 
-*Defined in [types/src/index.ts:25](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/types/src/index.ts#L25)*
+*Defined in [types/src/index.ts:25](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/types/src/index.ts#L25)*
 
 ___
 
@@ -2997,7 +3921,7 @@ ___
 
 *Inherited from [Order](#interface-order).[senderAddress](#senderaddress)*
 
-*Defined in [types/src/index.ts:19](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/types/src/index.ts#L19)*
+*Defined in [types/src/index.ts:19](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/types/src/index.ts#L19)*
 
 ___
 
@@ -3005,7 +3929,7 @@ ___
 
 • **signature**: *string*
 
-*Defined in [types/src/index.ts:33](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/types/src/index.ts#L33)*
+*Defined in [types/src/index.ts:33](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/types/src/index.ts#L33)*
 
 ___
 
@@ -3015,7 +3939,7 @@ ___
 
 *Inherited from [Order](#interface-order).[takerAddress](#takeraddress)*
 
-*Defined in [types/src/index.ts:17](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/types/src/index.ts#L17)*
+*Defined in [types/src/index.ts:17](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/types/src/index.ts#L17)*
 
 ___
 
@@ -3025,7 +3949,7 @@ ___
 
 *Inherited from [Order](#interface-order).[takerAssetAmount](#takerassetamount)*
 
-*Defined in [types/src/index.ts:21](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/types/src/index.ts#L21)*
+*Defined in [types/src/index.ts:21](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/types/src/index.ts#L21)*
 
 ___
 
@@ -3035,7 +3959,7 @@ ___
 
 *Inherited from [Order](#interface-order).[takerAssetData](#takerassetdata)*
 
-*Defined in [types/src/index.ts:27](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/types/src/index.ts#L27)*
+*Defined in [types/src/index.ts:27](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/types/src/index.ts#L27)*
 
 ___
 
@@ -3045,7 +3969,7 @@ ___
 
 *Inherited from [Order](#interface-order).[takerFee](#takerfee)*
 
-*Defined in [types/src/index.ts:23](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/types/src/index.ts#L23)*
+*Defined in [types/src/index.ts:23](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/types/src/index.ts#L23)*
 
 ___
 
@@ -3055,7 +3979,7 @@ ___
 
 *Inherited from [Order](#interface-order).[takerFeeAssetData](#takerfeeassetdata)*
 
-*Defined in [types/src/index.ts:29](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/types/src/index.ts#L29)*
+*Defined in [types/src/index.ts:29](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/types/src/index.ts#L29)*
 
 <hr />
 
@@ -3149,17 +4073,11 @@ ___
 
 ##  Type aliases
 
-
-
-
-
-
-
 ###  SwapQuote
 
 Ƭ **SwapQuote**: *[MarketBuySwapQuote](#interface-marketbuyswapquote) | [MarketSellSwapQuote](#interface-marketsellswapquote)*
 
-*Defined in [asset-swapper/src/types.ts:205](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/types.ts#L205)*
+*Defined in [asset-swapper/src/types.ts:124](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/types.ts#L124)*
 
 <hr />
 
@@ -3172,13 +4090,30 @@ ___
 
 #### ▪ **affiliateFeeUtils**: *object*
 
-*Defined in [asset-swapper/src/utils/affiliate_fee_utils.ts:7](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/utils/affiliate_fee_utils.ts#L7)*
+*Defined in [asset-swapper/src/utils/affiliate_fee_utils.ts:7](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/affiliate_fee_utils.ts#L7)*
+
+####  getFeeAmount
+
+▸ **getFeeAmount**(`swapQuoteInfo`: [SwapQuoteInfo](#interface-swapquoteinfo), `feePercentage`: number): *`BigNumber`*
+
+*Defined in [asset-swapper/src/utils/affiliate_fee_utils.ts:23](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/affiliate_fee_utils.ts#L23)*
+
+Get the affiliate fee owed to the forwarder fee recipient.
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`swapQuoteInfo` | [SwapQuoteInfo](#interface-swapquoteinfo) | SwapQuoteInfo to generate total eth amount from |
+`feePercentage` | number | Percentage of additive fees to apply to totalTakerAssetAmount + protocol fee.  |
+
+**Returns:** *`BigNumber`*
 
 ####  getTotalEthAmountWithAffiliateFee
 
 ▸ **getTotalEthAmountWithAffiliateFee**(`swapQuoteInfo`: [SwapQuoteInfo](#interface-swapquoteinfo), `feePercentage`: number): *`BigNumber`*
 
-*Defined in [asset-swapper/src/utils/affiliate_fee_utils.ts:13](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/utils/affiliate_fee_utils.ts#L13)*
+*Defined in [asset-swapper/src/utils/affiliate_fee_utils.ts:13](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/asset-swapper/src/utils/affiliate_fee_utils.ts#L13)*
 
 Get the amount of eth to send for a forwarder contract call (includes takerAssetAmount, protocol fees, and specified affiliate fee amount)
 
@@ -3187,7 +4122,7 @@ Get the amount of eth to send for a forwarder contract call (includes takerAsset
 Name | Type | Description |
 ------ | ------ | ------ |
 `swapQuoteInfo` | [SwapQuoteInfo](#interface-swapquoteinfo) | SwapQuoteInfo to generate total eth amount from |
-`feePercentage` | number | Percentage of additive fees to apply to totalTakerAssetAmount + protocol fee. (max 5%)  |
+`feePercentage` | number | Percentage of additive fees to apply to totalTakerAssetAmount + protocol fee.  |
 
 **Returns:** *`BigNumber`*
 
@@ -3195,45 +4130,37 @@ Name | Type | Description |
 
 
 
+<hr /> 
 
-##  Object literals
 
-#### `Const` protocolFeeUtils
 
-#### ▪ **protocolFeeUtils**: *object*
+<hr /> 
 
-*Defined in [asset-swapper/src/utils/protocol_fee_utils.ts:9](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/utils/protocol_fee_utils.ts#L9)*
 
-####  calculateWorstCaseProtocolFee
 
-▸ **calculateWorstCaseProtocolFee**<**T**>(`orders`: `T`[], `gasPrice`: `BigNumber`): *`BigNumber`*
 
-*Defined in [asset-swapper/src/utils/protocol_fee_utils.ts:27](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/utils/protocol_fee_utils.ts#L27)*
+##  Functions
 
-Calculates protocol fee with protofol fee multiplier for each fill.
+####  getContractAddressesForChainOrThrow
 
-**Type parameters:**
+▸ **getContractAddressesForChainOrThrow**(`chainId`: [ChainId](#enumeration-chainid)): *[ContractAddresses](#interface-contractaddresses)*
 
-▪ **T**: *`Order`*
+*Defined in [contract-addresses/src/index.ts:51](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/contract-addresses/src/index.ts#L51)*
+
+Used to get addresses of contracts that have been deployed to either the
+Ethereum mainnet or a supported testnet. Throws if there are no known
+contracts deployed on the corresponding chain.
 
 **Parameters:**
 
-Name | Type |
------- | ------ |
-`orders` | `T`[] |
-`gasPrice` | `BigNumber` |
+Name | Type | Description |
+------ | ------ | ------ |
+`chainId` | [ChainId](#enumeration-chainid) | The desired chainId. |
 
-**Returns:** *`BigNumber`*
+**Returns:** *[ContractAddresses](#interface-contractaddresses)*
 
-####  getGasPriceEstimationOrThrowAsync
-
-▸ **getGasPriceEstimationOrThrowAsync**(): *`Promise<BigNumber>`*
-
-*Defined in [asset-swapper/src/utils/protocol_fee_utils.ts:13](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/asset-swapper/src/utils/protocol_fee_utils.ts#L13)*
-
-Gets 'fast' gas price from Eth Gas Station.
-
-**Returns:** *`Promise<BigNumber>`*
+The set of addresses for contracts which have been deployed on the
+given chainId.
 
 <hr />
 
@@ -3246,13 +4173,7 @@ Gets 'fast' gas price from Eth Gas Station.
 
 
 
-###  ConstructorStateMutability
 
-Ƭ **ConstructorStateMutability**: *"nonpayable" | "payable"*
-
-*Defined in [ethereum-types/src/index.ts:84](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L84)*
-
-___
 
 
 
@@ -3264,7 +4185,7 @@ ___
 
 Ƭ **EIP1193Event**: *"accountsChanged" | "networkChanged" | "close" | "connect" | "notification"*
 
-*Defined in [ethereum-types/src/index.ts:70](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L70)*
+*Defined in [ethereum-types/src/index.ts:70](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L70)*
 
 Interface for providers that conform to EIP 1193
 Source: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1193.md
@@ -3281,7 +4202,7 @@ ___
 
 Ƭ **JSONRPCErrorCallback**: *function*
 
-*Defined in [ethereum-types/src/index.ts:3](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L3)*
+*Defined in [ethereum-types/src/index.ts:3](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L3)*
 
 #### Type declaration:
 
@@ -3304,19 +4225,13 @@ ___
 
 
 
-###  StateMutability
 
-Ƭ **StateMutability**: *"pure" | "view" | [ConstructorStateMutability](#constructorstatemutability)*
-
-*Defined in [ethereum-types/src/index.ts:85](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L85)*
-
-___
 
 ###  SupportedProvider
 
 Ƭ **SupportedProvider**: *[Web3JsProvider](_ethereum_types_src_index_.md#web3jsprovider) | [GanacheProvider](#interface-ganacheprovider) | [EIP1193Provider](#interface-eip1193provider) | [ZeroExProvider](#interface-zeroexprovider)*
 
-*Defined in [ethereum-types/src/index.ts:9](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L9)*
+*Defined in [ethereum-types/src/index.ts:9](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L9)*
 
 Do not create your own provider. Use an existing provider from a Web3 or ProviderEngine library
 Read more about Providers in the guides section of the 0x docs.
@@ -3331,7 +4246,7 @@ ___
 
 Ƭ **Web3JsProvider**: *[Web3JsV1Provider](#interface-web3jsv1provider) | [Web3JsV2Provider](#interface-web3jsv2provider) | [Web3JsV3Provider](#interface-web3jsv3provider)*
 
-*Defined in [ethereum-types/src/index.ts:11](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/ethereum-types/src/index.ts#L11)*
+*Defined in [ethereum-types/src/index.ts:11](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/ethereum-types/src/index.ts#L11)*
 
 <hr />
 
@@ -3344,7 +4259,7 @@ ___
 
 • **DEFAULT_TOKEN_PRECISION**: *`18`* = 18
 
-*Defined in [orderbook/src/order_provider/base_order_provider.ts:9](https://github.com/0xProject/0x-monorepo/blob/36d7afd2a/packages/orderbook/src/order_provider/base_order_provider.ts#L9)*
+*Defined in [orderbook/src/order_provider/base_order_provider.ts:9](https://github.com/0xProject/0x-monorepo/blob/e5215bcb9/packages/orderbook/src/order_provider/base_order_provider.ts#L9)*
 
 <hr />
 
@@ -3364,5 +4279,6 @@ ___
 
 
 ##  Type aliases
+
 
 

--- a/packages/asset-swapper/src/constants.ts
+++ b/packages/asset-swapper/src/constants.ts
@@ -41,6 +41,7 @@ const DEFAULT_SWAP_QUOTER_OPTS: SwapQuoterOpts = {
     ...{
         chainId: MAINNET_CHAIN_ID,
         orderRefreshIntervalMs: 10000, // 10 seconds
+        jsonRpcIdNameSpace: '0x-asset-swapper',
     },
     ...DEFAULT_ORDER_PRUNER_OPTS,
     samplerGasLimit: 59e6,

--- a/packages/asset-swapper/src/quote_consumers/exchange_swap_quote_consumer.ts
+++ b/packages/asset-swapper/src/quote_consumers/exchange_swap_quote_consumer.ts
@@ -19,10 +19,10 @@ import { swapQuoteConsumerUtils } from '../utils/swap_quote_consumer_utils';
 
 export class ExchangeSwapQuoteConsumer implements SwapQuoteConsumerBase {
     public readonly provider: ZeroExProvider;
-    public readonly web3Wrapper: Web3Wrapper;
     public readonly chainId: number;
 
     private readonly _exchangeContract: ExchangeContract;
+    private readonly _web3Wrapper: Web3Wrapper;
 
     constructor(
         supportedProvider: SupportedProvider,
@@ -33,7 +33,7 @@ export class ExchangeSwapQuoteConsumer implements SwapQuoteConsumerBase {
         assert.isNumber('chainId', chainId);
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
         this.provider = provider;
-        this.web3Wrapper = new Web3Wrapper(this.provider, undefined, jsonRpcIdNameSpace);
+        this._web3Wrapper = new Web3Wrapper(this.provider, undefined, jsonRpcIdNameSpace);
         this.chainId = chainId;
         this._exchangeContract = new ExchangeContract(
             contractAddresses.exchange,
@@ -91,7 +91,7 @@ export class ExchangeSwapQuoteConsumer implements SwapQuoteConsumerBase {
         const { orders, gasPrice } = quote;
         const signatures = orders.map(o => o.signature);
 
-        const finalTakerAddress = await swapQuoteConsumerUtils.getTakerAddressOrThrowAsync(this.web3Wrapper, opts);
+        const finalTakerAddress = await swapQuoteConsumerUtils.getTakerAddressOrThrowAsync(this._web3Wrapper, opts);
         const value = ethAmount || quote.worstCaseQuoteInfo.protocolFeeInWeiAmount;
         let txHash: string;
         if (quote.type === MarketOperation.Buy) {

--- a/packages/asset-swapper/src/quote_consumers/forwarder_swap_quote_consumer.ts
+++ b/packages/asset-swapper/src/quote_consumers/forwarder_swap_quote_consumer.ts
@@ -21,11 +21,11 @@ import { swapQuoteConsumerUtils } from '../utils/swap_quote_consumer_utils';
 
 export class ForwarderSwapQuoteConsumer implements SwapQuoteConsumerBase {
     public readonly provider: ZeroExProvider;
-    public readonly web3Wrapper: Web3Wrapper;
     public readonly chainId: number;
 
     private readonly _contractAddresses: ContractAddresses;
     private readonly _forwarder: ForwarderContract;
+    private readonly _web3Wrapper: Web3Wrapper;
 
     constructor(
         supportedProvider: SupportedProvider,
@@ -36,7 +36,7 @@ export class ForwarderSwapQuoteConsumer implements SwapQuoteConsumerBase {
         assert.isNumber('chainId', chainId);
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
         this.provider = provider;
-        this.web3Wrapper = new Web3Wrapper(this.provider, undefined, jsonRpcIdNameSpace);
+        this._web3Wrapper = new Web3Wrapper(this.provider, undefined, jsonRpcIdNameSpace);
         this.chainId = chainId;
         this._contractAddresses = contractAddresses;
         this._forwarder = new ForwarderContract(
@@ -129,7 +129,7 @@ export class ForwarderSwapQuoteConsumer implements SwapQuoteConsumerBase {
         const signatures = orders.map(o => o.signature);
 
         // get taker address
-        const finalTakerAddress = await swapQuoteConsumerUtils.getTakerAddressOrThrowAsync(this.web3Wrapper, opts);
+        const finalTakerAddress = await swapQuoteConsumerUtils.getTakerAddressOrThrowAsync(this._web3Wrapper, opts);
         // if no ethAmount is provided, default to the worst totalTakerAssetAmount
         const ethAmountWithFees =
             providedEthAmount ||

--- a/packages/asset-swapper/src/quote_consumers/swap_quote_consumer.ts
+++ b/packages/asset-swapper/src/quote_consumers/swap_quote_consumer.ts
@@ -22,12 +22,12 @@ import { ForwarderSwapQuoteConsumer } from './forwarder_swap_quote_consumer';
 
 export class SwapQuoteConsumer implements SwapQuoteConsumerBase {
     public readonly provider: ZeroExProvider;
-    public readonly web3Wrapper: Web3Wrapper;
     public readonly chainId: number;
 
     private readonly _exchangeConsumer: ExchangeSwapQuoteConsumer;
     private readonly _forwarderConsumer: ForwarderSwapQuoteConsumer;
     private readonly _contractAddresses: ContractAddresses;
+    private readonly _web3Wrapper: Web3Wrapper;
 
     public static getSwapQuoteConsumer(
         supportedProvider: SupportedProvider,
@@ -42,7 +42,7 @@ export class SwapQuoteConsumer implements SwapQuoteConsumerBase {
 
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
         this.provider = provider;
-        this.web3Wrapper = new Web3Wrapper(provider, undefined, jsonRpcIdNameSpace);
+        this._web3Wrapper = new Web3Wrapper(provider, undefined, jsonRpcIdNameSpace);
         this.chainId = chainId;
         this._contractAddresses = options.contractAddresses || getContractAddressesForChainOrThrow(chainId);
         this._exchangeConsumer = new ExchangeSwapQuoteConsumer(supportedProvider, this._contractAddresses, options);
@@ -89,7 +89,7 @@ export class SwapQuoteConsumer implements SwapQuoteConsumerBase {
         return swapQuoteConsumerUtils.getExtensionContractTypeForSwapQuoteAsync(
             quote,
             this._contractAddresses,
-            this.web3Wrapper,
+            this._web3Wrapper,
             opts,
         );
     }

--- a/packages/asset-swapper/src/quote_consumers/swap_quote_consumer.ts
+++ b/packages/asset-swapper/src/quote_consumers/swap_quote_consumer.ts
@@ -1,6 +1,6 @@
 import { ContractAddresses, getContractAddressesForChainOrThrow } from '@0x/contract-addresses';
 import { providerUtils } from '@0x/utils';
-import { SupportedProvider, ZeroExProvider } from '@0x/web3-wrapper';
+import { SupportedProvider, Web3Wrapper, ZeroExProvider } from '@0x/web3-wrapper';
 import * as _ from 'lodash';
 
 import { constants } from '../constants';
@@ -22,6 +22,7 @@ import { ForwarderSwapQuoteConsumer } from './forwarder_swap_quote_consumer';
 
 export class SwapQuoteConsumer implements SwapQuoteConsumerBase {
     public readonly provider: ZeroExProvider;
+    public readonly web3Wrapper: Web3Wrapper;
     public readonly chainId: number;
 
     private readonly _exchangeConsumer: ExchangeSwapQuoteConsumer;
@@ -36,11 +37,12 @@ export class SwapQuoteConsumer implements SwapQuoteConsumerBase {
     }
 
     constructor(supportedProvider: SupportedProvider, options: Partial<SwapQuoteConsumerOpts> = {}) {
-        const { chainId } = _.merge({}, constants.DEFAULT_SWAP_QUOTER_OPTS, options);
+        const { chainId, jsonRpcIdNameSpace } = _.merge({}, constants.DEFAULT_SWAP_QUOTER_OPTS, options);
         assert.isNumber('chainId', chainId);
 
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
         this.provider = provider;
+        this.web3Wrapper = new Web3Wrapper(provider, undefined, jsonRpcIdNameSpace);
         this.chainId = chainId;
         this._contractAddresses = options.contractAddresses || getContractAddressesForChainOrThrow(chainId);
         this._exchangeConsumer = new ExchangeSwapQuoteConsumer(supportedProvider, this._contractAddresses, options);
@@ -87,7 +89,7 @@ export class SwapQuoteConsumer implements SwapQuoteConsumerBase {
         return swapQuoteConsumerUtils.getExtensionContractTypeForSwapQuoteAsync(
             quote,
             this._contractAddresses,
-            this.provider,
+            this.web3Wrapper,
             opts,
         );
     }

--- a/packages/asset-swapper/src/swap_quoter.ts
+++ b/packages/asset-swapper/src/swap_quoter.ts
@@ -159,13 +159,27 @@ export class SwapQuoter {
         this.expiryBufferMs = expiryBufferMs;
         this.permittedOrderFeeTypes = permittedOrderFeeTypes;
         this._contractAddresses = options.contractAddresses || getContractAddressesForChainOrThrow(chainId);
-        this._devUtilsContract = new DevUtilsContract(this._contractAddresses.devUtils, provider);
+        this._devUtilsContract = new DevUtilsContract(
+            this._contractAddresses.devUtils,
+            provider,
+            undefined,
+            undefined,
+            undefined,
+            options.jsonRpcIdNameSpace,
+        );
         this._protocolFeeUtils = new ProtocolFeeUtils(constants.PROTOCOL_FEE_UTILS_POLLING_INTERVAL_IN_MS);
         this._orderStateUtils = new OrderStateUtils(this._devUtilsContract);
         const sampler = new DexOrderSampler(
-            new IERC20BridgeSamplerContract(this._contractAddresses.erc20BridgeSampler, this.provider, {
-                gas: samplerGasLimit,
-            }),
+            new IERC20BridgeSamplerContract(
+                this._contractAddresses.erc20BridgeSampler,
+                this.provider,
+                {
+                    gas: samplerGasLimit,
+                },
+                undefined,
+                undefined,
+                options.jsonRpcIdNameSpace,
+            ),
         );
         this._marketOperationUtils = new MarketOperationUtils(sampler, this._contractAddresses, {
             chainId,

--- a/packages/asset-swapper/src/types.ts
+++ b/packages/asset-swapper/src/types.ts
@@ -89,6 +89,7 @@ export interface SwapQuoteConsumerBase {
 export interface SwapQuoteConsumerOpts {
     chainId: number;
     contractAddresses?: ContractAddresses;
+    jsonRpcIdNameSpace?: string;
 }
 
 /**
@@ -212,6 +213,7 @@ export interface SwapQuoterOpts extends OrderPrunerOpts {
     expiryBufferMs: number;
     contractAddresses?: ContractAddresses;
     samplerGasLimit?: number;
+    jsonRpcIdNameSpace?: string;
 }
 
 /**

--- a/packages/base-contract/CHANGELOG.json
+++ b/packages/base-contract/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "6.3.0",
+        "changes": [
+            {
+                "note": "Add support for jsonRpcIdNameSpace",
+                "pr": 2508
+            }
+        ]
+    },
+    {
         "timestamp": 1582623685,
         "version": "6.2.1",
         "changes": [

--- a/packages/base-contract/src/index.ts
+++ b/packages/base-contract/src/index.ts
@@ -358,6 +358,7 @@ export class BaseContract {
         callAndTxnDefaults?: Partial<CallData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode?: string,
+        jsonRpcIdNameSpace?: string,
     ) {
         assert.isString('contractName', contractName);
         assert.isETHAddressHex('address', address);
@@ -383,7 +384,7 @@ export class BaseContract {
             ]);
         }
         this.contractName = contractName;
-        this._web3Wrapper = new Web3Wrapper(provider, callAndTxnDefaults);
+        this._web3Wrapper = new Web3Wrapper(provider, callAndTxnDefaults, jsonRpcIdNameSpace);
         this.abi = abi;
         this.address = address;
         const methodAbis = this.abi.filter(

--- a/packages/contract-wrappers/CHANGELOG.json
+++ b/packages/contract-wrappers/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "13.7.0",
+        "changes": [
+            {
+                "note": "Add support for jsonRpcIdNameSpace",
+                "pr": 2508
+            }
+        ]
+    },
+    {
         "timestamp": 1582837861,
         "version": "13.6.2",
         "changes": [

--- a/packages/contract-wrappers/src/contract_wrappers.ts
+++ b/packages/contract-wrappers/src/contract_wrappers.ts
@@ -63,7 +63,7 @@ export class ContractWrappers {
         const txDefaults = {
             gasPrice: config.gasPrice,
         };
-        this._web3Wrapper = new Web3Wrapper(supportedProvider, txDefaults);
+        this._web3Wrapper = new Web3Wrapper(supportedProvider, txDefaults, config.jsonRpcIdNameSpace);
         const contractsArray = [
             CoordinatorContract,
             DevUtilsContract,

--- a/packages/contract-wrappers/src/generated-wrappers/broker.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/broker.ts
@@ -9,6 +9,7 @@ import {
     BaseContract,
     PromiseWithTransactionHash,
     methodAbiToFunctionSignature,
+    linkLibrariesInBytecode,
 } from '@0x/base-contract';
 import { schemas } from '@0x/json-schemas';
 import {
@@ -25,7 +26,7 @@ import {
     TxDataPayable,
     SupportedProvider,
 } from 'ethereum-types';
-import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
+import { BigNumber, classUtils, hexUtils, logUtils, providerUtils } from '@0x/utils';
 import { EventCallback, IndexedFilterValues, SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 import { assert } from '@0x/assert';
@@ -33,6 +34,7 @@ import * as ethers from 'ethers';
 // tslint:enable:no-unused-variable
 
 /* istanbul ignore next */
+// tslint:disable:array-type
 // tslint:disable:no-parameter-reassignment
 // tslint:disable-next-line:class-name
 export class BrokerContract extends BaseContract {
@@ -77,6 +79,50 @@ export class BrokerContract extends BaseContract {
             weth,
         );
     }
+
+    public static async deployWithLibrariesFrom0xArtifactAsync(
+        artifact: ContractArtifact,
+        libraryArtifacts: { [libraryName: string]: ContractArtifact },
+        supportedProvider: SupportedProvider,
+        txDefaults: Partial<TxData>,
+        logDecodeDependencies: { [contractName: string]: ContractArtifact | SimpleContractArtifact },
+        exchange: string,
+        weth: string,
+    ): Promise<BrokerContract> {
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
+        if (artifact.compilerOutput === undefined) {
+            throw new Error('Compiler output not found in the artifact file');
+        }
+        const provider = providerUtils.standardizeOrThrow(supportedProvider);
+        const abi = artifact.compilerOutput.abi;
+        const logDecodeDependenciesAbiOnly: { [contractName: string]: ContractAbi } = {};
+        if (Object.keys(logDecodeDependencies) !== undefined) {
+            for (const key of Object.keys(logDecodeDependencies)) {
+                logDecodeDependenciesAbiOnly[key] = logDecodeDependencies[key].compilerOutput.abi;
+            }
+        }
+        const libraryAddresses = await BrokerContract._deployLibrariesAsync(
+            artifact,
+            libraryArtifacts,
+            new Web3Wrapper(provider),
+            txDefaults,
+        );
+        const bytecode = linkLibrariesInBytecode(artifact, libraryAddresses);
+        return BrokerContract.deployAsync(
+            bytecode,
+            abi,
+            provider,
+            txDefaults,
+            logDecodeDependenciesAbiOnly,
+            exchange,
+            weth,
+        );
+    }
+
     public static async deployAsync(
         bytecode: string,
         abi: ContractAbi,
@@ -432,12 +478,58 @@ export class BrokerContract extends BaseContract {
         return abi;
     }
 
+    protected static async _deployLibrariesAsync(
+        artifact: ContractArtifact,
+        libraryArtifacts: { [libraryName: string]: ContractArtifact },
+        web3Wrapper: Web3Wrapper,
+        txDefaults: Partial<TxData>,
+        libraryAddresses: { [libraryName: string]: string } = {},
+    ): Promise<{ [libraryName: string]: string }> {
+        const links = artifact.compilerOutput.evm.bytecode.linkReferences;
+        // Go through all linked libraries, recursively deploying them if necessary.
+        for (const link of Object.values(links)) {
+            for (const libraryName of Object.keys(link)) {
+                if (!libraryAddresses[libraryName]) {
+                    // Library not yet deployed.
+                    const libraryArtifact = libraryArtifacts[libraryName];
+                    if (!libraryArtifact) {
+                        throw new Error(`Missing artifact for linked library "${libraryName}"`);
+                    }
+                    // Deploy any dependent libraries used by this library.
+                    await BrokerContract._deployLibrariesAsync(
+                        libraryArtifact,
+                        libraryArtifacts,
+                        web3Wrapper,
+                        txDefaults,
+                        libraryAddresses,
+                    );
+                    // Deploy this library.
+                    const linkedLibraryBytecode = linkLibrariesInBytecode(libraryArtifact, libraryAddresses);
+                    const txDataWithDefaults = await BaseContract._applyDefaultsToContractTxDataAsync(
+                        {
+                            data: linkedLibraryBytecode,
+                            ...txDefaults,
+                        },
+                        web3Wrapper.estimateGasAsync.bind(web3Wrapper),
+                    );
+                    const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+                    logUtils.log(`transactionHash: ${txHash}`);
+                    const { contractAddress } = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
+                    logUtils.log(`${libraryArtifact.contractName} successfully deployed at ${contractAddress}`);
+                    libraryAddresses[libraryArtifact.contractName] = contractAddress as string;
+                }
+            }
+        }
+        return libraryAddresses;
+    }
+
     public getFunctionSignature(methodName: string): string {
         const index = this._methodABIIndex[methodName];
         const methodAbi = BrokerContract.ABI()[index] as MethodAbi; // tslint:disable-line:no-unnecessary-type-assertion
         const functionSignature = methodAbiToFunctionSignature(methodAbi);
         return functionSignature;
     }
+
     public getABIDecodedTransactionData<T>(methodName: string, callData: string): T {
         const functionSignature = this.getFunctionSignature(methodName);
         const self = (this as any) as BrokerContract;
@@ -445,6 +537,7 @@ export class BrokerContract extends BaseContract {
         const abiDecodedCallData = abiEncoder.strictDecode<T>(callData);
         return abiDecodedCallData;
     }
+
     public getABIDecodedReturnData<T>(methodName: string, callData: string): T {
         const functionSignature = this.getFunctionSignature(methodName);
         const self = (this as any) as BrokerContract;
@@ -452,6 +545,7 @@ export class BrokerContract extends BaseContract {
         const abiDecodedCallData = abiEncoder.strictDecodeReturnValue<T>(callData);
         return abiDecodedCallData;
     }
+
     public getSelector(methodName: string): string {
         const functionSignature = this.getFunctionSignature(methodName);
         const self = (this as any) as BrokerContract;
@@ -801,6 +895,7 @@ export class BrokerContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = BrokerContract.deployedBytecode,
+        jsonRpcIdNameSpace?: string,
     ) {
         super(
             'Broker',
@@ -810,6 +905,7 @@ export class BrokerContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
+            jsonRpcIdNameSpace,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         BrokerContract.ABI().forEach((item, index) => {

--- a/packages/contract-wrappers/src/generated-wrappers/coordinator.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/coordinator.ts
@@ -967,6 +967,7 @@ export class CoordinatorContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = CoordinatorContract.deployedBytecode,
+        jsonRpcIdNameSpace?: string,
     ) {
         super(
             'Coordinator',
@@ -976,6 +977,7 @@ export class CoordinatorContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
+            jsonRpcIdNameSpace,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         CoordinatorContract.ABI().forEach((item, index) => {

--- a/packages/contract-wrappers/src/generated-wrappers/dev_utils.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/dev_utils.ts
@@ -3262,6 +3262,7 @@ export class DevUtilsContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = DevUtilsContract.deployedBytecode,
+        jsonRpcIdNameSpace?: string,
     ) {
         super(
             'DevUtils',
@@ -3271,6 +3272,7 @@ export class DevUtilsContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
+            jsonRpcIdNameSpace,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         DevUtilsContract.ABI().forEach((item, index) => {

--- a/packages/contract-wrappers/src/generated-wrappers/erc20_token.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/erc20_token.ts
@@ -740,6 +740,7 @@ export class ERC20TokenContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = ERC20TokenContract.deployedBytecode,
+        jsonRpcIdNameSpace?: string,
     ) {
         super(
             'ERC20Token',
@@ -749,6 +750,7 @@ export class ERC20TokenContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
+            jsonRpcIdNameSpace,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         this._subscriptionManager = new SubscriptionManager<ERC20TokenEventArgs, ERC20TokenEvents>(

--- a/packages/contract-wrappers/src/generated-wrappers/erc721_token.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/erc721_token.ts
@@ -1000,6 +1000,7 @@ export class ERC721TokenContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = ERC721TokenContract.deployedBytecode,
+        jsonRpcIdNameSpace?: string,
     ) {
         super(
             'ERC721Token',
@@ -1009,6 +1010,7 @@ export class ERC721TokenContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
+            jsonRpcIdNameSpace,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         this._subscriptionManager = new SubscriptionManager<ERC721TokenEventArgs, ERC721TokenEvents>(

--- a/packages/contract-wrappers/src/generated-wrappers/exchange.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/exchange.ts
@@ -6012,6 +6012,7 @@ export class ExchangeContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = ExchangeContract.deployedBytecode,
+        jsonRpcIdNameSpace?: string,
     ) {
         super(
             'Exchange',
@@ -6021,6 +6022,7 @@ export class ExchangeContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
+            jsonRpcIdNameSpace,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         this._subscriptionManager = new SubscriptionManager<ExchangeEventArgs, ExchangeEvents>(

--- a/packages/contract-wrappers/src/generated-wrappers/forwarder.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/forwarder.ts
@@ -1329,6 +1329,7 @@ export class ForwarderContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = ForwarderContract.deployedBytecode,
+        jsonRpcIdNameSpace?: string,
     ) {
         super(
             'Forwarder',
@@ -1338,6 +1339,7 @@ export class ForwarderContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
+            jsonRpcIdNameSpace,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         this._subscriptionManager = new SubscriptionManager<ForwarderEventArgs, ForwarderEvents>(

--- a/packages/contract-wrappers/src/generated-wrappers/gods_unchained_validator.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/gods_unchained_validator.ts
@@ -9,6 +9,7 @@ import {
     BaseContract,
     PromiseWithTransactionHash,
     methodAbiToFunctionSignature,
+    linkLibrariesInBytecode,
 } from '@0x/base-contract';
 import { schemas } from '@0x/json-schemas';
 import {
@@ -25,7 +26,7 @@ import {
     TxDataPayable,
     SupportedProvider,
 } from 'ethereum-types';
-import { BigNumber, classUtils, logUtils, providerUtils } from '@0x/utils';
+import { BigNumber, classUtils, hexUtils, logUtils, providerUtils } from '@0x/utils';
 import { EventCallback, IndexedFilterValues, SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 import { assert } from '@0x/assert';
@@ -33,6 +34,7 @@ import * as ethers from 'ethers';
 // tslint:enable:no-unused-variable
 
 /* istanbul ignore next */
+// tslint:disable:array-type
 // tslint:disable:no-parameter-reassignment
 // tslint:disable-next-line:class-name
 export class GodsUnchainedValidatorContract extends BaseContract {
@@ -75,6 +77,48 @@ export class GodsUnchainedValidatorContract extends BaseContract {
             _godsUnchained,
         );
     }
+
+    public static async deployWithLibrariesFrom0xArtifactAsync(
+        artifact: ContractArtifact,
+        libraryArtifacts: { [libraryName: string]: ContractArtifact },
+        supportedProvider: SupportedProvider,
+        txDefaults: Partial<TxData>,
+        logDecodeDependencies: { [contractName: string]: ContractArtifact | SimpleContractArtifact },
+        _godsUnchained: string,
+    ): Promise<GodsUnchainedValidatorContract> {
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
+            schemas.addressSchema,
+            schemas.numberSchema,
+            schemas.jsNumber,
+        ]);
+        if (artifact.compilerOutput === undefined) {
+            throw new Error('Compiler output not found in the artifact file');
+        }
+        const provider = providerUtils.standardizeOrThrow(supportedProvider);
+        const abi = artifact.compilerOutput.abi;
+        const logDecodeDependenciesAbiOnly: { [contractName: string]: ContractAbi } = {};
+        if (Object.keys(logDecodeDependencies) !== undefined) {
+            for (const key of Object.keys(logDecodeDependencies)) {
+                logDecodeDependenciesAbiOnly[key] = logDecodeDependencies[key].compilerOutput.abi;
+            }
+        }
+        const libraryAddresses = await GodsUnchainedValidatorContract._deployLibrariesAsync(
+            artifact,
+            libraryArtifacts,
+            new Web3Wrapper(provider),
+            txDefaults,
+        );
+        const bytecode = linkLibrariesInBytecode(artifact, libraryAddresses);
+        return GodsUnchainedValidatorContract.deployAsync(
+            bytecode,
+            abi,
+            provider,
+            txDefaults,
+            logDecodeDependenciesAbiOnly,
+            _godsUnchained,
+        );
+    }
+
     public static async deployAsync(
         bytecode: string,
         abi: ContractAbi,
@@ -160,12 +204,58 @@ export class GodsUnchainedValidatorContract extends BaseContract {
         return abi;
     }
 
+    protected static async _deployLibrariesAsync(
+        artifact: ContractArtifact,
+        libraryArtifacts: { [libraryName: string]: ContractArtifact },
+        web3Wrapper: Web3Wrapper,
+        txDefaults: Partial<TxData>,
+        libraryAddresses: { [libraryName: string]: string } = {},
+    ): Promise<{ [libraryName: string]: string }> {
+        const links = artifact.compilerOutput.evm.bytecode.linkReferences;
+        // Go through all linked libraries, recursively deploying them if necessary.
+        for (const link of Object.values(links)) {
+            for (const libraryName of Object.keys(link)) {
+                if (!libraryAddresses[libraryName]) {
+                    // Library not yet deployed.
+                    const libraryArtifact = libraryArtifacts[libraryName];
+                    if (!libraryArtifact) {
+                        throw new Error(`Missing artifact for linked library "${libraryName}"`);
+                    }
+                    // Deploy any dependent libraries used by this library.
+                    await GodsUnchainedValidatorContract._deployLibrariesAsync(
+                        libraryArtifact,
+                        libraryArtifacts,
+                        web3Wrapper,
+                        txDefaults,
+                        libraryAddresses,
+                    );
+                    // Deploy this library.
+                    const linkedLibraryBytecode = linkLibrariesInBytecode(libraryArtifact, libraryAddresses);
+                    const txDataWithDefaults = await BaseContract._applyDefaultsToContractTxDataAsync(
+                        {
+                            data: linkedLibraryBytecode,
+                            ...txDefaults,
+                        },
+                        web3Wrapper.estimateGasAsync.bind(web3Wrapper),
+                    );
+                    const txHash = await web3Wrapper.sendTransactionAsync(txDataWithDefaults);
+                    logUtils.log(`transactionHash: ${txHash}`);
+                    const { contractAddress } = await web3Wrapper.awaitTransactionSuccessAsync(txHash);
+                    logUtils.log(`${libraryArtifact.contractName} successfully deployed at ${contractAddress}`);
+                    libraryAddresses[libraryArtifact.contractName] = contractAddress as string;
+                }
+            }
+        }
+        return libraryAddresses;
+    }
+
     public getFunctionSignature(methodName: string): string {
         const index = this._methodABIIndex[methodName];
         const methodAbi = GodsUnchainedValidatorContract.ABI()[index] as MethodAbi; // tslint:disable-line:no-unnecessary-type-assertion
         const functionSignature = methodAbiToFunctionSignature(methodAbi);
         return functionSignature;
     }
+
     public getABIDecodedTransactionData<T>(methodName: string, callData: string): T {
         const functionSignature = this.getFunctionSignature(methodName);
         const self = (this as any) as GodsUnchainedValidatorContract;
@@ -173,6 +263,7 @@ export class GodsUnchainedValidatorContract extends BaseContract {
         const abiDecodedCallData = abiEncoder.strictDecode<T>(callData);
         return abiDecodedCallData;
     }
+
     public getABIDecodedReturnData<T>(methodName: string, callData: string): T {
         const functionSignature = this.getFunctionSignature(methodName);
         const self = (this as any) as GodsUnchainedValidatorContract;
@@ -180,6 +271,7 @@ export class GodsUnchainedValidatorContract extends BaseContract {
         const abiDecodedCallData = abiEncoder.strictDecodeReturnValue<T>(callData);
         return abiDecodedCallData;
     }
+
     public getSelector(methodName: string): string {
         const functionSignature = this.getFunctionSignature(methodName);
         const self = (this as any) as GodsUnchainedValidatorContract;
@@ -223,6 +315,7 @@ export class GodsUnchainedValidatorContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = GodsUnchainedValidatorContract.deployedBytecode,
+        jsonRpcIdNameSpace?: string,
     ) {
         super(
             'GodsUnchainedValidator',
@@ -232,6 +325,7 @@ export class GodsUnchainedValidatorContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
+            jsonRpcIdNameSpace,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         GodsUnchainedValidatorContract.ABI().forEach((item, index) => {

--- a/packages/contract-wrappers/src/generated-wrappers/i_asset_data.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/i_asset_data.ts
@@ -709,6 +709,7 @@ export class IAssetDataContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = IAssetDataContract.deployedBytecode,
+        jsonRpcIdNameSpace?: string,
     ) {
         super(
             'IAssetData',
@@ -718,6 +719,7 @@ export class IAssetDataContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
+            jsonRpcIdNameSpace,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         IAssetDataContract.ABI().forEach((item, index) => {

--- a/packages/contract-wrappers/src/generated-wrappers/i_erc20_bridge_sampler.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/i_erc20_bridge_sampler.ts
@@ -945,6 +945,7 @@ export class IERC20BridgeSamplerContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = IERC20BridgeSamplerContract.deployedBytecode,
+        jsonRpcIdNameSpace?: string,
     ) {
         super(
             'IERC20BridgeSampler',
@@ -954,6 +955,7 @@ export class IERC20BridgeSamplerContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
+            jsonRpcIdNameSpace,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         IERC20BridgeSamplerContract.ABI().forEach((item, index) => {

--- a/packages/contract-wrappers/src/generated-wrappers/staking.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/staking.ts
@@ -3562,6 +3562,7 @@ export class StakingContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = StakingContract.deployedBytecode,
+        jsonRpcIdNameSpace?: string,
     ) {
         super(
             'Staking',
@@ -3571,6 +3572,7 @@ export class StakingContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
+            jsonRpcIdNameSpace,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         this._subscriptionManager = new SubscriptionManager<StakingEventArgs, StakingEvents>(

--- a/packages/contract-wrappers/src/generated-wrappers/staking_proxy.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/staking_proxy.ts
@@ -1686,6 +1686,7 @@ export class StakingProxyContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = StakingProxyContract.deployedBytecode,
+        jsonRpcIdNameSpace?: string,
     ) {
         super(
             'StakingProxy',
@@ -1695,6 +1696,7 @@ export class StakingProxyContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
+            jsonRpcIdNameSpace,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         this._subscriptionManager = new SubscriptionManager<StakingProxyEventArgs, StakingProxyEvents>(

--- a/packages/contract-wrappers/src/generated-wrappers/weth9.ts
+++ b/packages/contract-wrappers/src/generated-wrappers/weth9.ts
@@ -989,6 +989,7 @@ export class WETH9Contract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = WETH9Contract.deployedBytecode,
+        jsonRpcIdNameSpace?: string,
     ) {
         super(
             'WETH9',
@@ -998,6 +999,7 @@ export class WETH9Contract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
+            jsonRpcIdNameSpace,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         this._subscriptionManager = new SubscriptionManager<WETH9EventArgs, WETH9Events>(

--- a/packages/contract-wrappers/src/types.ts
+++ b/packages/contract-wrappers/src/types.ts
@@ -31,6 +31,7 @@ export interface ContractWrappersConfig {
     gasPrice?: BigNumber;
     contractAddresses?: ContractAddresses;
     blockPollingIntervalMs?: number;
+    jsonRpcIdNameSpace?: string;
 }
 
 export interface OrderInfo {

--- a/packages/web3-wrapper/CHANGELOG.json
+++ b/packages/web3-wrapper/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "7.1.0",
+        "changes": [
+            {
+                "note": "Add jsonRpcIdNameSpace to originate JSON RPC requests for debugging purposes",
+                "pr": 2508
+            }
+        ]
+    },
+    {
         "timestamp": 1582623685,
         "version": "7.0.7",
         "changes": [

--- a/packages/web3-wrapper/src/web3_wrapper.ts
+++ b/packages/web3-wrapper/src/web3_wrapper.ts
@@ -56,6 +56,7 @@ export class Web3Wrapper {
     // Raw provider passed in. Do not use. Only here to return the unmodified provider passed in via `getProvider()`
     private readonly _supportedProvider: SupportedProvider;
     private readonly _callAndTxnDefaults: Partial<CallData> | undefined;
+    private _jsonRpcRequestNameSpace: string;
     private _jsonRpcRequestId: number;
     /**
      * Check if an address is a valid Ethereum address
@@ -149,12 +150,17 @@ export class Web3Wrapper {
      * @param   callAndTxnDefaults  Override Call and Txn Data defaults sent with RPC requests to the backing Ethereum node.
      * @return  An instance of the Web3Wrapper class.
      */
-    constructor(supportedProvider: SupportedProvider, callAndTxnDefaults: Partial<CallData> = {}) {
+    constructor(
+        supportedProvider: SupportedProvider,
+        callAndTxnDefaults: Partial<CallData> = {},
+        jsonRpcIdNameSpace: string = '',
+    ) {
         this.abiDecoder = new AbiDecoder([]);
         this._supportedProvider = supportedProvider;
         this._provider = providerUtils.standardizeOrThrow(supportedProvider);
         this._callAndTxnDefaults = callAndTxnDefaults;
         this._jsonRpcRequestId = 1;
+        this._jsonRpcRequestNameSpace = jsonRpcIdNameSpace;
     }
     /**
      * Get the contract defaults set to the Web3Wrapper instance
@@ -679,7 +685,7 @@ export class Web3Wrapper {
     public async sendRawPayloadAsync<A>(payload: Partial<JSONRPCRequestPayload>): Promise<A> {
         const sendAsync = this._provider.sendAsync.bind(this._provider);
         const payloadWithDefaults = {
-            id: this._jsonRpcRequestId++,
+            id: `${this._jsonRpcRequestNameSpace}.${this._jsonRpcRequestId++}`,
             params: [],
             jsonrpc: '2.0',
             ...payload,

--- a/packages/web3-wrapper/src/web3_wrapper.ts
+++ b/packages/web3-wrapper/src/web3_wrapper.ts
@@ -685,7 +685,8 @@ export class Web3Wrapper {
     public async sendRawPayloadAsync<A>(payload: Partial<JSONRPCRequestPayload>): Promise<A> {
         const sendAsync = this._provider.sendAsync.bind(this._provider);
         const payloadWithDefaults = {
-            id: `${!!this._jsonRpcRequestNameSpace ? `${this._jsonRpcRequestNameSpace}.` : ''}${this._jsonRpcRequestId++}`,
+            id: `${!!this._jsonRpcRequestNameSpace ? `${this._jsonRpcRequestNameSpace}.` : ''}${this
+                ._jsonRpcRequestId++}`,
             params: [],
             jsonrpc: '2.0',
             ...payload,

--- a/packages/web3-wrapper/src/web3_wrapper.ts
+++ b/packages/web3-wrapper/src/web3_wrapper.ts
@@ -56,7 +56,7 @@ export class Web3Wrapper {
     // Raw provider passed in. Do not use. Only here to return the unmodified provider passed in via `getProvider()`
     private readonly _supportedProvider: SupportedProvider;
     private readonly _callAndTxnDefaults: Partial<CallData> | undefined;
-    private _jsonRpcRequestNameSpace: string;
+    private readonly _jsonRpcRequestNameSpace?: string;
     private _jsonRpcRequestId: number;
     /**
      * Check if an address is a valid Ethereum address
@@ -153,7 +153,7 @@ export class Web3Wrapper {
     constructor(
         supportedProvider: SupportedProvider,
         callAndTxnDefaults: Partial<CallData> = {},
-        jsonRpcIdNameSpace: string = '',
+        jsonRpcIdNameSpace?: string,
     ) {
         this.abiDecoder = new AbiDecoder([]);
         this._supportedProvider = supportedProvider;
@@ -685,7 +685,7 @@ export class Web3Wrapper {
     public async sendRawPayloadAsync<A>(payload: Partial<JSONRPCRequestPayload>): Promise<A> {
         const sendAsync = this._provider.sendAsync.bind(this._provider);
         const payloadWithDefaults = {
-            id: `${this._jsonRpcRequestNameSpace}.${this._jsonRpcRequestId++}`,
+            id: `${!!this._jsonRpcRequestNameSpace ? `${this._jsonRpcRequestNameSpace}.` : ''}${this._jsonRpcRequestId++}`,
             params: [],
             jsonrpc: '2.0',
             ...payload,


### PR DESCRIPTION
## Description

To help 0x-API (and other future products made with 0x tooling) to originate JSON rpc requests for debugging and alerting, added a `jsonRPCIdNameSpace` option to 0x tooling. 

Packages that have been updated: 
- `@0x/web-wrapper`
- `@0x/base-contract`
- `@0x/abi-gen`
- `@0x/contract-wrappers`
- `@0x/asset-swapper` 

By passing a `jsonRPCIdNameSpace`, all JSON RPC requests' `id` key to a node will be prepended with the namespace with a `.` delimiter.

Ex:
```
0x-asset-swapper.1
```

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
