### PR TITLE
asset-s/QuoteRequestor: fix statusCode logging

### DIFF
--- a/packages/asset-swapper/src/utils/quote_requestor.ts
+++ b/packages/asset-swapper/src/utils/quote_requestor.ts
@@ -324,7 +324,7 @@ export class QuoteRequestor {
                             rfqtMakerInteraction: {
                                 ...partialLogEntry,
                                 response: {
-                                    statusCode: err.code,
+                                    statusCode: err.response.status,
                                     latencyMs: Date.now() - timeBeforeAwait,
                                 },
                             },


### PR DESCRIPTION
An example of a test's output before this change:

`{"rfqtMakerInteraction":{"url":"https://37.0.0.1","quoteType":"firm","requestParams":{"takerAddress":"0xd209925defc99488e3afff1174e48b4fa628302a","buyToken":"0x34d402f14d58e001d8efbe6585051bf9706aa064","sellToken":"0x25b8fe1de9daf8ba351890744ff28cf7dfa8f5e3","sellAmount":"10000"},"response":{"latencyMs":27}}}`

And that same test's output after this change:

`{"rfqtMakerInteraction":{"url":"https://37.0.0.1","quoteType":"firm","requestParams":{"takerAddress":"0xd209925defc99488e3afff1174e48b4fa628302a","buyToken":"0x34d402f14d58e001d8efbe6585051bf9706aa064","sellToken":"0x25b8fe1de9daf8ba351890744ff28cf7dfa8f5e3","sellAmount":"10000"},"response":{"statusCode":404,"latencyMs":4}}}`