### PR TITLE
Always use DFB in asset-swapper

### DIFF
--- a/packages/asset-swapper/src/utils/market_operation_utils/orders.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/orders.ts
@@ -38,7 +38,7 @@ interface DexForwaderBridgeData {
     }>;
 }
 
-const dexForwarderBridgeDataEncoder = AbiEncoder.create([
+export const dexForwarderBridgeDataEncoder = AbiEncoder.create([
     { name: 'inputToken', type: 'address' },
     {
         name: 'calls',
@@ -169,7 +169,8 @@ export function createOrdersFromPath(path: Fill[], opts: CreateOrderFromPathOpts
             }
             contiguousBridgeFills.push(collapsedPath[j]);
         }
-        if (contiguousBridgeFills.length === 1 || !opts.shouldBatchBridgeOrders) {
+        // Always use DexForwarderBridge unless configured not to
+        if (!opts.shouldBatchBridgeOrders) {
             orders.push(createBridgeOrder(contiguousBridgeFills[0], opts));
             i += 1;
         } else {

--- a/packages/asset-swapper/src/utils/market_operation_utils/orders.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/orders.ts
@@ -38,7 +38,7 @@ interface DexForwaderBridgeData {
     }>;
 }
 
-export const dexForwarderBridgeDataEncoder = AbiEncoder.create([
+const dexForwarderBridgeDataEncoder = AbiEncoder.create([
     { name: 'inputToken', type: 'address' },
     {
         name: 'calls',

--- a/packages/asset-swapper/test/market_operation_utils_test.ts
+++ b/packages/asset-swapper/test/market_operation_utils_test.ts
@@ -16,7 +16,6 @@ import * as _ from 'lodash';
 
 import { MarketOperationUtils } from '../src/utils/market_operation_utils/';
 import { BUY_SOURCES, DEFAULT_CURVE_OPTS, SELL_SOURCES } from '../src/utils/market_operation_utils/constants';
-import { dexForwarderBridgeDataEncoder } from '../src/utils/market_operation_utils/orders';
 import { DexOrderSampler } from '../src/utils/market_operation_utils/sampler';
 import { DexSample, ERC20BridgeSource } from '../src/utils/market_operation_utils/types';
 
@@ -28,7 +27,6 @@ describe('MarketOperationUtils tests', () => {
     const KYBER_BRIDGE_ADDRESS = contractAddresses.kyberBridge;
     const UNISWAP_BRIDGE_ADDRESS = contractAddresses.uniswapBridge;
     const CURVE_BRIDGE_ADDRESS = contractAddresses.curveBridge;
-    const DEX_FORWARDER_BRIDGE_ADDRESS = contractAddresses.dexForwarderBridge;
 
     const MAKER_TOKEN = randomAddress();
     const TAKER_TOKEN = randomAddress();
@@ -75,13 +73,7 @@ describe('MarketOperationUtils tests', () => {
         if (!assetDataUtils.isERC20BridgeAssetData(bridgeData)) {
             throw new Error('AssetData is not ERC20BridgeAssetData');
         }
-        let { bridgeAddress } = bridgeData;
-        // If this is a DexForwarderBridge encoding, use the first address for testing
-        if (bridgeData.bridgeAddress === DEX_FORWARDER_BRIDGE_ADDRESS.toLowerCase()) {
-            const dexForwarderBridgeData = dexForwarderBridgeDataEncoder.decodeAsArray(bridgeData.bridgeData);
-            const [, bridgeCallDatas] = dexForwarderBridgeData;
-            bridgeAddress = bridgeCallDatas[0].target;
-        }
+        const { bridgeAddress } = bridgeData;
         switch (bridgeAddress) {
             case KYBER_BRIDGE_ADDRESS.toLowerCase():
                 return ERC20BridgeSource.Kyber;


### PR DESCRIPTION
## Description

Use DFB even when there is only one source.

* Gives us a single entry point to monitor
* Allows burning of GST over all sources