### PR TITLE
[WIP] Reduce gas consumption for ERC20 transfers

### DIFF
--- a/contracts/zero-ex/contracts/src/external/IAllowanceTarget.sol
+++ b/contracts/zero-ex/contracts/src/external/IAllowanceTarget.sol
@@ -26,14 +26,25 @@ import "@0x/contracts-utils/contracts/src/v06/interfaces/IAuthorizableV06.sol";
 interface IAllowanceTarget is
     IAuthorizableV06
 {
-    /// @dev Execute an arbitrary call. Only an authority can call this.
+    /// @dev Execute an arbitrary call. Only an authority can call this. Returns raw (unencoded) return data from the call.
     /// @param target The call target.
     /// @param callData The call data.
-    /// @return resultData The data returned by the call.
     function executeCall(
         address payable target,
         bytes calldata callData
     )
-        external
-        returns (bytes memory resultData);
+        external;
+
+    /// @dev Execute an ERC20 transferFrom. Only an authority can call this. Returns raw (unencoded) return data from the call.
+    /// @param token The ERC20 token address.
+    /// @param sender The token sender.
+    /// @param recipient The token recipient.
+    /// @param amount The amount to transfer.
+    function transferFrom(
+        address token,
+        address sender,
+        address recipient,
+        uint256 amount
+    )
+        external;
 }

--- a/contracts/zero-ex/contracts/src/features/TokenSpenderFeature.sol
+++ b/contracts/zero-ex/contracts/src/features/TokenSpenderFeature.sol
@@ -79,23 +79,73 @@ contract TokenSpenderFeature is
         onlySelf
     {
         IAllowanceTarget spender = LibTokenSpenderStorage.getStorage().allowanceTarget;
-        // Have the allowance target execute an ERC20 `transferFrom()`.
-        (bool didSucceed, bytes memory resultData) = address(spender).call(
-            abi.encodeWithSelector(
-                IAllowanceTarget.executeCall.selector,
-                address(token),
-                abi.encodeWithSelector(
-                    IERC20TokenV06.transferFrom.selector,
-                    owner,
-                    to,
-                    amount
-                )
-            )
-        );
-        if (didSucceed) {
-            resultData = abi.decode(resultData, (bytes));
+
+        // Gas savings from assembly: 2324
+        bytes4 esel = IAllowanceTarget.executeCall.selector;
+        bytes4 tsel = IERC20TokenV06.transferFrom.selector;
+        bool didSucceed;
+        bytes memory resultData;
+        assembly {
+            let ptr := mload(0x40)
+            if iszero(ptr) { ptr := 0x60 }
+
+            mstore(           ptr, esel)   // executeCall.selector  : 4 bytes
+            mstore(add(ptr, 0x04), token)  // target                : 32
+            mstore(add(ptr, 0x24), 0x40)   // offset to callData    : 32
+            mstore(add(ptr, 0x44), 100)    // length of callData    : 32
+            mstore(add(ptr, 0x64), tsel)   // transferFrom.selector : 4
+            mstore(add(ptr, 0x68), owner)  //                       : 32
+            mstore(add(ptr, 0x88), to)     //                       : 32
+            mstore(add(ptr, 0xa8), amount) //                       : 32
+                                           //                  total: 200
+
+            didSucceed := call(gas(), spender, 0, ptr, 200, 0, 0)
+
+            // Set new free memory pointer, accounting for allocation of
+            // max(200, returndatasize()) bytes. We're using at least 200 for
+            // the call data, and at least returndatasize() for the result.
+            switch gt(add(returndatasize(), 32), 200)
+            case 1 {
+                mstore(0x40, add(ptr, add(returndatasize(), 32)))
+            }
+            default {
+                mstore(0x40, add(ptr, 200))
+            }
+
+            // Reuse memory we just used for call().
+            mstore(ptr, returndatasize())
+            returndatacopy(add(ptr, 32), 0, returndatasize())
+
+            // In case of failure, we want resultData to be length-prefixed
+            // bytes with the exact revert data we got.
+            resultData := ptr
+
+            if didSucceed {
+                // On a successful call to the AllowanceTarget, return data
+                // will be an ABI encoded `bytes`:
+                // * First word is 0x20 (offset to returned bytes).
+                // * Second word is the length of the returned bytes.
+                // * Beyond that is the actual data.
+
+                // In successful calls, we need to ABI decode the return data.
+                // Skip to the actual data. This is the equivalent of:
+                // resultData = abi.decode(resultData, (bytes))
+                resultData := add(resultData, 64)
+
+                let rdlen := mload(resultData)
+                if rdlen {
+                    // If we have a non-zero length, the length has to be
+                    // exactly 64, and the data has to be exactly 1.
+
+                    didSucceed := and(
+                        eq(rdlen, 32),
+                        eq(mload(add(resultData, 0x20)), 1)
+                    )
+                }
+            }
         }
-        if (!didSucceed || !LibERC20TokenV06.isSuccessfulResult(resultData)) {
+
+        if (!didSucceed) {
             LibSpenderRichErrors.SpenderERC20TransferFromFailedError(
                 address(token),
                 owner,

--- a/contracts/zero-ex/test/allowance_target_test.ts
+++ b/contracts/zero-ex/test/allowance_target_test.ts
@@ -1,30 +1,39 @@
 import { blockchainTests, constants, expect, randomAddress, verifyEventsFromLogs } from '@0x/contracts-test-utils';
-import { AuthorizableRevertErrors, hexUtils, StringRevertError } from '@0x/utils';
+import { AuthorizableRevertErrors, BigNumber, hexUtils, StringRevertError } from '@0x/utils';
 
 import { artifacts } from './artifacts';
-import { AllowanceTargetContract, TestCallTargetContract, TestCallTargetEvents, IAllowanceTargetContract } from './wrappers';
+import { AllowanceTargetContract, TestCallTargetContract, TestCallTargetEvents, TestTokenSpenderERC20TokenContract, TestTokenSpenderERC20TokenEvents, IAllowanceTargetContract } from './wrappers';
 
 blockchainTests.resets('AllowanceTarget', env => {
     let owner: string;
     let authority: string;
-    let allowanceTarget: AllowanceTargetContract;
-    let iAllowanceTarget: IAllowanceTargetContract;
+    let allowanceTarget: IAllowanceTargetContract;
     let callTarget: TestCallTargetContract;
+    let token: TestTokenSpenderERC20TokenContract;
 
     before(async () => {
         [owner, authority] = await env.getAccountAddressesAsync();
-        allowanceTarget = await AllowanceTargetContract.deployFrom0xArtifactAsync(
+        let allowanceTargetImpl = await AllowanceTargetContract.deployFrom0xArtifactAsync(
             artifacts.AllowanceTarget,
             env.provider,
             env.txDefaults,
             artifacts,
         );
+        allowanceTarget = new IAllowanceTargetContract(
+            allowanceTargetImpl.address, env.provider, env.txDefaults,
+            {
+                "TestCallTarget": artifacts.TestCallTarget.compilerOutput.abi,
+                "TestTokenSpenderERC20Token": artifacts.TestTokenSpenderERC20Token.compilerOutput.abi
+            }); // logDecodeDependencies
         await allowanceTarget.addAuthorizedAddress(authority).awaitTransactionSuccessAsync();
-        iAllowanceTarget = new IAllowanceTargetContract(
-            allowanceTarget.address, env.provider, env.txDefaults,
-            { "TestCallTarget": artifacts.TestCallTarget.compilerOutput.abi }); // logDecodeDependencies
         callTarget = await TestCallTargetContract.deployFrom0xArtifactAsync(
             artifacts.TestCallTarget,
+            env.provider,
+            env.txDefaults,
+            artifacts,
+        );
+        token = await TestTokenSpenderERC20TokenContract.deployFrom0xArtifactAsync(
+            artifacts.TestTokenSpenderERC20Token,
             env.provider,
             env.txDefaults,
             artifacts,
@@ -37,7 +46,7 @@ blockchainTests.resets('AllowanceTarget', env => {
     describe('executeCall()', () => {
         it('non-authority cannot call executeCall()', async () => {
             const notAuthority = randomAddress();
-            const tx = iAllowanceTarget
+            const tx = allowanceTarget
                 .executeCall(randomAddress(), hexUtils.random())
                 .callAsync({ from: notAuthority });
             return expect(tx).to.revertWith(new AuthorizableRevertErrors.SenderNotAuthorizedError(notAuthority));
@@ -45,7 +54,7 @@ blockchainTests.resets('AllowanceTarget', env => {
 
         it('authority can call executeCall()', async () => {
             const targetData = hexUtils.random(128);
-            const receipt = await iAllowanceTarget
+            const receipt = await allowanceTarget
                 .executeCall(callTarget.address, targetData)
                 .awaitTransactionSuccessAsync({ from: authority });
             verifyEventsFromLogs(
@@ -62,15 +71,15 @@ blockchainTests.resets('AllowanceTarget', env => {
             );
         });
 
-        it('AllowanceTarget returns call result', async () => {
-            const result = await iAllowanceTarget
+        it('executeCall() returns call result', async () => {
+            const result = await allowanceTarget
                 .executeCall(callTarget.address, hexUtils.random(128))
-                .callAsync({ from: authority });
+                .rawCallAsync({ from: authority });
             expect(result).to.eq(TARGET_RETURN_VALUE);
         });
 
-        it('AllowanceTarget returns raw call revert', async () => {
-            const tx = iAllowanceTarget.executeCall(callTarget.address, REVERTING_DATA).callAsync({ from: authority });
+        it('executeCall() returns raw call revert', async () => {
+            const tx = allowanceTarget.executeCall(callTarget.address, REVERTING_DATA).callAsync({ from: authority });
             return expect(tx).to.revertWith(new StringRevertError('TestCallTarget/REVERT'));
         });
 
@@ -81,6 +90,45 @@ blockchainTests.resets('AllowanceTarget', env => {
                 value: 0,
             });
             return expect(tx).to.eventually.be.rejected();
+        });
+    });
+
+    describe('transferFrom()', () => {
+        const fromAddress = randomAddress();
+        const toAddress = randomAddress();
+        const tokenAmount = new BigNumber(123456);
+
+        it('non-authority cannot call transferFrom()', async () => {
+            const notAuthority = randomAddress();
+            const tx = allowanceTarget
+                .transferFrom(callTarget.address, fromAddress, toAddress, tokenAmount)
+                .callAsync({ from: notAuthority });
+            return expect(tx).to.revertWith(new AuthorizableRevertErrors.SenderNotAuthorizedError(notAuthority));
+        });
+
+        it('authority can call transferFrom()', async () => {
+            const receipt = await allowanceTarget
+                .transferFrom(token.address, fromAddress, toAddress, tokenAmount)
+                .awaitTransactionSuccessAsync({ from: authority });
+            verifyEventsFromLogs(
+                receipt.logs,
+                [
+                    {
+                        sender: allowanceTarget.address,
+                        from: fromAddress,
+                        to: toAddress,
+                        amount: tokenAmount,
+                    },
+                ],
+                TestTokenSpenderERC20TokenEvents.TransferFromCalled,
+            );
+        });
+
+        it('transferFrom() returns raw call result', async () => {
+            const result = await allowanceTarget
+                .transferFrom(callTarget.address, fromAddress, toAddress, tokenAmount)
+                .rawCallAsync({ from: authority });
+            expect(result).to.eq(TARGET_RETURN_VALUE);
         });
     });
 });

--- a/packages/abi-gen/templates/TypeScript/partials/method_call.handlebars
+++ b/packages/abi-gen/templates/TypeScript/partials/method_call.handlebars
@@ -1,18 +1,23 @@
+async rawCallAsync(
+    callData: Partial<CallData> = {},
+    defaultBlock?: BlockParam,
+): Promise<string> {
+    BaseContract._assertCallParams(callData, defaultBlock);
+    {{#ifEquals this.stateMutability "pure" }}
+    if (self._deployedBytecodeIfExists) {
+        return await self._evmExecAsync(this.getABIEncodedTransactionData());
+    } else {
+        return await self._performCallAsync({ data: this.getABIEncodedTransactionData(), ...callData }, defaultBlock);
+    }
+    {{else}}
+    return await self._performCallAsync({ data: this.getABIEncodedTransactionData(), ...callData }, defaultBlock);
+    {{/ifEquals}}
+},
 async callAsync(
     callData: Partial<CallData> = {},
     defaultBlock?: BlockParam,
 ): Promise<{{> return_type outputs=outputs}}> {
-    BaseContract._assertCallParams(callData, defaultBlock);
-    {{#ifEquals this.stateMutability "pure" }}
-    let rawCallResult;
-    if (self._deployedBytecodeIfExists) {
-        rawCallResult = await self._evmExecAsync(this.getABIEncodedTransactionData());
-    } else {
-        rawCallResult = await self._performCallAsync({ data: this.getABIEncodedTransactionData(), ...callData }, defaultBlock);
-    }
-    {{else}}
-    const rawCallResult = await self._performCallAsync({ data: this.getABIEncodedTransactionData(), ...callData }, defaultBlock);
-    {{/ifEquals}}
+    let rawCallResult = await this.rawCallAsync(callData, defaultBlock);
     const abiEncoder = self._lookupAbiEncoder(functionSignature);
     BaseContract._throwIfUnexpectedEmptyCallResult(rawCallResult, abiEncoder);
     return abiEncoder.strictDecodeReturnValue<{{> return_type outputs=outputs}}>(rawCallResult);

--- a/packages/base-contract/src/types.ts
+++ b/packages/base-contract/src/types.ts
@@ -42,6 +42,7 @@ export interface AwaitTransactionSuccessOpts extends SendTransactionOpts {
 
 export interface ContractFunctionObj<T> {
     callAsync(callData?: Partial<CallData>, defaultBlock?: BlockParam): Promise<T>;
+    rawCallAsync(callData?: Partial<CallData>, defaultBlock?: BlockParam): Promise<string>;
     getABIEncodedTransactionData(): string;
 }
 


### PR DESCRIPTION
## Description

This rewrites `AllowanceTarget.exceuteCall()` and `TokenSpenderFeature._spendERC20Tokens()` in assembly to save 2798 gas per `_spendERC20Tokens()` call.

## Testing instructions

No test changes are necessary. `yarn test` tests the new, rewritten versions.

## Types of changes

* Bug fix (non-breaking change which fixes an issue)

Specifically, this is just gas optimization. No change in behavior is expected.

## Checklist:

-   [x] Prefix PR title with `[WIP]` if necessary.
-   [x] Add tests to cover changes as needed.
-   [x] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.