### PR TITLE
Update solc to 0.6.x

### DIFF
--- a/packages/sol-compiler/package.json
+++ b/packages/sol-compiler/package.json
@@ -91,7 +91,7 @@
         "pluralize": "^7.0.0",
         "require-from-string": "^2.0.1",
         "semver": "5.5.0",
-        "solc": "^0.5.5",
+        "solc": "^0.6.4",
         "source-map-support": "^0.5.0",
         "web3-eth-abi": "^1.0.0-beta.24",
         "yargs": "^10.0.3"

--- a/packages/sol-compiler/src/utils/compiler.ts
+++ b/packages/sol-compiler/src/utils/compiler.ts
@@ -145,7 +145,7 @@ export async function compileSolcJSAsync(
     standardInput: solc.StandardInput,
 ): Promise<solc.StandardOutput> {
     const standardInputStr = JSON.stringify(standardInput);
-    const standardOutputStr = solcInstance.compileStandardWrapper(standardInputStr);
+    const standardOutputStr = solcInstance.compile(standardInputStr);
     const compiled: solc.StandardOutput = JSON.parse(standardOutputStr);
     return compiled;
 }

--- a/packages/sol-tracing-utils/package.json
+++ b/packages/sol-tracing-utils/package.json
@@ -57,7 +57,7 @@
         "mkdirp": "^0.5.1",
         "rimraf": "^2.6.2",
         "semaphore-async-await": "^1.5.1",
-        "solc": "^0.5.5",
+        "solc": "^0.6.4",
         "solidity-parser-antlr": "^0.4.2"
     },
     "devDependencies": {

--- a/packages/typescript-typings/types/solc/index.d.ts
+++ b/packages/typescript-typings/types/solc/index.d.ts
@@ -99,12 +99,7 @@ declare module 'solc' {
         settings: CompilerSettings;
     }
     export interface SolcInstance {
-        compile(
-            sources: InputSources,
-            optimizerEnabled: number,
-            findImports: (importPath: string) => ImportContents,
-        ): CompilationResult;
-        compileStandardWrapper(input: string, findImports?: (importPath: string) => ImportContents): string;
+        compile(input: string, findImports?: (importPath: string) => ImportContents): string;
     }
     export function loadRemoteVersion(
         versionName: string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4932,6 +4932,11 @@ commander@2.18.0:
   version "2.18.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.18.0.tgz#2bf063ddee7c7891176981a2cc798e5754bc6970"
 
+commander@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-3.0.2.tgz#6837c3fb677ad9933d1cfba42dd14d5117d6b39e"
+  integrity sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==
+
 commander@^2.15.1:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
@@ -10348,6 +10353,11 @@ js-sha3@0.5.7, js-sha3@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.5.7.tgz#0d4ffd8002d5333aabaf4a23eed2f6374c9f28e7"
 
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 js-sha3@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.3.1.tgz#86122802142f0828502a0d1dee1d95e253bb0243"
@@ -15172,18 +15182,19 @@ solc@^0.4.2:
     semver "^5.3.0"
     yargs "^4.7.1"
 
-solc@^0.5.5:
-  version "0.5.5"
-  resolved "https://registry.npmjs.org/solc/-/solc-0.5.5.tgz#bdedd988e1a958f48bb8d84df5414f0ae9f62764"
+solc@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.6.4.tgz#4b0f11fccd6f5ef9802c6bb1c007abb16881c2ca"
+  integrity sha512-HjUCys7ue9n7lGCa1XNf+wDdEY/wY64CpwnD4iPxW+BYYUX6ytwWXKitoolPXOOVxq4jewvwtL7Pngs+5k954A==
   dependencies:
     command-exists "^1.2.8"
+    commander "3.0.2"
     fs-extra "^0.30.0"
-    keccak "^1.0.2"
+    js-sha3 "0.8.0"
     memorystream "^0.3.1"
     require-from-string "^2.0.0"
     semver "^5.5.0"
     tmp "0.0.33"
-    yargs "^11.0.0"
 
 solhint@^1.4.1:
   version "1.5.0"


### PR DESCRIPTION
## Description
Update solc to 0.6.x

Solc 0.6.x addresses a rate limiting fix that prevents downstream users
from downloading the required version of solc-js more often.
See: https://github.com/ethereum/solc-js/pull/446

## Testing instructions
Should just pass CI.
<!--- Please describe how reviewers can test your changes -->

## Types of changes
- Change typescript typings to reflect new solc breaking changes to API.
- Update `sol-compiler` to use `compile` instead of `compileStandardWrapper`. It has been renamed to be the same thing.

