### PR TITLE
ZeroEx: Always offset storage bucket ID by 1.

### DIFF
--- a/contracts/zero-ex/contracts/src/storage/LibOwnableStorage.sol
+++ b/contracts/zero-ex/contracts/src/storage/LibOwnableStorage.sol
@@ -33,9 +33,9 @@ library LibOwnableStorage {
 
     /// @dev Get the storage bucket for this contract.
     function getStorage() internal pure returns (Storage storage stor) {
-        uint256 storageOffset = LibStorage.getStorageOffset(
+        uint256 storageSlot = LibStorage.getStorageSlot(
             LibStorage.StorageId.Ownable
         );
-        assembly { stor_slot := storageOffset }
+        assembly { stor_slot := storageSlot }
     }
 }

--- a/contracts/zero-ex/contracts/src/storage/LibProxyStorage.sol
+++ b/contracts/zero-ex/contracts/src/storage/LibProxyStorage.sol
@@ -33,9 +33,9 @@ library LibProxyStorage {
 
     /// @dev Get the storage bucket for this contract.
     function getStorage() internal pure returns (Storage storage stor) {
-        uint256 storageOffset = LibStorage.getStorageOffset(
+        uint256 storageSlot = LibStorage.getStorageSlot(
             LibStorage.StorageId.Proxy
         );
-        assembly { stor_slot := storageOffset }
+        assembly { stor_slot := storageSlot }
     }
 }

--- a/contracts/zero-ex/contracts/src/storage/LibSimpleFunctionRegistryStorage.sol
+++ b/contracts/zero-ex/contracts/src/storage/LibSimpleFunctionRegistryStorage.sol
@@ -33,9 +33,9 @@ library LibSimpleFunctionRegistryStorage {
 
     /// @dev Get the storage bucket for this contract.
     function getStorage() internal pure returns (Storage storage stor) {
-        uint256 storageOffset = LibStorage.getStorageOffset(
+        uint256 storageSlot = LibStorage.getStorageSlot(
             LibStorage.StorageId.SimpleFunctionRegistry
         );
-        assembly { stor_slot := storageOffset }
+        assembly { stor_slot := storageSlot }
     }
 }

--- a/contracts/zero-ex/contracts/src/storage/LibStorage.sol
+++ b/contracts/zero-ex/contracts/src/storage/LibStorage.sol
@@ -23,29 +23,29 @@ pragma experimental ABIEncoderV2;
 /// @dev Common storage helpers
 library LibStorage {
 
-    /// @dev What to multiply a storage ID by to get its offset.
-    ///      This is also the maximum number of fields inside a storage
-    ///      bucket.
-    uint256 internal constant STORAGE_OFFSET_MULTIPLIER = 1e18;
+    /// @dev What to bit-shift a storage ID by to get its slot.
+    ///      This gives us a maximum of 2**128 inline fields in each bucket.
+    uint256 private constant STORAGE_SLOT_EXP = 128;
 
     /// @dev Storage IDs for feature storage buckets.
     enum StorageId {
-        Unused, // Unused buffer for state accidents.
         Proxy,
         SimpleFunctionRegistry,
         Ownable
     }
 
-    /// @dev Get the storage offset given a storage ID.
+    /// @dev Get the storage slot given a storage ID. We assign unique, well-spaced
+    ///     slots to storage bucket variables to ensure they do not overlap.
+    ///     See: https://solidity.readthedocs.io/en/v0.6.6/assembly.html#access-to-external-variables-functions-and-libraries
     /// @param storageId An entry in `StorageId`
-    /// @return offset The storage offset.
-    function getStorageOffset(StorageId storageId)
+    /// @return slot The storage slot.
+    function getStorageSlot(StorageId storageId)
         internal
         pure
-        returns (uint256 offset)
+        returns (uint256 slot)
     {
-        // This should never overflow with a reasonable `STORAGE_OFFSET_MULTIPLIER`
+        // This should never overflow with a reasonable `STORAGE_SLOT_EXP`
         // because Solidity will do a range check on `storageId` during the cast.
-        return uint256(storageId) * STORAGE_OFFSET_MULTIPLIER;
+        return (uint256(storageId) + 1) << STORAGE_SLOT_EXP;
     }
 }


### PR DESCRIPTION
## Description
Some small changes based on early audit feedback.

- Remove `Unused` enum value from `StorageId`.
- Always add `1` to the (uint256 cast) storage ID, so no more need for ^.
- Bit-shift by `128` instead of multiplying by `10**18` to save gas and space buckets out even more.
- Link to solidity docs in comments.
- Rename "offset" verbiage to "slot," since this is more accurate.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
