### PR TITLE
Update addresses.json

### DIFF
--- a/packages/contract-addresses/addresses.json
+++ b/packages/contract-addresses/addresses.json
@@ -117,7 +117,7 @@
         "erc20BridgeProxy": "0xfb2dd2a1366de37f7241c83d47da58fd503e2c64",
         "uniswapBridge": "0x0e85f89f29998df65402391478e5924700c0079d",
         "eth2DaiBridge": "0x2d47147429b474d2e4f83e658015858a1312ed5b",
-        "erc20BridgeSampler": "0x4f1556e5fe03a0da39091260f78d2cf765baa091",
+        "erc20BridgeSampler": "0xd3fccc4af0732e99290a57bbc2cc2afcbd08283f",
         "kyberBridge": "0xaecfa25920f892b6eb496e1f6e84037f59da7f44",
         "chaiBridge": "0x0000000000000000000000000000000000000000",
         "dydxBridge": "0x080e183c0193b4765d504e402db2f5621d4567e4",


### PR DESCRIPTION
## Description

I have a concern that the most recent deploy of Kovan’s ERC20BridgeSampler (at address 0x4f1556e5fe03a0da39091260f78d2cf765baa091) is not setup correctly.
If you browse the source code of the [deployed contract](https://kovan.etherscan.io/address/0x4f1556e5fe03a0da39091260f78d2cf765baa091#code) you may notice how the constant `DEV_UTILS_ADDRESS` references `0x161793Cdca4fF9E766A706c2C49c36AC1340bbcd` which is a DevUtils contract address that was deployed ~46 days ago. Instead, based on [addresses.json](https://github.com/0xProject/0x-monorepo/blob/development/packages/contract-addresses/addresses.json), it looks like the latest DevUtils contract should be 0x9402639a828bdf4e9e4103ac3b69e1a6e522eb59 (deployed 12 days ago).

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] Prefix PR title with `[WIP]` if necessary.
-   [X] Add tests to cover changes as needed.
-   [X] Update documentation as needed.
-   [X] Add new entries to the relevant CHANGELOG.jsons.
