### PR TITLE
[WIP] Feature/subproviders/lattice support

### DIFF
--- a/packages/subproviders/CHANGELOG.json
+++ b/packages/subproviders/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "timestamp": 1601647297,
+        "version": "6.2.0",
+        "changes": [
+            {
+                "note": "Lattice support added"
+            }
+        ]
+    },
+    {
         "timestamp": 1594788383,
         "version": "6.1.1",
         "changes": [

--- a/packages/subproviders/CHANGELOG.json
+++ b/packages/subproviders/CHANGELOG.json
@@ -1,6 +1,5 @@
 [
     {
-        "timestamp": 1601647297,
         "version": "6.2.0",
         "changes": [
             {

--- a/packages/subproviders/src/index.ts
+++ b/packages/subproviders/src/index.ts
@@ -53,6 +53,7 @@ export {
     MnemonicWalletSubproviderConfigs,
     LedgerGetAddressResult,
     TrezorSubproviderConfig,
+    LatticeSubproviderConfig,
 } from './types';
 
 export { ECSignature, EIP712Object, EIP712ObjectValue, EIP712TypedData, EIP712Types, EIP712Parameter } from '@0x/types';

--- a/packages/subproviders/src/subproviders/lattice.ts
+++ b/packages/subproviders/src/subproviders/lattice.ts
@@ -115,7 +115,7 @@ export class LatticeSubprovider extends BaseWalletSubprovider {
         try {
             const data = {
                 protocol: 'eth_signTypedData',
-                data: typedData,
+                payload: typedData,
             };
             const sig = await this._latticeConnectClient.signMessage(address, data);
             return sig;

--- a/packages/subproviders/src/subproviders/lattice.ts
+++ b/packages/subproviders/src/subproviders/lattice.ts
@@ -102,7 +102,6 @@ export class LatticeSubprovider extends BaseWalletSubprovider {
 
     /**
      * Sign a typed data message from the account specified in the `address` param.
-     * NOTE: This method is not implemented on the Lattice in v1, but we plan to support it in future versions.
      * @param address Address from which to sign. Must be the address at `m/44'/60'/0'/0/0` of the current wallet.
      * @param typedData The data to be signed.
      * @return Signature hex string of form `0x{r}{s}{v}

--- a/packages/subproviders/src/subproviders/lattice.ts
+++ b/packages/subproviders/src/subproviders/lattice.ts
@@ -1,0 +1,126 @@
+import { assert } from '@0x/assert';
+import { addressUtils } from '@0x/utils';
+import EthereumTx = require('ethereumjs-tx');
+import * as _ from 'lodash';
+
+import { LatticeSubproviderConfig, PartialTxParams, WalletSubproviderErrors } from '../types';
+
+import { BaseWalletSubprovider } from './base_wallet_subprovider';
+
+const DEFAULT_NUM_ADDRESSES_TO_FETCH = 1;
+const MAINNET_ID = 1;
+const ROPSTEN_ID = 3;
+const RINKEBY_ID = 4;
+const KOVAN_ID = 42;
+const GOERLI_ID = 6284;
+
+function getNetwork(networkId: number): string {
+    switch (networkId) {
+        case ROPSTEN_ID:
+            return 'ropsten';
+        case RINKEBY_ID:
+            return 'rinkeby';
+        case KOVAN_ID:
+            return 'kovan';
+        case GOERLI_ID:
+            return 'goerli';
+        case MAINNET_ID:
+        default:
+            return 'mainnet';
+    }
+}
+
+export class LatticeSubprovider extends BaseWalletSubprovider {
+    private readonly _latticeConnectClient: any;
+    /**
+     * Instantiates a LatticeSubprovider. Private key path is set to `44'/60'/0'/0/`.
+     * This subprovider must be initialized with the GridPlus `eth-lattice-keyring` module as
+     * the `config.latticeConnectClient` object: https://www.npmjs.com/package/eth-lattice-keyring
+     */
+    constructor(config: LatticeSubproviderConfig) {
+        super();
+        const opts = {
+            name: config.appName,
+            network: getNetwork(config.networkId),
+        };
+        this._latticeConnectClient = new config.latticeConnectClient(opts);
+    }
+
+    /**
+     * Fetches the current Lattice wallet Ethereum address at path `44'/60'/0'/0/0`. Only the 0-th index address
+     * may be fetched, but the Lattice user may switch wallets on their device at any time, in which case this
+     * function would return a new address (in the form of a 1-element string array).
+     * @param numberOfAccounts number of accounts to fetch. Currently this is ignored in the connect client, as only one address may be fetched at a time
+     * @return A one-element array of addresses representing the current Lattice wallet's Ethereum account.
+     */
+    public async getAccountsAsync(numberOfAccounts: number = DEFAULT_NUM_ADDRESSES_TO_FETCH): Promise<string[]> {
+        try {
+            const accounts = await this._latticeConnectClient.addAccounts(numberOfAccounts);
+            return accounts;
+        } catch (err) {
+            throw err;
+        }
+    }
+
+    /**
+     * Signs a transaction from the account specified by the `from` field in txParams.
+     * @param txParams Parameters of the transaction to sign.
+     * @return Signed transaction hex string. This is a serialized `ethereum-tx` Transaction object.
+     */
+    public async signTransactionAsync(txData: PartialTxParams): Promise<string> {
+        if (txData.from === undefined || !addressUtils.isAddress(txData.from)) {
+            throw new Error(WalletSubproviderErrors.FromAddressMissingOrInvalid);
+        }
+        const txReq = new EthereumTx(txData);
+        try {
+            const signedTx = await this._latticeConnectClient.signTransaction(txData.from, txReq);
+            return `0x${signedTx.serialize().toString('hex')}`;
+        } catch (err) {
+            throw err;
+        }
+    }
+
+    /**
+     * Sign a personal Ethereum message from the account specified in the `address` param.
+     * @param data Data to be signed. May be represented in hex or ASCII; this representation will be preserved.
+     * @param address Address from which to sign. Must be the address at `m/44'/60'/0'/0/0` of the current wallet.
+     * @return Signature hex string of form `0x{r}{s}{v}
+     */
+    public async signPersonalMessageAsync(data: string, address: string): Promise<string> {
+        if (data === undefined) {
+            throw new Error(WalletSubproviderErrors.DataMissingForSignPersonalMessage);
+        }
+        assert.isHexString('data', data);
+        assert.isETHAddressHex('address', address);
+        try {
+            const sig = await this._latticeConnectClient.signPersonalMessage(address, data);
+            return sig;
+        } catch (err) {
+            throw err;
+        }
+    }
+
+    /**
+     * Sign a typed data message from the account specified in the `address` param.
+     * NOTE: This method is not implemented on the Lattice in v1, but we plan to support it in future versions.
+     * @param address Address from which to sign. Must be the address at `m/44'/60'/0'/0/0` of the current wallet.
+     * @param typedData The data to be signed.
+     * @return Signature hex string of form `0x{r}{s}{v}
+     */
+    public async signTypedDataAsync(address: string, typedData: any): Promise<string> {
+        if (typedData === undefined) {
+            throw new Error(WalletSubproviderErrors.DataMissingForSignTypedData);
+        }
+        assert.isETHAddressHex('address', address);
+        try {
+            const data = {
+                protocol: 'eth_signTypedData',
+                data: typedData,
+            };
+            const sig = await this._latticeConnectClient.signMessage(address, data);
+            return sig;
+        } catch (err) {
+            throw err;
+        }
+    }
+}

--- a/packages/subproviders/src/types.ts
+++ b/packages/subproviders/src/types.ts
@@ -175,3 +175,9 @@ export interface TrezorConnectResponse {
     id: number;
     success: boolean;
 }
+
+export interface LatticeSubproviderConfig {
+    latticeConnectClient: any;
+    networkId: number;
+    appName: string;
+}


### PR DESCRIPTION
## Description

Hello! This PR adds support for interfacing with the GridPlus [Lattice1 hardware wallet](https://gridplus.io/lattice). It was developed along with [GridPlus' `web3-react` fork](https://github.com/GridPlus/web3-react/tree/add-lattice-example) in an effort to allow integrations with the Lattice. The addition is a simple subprovider schema that can be used by other modules such as `web3-react`. It was designed to match those of Trezor and Ledger.

### About the Lattice

The [Lattice](https://gridplus.io/lattice) is a brand new, next-generation hardware wallet designed for ease of use. Its large screen makes reading transactions and messages much more user-friendly. Keys are held in an HSM and all logic executes in a secure compute environment, which is physically separated from the network interface and protected by a physical anti-tamper mesh. The separated network interface is used to connect to external applications like this one. 

The initial batch of Lattice devices is currently being manufactured and sent to presale buyers, at which point we will turn the web store back on for more orders.

For more info see https://gridplus.io/lattice

### Product Shots

Here are some shots of my development device! (Data shown is not related to this PR)

**Sign Transaction:**

![image](https://user-images.githubusercontent.com/7378490/93615146-a366f400-f998-11ea-9cef-dce707748542.png)

**Sign Personal Message:**

![image](https://user-images.githubusercontent.com/7378490/93615268-c98c9400-f998-11ea-9eab-4ea33f95c6e3.png)

## Testing instructions

You can't test this PR without a Lattice device, but I will provide information on how I tested it on my side. If you need to test this yourself, please reach out to justin.leroux@gridplus.io and we can work out how to get you a Lattice for testing.

I was able to test with `web3-react`'s `example` Next.js app which is included in [the repo](https://github.com/NoahZinsmeister/web3-react/tree/v6/example). All changes to the app itself are found in [this commit](https://github.com/NoahZinsmeister/web3-react/commit/ffabb34a46fbe375bdf74f60ec730becbef5d7fb) of our fork. This is a simple app where you just select your wallet and then test a `signPersonalMessage` request. Here are shots of my test:

**1. Message is sent to the device from the app:**

![image](https://user-images.githubusercontent.com/7378490/94950736-b73a4c00-04a8-11eb-93d8-e9c37b386bd3.png)

**2. Message is signed on device and returned to app, which checks it against the available public key for validity:**

![Screen Shot 2020-10-02 at 9 14 38 AM](https://user-images.githubusercontent.com/7378490/94950839-e05adc80-04a8-11eb-96ea-7203ac685b3e.png)

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->


<!-- * Bug fix (non-breaking change which fixes an issue) -->

 * New feature (non-breaking change which adds functionality)

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Prefix PR title with `[WIP]` if necessary.
-   [x] Add tests to cover changes as needed. **-- I can't think of how to provide tests here, as this module must be used with others in order to interact with the Lattice**
-   [ ] Update documentation as needed. **-- Need more clarity on this. I didn't want to make manual changes to `docs/reference.mdx` since it looks like that gets generated automatically. Not sure where else to provide docs.**
-   [x] Add new entries to the relevant CHANGELOG.jsons.
