### PR TITLE
Don't allow new 1155 token creation with a type that already exists

### DIFF
--- a/contracts/erc1155/contracts/src/ERC1155Mintable.sol
+++ b/contracts/erc1155/contracts/src/ERC1155Mintable.sol
@@ -66,6 +66,8 @@ contract ERC1155Mintable is
             type_ = type_ | TYPE_NF_BIT;
         }
 
+        require(creators[type_] == address(0x0), "TOKEN_ALREADY_EXISTS");
+
         // This will allow restricted access to creators.
         creators[type_] = msg.sender;
 
@@ -92,6 +94,8 @@ contract ERC1155Mintable is
     )
         external
     {
+        require(creators[type_] == address(0x0), "TOKEN_ALREADY_EXISTS");
+
         // This will allow restricted access to creators.
         creators[type_] = msg.sender;
 

--- a/contracts/erc1155/src/erc1155_wrapper.ts
+++ b/contracts/erc1155/src/erc1155_wrapper.ts
@@ -66,6 +66,16 @@ export class Erc1155Wrapper {
         await this.mintKnownFungibleTokensAsync(tokenId, beneficiaries, tokenAmounts);
         return tokenId;
     }
+    public async mintFungibleTokensFromUnauthorizedAccountWithTypeAsync(
+        tokenId: BigNumber,
+        unauthorizedAccount: string,
+    ): Promise<BigNumber> {
+        const tokenUri = 'dummyFungibleToken';
+        await this._erc1155Contract.createWithType(tokenId, tokenUri).awaitTransactionSuccessAsync({
+            from: unauthorizedAccount,
+        });
+        return tokenId;
+    }
     public async mintKnownFungibleTokensAsync(
         tokenId: BigNumber,
         beneficiaries: string[],

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -331,6 +331,7 @@ export enum RevertReason {
     TokenAndValuesLengthMismatch = 'TOKEN_AND_VALUES_LENGTH_MISMATCH',
     TriedToMintFungibleForNonFungibleToken = 'TRIED_TO_MINT_FUNGIBLE_FOR_NON_FUNGIBLE_TOKEN',
     TriedToMintNonFungibleForFungibleToken = 'TRIED_TO_MINT_NON_FUNGIBLE_FOR_FUNGIBLE_TOKEN',
+    TokenAlreadyExists = 'TOKEN_ALREADY_EXISTS',
     TransferRejected = 'TRANSFER_REJECTED',
     Uint256Underflow = 'UINT256_UNDERFLOW',
     InvalidIdsOffset = 'INVALID_IDS_OFFSET',


### PR DESCRIPTION
## Description

Currently anyone can become the creator of a token type by simply calling createWithType and passing an existing token type.

## Testing instructions

Added a test for createWithType that reverts properly. To see the old bug, modify the test so that `mintFungibleTokensFromUnauthorizedAccountWithTypeAsync` is expected to pass and then see how the safeTransferFrom fails since the new account is now the creator.

## Types of changes

* Bug fix (non-breaking change which fixes an issue)
## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Prefix PR title with `[WIP]` if necessary.
-   [x] Add tests to cover changes as needed.
-   [x] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
