### PR TITLE
asset-swapper: Quicker path-finding

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -13,6 +13,10 @@
             {
                 "note": "Support more varied curves",
                 "pr": 2633
+            },
+            {
+                "note": "Make path optimization go faster",
+                "pr": 2640
             }
         ]
     },

--- a/packages/asset-swapper/src/utils/market_operation_utils/path_optimizer.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/path_optimizer.ts
@@ -3,16 +3,12 @@ import { BigNumber } from '@0x/utils';
 import { MarketOperation } from '../../types';
 
 import { ZERO_AMOUNT } from './constants';
-import { getPathAdjustedSize, getPathSize, isValidPath } from './fills';
+import { getPathAdjustedRate, getPathSize, isValidPath } from './fills';
 import { Fill } from './types';
 
 // tslint:disable: prefer-for-of custom-no-magic-numbers completed-docs
 
-const RUN_LIMIT_DECAY_FACTOR = 0.8;
-// Used to yield the event loop when performing CPU intensive tasks
-// tislint:disable-next-line:no-inferred-empty-object-type
-const setImmediateAsync = async (delay: number = 0) =>
-    new Promise<void>(resolve => setImmediate(() => resolve(), delay));
+const RUN_LIMIT_DECAY_FACTOR = 0.5;
 
 /**
  * Find the optimal mixture of paths that maximizes (for sells) or minimizes
@@ -22,16 +18,19 @@ export async function findOptimalPathAsync(
     side: MarketOperation,
     paths: Fill[][],
     targetInput: BigNumber,
-    runLimit: number = 2 ** 15,
+    runLimit: number = 2 ** 8,
 ): Promise<Fill[] | undefined> {
-    // Sort paths in descending order by adjusted output amount.
+    // Sort paths by descending adjusted rate.
     const sortedPaths = paths
         .slice(0)
-        .sort((a, b) => getPathAdjustedSize(b, targetInput)[1].comparedTo(getPathAdjustedSize(a, targetInput)[1]));
+        .sort((a, b) =>
+            getPathAdjustedRate(side, b, targetInput).comparedTo(getPathAdjustedRate(side, a, targetInput)),
+        );
     let optimalPath = sortedPaths[0] || [];
     for (const [i, path] of sortedPaths.slice(1).entries()) {
         optimalPath = mixPaths(side, optimalPath, path, targetInput, runLimit * RUN_LIMIT_DECAY_FACTOR ** i);
-        await setImmediateAsync();
+        // Yield to event loop.
+        await Promise.resolve();
     }
     return isPathComplete(optimalPath, targetInput) ? optimalPath : undefined;
 }
@@ -43,9 +42,10 @@ function mixPaths(
     targetInput: BigNumber,
     maxSteps: number,
 ): Fill[] {
-    let bestPath: Fill[] = [];
-    let bestPathInput = ZERO_AMOUNT;
-    let bestPathRate = ZERO_AMOUNT;
+    const _maxSteps = Math.max(maxSteps, 16);
+    let bestPath: Fill[] = pathA;
+    let bestPathInput = getPathSize(pathA, targetInput)[0];
+    let bestPathRate = getPathAdjustedRate(side, pathA, targetInput);
     let steps = 0;
     const _isBetterPath = (input: BigNumber, rate: BigNumber) => {
         if (bestPathInput.lt(targetInput)) {
@@ -57,7 +57,7 @@ function mixPaths(
     };
     const _walk = (path: Fill[], input: BigNumber, output: BigNumber, allFills: Fill[]) => {
         steps += 1;
-        const rate = getRate(side, input, output);
+        const rate = getRate(side, targetInput, output);
         if (_isBetterPath(input, rate)) {
             bestPath = path;
             bestPathInput = input;
@@ -65,13 +65,11 @@ function mixPaths(
         }
         const remainingInput = targetInput.minus(input);
         if (remainingInput.gt(0)) {
-            for (let i = 0; i < allFills.length; ++i) {
+            for (let i = 0; i < allFills.length && steps < _maxSteps; ++i) {
                 const fill = allFills[i];
-                if (steps + 1 >= maxSteps) {
-                    break;
-                }
-                const childPath = [...path, fill];
-                if (!isValidPath(childPath, true)) {
+                const nextPath = [...path, fill];
+                // Only walk valid paths.
+                if (!isValidPath(nextPath, true)) {
                     continue;
                 }
                 // Remove this fill from the next list of candidate fills.
@@ -79,7 +77,7 @@ function mixPaths(
                 nextAllFills.splice(i, 1);
                 // Recurse.
                 _walk(
-                    childPath,
+                    [...path, fill],
                     input.plus(BigNumber.min(remainingInput, fill.input)),
                     output.plus(
                         // Clip the output of the next fill to the remaining
@@ -91,7 +89,27 @@ function mixPaths(
             }
         }
     };
-    _walk(bestPath, ZERO_AMOUNT, ZERO_AMOUNT, [...pathA, ...pathB].sort((a, b) => b.rate.comparedTo(a.rate)));
+    const allPaths = [...pathA, ...pathB];
+    const sources = allPaths.filter(f => f.index === 0).map(f => f.sourcePathId);
+    const rateBySource = Object.assign(
+        {},
+        ...sources.map(s => ({
+            [s]: getPathAdjustedRate(side, allPaths.filter(f => f.sourcePathId === s), targetInput),
+        })),
+    );
+    _walk(
+        [],
+        ZERO_AMOUNT,
+        ZERO_AMOUNT,
+        // Sort subpaths by rate and keep fills contiguous to improve our
+        // chances of walking ideal, valid paths first.
+        allPaths.sort((a, b) => {
+            if (a.sourcePathId !== b.sourcePathId) {
+                return rateBySource[b.sourcePathId].comparedTo(rateBySource[a.sourcePathId]);
+            }
+            return a.index - b.index;
+        }),
+    );
     return bestPath;
 }
 

--- a/packages/asset-swapper/src/utils/market_operation_utils/path_optimizer.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/path_optimizer.ts
@@ -77,7 +77,7 @@ function mixPaths(
                 nextAllFills.splice(i, 1);
                 // Recurse.
                 _walk(
-                    [...path, fill],
+                    nextPath,
                     input.plus(BigNumber.min(remainingInput, fill.input)),
                     output.plus(
                         // Clip the output of the next fill to the remaining

--- a/packages/asset-swapper/src/utils/market_operation_utils/types.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/types.ts
@@ -109,6 +109,10 @@ export enum FillFlags {
  * Represents a node on a fill path.
  */
 export interface Fill<TFillData extends FillData = FillData> {
+    // Unique ID of the original source path this fill belongs to.
+    // This is generated when the path is generated and is useful to distinguish
+    // paths that have the same `source` IDs but are distinct (e.g., Curves).
+    sourcePathId: string;
     // See `FillFlags`.
     flags: FillFlags;
     // Input fill amount (taker asset amount in a sell, maker asset amount in a buy).

--- a/packages/asset-swapper/test/market_operation_utils_test.ts
+++ b/packages/asset-swapper/test/market_operation_utils_test.ts
@@ -632,15 +632,9 @@ describe('MarketOperationUtils tests', () => {
                     { ...DEFAULT_OPTS, numSamples: 4, allowFallback: true },
                 );
                 const orderSources = improvedOrders.map(o => o.fills[0].source);
-                const firstSources = [
-                    ERC20BridgeSource.Native,
-                    ERC20BridgeSource.Native,
-                    ERC20BridgeSource.Native,
-                    ERC20BridgeSource.Uniswap,
-                ];
-                const secondSources = [ERC20BridgeSource.Eth2Dai, ERC20BridgeSource.Kyber];
-                expect(orderSources.slice(0, firstSources.length).sort()).to.deep.eq(firstSources.sort());
-                expect(orderSources.slice(firstSources.length).sort()).to.deep.eq(secondSources.sort());
+                const firstSources = orderSources.slice(0, 4);
+                const secondSources = orderSources.slice(4);
+                expect(_.intersection(firstSources, secondSources)).to.be.length(0);
             });
 
             it('does not create a fallback if below maxFallbackSlippage', async () => {
@@ -745,9 +739,9 @@ describe('MarketOperationUtils tests', () => {
                 expect(improvedOrders).to.be.length(3);
                 const orderFillSources = improvedOrders.map(o => o.fills.map(f => f.source));
                 expect(orderFillSources).to.deep.eq([
-                    [ERC20BridgeSource.Uniswap],
+                    [ERC20BridgeSource.Uniswap, ERC20BridgeSource.Curve],
                     [ERC20BridgeSource.Native],
-                    [ERC20BridgeSource.Eth2Dai, ERC20BridgeSource.Curve],
+                    [ERC20BridgeSource.Eth2Dai],
                 ]);
             });
         });
@@ -1010,15 +1004,9 @@ describe('MarketOperationUtils tests', () => {
                     { ...DEFAULT_OPTS, numSamples: 4, allowFallback: true },
                 );
                 const orderSources = improvedOrders.map(o => o.fills[0].source);
-                const firstSources = [
-                    ERC20BridgeSource.Native,
-                    ERC20BridgeSource.Native,
-                    ERC20BridgeSource.Native,
-                    ERC20BridgeSource.Uniswap,
-                ];
-                const secondSources = [ERC20BridgeSource.Eth2Dai];
-                expect(orderSources.slice(0, firstSources.length).sort()).to.deep.eq(firstSources.sort());
-                expect(orderSources.slice(firstSources.length).sort()).to.deep.eq(secondSources.sort());
+                const firstSources = orderSources.slice(0, 4);
+                const secondSources = orderSources.slice(4);
+                expect(_.intersection(firstSources, secondSources)).to.be.length(0);
             });
 
             it('does not create a fallback if below maxFallbackSlippage', async () => {
@@ -1062,7 +1050,7 @@ describe('MarketOperationUtils tests', () => {
                 const orderFillSources = improvedOrders.map(o => o.fills.map(f => f.source));
                 expect(orderFillSources).to.deep.eq([
                     [ERC20BridgeSource.Native],
-                    [ERC20BridgeSource.Eth2Dai, ERC20BridgeSource.Uniswap],
+                    [ERC20BridgeSource.Uniswap, ERC20BridgeSource.Eth2Dai],
                 ]);
             });
         });


### PR DESCRIPTION
## Description

We can reduce the number of iterations we go through (`runLimit`) to find a decent path if we:
- Pre-sort all the individual (unmixed) paths by descending adjusted rate
- When mixing two paths, sort the fill nodes such that:
  - Fill nodes are always contiguous (form a valid subpath)
  - Subpaths (segments of the same source) are sorted by descending rate.    
- Compute the "rate" of a path based off `targetInput` (fill amount) instead of `min(targetInput, pathSize)`.
  - This favors paths that cover more of the total fill (not sure about this).
-  Increase the `runLimit` decay rate to `0.5` (prev `0.8`). So we halve the number of iterations for each subsequent call to `mixPaths()`.
- Start the `bestPath` in `mixPaths()` off with the left path (the previous mixed path), instead of starting with none.

This makes it more likely that we walk the viable paths first, so we can cut `runLimit` down to something like `2**8` (previously `2**13`).

This results in a much faster (2-3x) response time with small change in quotes:

![ab-response-time](https://user-images.githubusercontent.com/48803443/88114784-ad2fcf00-cb82-11ea-9bbf-08e5a822d432.png)

![ab-realized](https://user-images.githubusercontent.com/48803443/88114793-b28d1980-cb82-11ea-81f7-9c776a012c05.png)

*Notes*: 
- WETH/DAI/USDC sims buy AND sell
- orange is this version w/ `runLimit = 2**8`
- blue is original version w/ `runLimit = 2**13`

We can probably tweak `runLimit` to improve results. This should buy us a little breathing room until we can entirely replace the algorithm with something better.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
