### PR TITLE
fix: Refactor rfq request positioning

### DIFF
--- a/packages/asset-swapper/package.json
+++ b/packages/asset-swapper/package.json
@@ -17,7 +17,7 @@
         "compile": "sol-compiler",
         "lint": "tslint --format stylish --project . --exclude ./generated-wrappers/**/* --exclude ./test/generated-wrappers/**/* --exclude ./generated-artifacts/**/* --exclude ./test/generated-artifacts/**/* --exclude **/lib/**/* && yarn lint-contracts",
         "lint-contracts": "#solhint -c .solhint.json contracts/**/**/**/**/*.sol",
-        "prettier": "prettier '**/*.{ts,tsx,json,md}' --config ../../.prettierrc  --ignore-path ../../.prettierignore",
+        "prettier": "prettier --write '**/*.{ts,tsx,json,md}' --config ../../.prettierrc  --ignore-path ../../.prettierignore",
         "fix": "tslint --fix --format stylish --project . --exclude ./generated-wrappers/**/* --exclude ./generated-artifacts/**/* --exclude ./test/generated-wrappers/**/* --exclude ./test/generated-artifacts/**/* --exclude **/lib/**/* && yarn lint-contracts",
         "test": "yarn run_mocha",
         "rebuild_and_test": "run-s clean build test",

--- a/packages/asset-swapper/src/swap_quoter.ts
+++ b/packages/asset-swapper/src/swap_quoter.ts
@@ -686,9 +686,12 @@ export class SwapQuoter {
         // If an API key was provided, but the key is not whitelisted, raise a warning and disable RFQ
         if (opts.rfqt && opts.rfqt.apiKey && !this._isApiKeyWhitelisted(opts.rfqt.apiKey)) {
             if (rfqtOptions && rfqtOptions.warningLogger) {
-                rfqtOptions.warningLogger({
-                    apiKey: opts.rfqt.apiKey,
-                }, 'Attempt at using an RFQ API key that is not whitelisted. Disabling RFQ for the request lifetime.');
+                rfqtOptions.warningLogger(
+                    {
+                        apiKey: opts.rfqt.apiKey,
+                    },
+                    'Attempt at using an RFQ API key that is not whitelisted. Disabling RFQ for the request lifetime.',
+                );
             }
             opts.rfqt = undefined;
         }

--- a/packages/asset-swapper/src/utils/market_operation_utils/index.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/index.ts
@@ -558,7 +558,7 @@ export class MarketOperationUtils {
         return {...optimizerResult, quoteReport};
     }
 
-    private async _generateOptimizedOrdersAsync(
+    public async _generateOptimizedOrdersAsync(
         marketSideLiquidity: MarketSideLiquidity,
         opts: GenerateOptimizedOrdersOpts,
     ): Promise<OptimizerResult> {

--- a/packages/asset-swapper/src/utils/market_operation_utils/index.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/index.ts
@@ -622,6 +622,9 @@ export class MarketOperationUtils {
                         // Re-run optimizer with the new firm quote. This is the second and last time
                         // we run the optimized in a block of code. In this case, we don't catch a potential `NoOptimalPath` exception
                         // and we let it bubble up if it happens.
+                        //
+                        // NOTE: as of now, we assume that RFQ orders are 100% fillable because these are trusted market makers, therefore
+                        // we do not perform an extra check to get fillable taker amounts.
                         optimizerResult = await this._generateOptimizedOrdersAsync({
                             ...marketSideLiquidity,
                             nativeOrders: marketSideLiquidity.nativeOrders.concat(firmQuotes.map(quote => quote.signedOrder)),

--- a/packages/asset-swapper/src/utils/market_operation_utils/index.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/index.ts
@@ -575,6 +575,8 @@ export class MarketOperationUtils {
             optimizerResult = await this._generateOptimizedOrdersAsync(marketSideLiquidity, optimizerOpts);
         } catch (e) {
             // If no on-chain or off-chain Open Orderbook orders are present, a `NoOptimalPath` will be thrown.
+            // If this happens at this stage, there is still a chance that an RFQ order is fillable, therefore
+            // we catch the error and continue.
             if (e.message !== AggregationError.NoOptimalPath) {
                 throw e;
             }

--- a/packages/asset-swapper/src/utils/market_operation_utils/orders.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/orders.ts
@@ -121,6 +121,12 @@ export function createSignedOrdersWithFillableAmounts(
     orders: SignedOrder[],
     fillableAmounts: BigNumber[],
 ): SignedOrderWithFillableAmounts[] {
+
+    // Quick safety check: ensures that orders maps perfectly to fillable amounts.
+    if (orders.length !== fillableAmounts.length) {
+        throw new Error(`Number of orders was ${orders.length} but fillable amounts was ${fillableAmounts.length}. This should never happen`);
+    }
+
     return orders
         .map((order: SignedOrder, i: number) => {
             const fillableAmount = fillableAmounts[i];

--- a/packages/asset-swapper/src/utils/market_operation_utils/orders.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/orders.ts
@@ -121,10 +121,13 @@ export function createSignedOrdersWithFillableAmounts(
     orders: SignedOrder[],
     fillableAmounts: BigNumber[],
 ): SignedOrderWithFillableAmounts[] {
-
     // Quick safety check: ensures that orders maps perfectly to fillable amounts.
     if (orders.length !== fillableAmounts.length) {
-        throw new Error(`Number of orders was ${orders.length} but fillable amounts was ${fillableAmounts.length}. This should never happen`);
+        throw new Error(
+            `Number of orders was ${orders.length} but fillable amounts was ${
+                fillableAmounts.length
+            }. This should never happen`,
+        );
     }
 
     return orders

--- a/packages/asset-swapper/src/utils/market_operation_utils/types.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/types.ts
@@ -5,6 +5,7 @@ import { BigNumber } from '@0x/utils';
 import { RfqtRequestOpts, SignedOrderWithFillableAmounts } from '../../types';
 import { QuoteRequestor } from '../../utils/quote_requestor';
 import { QuoteReport } from '../quote_report_generator';
+import { SourceFilters } from './source_filters';
 
 /**
  * Order domain keys: chainId and exchange
@@ -348,8 +349,19 @@ export interface MarketSideLiquidity {
     ethToInputRate: BigNumber;
     rfqtIndicativeQuotes: RFQTIndicativeQuote[];
     twoHopQuotes: Array<DexSample<MultiHopFillData>>;
+    quoteSourceFilters: SourceFilters;
 }
 
 export interface TokenAdjacencyGraph {
     [token: string]: string[];
+}
+
+export interface GenerateOptimizedOrdersOpts {
+    runLimit?: number;
+    bridgeSlippage?: number;
+    maxFallbackSlippage?: number;
+    excludedSources?: ERC20BridgeSource[];
+    feeSchedule?: FeeSchedule;
+    allowFallback?: boolean;
+    shouldBatchBridgeOrders?: boolean;
 }

--- a/packages/asset-swapper/src/utils/market_operation_utils/types.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/types.ts
@@ -5,6 +5,7 @@ import { BigNumber } from '@0x/utils';
 import { RfqtRequestOpts, SignedOrderWithFillableAmounts } from '../../types';
 import { QuoteRequestor } from '../../utils/quote_requestor';
 import { QuoteReport } from '../quote_report_generator';
+
 import { SourceFilters } from './source_filters';
 
 /**

--- a/packages/asset-swapper/test/market_operation_utils_test.ts
+++ b/packages/asset-swapper/test/market_operation_utils_test.ts
@@ -864,7 +864,7 @@ describe('MarketOperationUtils tests', () => {
                 expect(hasSecondOptimizationRun).to.eql(true);
             });
 
-            it.only('getMarketSellOrdersAsync() will raise a NoOptimalPath error if no path was found during on-chain DEX optimization and RFQ optimization', async () => {
+            it('getMarketSellOrdersAsync() will raise a NoOptimalPath error if no path was found during on-chain DEX optimization and RFQ optimization', async () => {
                 const mockedMarketOpUtils = TypeMoq.Mock.ofType(MarketOperationUtils, TypeMoq.MockBehavior.Loose, false, MOCK_SAMPLER, contractAddresses, ORDER_DOMAIN);
                 mockedMarketOpUtils.callBase = true;
                 mockedMarketOpUtils.setup(


### PR DESCRIPTION
## Description

Milestone 1 for Price-aware RFQ requests. This PR contains the following changes:
- removes the original calls to firm and indicative quotes
- refactored `getMarket{Buy|Sell}OrdersAsync` into `_getMarketSideOrdersAsync`
- Runs optimizer with only on-chain and open-orderbook liquidity first, then calls RFQ, and finally re-runs the optimizer again
- Documentation
- Unit tests 

## Testing instructions

There are unit tests, and i've also tried this branch directly on the 0x API. 

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] Prefix PR title with `[WIP]` if necessary.
-   [X] Add tests to cover changes as needed.
-   [X] Update documentation as needed.
-   [X] Add new entries to the relevant CHANGELOG.jsons.
