### PR TITLE
[asset-swapper] Fix getBatchMarketBuyOrdersAsync

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -33,6 +33,10 @@
             {
                 "note": "Fix quote optimizer bug not properly accounting for fees.",
                 "pr": 2526
+            },
+            {
+                "note": "Fix `getBatchMarketBuyOrdersAsync` throwing NO_OPTIMAL_PATH",
+                "pr": 2533
             }
         ]
     },

--- a/packages/asset-swapper/src/utils/market_operation_utils/index.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/index.ts
@@ -239,21 +239,27 @@ export class MarketOperationUtils {
             const ethToTakerAssetRate = batchEthToTakerAssetRate[i];
             const dexQuotes = batchDexQuotes[i];
             const makerAmount = makerAmounts[i];
-            return this._generateOptimizedOrders({
-                orderFillableAmounts,
-                nativeOrders,
-                dexQuotes,
-                inputToken: makerToken,
-                outputToken: takerToken,
-                side: MarketOperation.Buy,
-                inputAmount: makerAmount,
-                ethToOutputRate: ethToTakerAssetRate,
-                bridgeSlippage: _opts.bridgeSlippage,
-                maxFallbackSlippage: _opts.maxFallbackSlippage,
-                excludedSources: _opts.excludedSources,
-                feeSchedule: _opts.feeSchedule,
-                allowFallback: _opts.allowFallback,
-            });
+            try {
+                return this._generateOptimizedOrders({
+                    orderFillableAmounts,
+                    nativeOrders,
+                    dexQuotes,
+                    inputToken: makerToken,
+                    outputToken: takerToken,
+                    side: MarketOperation.Buy,
+                    inputAmount: makerAmount,
+                    ethToOutputRate: ethToTakerAssetRate,
+                    bridgeSlippage: _opts.bridgeSlippage,
+                    maxFallbackSlippage: _opts.maxFallbackSlippage,
+                    excludedSources: _opts.excludedSources,
+                    feeSchedule: _opts.feeSchedule,
+                    allowFallback: _opts.allowFallback,
+                });
+            } catch (e) {
+                // It's possible for one of the pairs to have no path
+                // rather than throw NO_OPTIMAL_PATH we return undefined
+                return undefined;
+            }
         });
     }
 


### PR DESCRIPTION
## Description

`_generateOptimizedOrders` Can throw `NO_OPTIMAL_PATH`, catch it since we don't want one throw to spoil the broth.