### PR TITLE
fix: UniswapV2 path order

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -85,6 +85,10 @@
             {
                 "note": "Add support for MultiBridge",
                 "pr": 2593
+            },
+            {
+                "note": "Fix Uniswap V2 path ordering",
+                "pr": 2601
             }
         ]
     },

--- a/packages/asset-swapper/src/utils/market_operation_utils/orders.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/orders.ts
@@ -234,7 +234,7 @@ function createBridgeOrder(fill: CollapsedFill, opts: CreateOrderFromPathOpts): 
             makerAssetData = assetDataUtils.encodeERC20BridgeAssetData(
                 makerToken,
                 bridgeAddress,
-                createUniswapV2BridgeData([makerToken, takerToken]),
+                createUniswapV2BridgeData([takerToken, makerToken]),
             );
             break;
         case ERC20BridgeSource.UniswapV2Eth:
@@ -246,7 +246,7 @@ function createBridgeOrder(fill: CollapsedFill, opts: CreateOrderFromPathOpts): 
             makerAssetData = assetDataUtils.encodeERC20BridgeAssetData(
                 makerToken,
                 bridgeAddress,
-                createUniswapV2BridgeData([makerToken, opts.contractAddresses.etherToken, takerToken]),
+                createUniswapV2BridgeData([takerToken, opts.contractAddresses.etherToken, makerToken]),
             );
             break;
         case ERC20BridgeSource.MultiBridge:


### PR DESCRIPTION
## Description
Re-order the UniswapV2 path to be takerToken to makerToken.
<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
