### PR TITLE
ZeroEx: IOwnable(V06) compatibility

### DIFF
--- a/contracts/utils/contracts/src/v06/interfaces/IOwnableV06.sol
+++ b/contracts/utils/contracts/src/v06/interfaces/IOwnableV06.sol
@@ -30,7 +30,7 @@ interface IOwnableV06 {
     /// @param newOwner The address that will become the owner.
     function transferOwnership(address newOwner) external;
 
-    /// @dev Get the owner of this contract.
-    /// @return owner_ The owner of this contract.
-    function getOwner() external view returns (address owner_);
+    /// @dev The owner of this contract.
+    /// @return ownerAddress The owner address.
+    function owner() external view returns (address ownerAddress);
 }

--- a/contracts/zero-ex/contracts/src/features/Ownable.sol
+++ b/contracts/zero-ex/contracts/src/features/Ownable.sol
@@ -63,7 +63,7 @@ contract Ownable is
 
         // Register feature functions.
         ISimpleFunctionRegistry(address(this)).extend(this.transferOwnership.selector, _implementation);
-        ISimpleFunctionRegistry(address(this)).extend(this.getOwner.selector, _implementation);
+        ISimpleFunctionRegistry(address(this)).extend(this.owner.selector, _implementation);
         ISimpleFunctionRegistry(address(this)).extend(this.migrate.selector, _implementation);
         return LibBootstrap.BOOTSTRAP_SUCCESS;
     }
@@ -119,7 +119,7 @@ contract Ownable is
 
     /// @dev Get the owner of this contract.
     /// @return owner_ The owner of this contract.
-    function getOwner() external override view returns (address owner_) {
+    function owner() external override view returns (address owner_) {
         return LibOwnableStorage.getStorage().owner;
     }
 }

--- a/contracts/zero-ex/contracts/test/TestMigrator.sol
+++ b/contracts/zero-ex/contracts/test/TestMigrator.sol
@@ -32,7 +32,7 @@ contract TestMigrator {
     function succeedingMigrate() external returns (bytes4 success) {
         emit TestMigrateCalled(
             msg.data,
-            IOwnable(address(this)).getOwner()
+            IOwnable(address(this)).owner()
         );
         return LibMigrate.MIGRATE_SUCCESS;
     }
@@ -40,7 +40,7 @@ contract TestMigrator {
     function failingMigrate() external returns (bytes4 success) {
         emit TestMigrateCalled(
             msg.data,
-            IOwnable(address(this)).getOwner()
+            IOwnable(address(this)).owner()
         );
         return 0xdeadbeef;
     }

--- a/contracts/zero-ex/test/features/ownable_test.ts
+++ b/contracts/zero-ex/test/features/ownable_test.ts
@@ -51,7 +51,7 @@ blockchainTests.resets('Ownable feature', env => {
                 ],
                 IOwnableEvents.OwnershipTransferred,
             );
-            expect(await ownable.getOwner().callAsync()).to.eq(newOwner);
+            expect(await ownable.owner().callAsync()).to.eq(newOwner);
         });
     });
 
@@ -80,7 +80,7 @@ blockchainTests.resets('Ownable feature', env => {
                 ],
                 TestMigratorEvents.TestMigrateCalled,
             );
-            expect(await ownable.getOwner().callAsync()).to.eq(newOwner);
+            expect(await ownable.owner().callAsync()).to.eq(newOwner);
         });
 
         it('failing migration reverts', async () => {

--- a/contracts/zero-ex/test/initial_migration_test.ts
+++ b/contracts/zero-ex/test/initial_migration_test.ts
@@ -45,7 +45,7 @@ blockchainTests.resets('Initial migration', env => {
         });
 
         it('has the correct owner', async () => {
-            const actualOwner = await ownable.getOwner().callAsync();
+            const actualOwner = await ownable.owner().callAsync();
             expect(actualOwner).to.eq(owner);
         });
     });


### PR DESCRIPTION
## Description

Reverts `IOwnableV06` to use `owner()` instead of `getOwner()`, so it's compatible with the old (pre-0.6) `IOwnable` interface.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
