### PR TITLE
Collapse on-chain sources into DexForwarderBridge

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -49,6 +49,10 @@
             {
                 "note": "Add support for indicative (non-committal) quotes via RFQ-T",
                 "pr": 2555
+            },
+            {
+                "note": "Collapse `LiquidityProvider` into `DexForwarderBridge`",
+                "pr": 2560
             }
         ]
     },

--- a/packages/asset-swapper/src/utils/market_operation_utils/orders.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/orders.ts
@@ -153,19 +153,10 @@ export function createOrdersFromPath(path: Fill[], opts: CreateOrderFromPathOpts
             ++i;
             continue;
         }
-        // Liquidity Provider must be called by ERC20BridgeProxy
-        if (collapsedPath[i].source === ERC20BridgeSource.LiquidityProvider) {
-            orders.push(createBridgeOrder(collapsedPath[i], opts));
-            ++i;
-            continue;
-        }
         // If there are contiguous bridge orders, we can batch them together.
         const contiguousBridgeFills = [collapsedPath[i]];
         for (let j = i + 1; j < collapsedPath.length; ++j) {
-            if (
-                collapsedPath[j].source === ERC20BridgeSource.Native ||
-                collapsedPath[j].source === ERC20BridgeSource.LiquidityProvider
-            ) {
+            if (collapsedPath[j].source === ERC20BridgeSource.Native) {
                 break;
             }
             contiguousBridgeFills.push(collapsedPath[j]);

--- a/packages/asset-swapper/test/market_operation_utils_test.ts
+++ b/packages/asset-swapper/test/market_operation_utils_test.ts
@@ -659,7 +659,7 @@ describe('MarketOperationUtils tests', () => {
                         }),
                     ],
                     Web3Wrapper.toBaseUnitAmount(10, 18),
-                    { excludedSources: SELL_SOURCES, numSamples: 4, bridgeSlippage: 0 },
+                    { excludedSources: SELL_SOURCES, numSamples: 4, bridgeSlippage: 0, shouldBatchBridgeOrders: false },
                 );
                 expect(result.length).to.eql(1);
                 expect(result[0].makerAddress).to.eql(liquidityProviderAddress);


### PR DESCRIPTION
Collapse as many sources into DexForwarderBridge as possible to reduce excess protocol fees for on-chain sources.