### PR TITLE
asset-swapper: Fix optimization of buy paths

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -33,6 +33,10 @@
             {
                 "note": "Add support for buy token affiliate fees",
                 "pr": 2658
+            },
+            {
+                "note": "Fix optimization of buy paths",
+                "pr": 2655
             }
         ]
     },

--- a/packages/asset-swapper/src/utils/market_operation_utils/fills.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/fills.ts
@@ -266,12 +266,27 @@ export function collapsePath(path: Fill[]): CollapsedFill[] {
     return collapsed;
 }
 
-export function getPathAdjustedRate(side: MarketOperation, path: Fill[], targetInput: BigNumber): BigNumber {
-    const [, output] = getPathAdjustedSize(path, targetInput);
-    if (output.eq(0)) {
+export function getPathAdjustedCompleteRate(side: MarketOperation, path: Fill[], targetInput: BigNumber): BigNumber {
+    const [input, output] = getPathAdjustedSize(path, targetInput);
+    if (input.eq(0) || output.eq(0) || targetInput.eq(0)) {
         return ZERO_AMOUNT;
     }
-    return side === MarketOperation.Sell ? output.div(targetInput) : targetInput.div(output);
+    // Penalize paths that fall short of the entire input amount by a factor of
+    // input / targetInput => (i / t)
+    if (side === MarketOperation.Sell) {
+        // (o / i) * (i / t) => (o / t)
+        return output.div(targetInput);
+    }
+    // (i / o) * (i / t)
+    return input.div(output).times(input.div(targetInput));
+}
+
+export function getPathAdjustedRate(side: MarketOperation, path: Fill[], targetInput: BigNumber): BigNumber {
+    const [input, output] = getPathAdjustedSize(path, targetInput);
+    if (input.eq(0) || output.eq(0)) {
+        return ZERO_AMOUNT;
+    }
+    return side === MarketOperation.Sell ? output.div(input) : input.div(output);
 }
 
 export function getPathAdjustedSlippage(

--- a/packages/asset-swapper/src/utils/market_operation_utils/fills.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/fills.ts
@@ -194,7 +194,9 @@ export function getPathAdjustedSize(path: Fill[], targetInput: BigNumber = POSIT
         if (input.plus(fill.input).gte(targetInput)) {
             const di = targetInput.minus(input);
             input = input.plus(di);
-            output = output.plus(fill.adjustedOutput.times(di.div(fill.input)));
+            // Penalty does not get interpolated.
+            const penalty = fill.adjustedOutput.minus(fill.output);
+            output = output.plus(fill.output.times(di.div(fill.input)).plus(penalty));
             break;
         } else {
             input = input.plus(fill.input);
@@ -223,6 +225,10 @@ export function isValidPath(path: Fill[], skipDuplicateCheck: boolean = false): 
         }
         flags |= path[i].flags;
     }
+    return arePathFlagsAllowed(flags);
+}
+
+export function arePathFlagsAllowed(flags: number): boolean {
     const multiBridgeConflict = FillFlags.MultiBridge | FillFlags.ConflictsWithMultiBridge;
     return (flags & multiBridgeConflict) !== multiBridgeConflict;
 }

--- a/packages/asset-swapper/src/utils/market_operation_utils/types.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/types.ts
@@ -130,10 +130,6 @@ export interface Fill<TFillData extends FillData = FillData> {
     input: BigNumber;
     // Output fill amount (maker asset amount in a sell, taker asset amount in a buy).
     output: BigNumber;
-    // The maker/taker rate.
-    rate: BigNumber;
-    // The maker/taker rate, adjusted by fees.
-    adjustedRate: BigNumber;
     // The output fill amount, ajdusted by fees.
     adjustedOutput: BigNumber;
     // Fill that must precede this one. This enforces certain fills to be contiguous.

--- a/packages/asset-swapper/test/market_operation_utils_test.ts
+++ b/packages/asset-swapper/test/market_operation_utils_test.ts
@@ -813,9 +813,9 @@ describe('MarketOperationUtils tests', () => {
                 expect(improvedOrders).to.be.length(3);
                 const orderFillSources = improvedOrders.map(o => o.fills.map(f => f.source));
                 expect(orderFillSources).to.deep.eq([
-                    [ERC20BridgeSource.Uniswap, ERC20BridgeSource.Curve],
+                    [ERC20BridgeSource.Uniswap],
                     [ERC20BridgeSource.Native],
-                    [ERC20BridgeSource.Eth2Dai],
+                    [ERC20BridgeSource.Eth2Dai, ERC20BridgeSource.Curve],
                 ]);
             });
         });
@@ -1114,8 +1114,8 @@ describe('MarketOperationUtils tests', () => {
             it('batches contiguous bridge sources', async () => {
                 const rates: RatesBySource = {};
                 rates[ERC20BridgeSource.Native] = [0.5, 0.01, 0.01, 0.01];
-                rates[ERC20BridgeSource.Eth2Dai] = [0.49, 0.01, 0.01, 0.01];
-                rates[ERC20BridgeSource.Uniswap] = [0.48, 0.47, 0.01, 0.01];
+                rates[ERC20BridgeSource.Eth2Dai] = [0.49, 0.02, 0.01, 0.01];
+                rates[ERC20BridgeSource.Uniswap] = [0.48, 0.01, 0.01, 0.01];
                 replaceSamplerOps({
                     getBuyQuotesAsync: createGetMultipleBuyQuotesOperationFromRates(rates),
                 });
@@ -1133,7 +1133,7 @@ describe('MarketOperationUtils tests', () => {
                 const orderFillSources = improvedOrders.map(o => o.fills.map(f => f.source));
                 expect(orderFillSources).to.deep.eq([
                     [ERC20BridgeSource.Native],
-                    [ERC20BridgeSource.Uniswap, ERC20BridgeSource.Eth2Dai],
+                    [ERC20BridgeSource.Eth2Dai, ERC20BridgeSource.Uniswap],
                 ]);
             });
         });


### PR DESCRIPTION
## Description

The adjusted rate for incomplete buy paths were being calculated wrongly, which caused us to perform unnecessary and detrimental splits on certain paths (e.g., DAI->BAL).

Also some other tweaks and significant speed ups to the path optimizer.

#### Buys and sells over ETH, DAI, USDC, USDT, WBTC, BAL against prod

![realized-eth-dai-usdc-usdt-wbtc-bal](https://user-images.githubusercontent.com/48803443/89539649-08400380-d7ca-11ea-9d00-d4574ea7ba22.png)

#### Latency over `development`
⚠ *colors have flipped* ⚠
![latency](https://user-images.githubusercontent.com/48803443/89504879-be89f580-d796-11ea-8077-62ab4b688987.png)

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.