### PR TITLE
[asset-swapper] clip native fill data

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -61,6 +61,10 @@
             {
                 "note": "Fix sporadically failing quote simulation tests",
                 "pr": 2564
+            },
+            {
+                "note": "Apply Native order penalty inline with the target amount",
+                "pr": 2565
             }
         ]
     },

--- a/packages/asset-swapper/src/utils/market_operation_utils/fills.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/fills.ts
@@ -74,7 +74,7 @@ function nativeOrdersToPath(
         const penalty = ethToOutputRate.times(fees[ERC20BridgeSource.Native] || 0);
         const rate = makerAmount.div(takerAmount);
         // targetInput can be less than the order size
-        // whilst the penalty is constant, it effects the adjusted output
+        // whilst the penalty is constant, it affects the adjusted output
         // only up until the target has been exhausted.
         // A large order and an order at the exact target should be penalized
         // the same.

--- a/packages/asset-swapper/src/utils/market_operation_utils/fills.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/fills.ts
@@ -35,7 +35,7 @@ export function createFillPaths(opts: {
     const dexQuotes = opts.dexQuotes || [];
     const ethToOutputRate = opts.ethToOutputRate || ZERO_AMOUNT;
     // Create native fill paths.
-    const nativePath = nativeOrdersToPath(side, orders, ethToOutputRate, feeSchedule);
+    const nativePath = nativeOrdersToPath(side, orders, opts.targetInput, ethToOutputRate, feeSchedule);
     // Create DEX fill paths.
     const dexPaths = dexQuotesToPaths(side, dexQuotes, ethToOutputRate, feeSchedule);
     return filterPaths([...dexPaths, nativePath].map(p => clipPathToInput(p, opts.targetInput)), excludedSources);
@@ -60,6 +60,7 @@ function filterPaths(paths: Fill[][], excludedSources: ERC20BridgeSource[]): Fil
 function nativeOrdersToPath(
     side: MarketOperation,
     orders: SignedOrderWithFillableAmounts[],
+    targetInput: BigNumber = POSITIVE_INF,
     ethToOutputRate: BigNumber,
     fees: { [source: string]: BigNumber },
 ): Fill[] {
@@ -71,19 +72,26 @@ function nativeOrdersToPath(
         const input = side === MarketOperation.Sell ? takerAmount : makerAmount;
         const output = side === MarketOperation.Sell ? makerAmount : takerAmount;
         const penalty = ethToOutputRate.times(fees[ERC20BridgeSource.Native] || 0);
-        const adjustedOutput = side === MarketOperation.Sell ? output.minus(penalty) : output.plus(penalty);
         const rate = makerAmount.div(takerAmount);
+        // targetInput can be less than the order size
+        // whilst the penalty is constant, it effects the adjusted output
+        // only up until the target has been exhausted.
+        // A large order and an order at the exact target should be penalized
+        // the same.
+        const clippedInput = BigNumber.min(targetInput, input);
+        // scale the clipped output inline with the input
+        const clippedOutput = clippedInput.dividedBy(input).times(output);
+        const adjustedOutput =
+            side === MarketOperation.Sell ? clippedOutput.minus(penalty) : clippedOutput.plus(penalty);
         const adjustedRate =
-            side === MarketOperation.Sell
-                ? makerAmount.minus(penalty).div(takerAmount)
-                : makerAmount.div(takerAmount.plus(penalty));
+            side === MarketOperation.Sell ? adjustedOutput.div(clippedInput) : clippedInput.div(adjustedOutput);
         // Skip orders with rates that are <= 0.
         if (adjustedRate.lte(0)) {
             continue;
         }
         path.push({
-            input,
-            output,
+            input: clippedInput,
+            output: clippedOutput,
             rate,
             adjustedRate,
             adjustedOutput,
@@ -117,7 +125,7 @@ function dexQuotesToPaths(
             const sample = quote[i];
             const prevSample = i === 0 ? undefined : quote[i - 1];
             const source = sample.source;
-            // Stop of the sample has zero output, which can occur if the source
+            // Stop if the sample has zero output, which can occur if the source
             // cannot fill the full amount.
             // TODO(dorothy-zbornak): Sometimes Kyber will dip to zero then pick back up.
             if (sample.output.eq(0)) {

--- a/packages/asset-swapper/src/utils/market_operation_utils/path_optimizer.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/path_optimizer.ts
@@ -92,11 +92,12 @@ function isPathComplete(path: Fill[], targetInput: BigNumber): boolean {
 }
 
 function clipFillAdjustedOutput(fill: Fill, remainingInput: BigNumber): BigNumber {
+    const penalty = fill.adjustedOutput.minus(fill.output);
+    const output = remainingInput.times(fill.rate).plus(penalty);
     if (fill.input.lte(remainingInput)) {
         return fill.adjustedOutput;
     }
-    const penalty = fill.adjustedOutput.minus(fill.output);
-    return fill.output.times(remainingInput.div(fill.input)).plus(penalty);
+    return output;
 }
 
 function getRate(side: MarketOperation, input: BigNumber, output: BigNumber): BigNumber {

--- a/packages/asset-swapper/src/utils/market_operation_utils/path_optimizer.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/path_optimizer.ts
@@ -92,12 +92,11 @@ function isPathComplete(path: Fill[], targetInput: BigNumber): boolean {
 }
 
 function clipFillAdjustedOutput(fill: Fill, remainingInput: BigNumber): BigNumber {
-    const penalty = fill.adjustedOutput.minus(fill.output);
-    const output = remainingInput.times(fill.rate).plus(penalty);
     if (fill.input.lte(remainingInput)) {
         return fill.adjustedOutput;
     }
-    return output;
+    const penalty = fill.adjustedOutput.minus(fill.output);
+    return remainingInput.times(fill.rate).plus(penalty);
 }
 
 function getRate(side: MarketOperation, input: BigNumber, output: BigNumber): BigNumber {


### PR DESCRIPTION
## Description

There is a scenario where perfectly sized Native orders were penalized more aggressively than they should have been. 

The previous behaviour was as follows:
```
penaltyMakerUnits = 10
input = 2000

SMALL_ORDER
makerAmount = 100
takerAmount = 200

adjustedOutput = 90
adjustedRate = 0.45


BIG_ORDER
makerAmount = 1000
takerAmount = 2000

adjustedOutput = 990
adjustedRate = 0.495
```

In the scenario where the user wishes to sell `2000` the `SMALL_ORDER` should be penalized over `BIG_ORDER` and `BIG_ORDER` should be favoured. 

In the scenario where the user wishes to sell `200` both `SMALL_ORDER` and `BIG_ORDER` are sufficient and either is acceptable to fill.

```
penaltyMakerUnits = 10
input = 200

SMALL_ORDER
makerAmount = 100
takerAmount = 200

adjustedOutput = (min(takerAmount, input) / takerAmount) * makerAmount - penaltyMakerUnits = 90
adjustedRate = 0.45


BIG_ORDER
makerAmount = 1000
takerAmount = 2000

adjustedOutput = (min(takerAmount, input) / takerAmount) * makerAmount - penaltyMakerUnits = 90
adjustedRate = 0.45
```

We effectively bring large orders in line with small orders when they completely cover the requested amount. 


### Issue
The following behaviour caused perfectly sized orders to disappear:
1. Perfectly sized orders were penalized more harshly than large orders
2. Native orders are sorted by `adjustedRate`, then a subset of native orders are chosen (enough to fill the requested amount).
3. Since better `rate` orders were dropped in 2), they would no longer be present when finding a path.
