### PR TITLE
[WIP] Migrate TSLint config to ESLint

### DIFF
--- a/packages/eslint-config/.eslintrc.js
+++ b/packages/eslint-config/.eslintrc.js
@@ -1,0 +1,326 @@
+module.exports = {
+    "env": {
+        "browser": true,
+        "es6": true
+    },
+    "extends": [
+        "plugin:react/recommended"
+    ],
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+        "project": "tsconfig.json",
+        "sourceType": "module"
+    },
+    "plugins": [
+        "@typescript-eslint",
+        "@typescript-eslint/tslint"
+    ],
+    "rules": {
+        "@typescript-eslint/adjacent-overload-signatures": "error",
+        "@typescript-eslint/array-type": [
+            "error",
+            {
+                "default": "array"
+            }
+        ],
+        "@typescript-eslint/await-thenable": "error",
+        "@typescript-eslint/ban-types": [
+            "error",
+            {
+                "types": {
+                    "Object": {
+                        "message": "Avoid using the `Object` type. Did you mean `object`?"
+                    },
+                    "Function": {
+                        "message": "Avoid using the `Function` type. Prefer a specific function type, like `() => void`."
+                    },
+                    "Boolean": {
+                        "message": "Avoid using the `Boolean` type. Did you mean `boolean`?"
+                    },
+                    "Number": {
+                        "message": "Avoid using the `Number` type. Did you mean `number`?"
+                    },
+                    "String": {
+                        "message": "Avoid using the `String` type. Did you mean `string`?"
+                    },
+                    "Symbol": {
+                        "message": "Avoid using the `Symbol` type. Did you mean `symbol`?"
+                    }
+                }
+            }
+        ],
+        "@typescript-eslint/consistent-type-assertions": "error",
+        "@typescript-eslint/consistent-type-definitions": "error",
+        "@typescript-eslint/dot-notation": "error",
+        "@typescript-eslint/explicit-member-accessibility": [
+            "error",
+            {
+                "accessibility": "explicit"
+            }
+        ],
+        "@typescript-eslint/indent": [
+            "error",
+            4,
+            {
+                "ObjectExpression": "first",
+                "FunctionDeclaration": {
+                    "parameters": "first"
+                },
+                "FunctionExpression": {
+                    "parameters": "first"
+                }
+            }
+        ],
+        "@typescript-eslint/member-delimiter-style": [
+            "error",
+            {
+                "multiline": {
+                    "delimiter": "semi",
+                    "requireLast": true
+                },
+                "singleline": {
+                    "delimiter": "semi",
+                    "requireLast": false
+                }
+            }
+        ],
+        "@typescript-eslint/member-ordering": "error",
+        "@typescript-eslint/naming-convention": "error",
+        "@typescript-eslint/no-empty-function": "error",
+        "@typescript-eslint/no-empty-interface": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-extraneous-class": "error",
+        "@typescript-eslint/no-floating-promises": "error",
+        "@typescript-eslint/no-misused-new": "error",
+        "@typescript-eslint/no-namespace": "error",
+        "@typescript-eslint/no-non-null-assertion": "off",
+        "@typescript-eslint/no-param-reassign": "error",
+        "@typescript-eslint/no-parameter-properties": "off",
+        "@typescript-eslint/no-this-alias": "off",
+        "@typescript-eslint/no-unnecessary-boolean-literal-compare": "error",
+        "@typescript-eslint/no-unnecessary-type-assertion": "error",
+        "@typescript-eslint/no-unused-expressions": "error",
+        "@typescript-eslint/no-unused-vars": "error",
+        "@typescript-eslint/no-use-before-define": "off",
+        "@typescript-eslint/no-var-requires": "error",
+        "@typescript-eslint/prefer-for-of": "error",
+        "@typescript-eslint/prefer-function-type": "error",
+        "@typescript-eslint/prefer-namespace-keyword": "error",
+        "@typescript-eslint/prefer-readonly": "error",
+        "@typescript-eslint/promise-function-async": "error",
+        "@typescript-eslint/quotes": [
+            "error",
+            "single",
+            {
+                "avoidEscape": true
+            }
+        ],
+        "@typescript-eslint/restrict-plus-operands": "error",
+        "@typescript-eslint/semi": [
+            "error",
+            "always"
+        ],
+        "@typescript-eslint/triple-slash-reference": [
+            "error",
+            {
+                "path": "always",
+                "types": "prefer-import",
+                "lib": "always"
+            }
+        ],
+        "@typescript-eslint/tslint/config": [
+            "error",
+            {
+                "rules": {
+                    "async-suffix": true,
+                    "boolean-naming": true,
+                    "completed-docs": true,
+                    "custom-no-magic-numbers": true,
+                    "encoding": true,
+                    "enum-naming": true,
+                    "import-spacing": true,
+                    "jsx-alignment": true,
+                    "jsx-no-lambda": true,
+                    "jsx-no-string-ref": true,
+                    "jsx-self-close": true,
+                    "no-inferred-empty-object-type": true,
+                    "no-lodash-isnull": true,
+                    "no-lodash-isundefined": true,
+                    "number-literal-format": true,
+                    "prefer-conditional-expression": true,
+                    "typedef": true,
+                    "underscore-private-and-protected": true,
+                    "whitespace": true
+                }
+            }
+        ],
+        "@typescript-eslint/unbound-method": "error",
+        "@typescript-eslint/unified-signatures": "error",
+        "arrow-body-style": "error",
+        "arrow-parens": [
+            "error",
+            "as-needed"
+        ],
+        "class-methods-use-this": "error",
+        "complexity": "off",
+        "constructor-super": "error",
+        "curly": "error",
+        "default-case": "error",
+        "eol-last": "error",
+        "eqeqeq": [
+            "error",
+            "smart"
+        ],
+        "guard-for-in": "error",
+        "id-blacklist": [
+            "error",
+            "any",
+            "Number",
+            "number",
+            "String",
+            "string",
+            "Boolean",
+            "boolean",
+            "Undefined",
+            "undefined"
+        ],
+        "id-match": "error",
+        "import/no-default-export": "error",
+        "import/no-extraneous-dependencies": [
+            "error",
+            {
+                "devDependencies": false
+            }
+        ],
+        "import/no-internal-modules": "off",
+        "import/order": "error",
+        "jsdoc/check-alignment": "error",
+        "jsdoc/check-indentation": "error",
+        "jsdoc/newline-after-description": "error",
+        "jsdoc/no-types": "error",
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "max-classes-per-file": [
+            "error",
+            1
+        ],
+        "max-len": "off",
+        "max-lines": [
+            "error",
+            500
+        ],
+        "new-parens": "error",
+        "no-bitwise": "error",
+        "no-caller": "error",
+        "no-cond-assign": "error",
+        "no-console": "error",
+        "no-debugger": "error",
+        "no-duplicate-case": "error",
+        "no-duplicate-imports": "error",
+        "no-empty": "error",
+        "no-eval": "error",
+        "no-extra-bind": "error",
+        "no-fallthrough": "error",
+        "no-invalid-this": "error",
+        "no-new-func": "error",
+        "no-new-wrappers": "error",
+        "no-redeclare": "error",
+        "no-return-await": "error",
+        "no-sequences": "error",
+        "no-shadow": [
+            "error",
+            {
+                "hoist": "all"
+            }
+        ],
+        "no-sparse-arrays": "error",
+        "no-template-curly-in-string": "error",
+        "no-throw-literal": "error",
+        "no-trailing-spaces": "error",
+        "no-undef-init": "error",
+        "no-underscore-dangle": "error",
+        "no-unsafe-finally": "error",
+        "no-unused-labels": "error",
+        "no-var": "error",
+        "object-shorthand": "error",
+        "one-var": [
+            "error",
+            "never"
+        ],
+        "padding-line-between-statements": [
+            "off",
+            {
+                "blankLine": "always",
+                "prev": "*",
+                "next": "return"
+            }
+        ],
+        "prefer-arrow/prefer-arrow-functions": "error",
+        "prefer-const": "error",
+        "prefer-object-spread": "error",
+        "prefer-template": "error",
+        "quote-props": "off",
+        "radix": "error",
+        "react/display-name": "error",
+        "react/jsx-boolean-value": "error",
+        "react/jsx-curly-spacing": [
+            "error",
+            {
+                "when": "never"
+            }
+        ],
+        "react/jsx-equals-spacing": [
+            "error",
+            "never"
+        ],
+        "react/jsx-key": "error",
+        "react/jsx-no-bind": "off",
+        "react/jsx-no-comment-textnodes": "error",
+        "react/jsx-no-duplicate-props": "error",
+        "react/jsx-no-target-blank": "error",
+        "react/jsx-no-undef": "error",
+        "react/jsx-uses-react": "error",
+        "react/jsx-uses-vars": "error",
+        "react/jsx-wrap-multilines": "off",
+        "react/no-children-prop": "error",
+        "react/no-danger-with-children": "error",
+        "react/no-deprecated": "error",
+        "react/no-direct-mutation-state": "error",
+        "react/no-find-dom-node": "error",
+        "react/no-is-mounted": "error",
+        "react/no-render-return-value": "error",
+        "react/no-string-refs": "error",
+        "react/no-unescaped-entities": "error",
+        "react/no-unknown-property": "error",
+        "react/no-unsafe": "off",
+        "react/prop-types": "error",
+        "react/react-in-jsx-scope": "error",
+        "react/require-render-return": "error",
+        "space-before-function-paren": [
+            "error",
+            {
+                "anonymous": "never",
+                "asyncArrow": "always",
+                "named": "never"
+            }
+        ],
+        "space-in-parens": [
+            "off",
+            "never"
+        ],
+        "spaced-comment": [
+            "error",
+            "always",
+            {
+                "markers": [
+                    "/"
+                ]
+            }
+        ],
+        "use-isnan": "error",
+        "valid-typeof": "off",
+        "yoda": "error"
+    }
+};

--- a/packages/eslint-config/.npmignore
+++ b/packages/eslint-config/.npmignore
@@ -1,0 +1,9 @@
+# Blacklist all files
+.*
+*
+# Whitelist lib
+!lib/**/*
+# Blacklist tests and publish scripts
+/lib/test/*
+/lib/monorepo_scripts/
+# Package specific ignore

--- a/packages/eslint-config/CHANGELOG.json
+++ b/packages/eslint-config/CHANGELOG.json
@@ -1,0 +1,11 @@
+[
+    {
+        "version": "0.1.0",
+        "changes": [
+            {
+                "note": "Migrate @0x/tslint-config to eslint"
+            }
+        ],
+        "timestamp": 1598213894
+    }
+]

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -1,0 +1,71 @@
+## @0x/eslint-config
+
+Eslint configuration and custom linter rules used by 0xProject.
+
+## Installation
+
+```bash
+yarn add --dev @0x/eslint-config
+```
+
+## Usage
+
+Add the following to your `.eslintrc.js` file
+
+```javascript
+{
+    "extends": ["@0x/eslint-config"]
+}
+```
+
+## Contributing
+
+We welcome improvements and fixes from the wider community! To report bugs within this package, please create an issue in this repository.
+
+Please read our [contribution guidelines](../../CONTRIBUTING.md) before getting started.
+
+### Install dependencies
+
+If you don't have yarn workspaces enabled (Yarn < v1.0) - enable them:
+
+```bash
+yarn config set workspaces-experimental true
+```
+
+Then install dependencies
+
+```bash
+yarn install
+```
+
+### Build
+
+To build this package and all other monorepo packages that it depends on, run the following from the monorepo root directory:
+
+```bash
+PKG=@0x/eslint-config yarn build
+```
+
+Or continuously rebuild on change:
+
+```bash
+PKG=@0x/eslint-config yarn watch
+```
+
+### Clean
+
+```bash
+yarn clean
+```
+
+### Lint
+
+```bash
+yarn lint
+```
+
+### Run Tests
+
+```bash
+yarn test
+```

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,0 +1,59 @@
+{
+    "name": "@0x/eslint-config",
+    "version": "4.1.0",
+    "engines": {
+        "node": ">=6.12"
+    },
+    "description": "Lint rules related to 0xProject for TSLint",
+    "main": "eslint.json",
+    "scripts": {
+        "build": "tsc -b",
+        "build:ci": "yarn build",
+        "test": "mocha ./lib/test/*.spec.js",
+        "clean": "shx rm -rf lib",
+        "lint": "eslint --format stylish ."
+    },
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/0xProject/0x-monorepo.git"
+    },
+    "keywords": [
+        "eslint",
+        "config",
+        "0xProject",
+        "typescript",
+        "ts"
+    ],
+    "author": {
+        "name": "Kim Persson",
+        "email": "kim@0xproject.com"
+    },
+    "license": "Apache-2.0",
+    "bugs": {
+        "url": "https://github.com/0xProject/0x-monorepo/issues"
+    },
+    "homepage": "https://github.com/0xProject/0x-monorepo/packages/eslint-config/README.md",
+    "devDependencies": {
+        "@types/lodash": "4.14.104",
+        "make-promises-safe": "^1.1.0",
+        "shx": "^0.2.2",
+        "typescript": "3.0.1"
+    },
+    "dependencies": {
+        "@typescript-eslint/eslint-plugin": "^3.9.1",
+        "@typescript-eslint/eslint-plugin-tslint": "^3.9.1",
+        "@typescript-eslint/parser": "^3.9.1",
+        "eslint": "^7.7.0",
+        "eslint-plugin-react": "^7.20.6",
+        "lodash": "^4.17.11",
+        "prettier": "^2.0.5",
+        "prettier-eslint": "^11.0.0",
+        "tslint": "^6.1.3",
+        "tslint-eslint-rules": "5.4.0",
+        "tslint-react": "^3.2.0",
+        "tsutils": "3.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
+}

--- a/packages/eslint-config/rules/asyncSuffixRule.ts
+++ b/packages/eslint-config/rules/asyncSuffixRule.ts
@@ -1,0 +1,10 @@
+import * as Lint from 'tslint';
+import * as ts from 'typescript';
+
+import { AsyncSuffixWalker } from './walkers/async_suffix';
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new AsyncSuffixWalker(sourceFile, this.getOptions()));
+    }
+}

--- a/packages/eslint-config/rules/booleanNamingRule.ts
+++ b/packages/eslint-config/rules/booleanNamingRule.ts
@@ -1,0 +1,68 @@
+import * as _ from 'lodash';
+import * as Lint from 'tslint';
+import * as ts from 'typescript';
+
+const VALID_BOOLEAN_PREFIXES = ['is', 'does', 'should', 'was', 'has', 'can', 'did', 'would', 'are'];
+// tslint:disable:no-unnecessary-type-assertion
+export class Rule extends Lint.Rules.TypedRule {
+    public static FAILURE_STRING = `Boolean variable names should begin with: ${VALID_BOOLEAN_PREFIXES.join(', ')}`;
+
+    public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
+        return this.applyWithFunction(sourceFile, walk, undefined, program.getTypeChecker());
+    }
+}
+
+function walk(ctx: Lint.WalkContext<void>, tc: ts.TypeChecker): void {
+    traverse(ctx.sourceFile);
+
+    function traverse(node: ts.Node): void {
+        checkNodeForViolations(ctx, node, tc);
+        return ts.forEachChild(node, traverse);
+    }
+}
+
+function checkNodeForViolations(ctx: Lint.WalkContext<void>, node: ts.Node, tc: ts.TypeChecker): void {
+    switch (node.kind) {
+        // Handle: const { timestamp } = ...
+        case ts.SyntaxKind.BindingElement: {
+            const bindingElementNode = node as ts.BindingElement;
+            if (bindingElementNode.name.kind === ts.SyntaxKind.Identifier) {
+                handleBooleanNaming(bindingElementNode, tc, ctx);
+            }
+            break;
+        }
+
+        // Handle regular assignments: const block = ...
+        case ts.SyntaxKind.VariableDeclaration:
+            const variableDeclarationNode = node as ts.VariableDeclaration;
+            if (variableDeclarationNode.name.kind === ts.SyntaxKind.Identifier) {
+                handleBooleanNaming(node as ts.VariableDeclaration, tc, ctx);
+            }
+            break;
+
+        default:
+            _.noop();
+    }
+}
+
+function handleBooleanNaming(
+    node: ts.VariableDeclaration | ts.BindingElement,
+    tc: ts.TypeChecker,
+    ctx: Lint.WalkContext<void>,
+): void {
+    const nodeName = node.name;
+    const variableName = nodeName.getText();
+    const lowercasedName = _.toLower(variableName);
+    const typeNode = tc.getTypeAtLocation(node);
+    const typeName = (typeNode as any).intrinsicName;
+    if (typeName === 'boolean') {
+        const hasProperName =
+            _.find(VALID_BOOLEAN_PREFIXES, prefix => {
+                return _.startsWith(lowercasedName, prefix);
+            }) !== undefined;
+        if (!hasProperName) {
+            ctx.addFailureAtNode(node, Rule.FAILURE_STRING);
+        }
+    }
+}
+// tslint:enable:no-unnecessary-type-assertion

--- a/packages/eslint-config/rules/customNoMagicNumbersRule.ts
+++ b/packages/eslint-config/rules/customNoMagicNumbersRule.ts
@@ -1,0 +1,79 @@
+import * as Lint from 'tslint';
+import { isPrefixUnaryExpression } from 'tsutils';
+import * as ts from 'typescript';
+
+// tslint:disable:no-unnecessary-type-assertion
+/**
+ * A modified version of the no-magic-numbers rule that allows for magic numbers
+ * when instantiating a BigNumber instance.
+ * E.g We want to be able to write:
+ *     const amount = new BigNumber(5);
+ * Original source: https://github.com/palantir/tslint/blob/42b058a6baa688f8be8558b277eb056c3ff79818/src/rules/noMagicNumbersRule.ts
+ */
+export class Rule extends Lint.Rules.AbstractRule {
+    public static ALLOWED_NODES = new Set<ts.SyntaxKind>([
+        ts.SyntaxKind.ExportAssignment,
+        ts.SyntaxKind.FirstAssignment,
+        ts.SyntaxKind.LastAssignment,
+        ts.SyntaxKind.PropertyAssignment,
+        ts.SyntaxKind.ShorthandPropertyAssignment,
+        ts.SyntaxKind.VariableDeclaration,
+        ts.SyntaxKind.VariableDeclarationList,
+        ts.SyntaxKind.EnumMember,
+        ts.SyntaxKind.PropertyDeclaration,
+        ts.SyntaxKind.Parameter,
+    ]);
+
+    public static DEFAULT_ALLOWED = [-1, 0, 1];
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        const allowedNumbers = this.ruleArguments.length > 0 ? this.ruleArguments : Rule.DEFAULT_ALLOWED;
+        return this.applyWithWalker(
+            // tslint:disable-next-line:no-inferred-empty-object-type
+            new CustomNoMagicNumbersWalker(sourceFile, this.ruleName, new Set(allowedNumbers.map(String))),
+        );
+    }
+}
+
+// tslint:disable-next-line:max-classes-per-file
+class CustomNoMagicNumbersWalker extends Lint.AbstractWalker<Set<string>> {
+    public static FAILURE_STRING = "'magic numbers' are not allowed";
+    private static _isNegativeNumberLiteral(
+        node: ts.Node,
+    ): node is ts.PrefixUnaryExpression & { operand: ts.NumericLiteral } {
+        return (
+            isPrefixUnaryExpression(node) &&
+            node.operator === ts.SyntaxKind.MinusToken &&
+            node.operand.kind === ts.SyntaxKind.NumericLiteral
+        );
+    }
+    public walk(sourceFile: ts.SourceFile): void {
+        const cb = (node: ts.Node): void => {
+            if (node.kind === ts.SyntaxKind.NumericLiteral) {
+                return this.checkNumericLiteral(node, (node as ts.NumericLiteral).text);
+            }
+            if (CustomNoMagicNumbersWalker._isNegativeNumberLiteral(node)) {
+                return this.checkNumericLiteral(node, `-${(node.operand as ts.NumericLiteral).text}`);
+            }
+            return ts.forEachChild(node, cb);
+        };
+        return ts.forEachChild(sourceFile, cb);
+    }
+
+    // tslint:disable:no-non-null-assertion
+    // tslint:disable-next-line:underscore-private-and-protected
+    private checkNumericLiteral(node: ts.Node, num: string): void {
+        if (!Rule.ALLOWED_NODES.has(node.parent!.kind) && !this.options.has(num)) {
+            if (node.parent!.kind === ts.SyntaxKind.NewExpression) {
+                const className = (node.parent! as any).expression.escapedText;
+                const BIG_NUMBER_NEW_EXPRESSION = 'BigNumber';
+                if (className === BIG_NUMBER_NEW_EXPRESSION) {
+                    return; // noop
+                }
+            }
+            this.addFailureAtNode(node, CustomNoMagicNumbersWalker.FAILURE_STRING);
+        }
+    }
+    // tslint:enable:no-non-null-assertion
+}
+// tslint:enable:no-unnecessary-type-assertion

--- a/packages/eslint-config/rules/enumNamingRule.ts
+++ b/packages/eslint-config/rules/enumNamingRule.ts
@@ -1,0 +1,60 @@
+import * as Lint from 'tslint';
+import * as ts from 'typescript';
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static FAILURE_STRING = `Enum member names should be PascalCase`;
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithFunction(sourceFile, walk);
+    }
+}
+
+function walk(ctx: Lint.WalkContext<void>): void {
+    // Recursively walk the AST starting with root node, `ctx.sourceFile`.
+    // Call the function `cb` (defined below) for each child.
+    return ts.forEachChild(ctx.sourceFile, cb);
+
+    function cb(node: ts.Node): void {
+        if (node.kind === ts.SyntaxKind.EnumMember) {
+            const keyNode = node.getFirstToken(ctx.sourceFile);
+            if (keyNode !== undefined) {
+                const keyText = keyNode.getText(ctx.sourceFile);
+                if (!isPascalCase(keyText)) {
+                    return ctx.addFailureAtNode(node, Rule.FAILURE_STRING, getFix(keyText, node));
+                }
+            }
+        }
+        // Continue recursion into the AST by calling function `cb` for every child of the current node.
+        return ts.forEachChild(node, cb);
+    }
+
+    function getFix(text: string, node: ts.Node): Lint.Replacement {
+        let fix = toPascalCase(text);
+        // check for `member = value`
+        if (node.getChildCount(ctx.sourceFile) === 3) {
+            const value = node.getLastToken(ctx.sourceFile);
+            if (value !== undefined) {
+                fix += ` = ${value.getText(ctx.sourceFile)}`;
+            }
+        }
+        return new Lint.Replacement(node.getStart(ctx.sourceFile), node.getWidth(ctx.sourceFile), fix);
+    }
+}
+
+// Modified from: https://github.com/jonschlinkert/pascalcase/
+function toPascalCase(str: string): string {
+    let result = str.replace(/([a-z0-9\W])([A-Z])/g, '$1 $2');
+    if (result.length === 1) {
+        return result.toUpperCase();
+    }
+    result = result.replace(/^[\W_\.]+|[\W_\.]+$/g, '').toLowerCase();
+    result = result.charAt(0).toUpperCase() + result.slice(1);
+    return result.replace(/[\W_\.]+(\w|$)/g, (_, ch) => {
+        return ch.toUpperCase();
+    });
+}
+function isPascalCase(s: string): boolean {
+    const regex = /^([A-Z0-9]+[a-z0-9]+)+$/g;
+    const key = s.split('=')[0].trim();
+    return regex.test(key);
+}

--- a/packages/eslint-config/rules/noLodashIsnullRule.ts
+++ b/packages/eslint-config/rules/noLodashIsnullRule.ts
@@ -1,0 +1,49 @@
+import * as Lint from 'tslint';
+import * as ts from 'typescript';
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static FAILURE_STRING = `Use built-in equivalent`;
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithFunction(sourceFile, walk);
+    }
+}
+
+function walk(ctx: Lint.WalkContext<void>): void {
+    // Recursively walk the AST starting with root node, `ctx.sourceFile`.
+    // Call the function `cb` (defined below) for each child.
+    return ts.forEachChild(ctx.sourceFile, cb);
+
+    function cb(node: ts.Node): void {
+        if (node.kind === ts.SyntaxKind.CallExpression) {
+            const firstChild = node.getChildAt(0, ctx.sourceFile);
+            if (
+                firstChild.kind === ts.SyntaxKind.PropertyAccessExpression &&
+                firstChild.getText(ctx.sourceFile) === '_.isNull'
+            ) {
+                return ctx.addFailureAtNode(node, Rule.FAILURE_STRING, getFix(node));
+            }
+        }
+        // Continue recursion into the AST by calling function `cb` for every child of the current node.
+        return ts.forEachChild(node, cb);
+    }
+
+    function getFix(node: ts.Node): Lint.Replacement {
+        const isNegated =
+            node.parent.kind === ts.SyntaxKind.PrefixUnaryExpression && node.parent.getText(ctx.sourceFile)[0] === '!';
+        const args = node.getChildAt(2, ctx.sourceFile).getText(ctx.sourceFile);
+        if (isNegated) {
+            return new Lint.Replacement(
+                node.parent.getStart(ctx.sourceFile),
+                node.parent.getWidth(ctx.sourceFile),
+                `${args} !== null`,
+            );
+        } else {
+            return new Lint.Replacement(
+                node.getStart(ctx.sourceFile),
+                node.getWidth(ctx.sourceFile),
+                `${args} === null`,
+            );
+        }
+    }
+}

--- a/packages/eslint-config/rules/noLodashIsundefinedRule.ts
+++ b/packages/eslint-config/rules/noLodashIsundefinedRule.ts
@@ -1,0 +1,49 @@
+import * as Lint from 'tslint';
+import * as ts from 'typescript';
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static FAILURE_STRING = `Use built-in equivalent`;
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithFunction(sourceFile, walk);
+    }
+}
+
+function walk(ctx: Lint.WalkContext<void>): void {
+    // Recursively walk the AST starting with root node, `ctx.sourceFile`.
+    // Call the function `cb` (defined below) for each child.
+    return ts.forEachChild(ctx.sourceFile, cb);
+
+    function cb(node: ts.Node): void {
+        if (node.kind === ts.SyntaxKind.CallExpression) {
+            const firstChild = node.getChildAt(0, ctx.sourceFile);
+            if (
+                firstChild.kind === ts.SyntaxKind.PropertyAccessExpression &&
+                firstChild.getText(ctx.sourceFile) === '_.isUndefined'
+            ) {
+                return ctx.addFailureAtNode(node, Rule.FAILURE_STRING, getFix(node));
+            }
+        }
+        // Continue recursion into the AST by calling function `cb` for every child of the current node.
+        return ts.forEachChild(node, cb);
+    }
+
+    function getFix(node: ts.Node): Lint.Replacement {
+        const isNegated =
+            node.parent.kind === ts.SyntaxKind.PrefixUnaryExpression && node.parent.getText(ctx.sourceFile)[0] === '!';
+        const args = node.getChildAt(2, ctx.sourceFile).getText(ctx.sourceFile);
+        if (isNegated) {
+            return new Lint.Replacement(
+                node.parent.getStart(ctx.sourceFile),
+                node.parent.getWidth(ctx.sourceFile),
+                `${args} !== undefined`,
+            );
+        } else {
+            return new Lint.Replacement(
+                node.getStart(ctx.sourceFile),
+                node.getWidth(ctx.sourceFile),
+                `${args} === undefined`,
+            );
+        }
+    }
+}

--- a/packages/eslint-config/rules/underscorePrivateAndProtectedRule.ts
+++ b/packages/eslint-config/rules/underscorePrivateAndProtectedRule.ts
@@ -1,0 +1,61 @@
+import * as Lint from 'tslint';
+import * as ts from 'typescript';
+
+const UNDERSCORE = '_';
+
+type RelevantClassMember =
+    | ts.MethodDeclaration
+    | ts.PropertyDeclaration
+    | ts.GetAccessorDeclaration
+    | ts.SetAccessorDeclaration;
+
+// Copied from: https://github.com/DanielRosenwasser/underscore-privates-tslint-rule
+// The version on github is not published on npm
+export class Rule extends Lint.Rules.AbstractRule {
+    public static FAILURE_STRING = 'private and protected members must be prefixed with an underscore';
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithFunction(sourceFile, walk);
+    }
+}
+function walk(ctx: Lint.WalkContext<void>): void {
+    traverse(ctx.sourceFile);
+
+    function traverse(node: ts.Node): void {
+        checkNodeForViolations(ctx, node);
+        return ts.forEachChild(node, traverse);
+    }
+}
+function checkNodeForViolations(ctx: Lint.WalkContext<void>, node: ts.Node): void {
+    if (!isRelevantClassMember(node)) {
+        return;
+    }
+    // The declaration might have a computed property name or a numeric name.
+    const name = node.name;
+    if (!nameIsIdentifier(name)) {
+        return;
+    }
+    if (!nameStartsWithUnderscore(name.text) && memberIsPrivate(node)) {
+        ctx.addFailureAtNode(name, Rule.FAILURE_STRING);
+    }
+}
+function isRelevantClassMember(node: ts.Node): node is RelevantClassMember {
+    switch (node.kind) {
+        case ts.SyntaxKind.MethodDeclaration:
+        case ts.SyntaxKind.PropertyDeclaration:
+        case ts.SyntaxKind.GetAccessor:
+        case ts.SyntaxKind.SetAccessor:
+            return true;
+        default:
+            return false;
+    }
+}
+function nameStartsWithUnderscore(text: string): boolean {
+    return text.charCodeAt(0) === UNDERSCORE.charCodeAt(0);
+}
+function memberIsPrivate(node: ts.Declaration): boolean {
+    return Lint.hasModifier(node.modifiers, ts.SyntaxKind.PrivateKeyword, ts.SyntaxKind.ProtectedKeyword);
+}
+function nameIsIdentifier(node: ts.Node): node is ts.Identifier {
+    return node.kind === ts.SyntaxKind.Identifier;
+}

--- a/packages/eslint-config/rules/walkers/async_suffix.ts
+++ b/packages/eslint-config/rules/walkers/async_suffix.ts
@@ -1,0 +1,34 @@
+import * as Lint from 'tslint';
+import * as ts from 'typescript';
+
+export class AsyncSuffixWalker extends Lint.RuleWalker {
+    public static FAILURE_STRING = 'async functions/methods must have an Async suffix';
+    public visitFunctionDeclaration(node: ts.FunctionDeclaration): void {
+        this._visitFunctionOrMethodDeclaration(node);
+        super.visitFunctionDeclaration(node);
+    }
+    public visitMethodDeclaration(node: ts.MethodDeclaration): void {
+        this._visitFunctionOrMethodDeclaration(node);
+        super.visitMethodDeclaration(node);
+    }
+    private _visitFunctionOrMethodDeclaration(node: ts.MethodDeclaration | ts.FunctionDeclaration): void {
+        const nameNode = node.name;
+        if (nameNode !== undefined) {
+            const name = nameNode.getText();
+            if (node.type !== undefined) {
+                if (node.type.kind === ts.SyntaxKind.TypeReference) {
+                    // tslint:disable-next-line:no-unnecessary-type-assertion
+                    const returnTypeName = (node.type as ts.TypeReferenceNode).typeName.getText();
+                    if (returnTypeName === 'Promise' && !name.endsWith('Async')) {
+                        const failure = this.createFailure(
+                            nameNode.getStart(),
+                            nameNode.getWidth(),
+                            AsyncSuffixWalker.FAILURE_STRING,
+                        );
+                        this.addFailure(failure);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/eslint-config/test/enumNamingSpec.spec.ts
+++ b/packages/eslint-config/test/enumNamingSpec.spec.ts
@@ -1,0 +1,88 @@
+import * as assert from 'assert';
+
+import { Rule } from '../rules/enumNamingRule';
+
+import { getFixedResult, helper } from './lintrunner';
+const rule = 'enum-naming';
+
+describe('enumNamingRule', () => {
+    it(`should not fail PascalCase`, () => {
+        const src = `enum test { MemberOne, MemberTwo }`;
+        const result = helper(src, rule);
+        assert.equal(result.errorCount, 0);
+    });
+    it(`should not fail PascalCase keys with uncased values`, () => {
+        const src = `enum test { MemberOne = 'member_one', MemberTwo = 'member two' }`;
+        const result = helper(src, rule);
+        assert.equal(result.errorCount, 0);
+    });
+    it(`should not fail PascalCase keys with numbers`, () => {
+        const src = `enum test { Member1 = 'member_one', MemberTwo = 'member two' }`;
+        const result = helper(src, rule);
+        assert.equal(result.errorCount, 0);
+    });
+    it(`should fail with camelCase`, () => {
+        const src = `enum test { memberOne, memberTwo }`;
+        const result = helper(src, rule);
+        assert.equal(result.errorCount, 2);
+    });
+    it(`should fail with snake case`, () => {
+        const src = `enum test { member_one, member_two }`;
+        const result = helper(src, rule);
+        assert.equal(result.errorCount, 2);
+    });
+    it(`should fail with all caps`, () => {
+        const src = `enum test { MEMBERONE, MEMBER_TWO }`;
+        const result = helper(src, rule);
+        assert.equal(result.errorCount, 2);
+    });
+    it(`should fail with mixed case`, () => {
+        const src = `enum test { member_one, MemberTwo }`;
+        const result = helper(src, rule);
+        assert.equal(result.errorCount, 1);
+    });
+
+    it(`should fail with the right position`, () => {
+        const src = `enum test { MemberOne, member_two }`;
+        const startPosition = src.indexOf('member_two');
+        const endPosition = startPosition + 'member_two'.length;
+        const failure = helper(src, rule).failures[0];
+
+        assert.equal(failure.getStartPosition().getPosition(), startPosition);
+        assert.equal(failure.getEndPosition().getPosition(), endPosition);
+        assert.equal(failure.getFailure(), Rule.FAILURE_STRING);
+    });
+
+    it(`should fail with the right message`, () => {
+        const src = `enum test { memberOne, memberTwo }`;
+        const failure = helper(src, rule).failures[0];
+
+        assert.equal(failure.getFailure(), Rule.FAILURE_STRING);
+    });
+});
+describe('enumNaming fixer', () => {
+    it('should fix keys', () => {
+        const src = `enum test { MemberOne, memberTwo, member_three, MEMBER_FOUR, MEMBERFIVE }`;
+        const expected = `enum test { MemberOne, MemberTwo, MemberThree, MemberFour, Memberfive }`;
+        const actual = getFixedResult(src, rule);
+        const result = helper(src, rule);
+        assert.equal(result.errorCount, 4); // tslint:disable-line:custom-no-magic-numbers
+        assert.equal(actual, expected);
+    });
+    it('should not fix values', () => {
+        const src = `enum test { MemberOne = 'MemberOne', memberTwo = 'memberTwo', member_three = 'member_three', MEMBER_FOUR = 'MEMBER_FOUR' }`;
+        const expected = `enum test { MemberOne = 'MemberOne', MemberTwo = 'memberTwo', MemberThree = 'member_three', MemberFour = 'MEMBER_FOUR' }`;
+        const actual = getFixedResult(src, rule);
+        const result = helper(src, rule);
+        assert.equal(result.errorCount, 3); // tslint:disable-line:custom-no-magic-numbers
+        assert.equal(actual, expected);
+    });
+    it('should preserve values with equals sign', () => {
+        const src = `enum Operators { assign = '=', EQUALS = '==', Triple_Equals = '===' }`;
+        const expected = `enum Operators { Assign = '=', Equals = '==', TripleEquals = '===' }`;
+        const actual = getFixedResult(src, rule);
+        const result = helper(src, rule);
+        assert.equal(result.errorCount, 3); // tslint:disable-line:custom-no-magic-numbers
+        assert.equal(actual, expected);
+    });
+});

--- a/packages/eslint-config/test/lintrunner.ts
+++ b/packages/eslint-config/test/lintrunner.ts
@@ -1,0 +1,23 @@
+import * as path from 'path';
+import { Configuration, Linter, Replacement } from 'tslint';
+
+export const helper = (src: string, rule: string) => {
+    const linter = new Linter({ fix: false });
+    linter.lint(
+        '',
+        src,
+        Configuration.parseConfigFile({
+            rules: {
+                [rule]: true,
+            },
+            rulesDirectory: path.join(__dirname, '../rules'),
+        }),
+    );
+    return linter.getResult();
+};
+
+export const getFixedResult = (src: string, rule: string) => {
+    const result = helper(src, rule);
+    const fixes = [].concat.apply(result.failures.map(x => x.getFix()));
+    return Replacement.applyFixes(src, fixes);
+};

--- a/packages/eslint-config/test/noLodashIsundefined.spec.ts
+++ b/packages/eslint-config/test/noLodashIsundefined.spec.ts
@@ -1,0 +1,96 @@
+import * as assert from 'assert';
+
+import { Rule } from '../rules/noLodashIsundefinedRule';
+
+import { getFixedResult, helper } from './lintrunner';
+const rule = 'no-lodash-isundefined';
+
+describe('noLodashIsundefinedRule', () => {
+    it(`should not fail built-in`, () => {
+        const src = `if (someObj === undefined) { // do stuff }`;
+        const result = helper(src, rule);
+        assert.equal(result.errorCount, 0);
+    });
+    it(`should not fail custom isUndefined`, () => {
+        const src = `if (isUndefined(someObj)) { // do stuff }`;
+        const result = helper(src, rule);
+        assert.equal(result.errorCount, 0);
+    });
+    it(`should fail _.isUndefined with simple identifier`, () => {
+        const src = `if (_.isUndefined(obj)) { // do stuff }`;
+        const result = helper(src, rule);
+        assert.equal(result.errorCount, 1);
+    });
+    it(`should fail _.isUndefined with property access expression`, () => {
+        const src = `if (_.isUndefined(this.property)) { // do stuff }`;
+        const result = helper(src, rule);
+        assert.equal(result.errorCount, 1);
+    });
+    it(`should fail _.isUndefined with element access expression`, () => {
+        const src = `if (_.isUndefined(someArray[nested])) { // do stuff }`;
+        const result = helper(src, rule);
+        assert.equal(result.errorCount, 1);
+    });
+    it(`should fail _.isUndefined with property and element access expression`, () => {
+        const src = `if (_.isUndefined(someObj.someArray[nested])) { // do stuff }`;
+        const result = helper(src, rule);
+        assert.equal(result.errorCount, 1);
+    });
+
+    it(`should fail with the right message`, () => {
+        const src = `if (_.isUndefined(obj)) { // do stuff }`;
+        const failure = helper(src, rule).failures[0];
+
+        assert.equal(failure.getFailure(), Rule.FAILURE_STRING);
+    });
+});
+describe('noLodashIsundefined fixer', () => {
+    it('should fix simple identifier', () => {
+        const src = `if (_.isUndefined(obj)) { // do stuff }`;
+        const expected = `if (obj === undefined) { // do stuff }`;
+        const actual = getFixedResult(src, rule);
+        const result = helper(src, rule);
+        assert.equal(result.errorCount, 1);
+        assert.equal(actual, expected);
+    });
+    it('should fix property access expression', () => {
+        const src = `if (_.isUndefined(this.property)) { // do stuff }`;
+        const expected = `if (this.property === undefined) { // do stuff }`;
+        const actual = getFixedResult(src, rule);
+        const result = helper(src, rule);
+        assert.equal(result.errorCount, 1);
+        assert.equal(actual, expected);
+    });
+    it('should fix element access expression', () => {
+        const src = `if (_.isUndefined(someArray[nested])) { // do stuff }`;
+        const expected = `if (someArray[nested] === undefined) { // do stuff }`;
+        const actual = getFixedResult(src, rule);
+        const result = helper(src, rule);
+        assert.equal(result.errorCount, 1);
+        assert.equal(actual, expected);
+    });
+    it('should fix property and element access expression', () => {
+        const src = `if (_.isUndefined(someObj.someArray[nested])) { // do stuff }`;
+        const expected = `if (someObj.someArray[nested] === undefined) { // do stuff }`;
+        const actual = getFixedResult(src, rule);
+        const result = helper(src, rule);
+        assert.equal(result.errorCount, 1);
+        assert.equal(actual, expected);
+    });
+    it('should fix negation', () => {
+        const src = `if (!_.isUndefined(someObj)) { // do stuff }`;
+        const expected = `if (someObj !== undefined) { // do stuff }`;
+        const actual = getFixedResult(src, rule);
+        const result = helper(src, rule);
+        assert.equal(result.errorCount, 1);
+        assert.equal(actual, expected);
+    });
+    it('should fix negation with property and element access expression', () => {
+        const src = `if (!_.isUndefined(someObj.someArray[nested])) { // do stuff }`;
+        const expected = `if (someObj.someArray[nested] !== undefined) { // do stuff }`;
+        const actual = getFixedResult(src, rule);
+        const result = helper(src, rule);
+        assert.equal(result.errorCount, 1);
+        assert.equal(actual, expected);
+    });
+});

--- a/packages/eslint-config/tsconfig.json
+++ b/packages/eslint-config/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig",
+    "compilerOptions": {
+        "outDir": "lib",
+        "rootDir": "."
+    },
+    "include": ["./rules/**/*", "test/**/*"]
+}


### PR DESCRIPTION
## Description

⚠️ Very much WIP 🚧 

TSLint has been deprecated for quite some time now and is not receiving new features, the official recommendation is to migrate to ESLint instead. This PR is very much WIP but I wanted to get the ball rolling of migrating our linting rules to support ESLint.

This uses [tslint-to-eslint-config](https://github.com/typescript-eslint/tslint-to-eslint-config) to automatically generated a closely matching base ESLint config from our `tslint.json` but our custom rules need to be manually migrated.

## Types of changes

* New feature (non-breaking change which adds functionality)

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
