### PR TITLE
Exchange Proxy: Address audit feedback (2)

### DIFF
--- a/contracts/asset-proxy/CHANGELOG.json
+++ b/contracts/asset-proxy/CHANGELOG.json
@@ -102,7 +102,7 @@
             },
             {
                 "note": "Add `setOperators()` to `IDydx`",
-                "pr": "TODO"
+                "pr": 2462
             }
         ],
         "timestamp": 1581204851

--- a/contracts/erc20/CHANGELOG.json
+++ b/contracts/erc20/CHANGELOG.json
@@ -9,6 +9,10 @@
             {
                 "note": "Add solidity 0.6 contracts",
                 "pr": 2545
+            },
+            {
+                "note": "Update `LibERC20TokenV06` comments.",
+                "pr": "TODO"
             }
         ]
     },

--- a/contracts/erc20/CHANGELOG.json
+++ b/contracts/erc20/CHANGELOG.json
@@ -12,7 +12,7 @@
             },
             {
                 "note": "Update `LibERC20TokenV06` comments.",
-                "pr": "TODO"
+                "pr": 2597
             }
         ]
     },

--- a/contracts/erc20/contracts/src/v06/LibERC20TokenV06.sol
+++ b/contracts/erc20/contracts/src/v06/LibERC20TokenV06.sol
@@ -27,8 +27,7 @@ library LibERC20TokenV06 {
     bytes constant private DECIMALS_CALL_DATA = hex"313ce567";
 
     /// @dev Calls `IERC20TokenV06(token).approve()`.
-    ///      Reverts if `false` is returned or if the return
-    ///      data length is nonzero and not 32 bytes.
+    ///      Reverts if the result fails `isSuccessfulResult()` or the call reverts.
     /// @param token The address of the token contract.
     /// @param spender The address that receives an allowance.
     /// @param allowance The allowance to set.
@@ -49,8 +48,7 @@ library LibERC20TokenV06 {
 
     /// @dev Calls `IERC20TokenV06(token).approve()` and sets the allowance to the
     ///      maximum if the current approval is not already >= an amount.
-    ///      Reverts if `false` is returned or if the return
-    ///      data length is nonzero and not 32 bytes.
+    ///      Reverts if the result fails `isSuccessfulResult()` or the call reverts.
     /// @param token The address of the token contract.
     /// @param spender The address that receives an allowance.
     /// @param amount The minimum allowance needed.
@@ -67,8 +65,7 @@ library LibERC20TokenV06 {
     }
 
     /// @dev Calls `IERC20TokenV06(token).transfer()`.
-    ///      Reverts if `false` is returned or if the return
-    ///      data length is nonzero and not 32 bytes.
+    ///      Reverts if the result fails `isSuccessfulResult()` or the call reverts.
     /// @param token The address of the token contract.
     /// @param to The address that receives the tokens
     /// @param amount Number of tokens to transfer.
@@ -88,8 +85,7 @@ library LibERC20TokenV06 {
     }
 
     /// @dev Calls `IERC20TokenV06(token).transferFrom()`.
-    ///      Reverts if `false` is returned or if the return
-    ///      data length is nonzero and not 32 bytes.
+    ///      Reverts if the result fails `isSuccessfulResult()` or the call reverts.
     /// @param token The address of the token contract.
     /// @param from The owner of the tokens.
     /// @param to The address that receives the tokens

--- a/contracts/utils/CHANGELOG.json
+++ b/contracts/utils/CHANGELOG.json
@@ -21,6 +21,10 @@
             {
                 "note": "Add UniswapV2 addresses to `DeploymentConstants`",
                 "pr": 2595
+            },
+            {
+                "note": "Update V06 contracts to get around 0.6.9 docstring errors",
+                "pr": "TODO"
             }
         ]
     },

--- a/contracts/utils/CHANGELOG.json
+++ b/contracts/utils/CHANGELOG.json
@@ -24,7 +24,7 @@
             },
             {
                 "note": "Update V06 contracts to get around 0.6.9 docstring errors",
-                "pr": "TODO"
+                "pr": 2597
             }
         ]
     },

--- a/contracts/zero-ex/contracts/src/errors/LibTransformERC20RichErrors.sol
+++ b/contracts/zero-ex/contracts/src/errors/LibTransformERC20RichErrors.sol
@@ -70,31 +70,20 @@ library LibTransformERC20RichErrors {
         );
     }
 
-    function UnauthorizedTransformerError(
+    function TransformerFailedError(
         address transformer,
-        bytes memory rlpNonce
+        bytes memory transformerData,
+        bytes memory resultData
     )
         internal
         pure
         returns (bytes memory)
     {
         return abi.encodeWithSelector(
-            bytes4(keccak256("UnauthorizedTransformerError(address,bytes)")),
+            bytes4(keccak256("TransformerFailedError(address,bytes,bytes)")),
             transformer,
-            rlpNonce
-        );
-    }
-
-    function InvalidRLPNonceError(
-        bytes memory rlpNonce
-    )
-        internal
-        pure
-        returns (bytes memory)
-    {
-        return abi.encodeWithSelector(
-            bytes4(keccak256("InvalidRLPNonceError(bytes)")),
-            rlpNonce
+            transformerData,
+            resultData
         );
     }
 

--- a/contracts/zero-ex/contracts/src/external/AllowanceTarget.sol
+++ b/contracts/zero-ex/contracts/src/external/AllowanceTarget.sol
@@ -42,7 +42,6 @@ contract AllowanceTarget is
         bytes calldata callData
     )
         external
-        payable
         override
         onlyAuthorized
         returns (bytes memory resultData)

--- a/contracts/zero-ex/contracts/src/external/IAllowanceTarget.sol
+++ b/contracts/zero-ex/contracts/src/external/IAllowanceTarget.sol
@@ -35,6 +35,5 @@ interface IAllowanceTarget is
         bytes calldata callData
     )
         external
-        payable
         returns (bytes memory resultData);
 }

--- a/contracts/zero-ex/contracts/src/features/ITransformERC20.sol
+++ b/contracts/zero-ex/contracts/src/features/ITransformERC20.sol
@@ -29,9 +29,10 @@ interface ITransformERC20 {
 
     /// @dev Defines a transformation to run in `transformERC20()`.
     struct Transformation {
-        // The transformation handler.
-        // Can receive the entire balance of `tokens`.
-        IERC20Transformer transformer;
+        // The deployment nonce for the transformer.
+        // The address of the transformer contract will be derived from this
+        // value.
+        uint32 deploymentNonce;
         // Arbitrary data to pass to the transformer.
         bytes data;
     }
@@ -51,6 +52,15 @@ interface ITransformERC20 {
         uint256 inputTokenAmount,
         uint256 outputTokenAmount
     );
+
+    /// @dev Raised when `setTransformerDeployer()` is called.
+    /// @param transformerDeployer The new deployer address.
+    event TransformerDeployerUpdated(address transformerDeployer);
+
+    /// @dev Replace the allowed deployer for transformers.
+    ///      Only callable by the owner.
+    function setTransformerDeployer(address transformerDeployer)
+        external;
 
     /// @dev Deploy a new flash wallet instance and replace the current one with it.
     ///      Useful if we somehow break the current wallet instance.

--- a/contracts/zero-ex/contracts/src/features/ITransformERC20.sol
+++ b/contracts/zero-ex/contracts/src/features/ITransformERC20.sol
@@ -59,6 +59,7 @@ interface ITransformERC20 {
 
     /// @dev Replace the allowed deployer for transformers.
     ///      Only callable by the owner.
+    /// @param transformerDeployer The address of the trusted deployer for transformers.
     function setTransformerDeployer(address transformerDeployer)
         external;
 

--- a/contracts/zero-ex/contracts/src/features/TransformERC20.sol
+++ b/contracts/zero-ex/contracts/src/features/TransformERC20.sol
@@ -44,13 +44,19 @@ contract TransformERC20 is
     FixinCommon
 {
 
+    /// @dev Stack vars for `_transformERC20Private()`.
+    struct TransformERC20PrivateState {
+        IFlashWallet wallet;
+        address transformerDeployer;
+        uint256 takerOutputTokenBalanceBefore;
+        uint256 takerOutputTokenBalanceAfter;
+    }
+
     // solhint-disable
     /// @dev Name of this feature.
     string public constant override FEATURE_NAME = "TransformERC20";
     /// @dev Version of this feature.
     uint256 public immutable override FEATURE_VERSION = _encodeVersion(1, 0, 0);
-    /// @dev The trusted deployer for all transformers.
-    address public immutable transformDeployer;
     /// @dev The implementation address of this feature.
     address private immutable _implementation;
     // solhint-enable
@@ -58,14 +64,14 @@ contract TransformERC20 is
     using LibSafeMathV06 for uint256;
     using LibRichErrorsV06 for bytes;
 
-    constructor(address trustedDeployer_) public {
+    constructor() public {
         _implementation = address(this);
-        transformDeployer = trustedDeployer_;
     }
 
     /// @dev Initialize and register this feature.
     ///      Should be delegatecalled by `Migrate.migrate()`.
-    function migrate() external returns (bytes4 success) {
+    /// @param transformerDeployer The trusted deployer for transformers.
+    function migrate(address transformerDeployer) external returns (bytes4 success) {
         ISimpleFunctionRegistry(address(this))
             .extend(this.getTransformerDeployer.selector, _implementation);
         ISimpleFunctionRegistry(address(this))
@@ -73,22 +79,36 @@ contract TransformERC20 is
         ISimpleFunctionRegistry(address(this))
             .extend(this.getTransformWallet.selector, _implementation);
         ISimpleFunctionRegistry(address(this))
+            .extend(this.setTransformerDeployer.selector, _implementation);
+        ISimpleFunctionRegistry(address(this))
             .extend(this.transformERC20.selector, _implementation);
         ISimpleFunctionRegistry(address(this))
             .extend(this._transformERC20.selector, _implementation);
         createTransformWallet();
+        LibTransformERC20Storage.getStorage().transformerDeployer = transformerDeployer;
         return LibMigrate.MIGRATE_SUCCESS;
+    }
+
+    /// @dev Replace the allowed deployer for transformers.
+    ///      Only callable by the owner.
+    function setTransformerDeployer(address transformerDeployer)
+        external
+        override
+        onlyOwner
+    {
+        LibTransformERC20Storage.getStorage().transformerDeployer = transformerDeployer;
+        emit TransformerDeployerUpdated(transformerDeployer);
     }
 
     /// @dev Return the allowed deployer for transformers.
     /// @return deployer The transform deployer address.
     function getTransformerDeployer()
-        external
+        public
         override
         view
         returns (address deployer)
     {
-        return transformDeployer;
+        return LibTransformERC20Storage.getStorage().transformerDeployer;
     }
 
     /// @dev Deploy a new wallet instance and replace the current one with it.
@@ -209,8 +229,7 @@ contract TransformERC20 is
         uint256 minOutputTokenAmount,
         Transformation[] memory transformations
     )
-        public
-        payable
+        private
         returns (uint256 outputTokenAmount)
     {
         // If the input token amount is -1, transform the taker's entire
@@ -220,31 +239,44 @@ contract TransformERC20 is
                 .getSpendableERC20BalanceOf(inputToken, taker);
         }
 
-        IFlashWallet wallet = getTransformWallet();
+        TransformERC20PrivateState memory state;
+        state.wallet = getTransformWallet();
+        state.transformerDeployer = getTransformerDeployer();
 
         // Remember the initial output token balance of the taker.
-        uint256 takerOutputTokenBalanceBefore =
+        state.takerOutputTokenBalanceBefore =
             LibERC20Transformer.getTokenBalanceOf(outputToken, taker);
 
         // Pull input tokens from the taker to the wallet and transfer attached ETH.
-        _transferInputTokensAndAttachedEth(inputToken, taker, address(wallet), inputTokenAmount);
+        _transferInputTokensAndAttachedEth(
+            inputToken,
+            taker,
+            address(state.wallet),
+            inputTokenAmount
+        );
 
         // Perform transformations.
         for (uint256 i = 0; i < transformations.length; ++i) {
-            _executeTransformation(wallet, transformations[i], taker, callDataHash);
+            _executeTransformation(
+                state.wallet,
+                transformations[i],
+                state.transformerDeployer,
+                taker,
+                callDataHash
+            );
         }
 
         // Compute how much output token has been transferred to the taker.
-        uint256 takerOutputTokenBalanceAfter =
+        state.takerOutputTokenBalanceAfter =
             LibERC20Transformer.getTokenBalanceOf(outputToken, taker);
-        if (takerOutputTokenBalanceAfter > takerOutputTokenBalanceBefore) {
-            outputTokenAmount = takerOutputTokenBalanceAfter.safeSub(
-                takerOutputTokenBalanceBefore
+        if (state.takerOutputTokenBalanceAfter > state.takerOutputTokenBalanceBefore) {
+            outputTokenAmount = state.takerOutputTokenBalanceAfter.safeSub(
+                state.takerOutputTokenBalanceBefore
             );
-        } else if (takerOutputTokenBalanceAfter < takerOutputTokenBalanceBefore) {
+        } else if (state.takerOutputTokenBalanceAfter < state.takerOutputTokenBalanceBefore) {
             LibTransformERC20RichErrors.NegativeTransformERC20OutputError(
                 address(outputToken),
-                takerOutputTokenBalanceBefore - takerOutputTokenBalanceAfter
+                state.takerOutputTokenBalanceBefore - state.takerOutputTokenBalanceAfter
             ).rrevert();
         }
         // Ensure enough output token has been sent to the taker.
@@ -316,20 +348,27 @@ contract TransformERC20 is
     /// @dev Executs a transformer in the context of `wallet`.
     /// @param wallet The wallet instance.
     /// @param transformation The transformation.
+    /// @param transformerDeployer The address of the transformer deployer.
     /// @param taker The taker address.
     /// @param callDataHash Hash of the calldata.
     function _executeTransformation(
         IFlashWallet wallet,
         Transformation memory transformation,
+        address transformerDeployer,
         address payable taker,
         bytes32 callDataHash
     )
         private
     {
+        // Derive the transformer address from the deployment nonce.
+        address payable transformer = LibERC20Transformer.getDeployedAddress(
+            transformerDeployer,
+            transformation.deploymentNonce
+        );
         // Call `transformer.transform()` as the wallet.
         bytes memory resultData = wallet.executeDelegateCall(
-            // Call target.
-            address(uint160(address(transformation.transformer))),
+            // The call target.
+            transformer,
             // Call data.
             abi.encodeWithSelector(
                 IERC20Transformer.transform.selector,
@@ -338,39 +377,15 @@ contract TransformERC20 is
                 transformation.data
             )
         );
-        // Ensure the transformer returned its valid rlp-encoded deployment nonce.
-        bytes memory rlpNonce = resultData.length == 0
-            ? new bytes(0)
-            : abi.decode(resultData, (bytes));
-        if (_getExpectedDeployment(rlpNonce) != address(transformation.transformer)) {
-            LibTransformERC20RichErrors.UnauthorizedTransformerError(
-                address(transformation.transformer),
-                rlpNonce
+        // Ensure the transformer returned the magic bytes.
+        if (resultData.length != 32 ||
+            abi.decode(resultData, (bytes4)) != LibERC20Transformer.TRANSFORMER_SUCCESS
+        ) {
+            LibTransformERC20RichErrors.TransformerFailedError(
+                transformer,
+                transformation.data,
+                resultData
             ).rrevert();
         }
-    }
-
-    /// @dev Compute the expected deployment address by `transformDeployer` at
-    ///      the nonce given by `rlpNonce`.
-    /// @param rlpNonce The RLP-encoded nonce that
-    ///        the deployer had when deploying a contract.
-    /// @return deploymentAddress The deployment address.
-    function _getExpectedDeployment(bytes memory rlpNonce)
-        private
-        view
-        returns (address deploymentAddress)
-    {
-        // See https://github.com/ethereum/wiki/wiki/RLP for RLP encoding rules.
-        // The RLP-encoded nonce may be prefixed with a length byte.
-        // We only support nonces up to 32-bits.
-        if (rlpNonce.length == 0 || rlpNonce.length > 5) {
-            LibTransformERC20RichErrors.InvalidRLPNonceError(rlpNonce).rrevert();
-        }
-        return address(uint160(uint256(keccak256(abi.encodePacked(
-            byte(uint8(0xC0 + 21 + rlpNonce.length)),
-            byte(uint8(0x80 + 20)),
-            transformDeployer,
-            rlpNonce
-        )))));
     }
 }

--- a/contracts/zero-ex/contracts/src/features/TransformERC20.sol
+++ b/contracts/zero-ex/contracts/src/features/TransformERC20.sol
@@ -71,6 +71,7 @@ contract TransformERC20 is
     /// @dev Initialize and register this feature.
     ///      Should be delegatecalled by `Migrate.migrate()`.
     /// @param transformerDeployer The trusted deployer for transformers.
+    /// @return success `LibMigrate.SUCCESS` on success.
     function migrate(address transformerDeployer) external returns (bytes4 success) {
         ISimpleFunctionRegistry(address(this))
             .extend(this.getTransformerDeployer.selector, _implementation);
@@ -91,6 +92,7 @@ contract TransformERC20 is
 
     /// @dev Replace the allowed deployer for transformers.
     ///      Only callable by the owner.
+    /// @param transformerDeployer The address of the trusted deployer for transformers.
     function setTransformerDeployer(address transformerDeployer)
         external
         override

--- a/contracts/zero-ex/contracts/src/migrations/FullMigration.sol
+++ b/contracts/zero-ex/contracts/src/migrations/FullMigration.sol
@@ -40,6 +40,11 @@ contract FullMigration {
         TransformERC20 transformERC20;
     }
 
+    /// @dev Parameters needed to initialize features.
+    struct MigrateOpts {
+        address transformerDeployer;
+    }
+
     /// @dev The allowed caller of `deploy()`.
     address public immutable deployer;
     /// @dev The initial migration contract.
@@ -62,9 +67,11 @@ contract FullMigration {
     /// @param owner The owner of the contract.
     /// @param features Features to add to the proxy.
     /// @return zeroEx The deployed and configured `ZeroEx` contract.
+    /// @param migrateOpts Parameters needed to initialize features.
     function deploy(
         address payable owner,
-        Features memory features
+        Features memory features,
+        MigrateOpts memory migrateOpts
     )
         public
         returns (ZeroEx zeroEx)
@@ -81,7 +88,7 @@ contract FullMigration {
         );
 
         // Add features.
-        _addFeatures(zeroEx, owner, features);
+        _addFeatures(zeroEx, owner, features, migrateOpts);
 
         // Transfer ownership to the real owner.
         IOwnable(address(zeroEx)).transferOwnership(owner);
@@ -106,10 +113,12 @@ contract FullMigration {
     /// @param zeroEx The bootstrapped ZeroEx contract.
     /// @param owner The ultimate owner of the ZeroEx contract.
     /// @param features Features to add to the proxy.
+    /// @param migrateOpts Parameters needed to initialize features.
     function _addFeatures(
         ZeroEx zeroEx,
         address owner,
-        Features memory features
+        Features memory features,
+        MigrateOpts memory migrateOpts
     )
         private
     {
@@ -138,7 +147,8 @@ contract FullMigration {
             ownable.migrate(
                 address(features.transformERC20),
                 abi.encodeWithSelector(
-                    TransformERC20.migrate.selector
+                    TransformERC20.migrate.selector,
+                    migrateOpts.transformerDeployer
                 ),
                 address(this)
             );

--- a/contracts/zero-ex/contracts/src/storage/LibTransformERC20Storage.sol
+++ b/contracts/zero-ex/contracts/src/storage/LibTransformERC20Storage.sol
@@ -30,6 +30,8 @@ library LibTransformERC20Storage {
     struct Storage {
         // The current wallet instance.
         IFlashWallet wallet;
+        // The transformer deployer address.
+        address transformerDeployer;
     }
 
     /// @dev Get the storage bucket for this contract.

--- a/contracts/zero-ex/contracts/src/transformers/FillQuoteTransformer.sol
+++ b/contracts/zero-ex/contracts/src/transformers/FillQuoteTransformer.sol
@@ -93,10 +93,9 @@ contract FillQuoteTransformer is
 
     /// @dev Create this contract.
     /// @param exchange_ The Exchange V3 instance.
-    /// @param deploymentNonce_ The nonce of the deployer when deploying this contract.
-    constructor(IExchange exchange_, uint256 deploymentNonce_)
+    constructor(IExchange exchange_)
         public
-        Transformer(deploymentNonce_)
+        Transformer()
     {
         exchange = exchange_;
         erc20Proxy = exchange_.getAssetProxy(ERC20_ASSET_PROXY_ID);
@@ -106,9 +105,7 @@ contract FillQuoteTransformer is
     ///      for `buyToken` by filling `orders`. Protocol fees should be attached
     ///      to this call. `buyToken` and excess ETH will be transferred back to the caller.
     /// @param data_ ABI-encoded `TransformData`.
-    /// @return rlpDeploymentNonce RLP-encoded deployment nonce of the deployer
-    ///         when this transformer was deployed. This is used to verify that
-    ///         this transformer was deployed by a trusted contract.
+    /// @return success The success bytes (`LibERC20Transformer.TRANSFORMER_SUCCESS`).
     function transform(
         bytes32, // callDataHash,
         address payable, // taker,
@@ -116,7 +113,7 @@ contract FillQuoteTransformer is
     )
         external
         override
-        returns (bytes memory rlpDeploymentNonce)
+        returns (bytes4 success)
     {
         TransformData memory data = abi.decode(data_, (TransformData));
 
@@ -231,7 +228,7 @@ contract FillQuoteTransformer is
                     ).rrevert();
             }
         }
-        return _getRLPEncodedDeploymentNonce();
+        return LibERC20Transformer.TRANSFORMER_SUCCESS;
     }
 
     /// @dev Try to sell up to `sellAmount` from an order.

--- a/contracts/zero-ex/contracts/src/transformers/IERC20Transformer.sol
+++ b/contracts/zero-ex/contracts/src/transformers/IERC20Transformer.sol
@@ -30,14 +30,12 @@ interface IERC20Transformer {
     /// @param callDataHash The hash of the `TransformERC20.transformERC20()` calldata.
     /// @param taker The taker address (caller of `TransformERC20.transformERC20()`).
     /// @param data Arbitrary data to pass to the transformer.
-    /// @return rlpDeploymentNonce RLP-encoded deployment nonce of the deployer
-    ///         when this transformer was deployed. This is used to verify that
-    ///         this transformer was deployed by a trusted contract.
+    /// @return success The success bytes (`LibERC20Transformer.TRANSFORMER_SUCCESS`).
     function transform(
         bytes32 callDataHash,
         address payable taker,
         bytes calldata data
     )
         external
-        returns (bytes memory rlpDeploymentNonce);
+        returns (bytes4 success);
 }

--- a/contracts/zero-ex/contracts/src/transformers/LibERC20Transformer.sol
+++ b/contracts/zero-ex/contracts/src/transformers/LibERC20Transformer.sol
@@ -72,7 +72,7 @@ library LibERC20Transformer {
         returns (uint256 tokenBalance)
     {
         if (isTokenETH(token)) {
-            return owner.balance
+            return owner.balance;
         }
         return token.balanceOf(owner);
     }

--- a/contracts/zero-ex/contracts/src/transformers/LibERC20Transformer.sol
+++ b/contracts/zero-ex/contracts/src/transformers/LibERC20Transformer.sol
@@ -29,6 +29,9 @@ library LibERC20Transformer {
 
     /// @dev ETH pseudo-token address.
     address constant internal ETH_TOKEN_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+    /// @dev Return value indicating success in `IERC20Transformer.transform()`.
+    ///      This is just `keccak256('TRANSFORMER_SUCCESS')`.
+    bytes4 constant internal TRANSFORMER_SUCCESS = 0x13c9929e;
 
     /// @dev Transfer ERC20 tokens and ETH.
     /// @param token An ERC20 or the ETH pseudo-token address (`ETH_TOKEN_ADDRESS`).
@@ -68,17 +71,21 @@ library LibERC20Transformer {
         view
         returns (uint256 tokenBalance)
     {
-        return isTokenETH(token) ? owner.balance : token.balanceOf(owner);
+        if (isTokenETH(token)) {
+            return owner.balance
+        }
+        return token.balanceOf(owner);
     }
 
     /// @dev RLP-encode a 32-bit or less account nonce.
     /// @param nonce A positive integer in the range 0 <= nonce < 2^32.
     /// @return rlpNonce The RLP encoding.
-    function rlpEncodeNonce(uint256 nonce)
+    function rlpEncodeNonce(uint32 nonce)
         internal
         pure
         returns (bytes memory rlpNonce)
     {
+        // See https://github.com/ethereum/wiki/wiki/RLP for RLP encoding rules.
         if (nonce == 0) {
             rlpNonce = new bytes(1);
             rlpNonce[0] = 0x80;
@@ -100,15 +107,36 @@ library LibERC20Transformer {
             rlpNonce[1] = byte(uint8((nonce & 0xFF0000) >> 16));
             rlpNonce[2] = byte(uint8((nonce & 0xFF00) >> 8));
             rlpNonce[3] = byte(uint8(nonce));
-        } else if (nonce <= 0xFFFFFFFF) {
+        } else {
             rlpNonce = new bytes(5);
             rlpNonce[0] = 0x84;
             rlpNonce[1] = byte(uint8((nonce & 0xFF000000) >> 24));
             rlpNonce[2] = byte(uint8((nonce & 0xFF0000) >> 16));
             rlpNonce[3] = byte(uint8((nonce & 0xFF00) >> 8));
             rlpNonce[4] = byte(uint8(nonce));
-        } else {
-            revert("LibERC20Transformer/INVALID_ENCODE_NONCE");
         }
+    }
+
+    /// @dev Compute the expected deployment address by `deployer` at
+    ///      the nonce given by `deploymentNonce`.
+    /// @param deployer The address of the deployer.
+    /// @param deploymentNonce The nonce that the deployer had when deploying
+    ///        a contract.
+    /// @return deploymentAddress The deployment address.
+    function getDeployedAddress(address deployer, uint32 deploymentNonce)
+        internal
+        pure
+        returns (address payable deploymentAddress)
+    {
+        // The address of if a deployed contract is the lower 20 bytes of the
+        // hash of the RLP-encoded deployer's account address + account nonce.
+        // See: https://ethereum.stackexchange.com/questions/760/how-is-the-address-of-an-ethereum-contract-computed
+        bytes memory rlpNonce = rlpEncodeNonce(deploymentNonce);
+        return address(uint160(uint256(keccak256(abi.encodePacked(
+            byte(uint8(0xC0 + 21 + rlpNonce.length)),
+            byte(uint8(0x80 + 20)),
+            deployer,
+            rlpNonce
+        )))));
     }
 }

--- a/contracts/zero-ex/contracts/src/transformers/PayTakerTransformer.sol
+++ b/contracts/zero-ex/contracts/src/transformers/PayTakerTransformer.sol
@@ -50,18 +50,15 @@ contract PayTakerTransformer is
     uint256 private constant MAX_UINT256 = uint256(-1);
 
     /// @dev Create this contract.
-    /// @param deploymentNonce_ The nonce of the deployer when deploying this contract.
-    constructor(uint256 deploymentNonce_)
+    constructor()
         public
-        Transformer(deploymentNonce_)
+        Transformer()
     {}
 
     /// @dev Forwards tokens to the taker.
     /// @param taker The taker address (caller of `TransformERC20.transformERC20()`).
     /// @param data_ ABI-encoded `TransformData`, indicating which tokens to transfer.
-    /// @return rlpDeploymentNonce RLP-encoded deployment nonce of the deployer
-    ///         when this transformer was deployed. This is used to verify that
-    ///         this transformer was deployed by a trusted contract.
+    /// @return success The success bytes (`LibERC20Transformer.TRANSFORMER_SUCCESS`).
     function transform(
         bytes32, // callDataHash,
         address payable taker,
@@ -69,7 +66,7 @@ contract PayTakerTransformer is
     )
         external
         override
-        returns (bytes memory rlpDeploymentNonce)
+        returns (bytes4 success)
     {
         TransformData memory data = abi.decode(data_, (TransformData));
 
@@ -85,6 +82,6 @@ contract PayTakerTransformer is
                 data.tokens[i].transformerTransfer(taker, amount);
             }
         }
-        return _getRLPEncodedDeploymentNonce();
+        return LibERC20Transformer.TRANSFORMER_SUCCESS;
     }
 }

--- a/contracts/zero-ex/contracts/src/transformers/Transformer.sol
+++ b/contracts/zero-ex/contracts/src/transformers/Transformer.sol
@@ -22,7 +22,6 @@ pragma experimental ABIEncoderV2;
 import "@0x/contracts-utils/contracts/src/v06/errors/LibRichErrorsV06.sol";
 import "../errors/LibTransformERC20RichErrors.sol";
 import "./IERC20Transformer.sol";
-import "./LibERC20Transformer.sol";
 
 
 /// @dev Abstract base class for transformers.
@@ -33,15 +32,11 @@ abstract contract Transformer is
 
     /// @dev The address of the deployer.
     address public immutable deployer;
-    /// @dev The nonce of the deployer when deploying this contract.
-    uint256 public immutable deploymentNonce;
     /// @dev The original address of this contract.
     address private immutable _implementation;
 
     /// @dev Create this contract.
-    /// @param deploymentNonce_ The nonce of the deployer when deploying this contract.
-    constructor(uint256 deploymentNonce_) public {
-        deploymentNonce = deploymentNonce_;
+    constructor() public {
         deployer = msg.sender;
         _implementation = address(this);
     }
@@ -66,15 +61,5 @@ abstract contract Transformer is
                 .rrevert();
         }
         selfdestruct(ethRecipient);
-    }
-
-    /// @dev Get the RLP-encoded deployment nonce of this contract.
-    /// @return rlpEncodedNonce The RLP-encoded deployment nonce.
-    function _getRLPEncodedDeploymentNonce()
-        internal
-        view
-        returns (bytes memory rlpEncodedNonce)
-    {
-        return LibERC20Transformer.rlpEncodeNonce(deploymentNonce);
     }
 }

--- a/contracts/zero-ex/contracts/src/transformers/WethTransformer.sol
+++ b/contracts/zero-ex/contracts/src/transformers/WethTransformer.sol
@@ -51,19 +51,16 @@ contract WethTransformer is
 
     /// @dev Construct the transformer and store the WETH address in an immutable.
     /// @param weth_ The weth token.
-    /// @param deploymentNonce_ The nonce of the deployer when deploying this contract.
-    constructor(IEtherTokenV06 weth_, uint256 deploymentNonce_)
+    constructor(IEtherTokenV06 weth_)
         public
-        Transformer(deploymentNonce_)
+        Transformer()
     {
         weth = weth_;
     }
 
     /// @dev Wraps and unwraps WETH.
     /// @param data_ ABI-encoded `TransformData`, indicating which token to wrap/umwrap.
-    /// @return rlpDeploymentNonce RLP-encoded deployment nonce of the deployer
-    ///         when this transformer was deployed. This is used to verify that
-    ///         this transformer was deployed by a trusted contract.
+    /// @return success The success bytes (`LibERC20Transformer.TRANSFORMER_SUCCESS`).
     function transform(
         bytes32, // callDataHash,
         address payable, // taker,
@@ -71,7 +68,7 @@ contract WethTransformer is
     )
         external
         override
-        returns (bytes memory rlpDeploymentNonce)
+        returns (bytes4 success)
     {
         TransformData memory data = abi.decode(data_, (TransformData));
         if (!data.token.isTokenETH() && data.token != weth) {
@@ -95,6 +92,6 @@ contract WethTransformer is
                 weth.withdraw(amount);
             }
         }
-        return _getRLPEncodedDeploymentNonce();
+        return LibERC20Transformer.TRANSFORMER_SUCCESS;
     }
 }

--- a/contracts/zero-ex/contracts/test/TestFillQuoteTransformerHost.sol
+++ b/contracts/zero-ex/contracts/test/TestFillQuoteTransformerHost.sol
@@ -35,12 +35,11 @@ contract TestFillQuoteTransformerHost is
     )
         external
         payable
-        returns (bytes memory rlpDeploymentNonce)
     {
         if (inputTokenAmount != 0) {
             inputToken.mint(address(this), inputTokenAmount);
         }
         // Have to make this call externally because transformers aren't payable.
-        return this.rawExecuteTransform(transformer, bytes32(0), msg.sender, data);
+        this.rawExecuteTransform(transformer, bytes32(0), msg.sender, data);
     }
 }

--- a/contracts/zero-ex/contracts/test/TestMintTokenERC20Transformer.sol
+++ b/contracts/zero-ex/contracts/test/TestMintTokenERC20Transformer.sol
@@ -34,7 +34,6 @@ contract TestMintTokenERC20Transformer is
         uint256 burnAmount;
         uint256 mintAmount;
         uint256 feeAmount;
-        bytes deploymentNonce;
     }
 
     event MintTransform(
@@ -54,7 +53,7 @@ contract TestMintTokenERC20Transformer is
     )
         external
         override
-        returns (bytes memory rlpDeploymentNonce)
+        returns (bytes4 success)
     {
         TransformData memory data = abi.decode(data_, (TransformData));
         emit MintTransform(
@@ -79,6 +78,6 @@ contract TestMintTokenERC20Transformer is
             // Burn fees from output.
             data.outputToken.burn(taker, data.feeAmount);
         }
-        return data.deploymentNonce;
+        return LibERC20Transformer.TRANSFORMER_SUCCESS;
     }
 }

--- a/contracts/zero-ex/contracts/test/TestTransformERC20.sol
+++ b/contracts/zero-ex/contracts/test/TestTransformERC20.sol
@@ -26,8 +26,8 @@ contract TestTransformERC20 is
     TransformERC20
 {
     // solhint-disable no-empty-blocks
-    constructor(address trustedDeployer)
-        TransformERC20(trustedDeployer)
+    constructor()
+        TransformERC20()
         public
     {}
 

--- a/contracts/zero-ex/contracts/test/TestTransformerBase.sol
+++ b/contracts/zero-ex/contracts/test/TestTransformerBase.sol
@@ -20,17 +20,12 @@ pragma solidity ^0.6.5;
 pragma experimental ABIEncoderV2;
 
 import "../src/transformers/Transformer.sol";
+import "../src/transformers/LibERC20Transformer.sol";
 
 
 contract TestTransformerBase is
     Transformer
 {
-    // solhint-disable no-empty-blocks
-    constructor(uint256 deploymentNonce_)
-        public
-        Transformer(deploymentNonce_)
-    {}
-
     function transform(
         bytes32,
         address payable,
@@ -38,16 +33,8 @@ contract TestTransformerBase is
     )
         external
         override
-        returns (bytes memory rlpDeploymentNonce)
+        returns (bytes4 success)
     {
-        return hex"";
-    }
-
-    function getRLPEncodedDeploymentNonce()
-        external
-        view
-        returns (bytes memory)
-    {
-        return _getRLPEncodedDeploymentNonce();
+        return LibERC20Transformer.TRANSFORMER_SUCCESS;
     }
 }

--- a/contracts/zero-ex/contracts/test/TestTransformerHost.sol
+++ b/contracts/zero-ex/contracts/test/TestTransformerHost.sol
@@ -37,19 +37,21 @@ contract TestTransformerHost {
         bytes calldata data
     )
         external
-        returns (bytes memory)
     {
-        (bool success, bytes memory resultData) =
+        (bool _success, bytes memory resultData) =
             address(transformer).delegatecall(abi.encodeWithSelector(
                 transformer.transform.selector,
                 callDataHash,
                 taker,
                 data
             ));
-        if (!success) {
+        if (!_success) {
             resultData.rrevert();
         }
-        assembly { return(add(resultData, 32), mload(resultData)) }
+        require(
+            abi.decode(resultData, (bytes4)) == LibERC20Transformer.TRANSFORMER_SUCCESS,
+            "TestTransformerHost/INVALID_TRANSFORMER_RESULT"
+        );
     }
 
     // solhint-disable

--- a/contracts/zero-ex/contracts/test/TestWethTransformerHost.sol
+++ b/contracts/zero-ex/contracts/test/TestWethTransformerHost.sol
@@ -43,12 +43,11 @@ contract TestWethTransformerHost is
     )
         external
         payable
-        returns (bytes memory rlpDeploymentNonce)
     {
         if (wethAmount != 0) {
             _weth.deposit{value: wethAmount}();
         }
         // Have to make this call externally because transformers aren't payable.
-        return this.rawExecuteTransform(transformer, bytes32(0), msg.sender, data);
+        this.rawExecuteTransform(transformer, bytes32(0), msg.sender, data);
     }
 }

--- a/contracts/zero-ex/test/transformers/fill_quote_transformer_test.ts
+++ b/contracts/zero-ex/test/transformers/fill_quote_transformer_test.ts
@@ -12,7 +12,6 @@ import { Order } from '@0x/types';
 import { BigNumber, hexUtils, ZeroExRevertErrors } from '@0x/utils';
 import * as _ from 'lodash';
 
-import { rlpEncodeNonce } from '../../src/nonce_utils';
 import {
     encodeFillQuoteTransformerData,
     FillQuoteTransformerData,
@@ -29,7 +28,6 @@ import {
 const { NULL_ADDRESS, NULL_BYTES, MAX_UINT256, ZERO_AMOUNT } = constants;
 
 blockchainTests.resets('FillQuoteTransformer', env => {
-    const deploymentNonce = _.random(0, 0xffffffff);
     let maker: string;
     let feeRecipient: string;
     let exchange: TestFillQuoteTransformerExchangeContract;
@@ -56,7 +54,6 @@ blockchainTests.resets('FillQuoteTransformer', env => {
             env.txDefaults,
             artifacts,
             exchange.address,
-            new BigNumber(deploymentNonce),
         );
         host = await TestFillQuoteTransformerHostContract.deployFrom0xArtifactAsync(
             artifacts.TestFillQuoteTransformerHost,
@@ -585,24 +582,6 @@ blockchainTests.resets('FillQuoteTransformer', env => {
                 makerAssetBalance: qfr.makerAssetBought,
             });
         });
-
-        it('returns the RLP-encoded nonce', async () => {
-            const orders = _.times(1, () => createOrder());
-            const signatures = orders.map(() => encodeExchangeBehavior());
-            const qfr = getExpectedSellQuoteFillResults(orders);
-            const r = await host
-                .executeTransform(
-                    transformer.address,
-                    takerToken.address,
-                    qfr.takerAssetSpent,
-                    encodeTransformData({
-                        orders,
-                        signatures,
-                    }),
-                )
-                .callAsync({ value: qfr.protocolFeePaid });
-            expect(r).to.eq(rlpEncodeNonce(deploymentNonce));
-        });
     });
 
     describe('buy quotes', () => {
@@ -880,26 +859,6 @@ blockchainTests.resets('FillQuoteTransformer', env => {
                 ...ZERO_BALANCES,
                 makerAssetBalance: qfr.makerAssetBought,
             });
-        });
-
-        it('returns the RLP-encoded nonce', async () => {
-            const orders = _.times(1, () => createOrder());
-            const signatures = orders.map(() => encodeExchangeBehavior());
-            const qfr = getExpectedBuyQuoteFillResults(orders);
-            const r = await host
-                .executeTransform(
-                    transformer.address,
-                    takerToken.address,
-                    qfr.takerAssetSpent,
-                    encodeTransformData({
-                        orders,
-                        signatures,
-                        side: FillQuoteTransformerSide.Buy,
-                        fillAmount: qfr.makerAssetBought,
-                    }),
-                )
-                .callAsync({ value: qfr.protocolFeePaid });
-            expect(r).to.eq(rlpEncodeNonce(deploymentNonce));
         });
     });
 });

--- a/contracts/zero-ex/test/transformers/pay_taker_transformer_test.ts
+++ b/contracts/zero-ex/test/transformers/pay_taker_transformer_test.ts
@@ -3,7 +3,6 @@ import { BigNumber, hexUtils } from '@0x/utils';
 import * as _ from 'lodash';
 
 import { ETH_TOKEN_ADDRESS } from '../../src/constants';
-import { rlpEncodeNonce } from '../../src/nonce_utils';
 import { encodePayTakerTransformerData } from '../../src/transformer_data_encoders';
 import { artifacts } from '../artifacts';
 import { PayTakerTransformerContract, TestMintableERC20TokenContract, TestTransformerHostContract } from '../wrappers';
@@ -12,7 +11,6 @@ const { MAX_UINT256, ZERO_AMOUNT } = constants;
 
 blockchainTests.resets('PayTakerTransformer', env => {
     const taker = randomAddress();
-    const deploymentNonce = _.random(0, 0xffffffff);
     let caller: string;
     let token: TestMintableERC20TokenContract;
     let transformer: PayTakerTransformerContract;
@@ -31,7 +29,6 @@ blockchainTests.resets('PayTakerTransformer', env => {
             env.provider,
             env.txDefaults,
             artifacts,
-            new BigNumber(deploymentNonce),
         );
         host = await TestTransformerHostContract.deployFrom0xArtifactAsync(
             artifacts.TestTransformerHost,
@@ -146,17 +143,5 @@ blockchainTests.resets('PayTakerTransformer', env => {
             tokenBalance: amounts[0].dividedToIntegerBy(2),
             ethBalance: amounts[1].dividedToIntegerBy(2),
         });
-    });
-
-    it('returns the RLP-encoded nonce', async () => {
-        const amounts = _.times(2, () => getRandomInteger(1, '1e18'));
-        const data = encodePayTakerTransformerData({
-            amounts,
-            tokens: [token.address, ETH_TOKEN_ADDRESS],
-        });
-        await mintHostTokensAsync(amounts[0]);
-        await sendEtherAsync(host.address, amounts[1]);
-        const r = await host.rawExecuteTransform(transformer.address, hexUtils.random(), taker, data).callAsync();
-        expect(r).to.eq(rlpEncodeNonce(deploymentNonce));
     });
 });

--- a/contracts/zero-ex/test/transformers/transformer_base_test.ts
+++ b/contracts/zero-ex/test/transformers/transformer_base_test.ts
@@ -1,13 +1,11 @@
 import { blockchainTests, constants, expect, randomAddress } from '@0x/contracts-test-utils';
-import { BigNumber, ZeroExRevertErrors } from '@0x/utils';
+import { ZeroExRevertErrors } from '@0x/utils';
 import * as _ from 'lodash';
 
-import { rlpEncodeNonce } from '../../src/nonce_utils';
 import { artifacts } from '../artifacts';
 import { TestDelegateCallerContract, TestTransformerBaseContract } from '../wrappers';
 
 blockchainTests.resets('Transformer (base)', env => {
-    const deploymentNonce = _.random(0, 0xffffffff);
     let deployer: string;
     let delegateCaller: TestDelegateCallerContract;
     let transformer: TestTransformerBaseContract;
@@ -28,15 +26,7 @@ blockchainTests.resets('Transformer (base)', env => {
                 from: deployer,
             },
             artifacts,
-            new BigNumber(deploymentNonce),
         );
-    });
-
-    describe('_getRLPEncodedDeploymentNonce()', () => {
-        it('returns the RLP encoded deployment nonce', async () => {
-            const r = await transformer.getRLPEncodedDeploymentNonce().callAsync();
-            expect(r).to.eq(rlpEncodeNonce(deploymentNonce));
-        });
     });
 
     describe('die()', () => {

--- a/contracts/zero-ex/test/transformers/weth_transformer_test.ts
+++ b/contracts/zero-ex/test/transformers/weth_transformer_test.ts
@@ -3,7 +3,6 @@ import { BigNumber, ZeroExRevertErrors } from '@0x/utils';
 import * as _ from 'lodash';
 
 import { ETH_TOKEN_ADDRESS } from '../../src/constants';
-import { rlpEncodeNonce } from '../../src/nonce_utils';
 import { encodeWethTransformerData } from '../../src/transformer_data_encoders';
 import { artifacts } from '../artifacts';
 import { TestWethContract, TestWethTransformerHostContract, WethTransformerContract } from '../wrappers';
@@ -11,7 +10,6 @@ import { TestWethContract, TestWethTransformerHostContract, WethTransformerContr
 const { MAX_UINT256, ZERO_AMOUNT } = constants;
 
 blockchainTests.resets('WethTransformer', env => {
-    const deploymentNonce = _.random(0, 0xffffffff);
     let weth: TestWethContract;
     let transformer: WethTransformerContract;
     let host: TestWethTransformerHostContract;
@@ -29,7 +27,6 @@ blockchainTests.resets('WethTransformer', env => {
             env.txDefaults,
             artifacts,
             weth.address,
-            new BigNumber(deploymentNonce),
         );
         host = await TestWethTransformerHostContract.deployFrom0xArtifactAsync(
             artifacts.TestWethTransformerHost,
@@ -151,15 +148,5 @@ blockchainTests.resets('WethTransformer', env => {
             ethBalance: amount.minus(amount.dividedToIntegerBy(2)),
             wethBalance: amount.dividedToIntegerBy(2),
         });
-    });
-
-    it('returns the RLP-encoded nonce', async () => {
-        const amount = getRandomInteger(1, '1e18');
-        const data = encodeWethTransformerData({
-            amount,
-            token: weth.address,
-        });
-        const r = await host.executeTransform(amount, transformer.address, data).callAsync({ value: amount });
-        expect(r).to.eq(rlpEncodeNonce(deploymentNonce));
     });
 });

--- a/packages/utils/CHANGELOG.json
+++ b/packages/utils/CHANGELOG.json
@@ -28,7 +28,7 @@
             },
             {
                 "note": "Update `ZeroExRevertErrors`",
-                "pr": "TODO"
+                "pr": 2597
             }
         ]
     },

--- a/packages/utils/CHANGELOG.json
+++ b/packages/utils/CHANGELOG.json
@@ -25,6 +25,10 @@
             {
                 "note": "Add more `ZeroExRevertErrors`",
                 "pr": 2576
+            },
+            {
+                "note": "Update `ZeroExRevertErrors`",
+                "pr": "TODO"
             }
         ]
     },

--- a/packages/utils/src/revert_errors/zero-ex/transform_erc20_revert_errors.ts
+++ b/packages/utils/src/revert_errors/zero-ex/transform_erc20_revert_errors.ts
@@ -38,18 +38,17 @@ export class NegativeTransformERC20OutputError extends RevertError {
     }
 }
 
-export class UnauthorizedTransformerError extends RevertError {
-    constructor(transformer?: string, rlpNonce?: string) {
-        super('UnauthorizedTransformerError', 'UnauthorizedTransformerError(address transformer, bytes rlpNonce)', {
-            transformer,
-            rlpNonce,
-        });
-    }
-}
-
-export class InvalidRLPNonceError extends RevertError {
-    constructor(rlpNonce?: string) {
-        super('InvalidRLPNonceError', 'InvalidRLPNonceError(bytes rlpNonce)', { rlpNonce });
+export class TransformerFailedError extends RevertError {
+    constructor(transformer?: string, transformerData?: string, resultData?: string) {
+        super(
+            'TransformerFailedError',
+            'TransformerFailedError(address transformer, bytes transformerData, bytes resultData)',
+            {
+                transformer,
+                transformerData,
+                resultData,
+            },
+        );
     }
 }
 
@@ -180,8 +179,7 @@ const types = [
     InsufficientEthAttachedError,
     IncompleteTransformERC20Error,
     NegativeTransformERC20OutputError,
-    UnauthorizedTransformerError,
-    InvalidRLPNonceError,
+    TransformerFailedError,
     IncompleteFillSellQuoteError,
     IncompleteFillBuyQuoteError,
     InsufficientTakerTokenError,


### PR DESCRIPTION
## Description

Aside from documentation stuff:

### TransformERC20 feature
- `IERC20Transformer.transform()` goes back to returning `TRANSFORMER_SUCCESS`.
- Instead of passing a transformer address into a `Transformation` struct, we pass a `uint32 deploymentNonce` and derive the transformer address before calling it.
- Make `AllowanceTarget.executeCall` *not* `payable`.
- Make `_transformERC20Private()` `private`.
- Add an `onlyOwner` `setTransformerDeployer()` function to upgrade the deployer.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
