### PR TITLE
[WIP] Add `solcBinariesDir` flag to compiler options

### DIFF
--- a/packages/ethereum-types/docs/reference.mdx
+++ b/packages/ethereum-types/docs/reference.mdx
@@ -1868,6 +1868,7 @@ contracts: List of contract names you wish to compile, or alternatively ['*'] to
 specified directory.
 useDockerisedSolc: If set to true - sol-compiler will try calling a dockerized installations of solc to achieve faster compilation times. Otherwise and by default - solcjs will be used. Defaults to false.
 isOfflineMode: If set to true - sol-compiler will not fetch the list of solc releases from github. It will use the hardcoded list. Defaults to false.
+solcBinariesDir: Directory containing solc binaries, if a binary is missing it will be downloaded into this directory.
 solcVersion: If you don't want to compile each contract with the Solidity version specified in-file, you can force all
 contracts to compile with the the version specified here.
 shouldSaveStandardInput: Write the standard JSON input in ${contractsDir}/${contractName}.input.json

--- a/packages/ethereum-types/src/index.ts
+++ b/packages/ethereum-types/src/index.ts
@@ -731,6 +731,7 @@ export interface Source {
  * specified directory.
  * useDockerisedSolc: If set to true - sol-compiler will try calling a dockerized installations of solc to achieve faster compilation times. Otherwise and by default - solcjs will be used. Defaults to false.
  * isOfflineMode: If set to true - sol-compiler will not fetch the list of solc releases from github. It will use the hardcoded list. Defaults to false.
+ * solcBinariesDir: Directory containing solc binaries, if a binary is missing it will be downloaded into this directory.
  * solcVersion: If you don't want to compile each contract with the Solidity version specified in-file, you can force all
  * contracts to compile with the the version specified here.
  * shouldSaveStandardInput: Write the standard JSON input in ${contractsDir}/${contractName}.input.json
@@ -742,6 +743,7 @@ export interface CompilerOptions {
     contracts?: string[] | '*';
     useDockerisedSolc?: boolean;
     isOfflineMode?: boolean;
+    solcBinariesDir?: string;
     solcVersion?: string;
     shouldSaveStandardInput?: boolean;
 }

--- a/packages/sol-compiler/src/compiler.ts
+++ b/packages/sol-compiler/src/compiler.ts
@@ -49,6 +49,7 @@ const DEFAULT_CONTRACTS_DIR = path.resolve('contracts');
 const DEFAULT_ARTIFACTS_DIR = path.resolve('artifacts');
 const DEFAULT_USE_DOCKERISED_SOLC = false;
 const DEFAULT_IS_OFFLINE_MODE = false;
+const DEFAULT_SOLC_BIN_DIR = constants.SOLC_BIN_DEFAULT_DIR;
 const DEFAULT_SHOULD_SAVE_STANDARD_INPUT = false;
 
 // Solc compiler settings cannot be configured from the commandline.
@@ -97,6 +98,7 @@ export class Compiler {
     private readonly _specifiedContracts: string[] | TYPE_ALL_FILES_IDENTIFIER;
     private readonly _useDockerisedSolc: boolean;
     private readonly _isOfflineMode: boolean;
+    private readonly _solcBinariesDir: string;
     private readonly _shouldSaveStandardInput: boolean;
     /**
      * Instantiates a new instance of the Compiler class.
@@ -126,6 +128,7 @@ export class Compiler {
         this._useDockerisedSolc =
             passedOpts.useDockerisedSolc || config.useDockerisedSolc || DEFAULT_USE_DOCKERISED_SOLC;
         this._isOfflineMode = passedOpts.isOfflineMode || config.isOfflineMode || DEFAULT_IS_OFFLINE_MODE;
+        this._solcBinariesDir = passedOpts.solcBinariesDir || config.solcBinariesDir || DEFAULT_SOLC_BIN_DIR;
         this._shouldSaveStandardInput =
             passedOpts.shouldSaveStandardInput || config.shouldSaveStandardInput || DEFAULT_SHOULD_SAVE_STANDARD_INPUT;
         this._nameResolver = new NameResolver(this._contractsDir);
@@ -142,7 +145,7 @@ export class Compiler {
      */
     public async compileAsync(): Promise<void> {
         await createDirIfDoesNotExistAsync(this._artifactsDir);
-        await createDirIfDoesNotExistAsync(constants.SOLC_BIN_DIR);
+        await createDirIfDoesNotExistAsync(this._solcBinariesDir);
         await this._compileContractsAsync(this.getContractNamesToCompile(), true);
     }
     /**
@@ -306,7 +309,7 @@ export class Compiler {
                 const solcInstance =
                     process.env.SOLCJS_PATH !== undefined
                         ? getSolcJSFromPath(process.env.SOLCJS_PATH)
-                        : await getSolcJSAsync(solcVersion, this._isOfflineMode);
+                        : await getSolcJSAsync(solcVersion, this._solcBinariesDir, this._isOfflineMode);
                 compilerOutput = await compileSolcJSAsync(solcInstance, input.standardInput);
             }
             if (compilerOutput.errors !== undefined) {

--- a/packages/sol-compiler/src/schemas/compiler_options_schema.ts
+++ b/packages/sol-compiler/src/schemas/compiler_options_schema.ts
@@ -21,6 +21,7 @@ export const compilerOptionsSchema = {
         },
         useDockerisedSolc: { type: 'boolean' },
         isOfflineMode: { type: 'boolean' },
+        solcBinariesDir: { type: 'string' },
         shouldSaveStandardInput: { type: 'boolean' },
     },
     type: 'object',

--- a/packages/sol-compiler/src/utils/compiler.ts
+++ b/packages/sol-compiler/src/utils/compiler.ts
@@ -340,15 +340,20 @@ function recursivelyGatherDependencySources(
  * Gets the solidity compiler instance. If the compiler is already cached - gets it from FS,
  * otherwise - fetches it and caches it.
  * @param solcVersion The compiler version. e.g. 0.5.0
+ * @param solcBinariesDir Solc binaries dir flag
  * @param isOfflineMode Offline mode flag
  */
-export async function getSolcJSAsync(solcVersion: string, isOfflineMode: boolean): Promise<solc.SolcInstance> {
+export async function getSolcJSAsync(
+    solcVersion: string,
+    solcBinariesDir: string,
+    isOfflineMode: boolean,
+): Promise<solc.SolcInstance> {
     const solcJSReleases = await getSolcJSReleasesAsync(isOfflineMode);
     const fullSolcVersion = solcJSReleases[solcVersion];
     if (fullSolcVersion === undefined) {
         throw new Error(`${solcVersion} is not a known compiler version`);
     }
-    const compilerBinFilename = path.join(constants.SOLC_BIN_DIR, fullSolcVersion);
+    const compilerBinFilename = path.join(solcBinariesDir, fullSolcVersion);
     let solcjs: string;
     if (await fsWrapper.doesFileExistAsync(compilerBinFilename)) {
         solcjs = (await fsWrapper.readFileAsync(compilerBinFilename)).toString();

--- a/packages/sol-compiler/src/utils/constants.ts
+++ b/packages/sol-compiler/src/utils/constants.ts
@@ -4,7 +4,7 @@ export const constants = {
     SOLIDITY_FILE_EXTENSION: '.sol',
     BASE_COMPILER_URL: 'https://ethereum.github.io/solc-bin/bin/',
     LATEST_ARTIFACT_VERSION: '2.0.0',
-    SOLC_BIN_DIR: path.join(__dirname, '..', '..', '..', 'solc_bin'),
+    SOLC_BIN_DEFAULT_DIR: path.join(__dirname, '..', '..', '..', 'solc_bin'),
     SOLC_BIN_PATHS: {
         '0.5.12': 'soljson-v0.5.12+commit.7709ece9.js',
         '0.5.11': 'soljson-v0.5.11+commit.c082d0b4.js',

--- a/packages/sol-compiler/test/compiler_test.ts
+++ b/packages/sol-compiler/test/compiler_test.ts
@@ -10,6 +10,9 @@ import { fsWrapper } from '../src/utils/fs_wrapper';
 import { exchange_binary } from './fixtures/exchange_bin';
 import { chaiSetup } from './util/chai_setup';
 import { constants } from './util/constants';
+import { constants as compilerConstants } from '../src/utils/constants';
+
+import * as uuid from 'uuid';
 
 chaiSetup.configure();
 const expect = chai.expect;
@@ -112,6 +115,30 @@ describe('#Compiler', function(): void {
         // make sure the artifacts dir only contains EmptyContract.json
         for (const artifact of await fsWrapper.readdirAsync(artifactsDir)) {
             expect(artifact).to.equal('EmptyContract.json');
+        }
+    });
+    it('should download binary to designated path by solcBinariesDir', async () => {
+        // remove all artifacts
+        for (const artifact of await fsWrapper.readdirAsync(artifactsDir)) {
+            await fsWrapper.removeFileAsync(join(artifactsDir, artifact));
+        }
+
+        const solcBinariesDir = '/tmp/' + uuid();
+        // remove all binaries cached
+        for (const solcBinary of await fsWrapper.readdirAsync(solcBinariesDir)) {
+            await fsWrapper.removeFileAsync(join(solcBinariesDir, solcBinary));
+        }
+
+        // compile EmptyContract
+        compilerOpts.contracts = ['EmptyContract'];
+        await new Compiler(compilerOpts).compileAsync();
+
+        const solcBinaryPath = join(solcBinariesDir, compilerConstants.SOLC_BIN_PATHS['0.4.14']);
+        expect(await fsWrapper.doesFileExistAsync(solcBinaryPath)).to.be.true;
+
+        // remove all binaries cached
+        for (const solcBinary of await fsWrapper.readdirAsync(solcBinariesDir)) {
+            await fsWrapper.removeFileAsync(join(solcBinariesDir, solcBinary));
         }
     });
 });

--- a/packages/sol-compiler/test/compiler_test.ts
+++ b/packages/sol-compiler/test/compiler_test.ts
@@ -7,8 +7,6 @@ import 'mocha';
 import { Compiler } from '../src/compiler';
 import { fsWrapper } from '../src/utils/fs_wrapper';
 
-import {constants as compilerConstants} from '../src/utils/constants';
-
 import { exchange_binary } from './fixtures/exchange_bin';
 import { chaiSetup } from './util/chai_setup';
 import { constants } from './util/constants';

--- a/packages/sol-compiler/test/compiler_test.ts
+++ b/packages/sol-compiler/test/compiler_test.ts
@@ -7,12 +7,11 @@ import 'mocha';
 import { Compiler } from '../src/compiler';
 import { fsWrapper } from '../src/utils/fs_wrapper';
 
+import {constants as compilerConstants} from '../src/utils/constants';
+
 import { exchange_binary } from './fixtures/exchange_bin';
 import { chaiSetup } from './util/chai_setup';
 import { constants } from './util/constants';
-import { constants as compilerConstants } from '../src/utils/constants';
-
-import * as uuid from 'uuid';
 
 chaiSetup.configure();
 const expect = chai.expect;
@@ -123,18 +122,15 @@ describe('#Compiler', function(): void {
             await fsWrapper.removeFileAsync(join(artifactsDir, artifact));
         }
 
-        const solcBinariesDir = '/tmp/' + uuid();
-        // remove all binaries cached
-        for (const solcBinary of await fsWrapper.readdirAsync(solcBinariesDir)) {
-            await fsWrapper.removeFileAsync(join(solcBinariesDir, solcBinary));
-        }
+        const solcBinariesDir = '/tmp/solc_bin';
 
         // compile EmptyContract
         compilerOpts.contracts = ['EmptyContract'];
+        compilerOpts.solcBinariesDir = solcBinariesDir;
         await new Compiler(compilerOpts).compileAsync();
 
-        const solcBinaryPath = join(solcBinariesDir, compilerConstants.SOLC_BIN_PATHS['0.4.14']);
-        expect(await fsWrapper.doesFileExistAsync(solcBinaryPath)).to.be.true;
+        const downloadedFiles = await fsWrapper.readdirAsync(solcBinariesDir);
+        expect(downloadedFiles.length).to.equal(1);
 
         // remove all binaries cached
         for (const solcBinary of await fsWrapper.readdirAsync(solcBinariesDir)) {


### PR DESCRIPTION
## Description

Add `solcBinariesDir` flag to compiler options. Directory containing solc binaries, if a binary is missing it will be downloaded and cached into this directory.

## Testing instructions

A test was placed for this feature. Just execute tests as usual.

## Types of changes

* New feature (non-breaking change which adds functionality)

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] Prefix PR title with `[WIP]` if necessary.
-   [X] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.

## Motivation

The dynamic downloading of files keeps the package from being able to execute correctly in read-only environments.

## Comments

Thanks for the awesome package, it is definitely useful.

I have got some doubts before merging:
1) I updated some of the documentation though I'm not quite sure about some lines, specifically the `ethereum-types/reference.mdx`. Each field points to a line in a specific commit, since this is not yet commited I haven't added an entry below `isOfflineMode` in the [reference](https://github.com/0xProject/0x-monorepo/blob/9e9e0d6592f089a372c1285c8f34217fb7b0d4c6/packages/ethereum-types/docs/reference.mdx#L1870)
2) Shall I upgrade `ethereum-types` to "3.1.1" and `sol-compiler` to "4.0.9" since its a minor change?
3) Is any timestamp fine for the CHANGELOGs?
