### PR TITLE
fix: asset-swapper allow a empty overrides to signal no default

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "4.6.1",
+        "changes": [
+            {
+                "note": "Allow an empty override for sampler overrides",
+                "pr": 2635
+            }
+        ]
+    },
+    {
         "version": "4.6.0",
         "changes": [
             {

--- a/packages/asset-swapper/src/swap_quoter.ts
+++ b/packages/asset-swapper/src/swap_quoter.ts
@@ -193,8 +193,7 @@ export class SwapQuoter {
                   [this._contractAddresses.erc20BridgeSampler]: { code: samplerBytecode },
               }
             : {};
-        const samplerOverrides = _.merge(
-            {},
+        const samplerOverrides = _.assign(
             { block: BlockParamLiteral.Latest, overrides: defaultCodeOverrides },
             options.samplerOverrides,
         );


### PR DESCRIPTION
## Description

Borked the merge, its really difficult to avoid the default merged in, i.e in Ganache. 

```
samplerOverrides = { overrides: {} }
```

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
