### PR TITLE
Python: adapt to latest version of pylint

### DIFF
--- a/python-packages/middlewares/setup.py
+++ b/python-packages/middlewares/setup.py
@@ -82,7 +82,7 @@ class TestPublishCommand(distutils.command.build_py.build_py):
     """Custom command to publish to test.pypi.org."""
 
     description = (
-        "Publish dist/* to test.pypi.org." "Run sdist & bdist_wheel first."
+        "Publish dist/* to test.pypi.org. Run sdist & bdist_wheel first."
     )
 
     def run(self):

--- a/python-packages/order_utils/src/zero_ex/order_utils/asset_data_utils.py
+++ b/python-packages/order_utils/src/zero_ex/order_utils/asset_data_utils.py
@@ -170,7 +170,7 @@ def decode_erc721_asset_data(asset_data: str) -> ERC721AssetData:
     ):
         raise ValueError(
             "Could not decode ERC721 Asset Data. Expected Asset Proxy Id to be"
-            + f" ERC721 ("
+            + " ERC721 ("
             + f"{abi_utils.method_id('ERC721Token', ['address', 'uint256'])}"
             + f"), but got {asset_proxy_id}"
         )


### PR DESCRIPTION
The `development` branch is failing, due to a recent update to `pylint` that is apparently checking some things more stringently.  This PR changes a few tiny code spots in order to conform to the new checks.