### PR TITLE
fix: [asset-swapper] Catch Uint256BinOp which can occur

### DIFF
--- a/packages/asset-swapper/contracts/src/ApproximateBuys.sol
+++ b/packages/asset-swapper/contracts/src/ApproximateBuys.sol
@@ -125,6 +125,7 @@ contract ApproximateBuys {
             );
         }
     }
+
     function _safeGetPartialAmountCeil(
         uint256 numerator,
         uint256 denominator,
@@ -134,28 +135,9 @@ contract ApproximateBuys {
         view
         returns (uint256 partialAmount)
     {
-        (bool success, bytes memory resultData) =
-            address(this).staticcall(abi.encodeWithSelector(
-                this._getPartialAmountCeil.selector,
-                numerator,
-                denominator,
-                target
-            ));
-        if (!success) {
-            return 0;
-        }
-        return abi.decode(resultData, (uint256));
-    }
-
-    function _getPartialAmountCeil(
-        uint256 numerator,
-        uint256 denominator,
-        uint256 target
-    )
-        public
-        pure
-        returns (uint256 partialAmount)
-    {
-        return LibMath.getPartialAmountCeil(numerator, denominator, target);
+        if (numerator == 0 || target == 0 || denominator == 0) return 0;
+        uint256 c = numerator * target;
+        if (c / numerator != target) return 0;
+        return (c + (denominator - 1)) / denominator;
     }
 }

--- a/packages/asset-swapper/contracts/src/ApproximateBuys.sol
+++ b/packages/asset-swapper/contracts/src/ApproximateBuys.sol
@@ -78,16 +78,22 @@ contract ApproximateBuys {
         for (uint256 i = 0; i < makerTokenAmounts.length; i++) {
             for (uint256 iter = 0; iter < APPROXIMATE_BUY_MAX_ITERATIONS; iter++) {
                 // adjustedSellAmount = previousSellAmount * (target/actual) * JUMP_MULTIPLIER
-                sellAmount = LibMath.getPartialAmountCeil(
+                sellAmount = _safeGetPartialAmountCeil(
                     makerTokenAmounts[i],
                     buyAmount,
                     sellAmount
                 );
-                sellAmount = LibMath.getPartialAmountCeil(
+                if (sellAmount == 0) {
+                    break;
+                }
+                sellAmount = _safeGetPartialAmountCeil(
                     (ONE_HUNDED_PERCENT_BPS + APPROXIMATE_BUY_TARGET_EPSILON_BPS),
                     ONE_HUNDED_PERCENT_BPS,
                     sellAmount
                 );
+                if (sellAmount == 0) {
+                    break;
+                }
                 uint256 _buyAmount = opts.getSellQuoteCallback(
                     opts.takerTokenData,
                     opts.makerTokenData,
@@ -112,11 +118,44 @@ contract ApproximateBuys {
             // We do our best to close in on the requested amount, but we can either over buy or under buy and exit
             // if we hit a max iteration limit
             // We scale the sell amount to get the approximate target
-            takerTokenAmounts[i] = LibMath.getPartialAmountCeil(
+            takerTokenAmounts[i] = _safeGetPartialAmountCeil(
                 makerTokenAmounts[i],
                 buyAmount,
                 sellAmount
             );
         }
+    }
+    function _safeGetPartialAmountCeil(
+        uint256 numerator,
+        uint256 denominator,
+        uint256 target
+    )
+        internal
+        view
+        returns (uint256 partialAmount)
+    {
+        (bool success, bytes memory resultData) =
+            address(this).staticcall(abi.encodeWithSelector(
+                this._getPartialAmountCeil.selector,
+                numerator,
+                denominator,
+                target
+            ));
+        if (!success) {
+            return 0;
+        }
+        return abi.decode(resultData, (uint256));
+    }
+
+    function _getPartialAmountCeil(
+        uint256 numerator,
+        uint256 denominator,
+        uint256 target
+    )
+        public
+        pure
+        returns (uint256 partialAmount)
+    {
+        return LibMath.getPartialAmountCeil(numerator, denominator, target);
     }
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Sometimes Kyber was throwing a Uint256BinOpError for large buy amounts on certain pairs.
```
values: { error: 1, a: 4543042830303884935323379, b: 457454875418173172390967323045417612818571949129435461 }, abi: { type: 'error', name: 'Uint256BinOpError'
```

This would bubble all the way up the top and not be properly handled in a try/catch. I believe Mooniswap may also have the similar issue, but we check for balances of the pool.

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
