### PR TITLE
AssetSwapper: Fix quote optimizer fee bug

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -29,6 +29,10 @@
             {
                 "note": "Fix fee schedule not being scaled by gas price.",
                 "pr": 2522
+            },
+            {
+                "note": "Fix quote optimizer bug not properly accounting for fees.",
+                "pr": 2526
             }
         ]
     },

--- a/packages/asset-swapper/src/constants.ts
+++ b/packages/asset-swapper/src/constants.ts
@@ -29,8 +29,8 @@ const DEFAULT_ORDER_PRUNER_OPTS: OrderPrunerOpts = {
     ]), // Default asset-swapper for CFL oriented fee types
 };
 
-// 15 seconds polling interval
-const PROTOCOL_FEE_UTILS_POLLING_INTERVAL_IN_MS = 15000;
+// 6 seconds polling interval
+const PROTOCOL_FEE_UTILS_POLLING_INTERVAL_IN_MS = 6000;
 const PROTOCOL_FEE_MULTIPLIER = new BigNumber(150000);
 
 // default 50% buffer for selecting native orders to be aggregated with other sources

--- a/packages/asset-swapper/src/utils/market_operation_utils/fills.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/fills.ts
@@ -197,7 +197,7 @@ export function getPathAdjustedSize(path: Fill[], targetInput: BigNumber = POSIT
     return [input.integerValue(), output.integerValue()];
 }
 
-export function isValidPath(path: Fill[]): boolean {
+export function isValidPath(path: Fill[], skipDuplicateCheck: boolean = false): boolean {
     let flags = 0;
     for (let i = 0; i < path.length; ++i) {
         // Fill must immediately follow its parent.
@@ -206,10 +206,12 @@ export function isValidPath(path: Fill[]): boolean {
                 return false;
             }
         }
-        // Fill must not be duplicated.
-        for (let j = 0; j < i; ++j) {
-            if (path[i] === path[j]) {
-                return false;
+        if (!skipDuplicateCheck) {
+            // Fill must not be duplicated.
+            for (let j = 0; j < i; ++j) {
+                if (path[i] === path[j]) {
+                    return false;
+                }
             }
         }
         flags |= path[i].flags;


### PR DESCRIPTION
## Description

When the optimizer was building a quote, it wasn't clipping the input/output amounts of a tail-end fill by the remaining input amount. So a large enough fill (usually native orders) could be attributed a higher return rate than it really should. This fix also apparently improves quoted and realized prices slightly, even though I wasn't trying to.

Also updated the ethgasstation poll rate to ~half the block time, because gas price is a lot more mercurial during the end of the world.

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
