### PR TITLE
Python: pin mypy to <= 0.770

### DIFF
--- a/python-packages/contract_addresses/setup.py
+++ b/python-packages/contract_addresses/setup.py
@@ -178,7 +178,7 @@ setup(
             "black",
             "coverage",
             "coveralls",
-            "mypy",
+            "mypy<=0.770",  # see https://github.com/python/mypy/issues/8953
             "mypy_extensions",
             "pycodestyle",
             "pydocstyle",

--- a/python-packages/contract_artifacts/setup.py
+++ b/python-packages/contract_artifacts/setup.py
@@ -179,7 +179,7 @@ setup(
             "black",
             "coverage",
             "coveralls",
-            "mypy",
+            "mypy<=0.770",  # https://github.com/python/mypy/issues/8953
             "mypy_extensions",
             "pycodestyle",
             "pydocstyle",

--- a/python-packages/contract_wrappers/setup.py
+++ b/python-packages/contract_wrappers/setup.py
@@ -219,7 +219,7 @@ setup(
             "black",
             "coverage",
             "coveralls",
-            "mypy",
+            "mypy<=0.770",  # see https://github.com/python/mypy/issues/8953
             "mypy_extensions",
             "pycodestyle",
             "pydocstyle",

--- a/python-packages/json_schemas/setup.py
+++ b/python-packages/json_schemas/setup.py
@@ -172,7 +172,7 @@ setup(
             "coverage",
             "coveralls",
             "eth_utils",
-            "mypy",
+            "mypy<=0.770",  # see https://github.com/python/mypy/issues/8953
             "mypy_extensions",
             "pycodestyle",
             "pydocstyle",

--- a/python-packages/middlewares/setup.py
+++ b/python-packages/middlewares/setup.py
@@ -173,7 +173,7 @@ setup(
             "coverage",
             "coveralls",
             "eth_utils",
-            "mypy",
+            "mypy<=0.770",  # see https://github.com/python/mypy/issues/8953
             "mypy_extensions",
             "pycodestyle",
             "pydocstyle",

--- a/python-packages/order_utils/setup.py
+++ b/python-packages/order_utils/setup.py
@@ -193,7 +193,7 @@ setup(
             "black",
             "coverage",
             "coveralls",
-            "mypy",
+            "mypy<=0.770",  # see https://github.com/python/mypy/issues/8953
             "mypy_extensions",
             "pycodestyle",
             "pydocstyle",


### PR DESCRIPTION
A new check in the `mypy` Python type checker is flagging an issue with our code.  I took a look at fixing our code, and it was non-trivial, so in the mean time this change pins `mypy` to the version which doesn't flag this issue.

See also https://github.com/python/mypy/issues/8953