### PR TITLE
fix: exchange proxy overhead scaled by gas price

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -141,6 +141,10 @@
             {
                 "note": "Added `Shell`",
                 "pr": 2722
+            },
+            {
+                "note": "Fix exchange proxy overhead gas being scaled by gas price",
+                "pr": 2723
             }
         ]
     },

--- a/packages/asset-swapper/src/utils/swap_quote_calculator.ts
+++ b/packages/asset-swapper/src/utils/swap_quote_calculator.ts
@@ -25,10 +25,9 @@ import {
     GetMarketOrdersOpts,
     OptimizedMarketOrder,
 } from './market_operation_utils/types';
-import { getTokenFromAssetData, isSupportedAssetDataInOrders } from './utils';
-
 import { QuoteReport } from './quote_report_generator';
 import { QuoteFillResult, simulateBestCaseFill, simulateWorstCaseFill } from './quote_simulation';
+import { getTokenFromAssetData, isSupportedAssetDataInOrders } from './utils';
 
 // TODO(dave4506) How do we want to reintroduce InsufficientAssetLiquidityError?
 export class SwapQuoteCalculator {
@@ -195,7 +194,8 @@ export class SwapQuoteCalculator {
                       opts.gasSchedule,
                       quoteReport,
                   );
-        const exchangeProxyOverhead = _opts.exchangeProxyOverhead(sourceFlags).toNumber();
+        // Use the raw gas, not scaled by gas price
+        const exchangeProxyOverhead = opts.exchangeProxyOverhead(sourceFlags).toNumber();
         swapQuote.bestCaseQuoteInfo.gas += exchangeProxyOverhead;
         swapQuote.worstCaseQuoteInfo.gas += exchangeProxyOverhead;
         return swapQuote;


### PR DESCRIPTION
## Description

[`_opts.exchangeProxyOverhead` was scaled](https://github.com/0xProject/0x-monorepo/blob/e3bdf5eedfbc8e20da03aea405f5118c0f8b4c3a/packages/asset-swapper/src/utils/swap_quote_calculator.ts#L141) by the `gasPrice` (aka ETH) for routing. We only want the gas component for the gas estimate.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
