### PR TITLE
ZeroEx: Add `Unused` to `StorageId` enum

### DIFF
--- a/contracts/zero-ex/contracts/src/features/Migrate.sol
+++ b/contracts/zero-ex/contracts/src/features/Migrate.sol
@@ -72,7 +72,7 @@ contract Migrate is
             // If the owner is already set to ourselves then we've reentered.
             _rrevert(LibMigrateRichErrors.AlreadyMigratingError());
         }
-        // Temporarily set the owner to ourselves.
+        // Temporarily set the owner to ourselves to enable admin functions.
         ownableStor.owner = address(this);
         stor.migrationOwner = prevOwner;
 

--- a/contracts/zero-ex/contracts/src/features/Ownable.sol
+++ b/contracts/zero-ex/contracts/src/features/Ownable.sol
@@ -48,7 +48,7 @@ contract Ownable is
     /// @param impl the actual address of this feature contract.
     /// @return success Magic bytes if successful.
     function bootstrap(address impl) external returns (bytes4 success) {
-        // Set the owner.
+        // Set the owner to ourselves to allow bootstrappers to call `extend()`.
         LibOwnableStorage.getStorage().owner = address(this);
 
         // Register feature functions.

--- a/contracts/zero-ex/contracts/src/storage/LibStorage.sol
+++ b/contracts/zero-ex/contracts/src/storage/LibStorage.sol
@@ -30,6 +30,7 @@ library LibStorage {
 
     /// @dev Storage IDs for feature storage buckets.
     enum StorageId {
+        Unused, // Unused buffer for state accidents.
         Proxy,
         SimpleFunctionRegistry,
         Ownable,
@@ -44,7 +45,6 @@ library LibStorage {
         pure
         returns (uint256 offset)
     {
-        // We don't use safeMul here to save gas.
         // This should never overflow with a reasonable `STORAGE_OFFSET_MULTIPLIER`
         // because Solidity will do a range check on `storageId` during the cast.
         return uint256(storageId) * STORAGE_OFFSET_MULTIPLIER;


### PR DESCRIPTION
## Description

Adds `Unused` as the first enum value in the `StorageId` enum.
This means real buckets start at `1e18`, which gives us a safety buffer in case we accidentally deploy a feature that uses non-bucketed state variables.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
