### PR TITLE
ZeroEx: InitialMigration Race Condition/Self-destruct

### DIFF
--- a/contracts/zero-ex/contracts/test/TestInitialMigration.sol
+++ b/contracts/zero-ex/contracts/test/TestInitialMigration.sol
@@ -28,6 +28,10 @@ contract TestInitialMigration is
     InitialMigration
 {
     address public bootstrapFeature;
+    address public dieRecipient;
+
+    // solhint-disable-next-line no-empty-blocks
+    constructor(address deployer) public InitialMigration(deployer) {}
 
     function callBootstrap(ZeroEx zeroEx) external {
         IBootstrap(address(zeroEx)).bootstrap(address(this), new bytes(0));
@@ -42,5 +46,9 @@ contract TestInitialMigration is
         // Snoop the bootstrap feature contract.
         bootstrapFeature = ZeroEx(address(uint160(address(this))))
             .getFunctionImplementation(IBootstrap.bootstrap.selector);
+    }
+
+    function die(address payable ethRecipient) public override {
+        dieRecipient = ethRecipient;
     }
 }

--- a/contracts/zero-ex/test/utils/migration.ts
+++ b/contracts/zero-ex/test/utils/migration.ts
@@ -15,6 +15,7 @@ export async function initialMigrateAsync(
         provider,
         txDefaults,
         artifacts,
+        txDefaults.from as string,
     );
     const deployCall = migrator.deploy(owner);
     const zeroEx = new ZeroExContract(await deployCall.callAsync(), provider, {});

--- a/packages/contract-wrappers-test/package.json
+++ b/packages/contract-wrappers-test/package.json
@@ -15,7 +15,7 @@
         "fix": "tslint --fix --format stylish --project .--exclude **/lib/**/*",
         "test:circleci": "run-s test:coverage",
         "test": "yarn run_mocha",
-        "run_mocha": "mocha --require source-map-support/register --require make-promises-safe lib/test/**/*_test.js lib/test/global_hooks.js --timeout 10000 --bail --exit",
+        "run_mocha": "mocha --require source-map-support/register --require make-promises-safe lib/test/**/*_test.js lib/test/global_hooks.js --timeout 20000 --bail --exit",
         "test:coverage": "nyc npm run test --all && yarn coverage:report:lcov",
         "coverage:report:lcov": "nyc report --reporter=text-lcov > coverage/lcov.info",
         "prettier": "prettier --write **/* --config ../../.prettierrc",


### PR DESCRIPTION
## Description

The `InitialMigration` contract had a race condition where anyone could call `deploy()` first and prevent the governor from calling it. Not a vuln, just a nuisance.

Now the caller to `deploy()` is set in the constructor of `InitialMigration` AND the contract self-destructs before returning. The old comments actually stated this latter behavior but the code never actually did it.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
