### PR TITLE
TransformerDeployer: Fix `kill()` interface mismatch.

### DIFF
--- a/contracts/zero-ex/CHANGELOG.json
+++ b/contracts/zero-ex/CHANGELOG.json
@@ -9,6 +9,10 @@
             {
                 "note": "Export `AffiliateFeeTransformerContract`",
                 "pr": 2622
+            },
+            {
+                "note": "Fix `TransformerDeployer.kill()` calling the wrong `die()` interface.",
+                "pr": 2624
             }
         ]
     },

--- a/contracts/zero-ex/contracts/src/external/TransformerDeployer.sol
+++ b/contracts/zero-ex/contracts/src/external/TransformerDeployer.sol
@@ -24,7 +24,7 @@ import "@0x/contracts-utils/contracts/src/v06/AuthorizableV06.sol";
 
 /// @dev A contract with a `die()` function.
 interface IKillable {
-    function die() external;
+    function die(address payable ethRecipient) external;
 }
 
 /// @dev Deployer contract for ERC20 transformers.
@@ -67,16 +67,19 @@ contract TransformerDeployer is
         assembly {
             deployedAddress := create(callvalue(), add(bytecode, 32), mload(bytecode))
         }
+        require(deployedAddress != address(0), 'TransformerDeployer/DEPLOY_FAILED');
         toDeploymentNonce[deployedAddress] = deploymentNonce;
         emit Deployed(deployedAddress, deploymentNonce, msg.sender);
     }
 
     /// @dev Call `die()` on a contract. Only callable by an authority.
-    function kill(IKillable target)
+    /// @param target The target contract to call `die()` on.
+    /// @param ethRecipient The Recipient of any ETH locked in `target`.
+    function kill(IKillable target, address payable ethRecipient)
         public
         onlyAuthorized
     {
-        target.die();
+        target.die(ethRecipient);
         emit Killed(address(target), msg.sender);
     }
 }

--- a/contracts/zero-ex/contracts/test/TestTransformerDeployerTransformer.sol
+++ b/contracts/zero-ex/contracts/test/TestTransformerDeployerTransformer.sol
@@ -24,10 +24,15 @@ import "../src/transformers/LibERC20Transformer.sol";
 
 contract TestTransformerDeployerTransformer {
 
+    uint256 public constant CONSTRUCTOR_FAIL_VALUE = 3333;
     address payable public immutable deployer;
 
     constructor() public payable {
         deployer = msg.sender;
+        require(
+            msg.value != CONSTRUCTOR_FAIL_VALUE,
+            "TestTransformerDeployerTransformer/CONSTRUCTOR_FAIL"
+        );
     }
 
     modifier onlyDeployer() {
@@ -35,11 +40,11 @@ contract TestTransformerDeployerTransformer {
         _;
     }
 
-    function die()
+    function die(address payable ethRecipient)
         external
         onlyDeployer
     {
-        selfdestruct(deployer);
+        selfdestruct(ethRecipient);
     }
 
     function isDeployedByDeployer(uint32 nonce)


### PR DESCRIPTION
## Description

The current `TransformerDeployer.die()` is calling `Transformer.kill()`, which does not exist. We actually want to call `Transformer.kill(address payable ethRecipient)`. This PR fixes this.

We also now throw a revert error in `deploy()` if the `create()` opcode returns a null address, which indicates a constructor revert.

#### TODO before merging:
- [ ] Redeploy `TransformerDeployer`
- [ ] Have governor call `TransformERC20.setTransformerDeployer()` to new `TransformerDeployer` instance on all networks.
- [ ] Update `contract-addresses`.

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
