### PR TITLE
Python: unpin Sphinx dependency, clean up warnings

### DIFF
--- a/python-packages/contract_wrappers/setup.py
+++ b/python-packages/contract_wrappers/setup.py
@@ -226,7 +226,6 @@ setup(
             "pylint",
             "pytest",
             "sphinx",
-            "sphinx-autodoc-typehints",
             "tox",
             "twine",
         ]

--- a/python-packages/contract_wrappers/setup.py
+++ b/python-packages/contract_wrappers/setup.py
@@ -225,7 +225,7 @@ setup(
             "pydocstyle",
             "pylint",
             "pytest",
-            "sphinx==2.4.4",  # pinned because of https://github.com/sphinx-doc/sphinx/issues/7429
+            "sphinx",
             "sphinx-autodoc-typehints",
             "tox",
             "twine",

--- a/python-packages/contract_wrappers/src/conf.py
+++ b/python-packages/contract_wrappers/src/conf.py
@@ -23,7 +23,6 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.coverage",
     "sphinx.ext.viewcode",
-    "sphinx_autodoc_typehints",
 ]
 
 templates_path = ["doc_templates"]

--- a/python-packages/contract_wrappers/src/conf.py
+++ b/python-packages/contract_wrappers/src/conf.py
@@ -54,3 +54,39 @@ htmlhelp_basename = "contract_wrapperspydoc"
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {"https://docs.python.org/": None}
+
+
+def annotate_gend_tuple_docstring(  # pylint: disable=too-many-arguments
+    app,  # pylint: disable=unused-argument
+    what,  # pylint: disable=unused-argument
+    name,  # pylint: disable=unused-argument
+    obj,  # pylint: disable=unused-argument
+    options,  # pylint: disable=unused-argument
+    lines,
+):
+    """Annotate docstrings of generated tuples."""
+    docstring_extensions = {
+        "LibOrderOrder": [
+            "This is the generated class representing `the Order struct <https://github.com/0xProject/0x-protocol-specification/blob/master/v3/v3-specification.md#order>`_."
+        ],
+        "LibFillResultsFillResults": [
+            "This is the generated class representing `the FillResults struct <https://github.com/0xProject/0x-protocol-specification/blob/master/v3/v3-specification.md#fillresults>`_."
+        ],
+        "LibFillResultsMatchedFillResults": [
+            "This is the generated class representing `the MatchedFillResults struct <https://github.com/0xProject/0x-protocol-specification/blob/master/v3/v3-specification.md#matchedfillresults>`_."
+        ],
+        "LibOrderOrderInfo": [
+            "This is the generated class representing `the OrderInfo struct <https://github.com/0xProject/0x-protocol-specification/blob/master/v3/v3-specification.md#orderinfo>`_."
+        ],
+        "LibZeroExTransactionZeroExTransaction": [
+            "This is the generated class representing `the ZeroExTransaction struct <https://github.com/0xProject/0x-protocol-specification/blob/master/v3/v3-specification.md#zeroextransaction>`_."
+        ],
+    }
+    unqualified_name = name.split(".")[-1]
+    if unqualified_name in docstring_extensions:
+        lines.extend(docstring_extensions[unqualified_name])
+
+
+def setup(app):
+    """Install callbacks."""
+    app.connect("autodoc-process-docstring", annotate_gend_tuple_docstring)

--- a/python-packages/contract_wrappers/src/index.rst
+++ b/python-packages/contract_wrappers/src/index.rst
@@ -198,29 +198,6 @@ zero_ex.contract_wrappers.exchange.types
 
 .. autoclass:: zero_ex.contract_wrappers.exchange.types.ZeroExTransaction
 
-zero_ex.contract_wrappers.exchange: Generated Tuples
-====================================================
-
-.. autoclass:: zero_ex.contract_wrappers.exchange.LibOrderOrder
-
-    This is the generated class representing `the Order struct <https://github.com/0xProject/0x-protocol-specification/blob/master/v3/v3-specification.md#order>`_.
-
-.. autoclass:: zero_ex.contract_wrappers.exchange.LibFillResultsFillResults
-
-    This is the generated class representing `the FillResults struct <https://github.com/0xProject/0x-protocol-specification/blob/master/v3/v3-specification.md#fillresults>`_.
-
-.. autoclass:: zero_ex.contract_wrappers.exchange.LibFillResultsMatchedFillResults
-
-    This is the generated class representing `the MatchedFillResults struct <https://github.com/0xProject/0x-protocol-specification/blob/master/v3/v3-specification.md#matchedfillresults>`_.
-
-.. autoclass:: zero_ex.contract_wrappers.exchange.LibOrderOrderInfo
-
-    This is the generated class representing `the OrderInfo struct <https://github.com/0xProject/0x-protocol-specification/blob/master/v3/v3-specification.md#orderinfo>`_.
-
-.. autoclass:: zero_ex.contract_wrappers.exchange.LibZeroExTransactionZeroExTransaction
-
-    This is the generated class representing `the ZeroExTransaction struct <https://github.com/0xProject/0x-protocol-specification/blob/master/v3/v3-specification.md#zeroextransaction>`_.
-
 Indices and tables
 ==================
 

--- a/python-packages/json_schemas/setup.py
+++ b/python-packages/json_schemas/setup.py
@@ -179,7 +179,6 @@ setup(
             "pylint",
             "pytest",
             "sphinx",
-            "sphinx-autodoc-typehints",
             "tox",
             "twine",
         ]

--- a/python-packages/json_schemas/src/conf.py
+++ b/python-packages/json_schemas/src/conf.py
@@ -22,7 +22,6 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.coverage",
     "sphinx.ext.viewcode",
-    "sphinx_autodoc_typehints",
 ]
 
 templates_path = ["doc_templates"]

--- a/python-packages/middlewares/setup.py
+++ b/python-packages/middlewares/setup.py
@@ -180,7 +180,6 @@ setup(
             "pylint",
             "pytest",
             "sphinx",
-            "sphinx-autodoc-typehints",
             "tox",
             "twine",
         ]

--- a/python-packages/middlewares/src/conf.py
+++ b/python-packages/middlewares/src/conf.py
@@ -22,7 +22,6 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.coverage",
     "sphinx.ext.viewcode",
-    "sphinx_autodoc_typehints",
 ]
 
 templates_path = ["doc_templates"]

--- a/python-packages/order_utils/setup.py
+++ b/python-packages/order_utils/setup.py
@@ -200,7 +200,6 @@ setup(
             "pylint",
             "pytest",
             "sphinx",
-            "sphinx-autodoc-typehints",
             "tox",
             "twine",
         ]

--- a/python-packages/order_utils/src/conf.py
+++ b/python-packages/order_utils/src/conf.py
@@ -22,7 +22,6 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.coverage",
     "sphinx.ext.viewcode",
-    "sphinx_autodoc_typehints",
 ]
 
 templates_path = ["doc_templates"]

--- a/python-packages/order_utils/src/index.rst
+++ b/python-packages/order_utils/src/index.rst
@@ -16,16 +16,6 @@ zero_ex.order_utils.asset_data_utils
 .. automodule:: zero_ex.order_utils.asset_data_utils
    :members:
 
-.. autoclass:: zero_ex.order_utils.asset_data_utils.ERC20AssetData
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-.. autoclass:: zero_ex.order_utils.asset_data_utils.ERC721AssetData
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 Indices and tables
 ==================
 

--- a/python-packages/sra_client/setup.py
+++ b/python-packages/sra_client/setup.py
@@ -227,7 +227,6 @@ setup(
             "pylint",
             "pytest",
             "sphinx",
-            "sphinx-autodoc-typehints",
         ]
     },
     command_options={

--- a/python-packages/sra_client/src/conf.py
+++ b/python-packages/sra_client/src/conf.py
@@ -22,7 +22,6 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.coverage",
     "sphinx.ext.viewcode",
-    "sphinx_autodoc_typehints",
 ]
 
 templates_path = ["doc_templates"]


### PR DESCRIPTION
Recently we pinned the Sphinx dependency to a specific version, because the latest version was breaking our build.

This PR changes our Sphinx usage in order to avoid the breakage, and removes the pin.