### PR TITLE
[Price-aware RFQ requests] Decouple QuoteReporter from _generateOptimizedOrdersAsync

### DIFF
--- a/packages/asset-swapper/package.json
+++ b/packages/asset-swapper/package.json
@@ -17,7 +17,7 @@
         "compile": "sol-compiler",
         "lint": "tslint --format stylish --project . --exclude ./generated-wrappers/**/* --exclude ./test/generated-wrappers/**/* --exclude ./generated-artifacts/**/* --exclude ./test/generated-artifacts/**/* --exclude **/lib/**/* && yarn lint-contracts",
         "lint-contracts": "#solhint -c .solhint.json contracts/**/**/**/**/*.sol",
-        "prettier": "prettier '**/*.{ts,tsx,json,md}' --config ../../.prettierrc  --ignore-path ../../.prettierignore",
+        "prettier": "prettier --write '**/*.{ts,tsx,json,md}' --config ../../.prettierrc  --ignore-path ../../.prettierignore",
         "fix": "tslint --fix --format stylish --project . --exclude ./generated-wrappers/**/* --exclude ./generated-artifacts/**/* --exclude ./test/generated-wrappers/**/* --exclude ./test/generated-artifacts/**/* --exclude **/lib/**/* && yarn lint-contracts",
         "test": "yarn run_mocha",
         "rebuild_and_test": "run-s clean build test",

--- a/packages/asset-swapper/src/utils/market_operation_utils/index.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/index.ts
@@ -40,6 +40,7 @@ import {
     OptimizerResultWithReport,
     OrderDomain,
     TokenAdjacencyGraph,
+    GenerateOptimizedOrdersOpts,
 } from './types';
 
 // tslint:disable:boolean-naming
@@ -79,7 +80,12 @@ export class MarketOperationUtils {
     private readonly _buySources: SourceFilters;
     private readonly _feeSources = new SourceFilters(FEE_QUOTE_SOURCES);
 
-    private static _computeQuoteReport(nativeOrders: SignedOrder[], quoteRequestor: QuoteRequestor, marketSideLiquidity: MarketSideLiquidity, optimizerResult: OptimizerResult): QuoteReport {
+    private static _computeQuoteReport(
+        nativeOrders: SignedOrder[],
+        quoteRequestor: QuoteRequestor | undefined,
+        marketSideLiquidity: MarketSideLiquidity,
+        optimizerResult: OptimizerResult,
+    ): QuoteReport {
         const {side, dexQuotes, twoHopQuotes, orderFillableAmounts } = marketSideLiquidity;
         const { liquidityDelivered } = optimizerResult;
         return generateQuoteReport(
@@ -366,9 +372,15 @@ export class MarketOperationUtils {
             shouldBatchBridgeOrders: defaultOpts.shouldBatchBridgeOrders,
         });
 
+        // Compute Quote Report and return the results.
         let quoteReport: QuoteReport | undefined;
-        if (defaultOpts.shouldGenerateQuoteReport && defaultOpts.rfqt && defaultOpts.rfqt.quoteRequestor) {
-            quoteReport = MarketOperationUtils._computeQuoteReport(nativeOrders, defaultOpts.rfqt.quoteRequestor, marketSideLiquidity, optimizerResult);
+        if (defaultOpts.shouldGenerateQuoteReport) {
+            quoteReport = MarketOperationUtils._computeQuoteReport(
+                nativeOrders,
+                defaultOpts.rfqt ? defaultOpts.rfqt.quoteRequestor : undefined,
+                marketSideLiquidity,
+                optimizerResult,
+            );
         }
         return {...optimizerResult, quoteReport};
     }

--- a/packages/asset-swapper/src/utils/market_operation_utils/index.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/index.ts
@@ -33,14 +33,13 @@ import {
     DexSample,
     ERC20BridgeSource,
     FeeSchedule,
-    FillData,
     GetMarketOrdersOpts,
     MarketSideLiquidity,
     OptimizedMarketOrder,
     OptimizerResult,
+    OptimizerResultWithReport,
     OrderDomain,
     TokenAdjacencyGraph,
-    OptimizerResultWithReport,
 } from './types';
 
 // tslint:disable:boolean-naming

--- a/packages/asset-swapper/src/utils/market_operation_utils/index.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/index.ts
@@ -85,7 +85,7 @@ export class MarketOperationUtils {
         marketSideLiquidity: MarketSideLiquidity,
         optimizerResult: OptimizerResult,
     ): QuoteReport {
-        const {side, dexQuotes, twoHopQuotes, orderFillableAmounts } = marketSideLiquidity;
+        const { side, dexQuotes, twoHopQuotes, orderFillableAmounts } = marketSideLiquidity;
         const { liquidityDelivered } = optimizerResult;
         return generateQuoteReport(
             side,
@@ -381,7 +381,7 @@ export class MarketOperationUtils {
                 optimizerResult,
             );
         }
-        return {...optimizerResult, quoteReport};
+        return { ...optimizerResult, quoteReport };
     }
 
     /**
@@ -409,9 +409,14 @@ export class MarketOperationUtils {
         });
         let quoteReport: QuoteReport | undefined;
         if (_opts.shouldGenerateQuoteReport && _opts.rfqt && _opts.rfqt.quoteRequestor) {
-            quoteReport = MarketOperationUtils._computeQuoteReport(nativeOrders, _opts.rfqt.quoteRequestor, marketSideLiquidity, optimizerResult);
+            quoteReport = MarketOperationUtils._computeQuoteReport(
+                nativeOrders,
+                _opts.rfqt.quoteRequestor,
+                marketSideLiquidity,
+                optimizerResult,
+            );
         }
-        return {...optimizerResult, quoteReport};
+        return { ...optimizerResult, quoteReport };
     }
 
     /**

--- a/packages/asset-swapper/src/utils/market_operation_utils/index.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/index.ts
@@ -40,7 +40,6 @@ import {
     OptimizerResultWithReport,
     OrderDomain,
     TokenAdjacencyGraph,
-    GenerateOptimizedOrdersOpts,
 } from './types';
 
 // tslint:disable:boolean-naming
@@ -361,23 +360,23 @@ export class MarketOperationUtils {
         takerAmount: BigNumber,
         opts?: Partial<GetMarketOrdersOpts>,
     ): Promise<OptimizerResultWithReport> {
-        const defaultOpts = { ...DEFAULT_GET_MARKET_ORDERS_OPTS, ...opts };
-        const marketSideLiquidity = await this.getMarketSellLiquidityAsync(nativeOrders, takerAmount, defaultOpts);
+        const _opts = { ...DEFAULT_GET_MARKET_ORDERS_OPTS, ...opts };
+        const marketSideLiquidity = await this.getMarketSellLiquidityAsync(nativeOrders, takerAmount, _opts);
         const optimizerResult = await this._generateOptimizedOrdersAsync(marketSideLiquidity, {
-            bridgeSlippage: defaultOpts.bridgeSlippage,
-            maxFallbackSlippage: defaultOpts.maxFallbackSlippage,
-            excludedSources: defaultOpts.excludedSources,
-            feeSchedule: defaultOpts.feeSchedule,
-            allowFallback: defaultOpts.allowFallback,
-            shouldBatchBridgeOrders: defaultOpts.shouldBatchBridgeOrders,
+            bridgeSlippage: _opts.bridgeSlippage,
+            maxFallbackSlippage: _opts.maxFallbackSlippage,
+            excludedSources: _opts.excludedSources,
+            feeSchedule: _opts.feeSchedule,
+            allowFallback: _opts.allowFallback,
+            shouldBatchBridgeOrders: _opts.shouldBatchBridgeOrders,
         });
 
         // Compute Quote Report and return the results.
         let quoteReport: QuoteReport | undefined;
-        if (defaultOpts.shouldGenerateQuoteReport) {
+        if (_opts.shouldGenerateQuoteReport) {
             quoteReport = MarketOperationUtils._computeQuoteReport(
                 nativeOrders,
-                defaultOpts.rfqt ? defaultOpts.rfqt.quoteRequestor : undefined,
+                _opts.rfqt ? _opts.rfqt.quoteRequestor : undefined,
                 marketSideLiquidity,
                 optimizerResult,
             );
@@ -398,19 +397,19 @@ export class MarketOperationUtils {
         makerAmount: BigNumber,
         opts?: Partial<GetMarketOrdersOpts>,
     ): Promise<OptimizerResultWithReport> {
-        const defaultOpts = { ...DEFAULT_GET_MARKET_ORDERS_OPTS, ...opts };
-        const marketSideLiquidity = await this.getMarketBuyLiquidityAsync(nativeOrders, makerAmount, defaultOpts);
+        const _opts = { ...DEFAULT_GET_MARKET_ORDERS_OPTS, ...opts };
+        const marketSideLiquidity = await this.getMarketBuyLiquidityAsync(nativeOrders, makerAmount, _opts);
         const optimizerResult = await this._generateOptimizedOrdersAsync(marketSideLiquidity, {
-            bridgeSlippage: defaultOpts.bridgeSlippage,
-            maxFallbackSlippage: defaultOpts.maxFallbackSlippage,
-            excludedSources: defaultOpts.excludedSources,
-            feeSchedule: defaultOpts.feeSchedule,
-            allowFallback: defaultOpts.allowFallback,
-            shouldBatchBridgeOrders: defaultOpts.shouldBatchBridgeOrders,
+            bridgeSlippage: _opts.bridgeSlippage,
+            maxFallbackSlippage: _opts.maxFallbackSlippage,
+            excludedSources: _opts.excludedSources,
+            feeSchedule: _opts.feeSchedule,
+            allowFallback: _opts.allowFallback,
+            shouldBatchBridgeOrders: _opts.shouldBatchBridgeOrders,
         });
         let quoteReport: QuoteReport | undefined;
-        if (defaultOpts.shouldGenerateQuoteReport && defaultOpts.rfqt && defaultOpts.rfqt.quoteRequestor) {
-            quoteReport = MarketOperationUtils._computeQuoteReport(nativeOrders, defaultOpts.rfqt.quoteRequestor, marketSideLiquidity, optimizerResult);
+        if (_opts.shouldGenerateQuoteReport && _opts.rfqt && _opts.rfqt.quoteRequestor) {
+            quoteReport = MarketOperationUtils._computeQuoteReport(nativeOrders, _opts.rfqt.quoteRequestor, marketSideLiquidity, optimizerResult);
         }
         return {...optimizerResult, quoteReport};
     }

--- a/packages/asset-swapper/src/utils/market_operation_utils/types.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/types.ts
@@ -4,6 +4,7 @@ import { BigNumber } from '@0x/utils';
 
 import { RfqtRequestOpts, SignedOrderWithFillableAmounts } from '../../types';
 import { QuoteRequestor } from '../../utils/quote_requestor';
+import { QuoteReport } from '../quote_report_generator';
 
 /**
  * Order domain keys: chainId and exchange
@@ -322,6 +323,10 @@ export interface OptimizerResult {
     optimizedOrders: OptimizedMarketOrder[];
     isTwoHop: boolean;
     liquidityDelivered: CollapsedFill[] | DexSample<MultiHopFillData>;
+}
+
+export interface OptimizerResultWithReport extends OptimizerResult {
+    quoteReport?: QuoteReport;
 }
 
 export type MarketDepthSide = Array<Array<DexSample<FillData>>>;

--- a/packages/asset-swapper/src/utils/market_operation_utils/types.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/types.ts
@@ -4,7 +4,6 @@ import { BigNumber } from '@0x/utils';
 
 import { RfqtRequestOpts, SignedOrderWithFillableAmounts } from '../../types';
 import { QuoteRequestor } from '../../utils/quote_requestor';
-import { QuoteReport } from '../quote_report_generator';
 
 /**
  * Order domain keys: chainId and exchange
@@ -322,7 +321,7 @@ export interface SourceQuoteOperation<TFillData extends FillData = FillData>
 export interface OptimizerResult {
     optimizedOrders: OptimizedMarketOrder[];
     isTwoHop: boolean;
-    quoteReport?: QuoteReport;
+    liquidityDelivered: CollapsedFill[] | DexSample<MultiHopFillData>;
 }
 
 export type MarketDepthSide = Array<Array<DexSample<FillData>>>;


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Decouples the quote reporter logic from generating an optimized order. This PR is simply a refactor in lieu of greater changes that will happen in separate PRs. There should be no impact on the end user.


## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

* Refactor

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] Prefix PR title with `[WIP]` if necessary.
-   [X] Add tests to cover changes as needed.
-   [X] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
