### PR TITLE
asset-swapper: support RFQ-T logger callback

### DIFF
--- a/packages/asset-swapper/src/swap_quoter.ts
+++ b/packages/asset-swapper/src/swap_quoter.ts
@@ -172,7 +172,7 @@ export class SwapQuoter {
         this._orderStateUtils = new OrderStateUtils(this._devUtilsContract);
         this._quoteRequestor = new QuoteRequestor(
             options.rfqt ? options.rfqt.makerEndpoints || [] : [],
-            options.rfqt ? options.rfqt.warningLogger || undefined : undefined,
+            options.rfqt ? options.rfqt.warningLogger : undefined,
         );
         const sampler = new DexOrderSampler(
             new IERC20BridgeSamplerContract(this._contractAddresses.erc20BridgeSampler, this.provider, {

--- a/packages/asset-swapper/src/swap_quoter.ts
+++ b/packages/asset-swapper/src/swap_quoter.ts
@@ -170,7 +170,10 @@ export class SwapQuoter {
         this._devUtilsContract = new DevUtilsContract(this._contractAddresses.devUtils, provider);
         this._protocolFeeUtils = new ProtocolFeeUtils(constants.PROTOCOL_FEE_UTILS_POLLING_INTERVAL_IN_MS);
         this._orderStateUtils = new OrderStateUtils(this._devUtilsContract);
-        this._quoteRequestor = new QuoteRequestor(options.rfqt ? options.rfqt.makerEndpoints || [] : []);
+        this._quoteRequestor = new QuoteRequestor(
+            options.rfqt ? options.rfqt.makerEndpoints || [] : [],
+            options.rfqt ? options.rfqt.warningLogger || undefined : undefined,
+        );
         const sampler = new DexOrderSampler(
             new IERC20BridgeSamplerContract(this._contractAddresses.erc20BridgeSampler, this.provider, {
                 gas: samplerGasLimit,

--- a/packages/asset-swapper/src/types.ts
+++ b/packages/asset-swapper/src/types.ts
@@ -225,6 +225,7 @@ export interface SwapQuoterOpts extends OrderPrunerOpts {
     rfqt?: {
         takerApiKeyWhitelist: string[];
         makerEndpoints: string[];
+        warningLogger?: (s: string) => void;
     };
 }
 

--- a/packages/asset-swapper/src/utils/quote_requestor.ts
+++ b/packages/asset-swapper/src/utils/quote_requestor.ts
@@ -85,7 +85,7 @@ export class QuoteRequestor {
     private readonly _schemaValidator: SchemaValidator = new SchemaValidator();
     private readonly _warningLogger: (s: string) => void;
 
-    constructor(rfqtMakerEndpoints: string[], logger: (s: string) => void = logUtils.warn.bind(logUtils)) {
+    constructor(rfqtMakerEndpoints: string[], logger: (s: string) => void = s => logUtils.warn(s)) {
         this._rfqtMakerEndpoints = rfqtMakerEndpoints;
         this._warningLogger = logger;
     }

--- a/packages/asset-swapper/src/utils/quote_requestor.ts
+++ b/packages/asset-swapper/src/utils/quote_requestor.ts
@@ -83,9 +83,12 @@ function hasExpectedAssetData(
 export class QuoteRequestor {
     private readonly _rfqtMakerEndpoints: string[];
     private readonly _schemaValidator: SchemaValidator = new SchemaValidator();
+    private readonly _warningLogger: (s: string) => void;
 
-    constructor(rfqtMakerEndpoints: string[]) {
+    constructor(rfqtMakerEndpoints: string[], logger: (s: string) => void = logUtils.warn.bind(logUtils)) {
         this._rfqtMakerEndpoints = rfqtMakerEndpoints;
+        this._warningLogger = logger;
+        this._warningLogger('inside QuoteRequestor constructor');
     }
 
     public async requestRfqtFirmQuotesAsync(
@@ -95,6 +98,7 @@ export class QuoteRequestor {
         marketOperation: MarketOperation,
         options?: Partial<RfqtRequestOpts>,
     ): Promise<SignedOrder[]> {
+        this._warningLogger('inside firm quotes');
         const _opts = _.merge({}, constants.DEFAULT_RFQT_REQUEST_OPTS, options);
         assertTakerAddressOrThrow(_opts.takerAddress);
 
@@ -112,12 +116,13 @@ export class QuoteRequestor {
                         timeout: _opts.makerEndpointMaxResponseTimeMs,
                     });
                 } catch (err) {
-                    logUtils.warn(
+                    logUtils.log(`failing`);
+                    this._warningLogger(
                         `Failed to get RFQ-T firm quote from market maker endpoint ${rfqtMakerEndpoint} for API key ${
                             _opts.apiKey
                         } for taker address ${_opts.takerAddress}`,
                     );
-                    logUtils.warn(err);
+                    this._warningLogger(err);
                     return undefined;
                 }
             }),
@@ -132,7 +137,7 @@ export class QuoteRequestor {
         const validatedOrdersWithStringInts = ordersWithStringInts.filter(order => {
             const hasValidSchema = this._schemaValidator.isValid(order, schemas.signedOrderSchema);
             if (!hasValidSchema) {
-                logUtils.warn(`Invalid RFQ-t order received, filtering out: ${JSON.stringify(order)}`);
+                this._warningLogger(`Invalid RFQ-t order received, filtering out: ${JSON.stringify(order)}`);
                 return false;
             }
 
@@ -144,7 +149,7 @@ export class QuoteRequestor {
                     order.takerAssetData.toLowerCase(),
                 )
             ) {
-                logUtils.warn(`Unexpected asset data in RFQ-T order, filtering out: ${JSON.stringify(order)}`);
+                this._warningLogger(`Unexpected asset data in RFQ-T order, filtering out: ${JSON.stringify(order)}`);
                 return false;
             }
 
@@ -190,12 +195,12 @@ export class QuoteRequestor {
                         timeout: options.makerEndpointMaxResponseTimeMs,
                     });
                 } catch (err) {
-                    logUtils.warn(
+                    this._warningLogger(
                         `Failed to get RFQ-T indicative quote from market maker endpoint ${rfqtMakerEndpoint} for API key ${
                             options.apiKey
                         } for taker address ${options.takerAddress}`,
                     );
-                    logUtils.warn(err);
+                    this._warningLogger(err);
                     return undefined;
                 }
             }),
@@ -209,13 +214,15 @@ export class QuoteRequestor {
 
         const validResponsesWithStringInts = responsesWithStringInts.filter(response => {
             if (!this._isValidRfqtIndicativeQuoteResponse(response)) {
-                logUtils.warn(`Invalid RFQ-T indicative quote received, filtering out: ${JSON.stringify(response)}`);
+                this._warningLogger(
+                    `Invalid RFQ-T indicative quote received, filtering out: ${JSON.stringify(response)}`,
+                );
                 return false;
             }
             if (
                 !hasExpectedAssetData(makerAssetData, takerAssetData, response.makerAssetData, response.takerAssetData)
             ) {
-                logUtils.warn(
+                this._warningLogger(
                     `Unexpected asset data in RFQ-T indicative quote, filtering out: ${JSON.stringify(response)}`,
                 );
                 return false;

--- a/packages/asset-swapper/src/utils/quote_requestor.ts
+++ b/packages/asset-swapper/src/utils/quote_requestor.ts
@@ -88,7 +88,6 @@ export class QuoteRequestor {
     constructor(rfqtMakerEndpoints: string[], logger: (s: string) => void = logUtils.warn.bind(logUtils)) {
         this._rfqtMakerEndpoints = rfqtMakerEndpoints;
         this._warningLogger = logger;
-        this._warningLogger('inside QuoteRequestor constructor');
     }
 
     public async requestRfqtFirmQuotesAsync(
@@ -98,7 +97,6 @@ export class QuoteRequestor {
         marketOperation: MarketOperation,
         options?: Partial<RfqtRequestOpts>,
     ): Promise<SignedOrder[]> {
-        this._warningLogger('inside firm quotes');
         const _opts = _.merge({}, constants.DEFAULT_RFQT_REQUEST_OPTS, options);
         assertTakerAddressOrThrow(_opts.takerAddress);
 
@@ -116,7 +114,6 @@ export class QuoteRequestor {
                         timeout: _opts.makerEndpointMaxResponseTimeMs,
                     });
                 } catch (err) {
-                    logUtils.log(`failing`);
                     this._warningLogger(
                         `Failed to get RFQ-T firm quote from market maker endpoint ${rfqtMakerEndpoint} for API key ${
                             _opts.apiKey


### PR DESCRIPTION
For use in integrations that have specific log formats to adhere to.