### PR TITLE
asset-swapper: Fix worst case asset amount calculations.

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "4.5.1",
+        "changes": [
+            {
+                "note": "Fix worst case asset amount calculations.",
+                "pr": 2615
+            }
+        ]
+    },
+    {
         "version": "4.5.0",
         "changes": [
             {

--- a/packages/asset-swapper/src/quote_consumers/exchange_proxy_swap_quote_consumer.ts
+++ b/packages/asset-swapper/src/quote_consumers/exchange_proxy_swap_quote_consumer.ts
@@ -89,6 +89,7 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumerBase {
 
         const sellToken = getTokenFromAssetData(quote.takerAssetData);
         const buyToken = getTokenFromAssetData(quote.makerAssetData);
+        const sellAmount = quote.worstCaseQuoteInfo.totalTakerAssetAmount;
 
         // Build up the transforms.
         const transforms = [];
@@ -98,7 +99,7 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumerBase {
                 deploymentNonce: this.transformerNonces.wethTransformer,
                 data: encodeWethTransformerData({
                     token: ETH_TOKEN_ADDRESS,
-                    amount: quote.worstCaseQuoteInfo.totalTakerAssetAmount,
+                    amount: sellAmount,
                 }),
             });
         }
@@ -141,7 +142,7 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumerBase {
             .transformERC20(
                 isFromETH ? ETH_TOKEN_ADDRESS : sellToken,
                 isToETH ? ETH_TOKEN_ADDRESS : buyToken,
-                quote.worstCaseQuoteInfo.totalTakerAssetAmount,
+                sellAmount,
                 quote.worstCaseQuoteInfo.makerAssetAmount,
                 transforms,
             )
@@ -149,7 +150,7 @@ export class ExchangeProxySwapQuoteConsumer implements SwapQuoteConsumerBase {
 
         let ethAmount = quote.worstCaseQuoteInfo.protocolFeeInWeiAmount;
         if (isFromETH) {
-            ethAmount = ethAmount.plus(quote.worstCaseQuoteInfo.takerAssetAmount);
+            ethAmount = ethAmount.plus(sellAmount);
         }
 
         return {


### PR DESCRIPTION
## Description

Worst case asset amount calculations were off by a lot because the fill simulator made the assumption that optimized orders were always sorted. Frequently this would result in worst case buy estimates being better than best case buy estimates. Temporarily sorting the orders before simulating a worst case fill gives us a more realistic lower-bound.

In the Forwarder/Exchange Proxy this manifested as a revert since we were not providing enough input tokens to fill the orders.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
