### PR TITLE
Pin python tests to ganache snapshot 6.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,6 +194,8 @@ jobs:
         docker:
             - image: nikolaik/python-nodejs:python3.7-nodejs8
             - image: 0xorg/ganache-cli:6.0.0
+              environment:
+                  VERSION: '6.0.0'
             - image: 0xorg/mesh:0xV3
               environment:
                   ETHEREUM_RPC_URL: 'http://localhost:8545'

--- a/python-packages/sra_client/test/relayer/docker-compose.yml
+++ b/python-packages/sra_client/test/relayer/docker-compose.yml
@@ -5,6 +5,8 @@ services:
         image: "0xorg/ganache-cli:6.0.0"
         ports:
             - "8545:8545"
+        environment:
+            - VERSION=6.0.0
     mesh:
         image: 0xorg/mesh:0xV3
         depends_on:


### PR DESCRIPTION
## Description

The "latest" ganache snapshot, 6.2.4, broke the test-python CI job.
- The last time this CI job passed on the development branch was March 6 at 15:34
- The first time it failed was on March 6 at 16:44.
- Ganahce snapshot 6.2.4, copied to latest, was published at 16:17, exactly in that window.
(All times EST)

The surface failure symptom is an SRA response HTTP 100, "Validation failed", with the reason `EthRPCRequestFailed: network request to Ethereum RPC endpoint failed`.

That RPC message seems to be being relayed from Mesh, whose log shows many entries like:
    `{"attempt_number":0,"error_string":"abi: unmarshalling empty output","level":"info","msg":"GetOrderRelevantStates request failed","myPeerID":"16Uiu2HAmNmNAjt947uJLhSg98FjXb6ymi2nUphBmHEwFfeiSTUL3","numOrders_number":3,"time":"2020-03-06T21:55:52Z"}`

I suspected that the ABI that mesh is using doesn't match what's been deployed in Ganache, so
I pinned the ganache snapshot to the previous version for now, and as you can see the CI is passing here.