### PR TITLE
feat: asset-swapper use ethToInputRate when ethToOutputRate is 0

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -41,6 +41,10 @@
             {
                 "note": "Fix depth buy scale",
                 "pr": 2659
+            },
+            {
+                "note": "Adjust fill by ethToInputRate when ethToOutputRate is 0",
+                "pr": 2660
             }
         ]
     },

--- a/packages/asset-swapper/src/utils/market_operation_utils/types.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/types.ts
@@ -291,5 +291,6 @@ export interface MarketSideLiquidity {
     nativeOrders: SignedOrder[];
     orderFillableAmounts: BigNumber[];
     ethToOutputRate: BigNumber;
+    ethToInputRate: BigNumber;
     rfqtIndicativeQuotes: RFQTIndicativeQuote[];
 }


### PR DESCRIPTION
## Description
Certain edgecase scenarios can exist when the liquidity only lives on 0x Native and an `ethToMakerRate` cannot be determined on-chain.

Without an `ethToMakerRate` all fills are considered free and many native orders can be filled costing a pretty penny.

### Simulations
[Sell - pause-perpetual-cave](https://metabase.0xproject.com/dashboard/139?run_id=pause-perpetual-cave)
[Buy - facilitate-tender-number](https://metabase.0xproject.com/dashboard/139?run_id=facilitate-tender-number)

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
