### PR TITLE
AS: respect max slippage in EP consumer

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -125,6 +125,10 @@
             {
                 "note": "Fix Balancer sampling",
                 "pr": 2711
+            },
+            {
+                "note": "Respect max slippage in EP consumer",
+                "pr": 2712
             }
         ]
     },

--- a/packages/asset-swapper/src/quote_consumers/utils.ts
+++ b/packages/asset-swapper/src/quote_consumers/utils.ts
@@ -1,0 +1,28 @@
+import { BigNumber } from '@0x/utils';
+import * as _ from 'lodash';
+
+import { MarketOperation, SwapQuote } from '../types';
+
+/**
+ * Compute the mminimum buy token amount for market operations by inferring
+ * the slippage from the orders in a quote. We cannot rely on
+ * `worstCaseQuoteInfo.makerAssetAmount` because that does not stop at
+ * maximum slippage.
+ */
+export function getMinBuyAmount(quote: SwapQuote): BigNumber {
+    // Infer the allowed maker asset slippage from the orders.
+    const totalOrderMakerAssetAmount = BigNumber.sum(...quote.orders.map(o => o.makerAssetAmount));
+    const totalFillMakerAssetAmount =
+        quote.type === MarketOperation.Sell
+            ? BigNumber.sum(...quote.orders.map(o => BigNumber.sum(0, ...o.fills.map(f => f.output))))
+            : BigNumber.sum(...quote.orders.map(o => BigNumber.sum(0, ...o.fills.map(f => f.input))));
+    if (totalFillMakerAssetAmount.eq(0)) {
+        return quote.worstCaseQuoteInfo.makerAssetAmount;
+    }
+    if (totalOrderMakerAssetAmount.eq(totalFillMakerAssetAmount)) {
+        // No slippage allowed on bought tokens.
+        return quote.bestCaseQuoteInfo.makerAssetAmount;
+    }
+    const slipRatio = totalOrderMakerAssetAmount.div(totalFillMakerAssetAmount);
+    return quote.bestCaseQuoteInfo.makerAssetAmount.times(slipRatio).integerValue(BigNumber.ROUND_DOWN);
+}


### PR DESCRIPTION
## Description

In the EP consumer we were setting `minBuyAmount = quote.worstCaseQuoteInfo.makerAssetAmount`, which would allow for very high slippage because the quote simulator (who populates this value) finds the actual worst case, irregardless of slippage limits.

:heavy_check_mark: SWRV/WETH pairs that slip >1% now revert as incomplete fills in simbot.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
