### PR TITLE
fix: asset-swapper source collapse regression

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -25,6 +25,10 @@
             {
                 "note": "Adds `getBidAskLiquidityForMakerTakerAssetPairAsync` to return more detailed sample information",
                 "pr": 2641
+            },
+            {
+                "note": "Fix regression where a split on the same source was collapsed into a single fill",
+                "pr": 2654
             }
         ]
     },

--- a/packages/asset-swapper/src/utils/market_operation_utils/fills.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/fills.ts
@@ -247,7 +247,7 @@ export function collapsePath(path: Fill[]): CollapsedFill[] {
         if (collapsed.length !== 0 && source !== ERC20BridgeSource.Native) {
             const prevFill = collapsed[collapsed.length - 1];
             // If the last fill is from the same source, merge them.
-            if (prevFill.source === source) {
+            if (prevFill.sourcePathId === fill.sourcePathId) {
                 prevFill.input = prevFill.input.plus(fill.input);
                 prevFill.output = prevFill.output.plus(fill.output);
                 prevFill.subFills.push(fill);
@@ -255,6 +255,7 @@ export function collapsePath(path: Fill[]): CollapsedFill[] {
             }
         }
         collapsed.push({
+            sourcePathId: fill.sourcePathId,
             source: fill.source,
             fillData: fill.fillData,
             input: fill.input,

--- a/packages/asset-swapper/src/utils/market_operation_utils/types.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/types.ts
@@ -151,6 +151,10 @@ export interface Fill<TFillData extends FillData = FillData> {
  * Represents continguous fills on a path that have been merged together.
  */
 export interface CollapsedFill<TFillData extends FillData = FillData> {
+    // Unique ID of the original source path this fill belongs to.
+    // This is generated when the path is generated and is useful to distinguish
+    // paths that have the same `source` IDs but are distinct (e.g., Curves).
+    sourcePathId: string;
     /**
      * The source DEX.
      */

--- a/packages/asset-swapper/test/quote_report_generator_test.ts
+++ b/packages/asset-swapper/test/quote_report_generator_test.ts
@@ -1,7 +1,7 @@
 // tslint:disable:custom-no-magic-numbers
 import { orderHashUtils } from '@0x/order-utils';
 import { SignedOrder } from '@0x/types';
-import { BigNumber } from '@0x/utils';
+import { BigNumber, hexUtils } from '@0x/utils';
 import * as chai from 'chai';
 import * as _ from 'lodash';
 import 'mocha';
@@ -31,6 +31,7 @@ const expect = chai.expect;
 
 const collapsedFillFromNativeOrder = (order: SignedOrder): NativeCollapsedFill => {
     return {
+        sourcePathId: hexUtils.random(),
         source: ERC20BridgeSource.Native,
         input: order.takerAssetAmount,
         output: order.makerAssetAmount,
@@ -102,8 +103,8 @@ describe('QuoteReportGenerator', async () => {
             ];
 
             // generate path
-            const uniswap2Fill: CollapsedFill = { ...uniswapSample2, subFills: [] };
-            const kyber2Fill: CollapsedFill = { ...kyberSample2, subFills: [] };
+            const uniswap2Fill: CollapsedFill = { ...uniswapSample2, subFills: [], sourcePathId: hexUtils.random() };
+            const kyber2Fill: CollapsedFill = { ...kyberSample2, subFills: [], sourcePathId: hexUtils.random() };
             const orderbookOrder2Fill: CollapsedFill = collapsedFillFromNativeOrder(orderbookOrder2);
             const rfqtOrder2Fill: CollapsedFill = collapsedFillFromNativeOrder(rfqtOrder2);
             const pathGenerated: CollapsedFill[] = [rfqtOrder2Fill, orderbookOrder2Fill, uniswap2Fill, kyber2Fill];
@@ -274,8 +275,8 @@ describe('QuoteReportGenerator', async () => {
 
             // generate path
             const orderbookOrder1Fill: CollapsedFill = collapsedFillFromNativeOrder(orderbookOrder1);
-            const uniswap1Fill: CollapsedFill = { ...uniswapSample1, subFills: [] };
-            const kyber1Fill: CollapsedFill = { ...kyberSample1, subFills: [] };
+            const uniswap1Fill: CollapsedFill = { ...uniswapSample1, subFills: [], sourcePathId: hexUtils.random() };
+            const kyber1Fill: CollapsedFill = { ...kyberSample1, subFills: [], sourcePathId: hexUtils.random() };
             const pathGenerated: CollapsedFill[] = [orderbookOrder1Fill, uniswap1Fill, kyber1Fill];
 
             const orderReport = new QuoteReportGenerator(

--- a/packages/asset-swapper/test/quote_simulation_test.ts
+++ b/packages/asset-swapper/test/quote_simulation_test.ts
@@ -1,6 +1,6 @@
 import { constants, expect, getRandomInteger, randomAddress } from '@0x/contracts-test-utils';
 import { assetDataUtils } from '@0x/order-utils';
-import { BigNumber } from '@0x/utils';
+import { BigNumber, hexUtils } from '@0x/utils';
 import * as _ from 'lodash';
 
 import { MarketOperation } from '../src/types';
@@ -155,7 +155,7 @@ describe('quote_simulation tests', async () => {
             signature: '0x',
         };
     }
-
+    const nativeSourcePathId = hexUtils.random();
     function createOrderCollapsedFills(input: BigNumber, output: BigNumber, count: number): CollapsedFill[] {
         const inputs = subdivideAmount(input, count);
         const outputs = subdivideAmount(output, count);
@@ -163,6 +163,7 @@ describe('quote_simulation tests', async () => {
             const subFillInputs = subdivideAmount(inputs[i], count);
             const subFillOutputs = subdivideAmount(outputs[i], count);
             return {
+                sourcePathId: nativeSourcePathId,
                 source: ERC20BridgeSource.Native,
                 input: inputs[i],
                 output: outputs[i],


### PR DESCRIPTION
fixes a source collapse regression where a split on the same source was collapsed into a single fill.
This should be kept distinct as separate fills.

## Description

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
