### PR TITLE
asset-swapper: "Fix" forwarder buys of low decimal tokens.

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -21,6 +21,10 @@
             {
                 "note": "Singleton Gas Price Oracle",
                 "pr": 2619
+            },
+            {
+                "note": "\"Fix\" forwarder buys of low decimal tokens.",
+                "pr": 2618
             }
         ]
     },

--- a/packages/asset-swapper/test/forwarder_swap_quote_consumer_test.ts
+++ b/packages/asset-swapper/test/forwarder_swap_quote_consumer_test.ts
@@ -197,6 +197,7 @@ describe('ForwarderSwapQuoteConsumer', () => {
         swapQuoteConsumer = new ForwarderSwapQuoteConsumer(provider, contractAddresses, {
             chainId,
         });
+        swapQuoteConsumer.buyQuoteSellAmountScalingFactor = 1;
     });
     afterEach(async () => {
         await blockchainLifecycle.revertAsync();


### PR DESCRIPTION
## Description

There seems to be a rounding bug in the Forwarder contract than can cause *buys* of  ETH->low decimal tokens to regularly (30-50%) fail. Simulations show a small "nudge" of the *maximum* sell amount of 1 bps is enough to overcome this rounding error in nearly all cases. This is PR applies this short-term hack to the `ForwarderSwapQuoteConsumer` until we identify and fix the rounding error in the Forwarder contract.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
