### PR TITLE
fix: contract-addresses ERC20BridgeSampler

### DIFF
--- a/packages/contract-addresses/CHANGELOG.json
+++ b/packages/contract-addresses/CHANGELOG.json
@@ -41,6 +41,14 @@
             {
                 "note": "Updated Ganache's ERC20BridgeSampler address",
                 "pr": 2541
+            },
+            {
+                "note": "Updated Mainnet ERC20BridgeSampler address",
+                "pr": 2551
+            },
+            {
+                "note": "Updated Kovan ERC20BridgeSampler address",
+                "pr": 2568
             }
         ]
     },

--- a/packages/contract-addresses/addresses.json
+++ b/packages/contract-addresses/addresses.json
@@ -120,7 +120,7 @@
         "erc20BridgeProxy": "0xfb2dd2a1366de37f7241c83d47da58fd503e2c64",
         "uniswapBridge": "0x0e85f89f29998df65402391478e5924700c0079d",
         "eth2DaiBridge": "0x2d47147429b474d2e4f83e658015858a1312ed5b",
-        "erc20BridgeSampler": "0x1fdfcf612026c8deed586353430821bee6330dc8",
+        "erc20BridgeSampler": "0x576e64b24a6b7bfd651e5e63fc0dc431dd3ef518",
         "kyberBridge": "0xaecfa25920f892b6eb496e1f6e84037f59da7f44",
         "chaiBridge": "0x0000000000000000000000000000000000000000",
         "dydxBridge": "0x3be8e59038d8c4e8d8776ca40ef2f024bad95ad1",


### PR DESCRIPTION
## Description

Previous ERC20BridgeSampler on Kovan had mainnet addresses for on-chain sources