### PR TITLE
py/contract_wrappers: Pin sphinx to prev version

### DIFF
--- a/python-packages/contract_wrappers/setup.py
+++ b/python-packages/contract_wrappers/setup.py
@@ -225,7 +225,7 @@ setup(
             "pydocstyle",
             "pylint",
             "pytest",
-            "sphinx",
+            "sphinx==2.4.4",  # pinned because of https://github.com/sphinx-doc/sphinx/issues/7429
             "sphinx-autodoc-typehints",
             "tox",
             "twine",


### PR DESCRIPTION
The latest version of the sphinx (documentation generation tool) broke our build.  I reported the problem [here](https://github.com/sphinx-doc/sphinx/issues/7429).  This change pins us to the previous version.