### PR TITLE
fix: [asset-swapper] MultiHop edge cases

### DIFF
--- a/packages/asset-swapper/CHANGELOG.json
+++ b/packages/asset-swapper/CHANGELOG.json
@@ -153,6 +153,10 @@
             {
                 "note": "Added `DODO`",
                 "pr": 2701
+            },
+            {
+                "note": "Fix for some edge cases with `includedSources` and `MultiHop`",
+                "pr": 2730
             }
         ]
     },

--- a/packages/asset-swapper/src/utils/market_operation_utils/multihop_utils.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/multihop_utils.ts
@@ -46,26 +46,37 @@ export function getBestTwoHopQuote(
     exchangeProxyOverhead?: ExchangeProxyOverhead,
 ): { quote: DexSample<MultiHopFillData> | undefined; adjustedRate: BigNumber } {
     const { side, inputAmount, ethToOutputRate, twoHopQuotes } = marketSideLiquidity;
-    if (twoHopQuotes.length === 0) {
-        return { adjustedRate: ZERO_AMOUNT, quote: undefined };
+    // Ensure the expected data we require exists. In the case where all hops reverted
+    // or there were no sources included that allowed for multi hop,
+    // we can end up with empty, but not undefined, fill data
+    const filteredQuotes = twoHopQuotes.filter(
+        quote =>
+            quote &&
+            quote.fillData &&
+            quote.fillData.firstHopSource &&
+            quote.fillData.secondHopSource &&
+            quote.output.isGreaterThan(ZERO_AMOUNT),
+    );
+    if (filteredQuotes.length === 0) {
+        return { quote: undefined, adjustedRate: ZERO_AMOUNT };
     }
-    const best = twoHopQuotes
+    const best = filteredQuotes
         .map(quote =>
             getTwoHopAdjustedRate(side, quote, inputAmount, ethToOutputRate, feeSchedule, exchangeProxyOverhead),
         )
         .reduce(
             (prev, curr, i) =>
-                curr.isGreaterThan(prev.adjustedRate) ? { adjustedRate: curr, quote: twoHopQuotes[i] } : prev,
+                curr.isGreaterThan(prev.adjustedRate) ? { adjustedRate: curr, quote: filteredQuotes[i] } : prev,
             {
                 adjustedRate: getTwoHopAdjustedRate(
                     side,
-                    twoHopQuotes[0],
+                    filteredQuotes[0],
                     inputAmount,
                     ethToOutputRate,
                     feeSchedule,
                     exchangeProxyOverhead,
                 ),
-                quote: twoHopQuotes[0],
+                quote: filteredQuotes[0],
             },
         );
     return best;

--- a/packages/asset-swapper/src/utils/market_operation_utils/sampler_operations.ts
+++ b/packages/asset-swapper/src/utils/market_operation_utils/sampler_operations.ts
@@ -600,11 +600,12 @@ export class SamplerOperations {
                     const [firstHop, secondHop, buyAmount] = this._samplerContract.getABIDecodedReturnData<
                         [HopInfo, HopInfo, BigNumber]
                     >('sampleTwoHopSell', callResults);
+                    // Ensure the hop sources are set even when the buy amount is zero
+                    fillData.firstHopSource = firstHopOps[firstHop.sourceIndex.toNumber()];
+                    fillData.secondHopSource = secondHopOps[secondHop.sourceIndex.toNumber()];
                     if (buyAmount.isZero()) {
                         return [ZERO_AMOUNT];
                     }
-                    fillData.firstHopSource = firstHopOps[firstHop.sourceIndex.toNumber()];
-                    fillData.secondHopSource = secondHopOps[secondHop.sourceIndex.toNumber()];
                     fillData.firstHopSource.handleCallResults(firstHop.returnData);
                     fillData.secondHopSource.handleCallResults(secondHop.returnData);
                     return [buyAmount];


### PR DESCRIPTION
## Description

Using `includedSources/excludedSources` can introduce a few edge cases.
* It modified feeSources which made it difficult to sometimes find an maker/ETH or taker/ETH price, so cost based routing could get weird.
* It can result in MultiHop not having anything to MultiHop to (e.g DAI/USDC with Curve only, theres no ability to ETH hop)
* There are cases where `firstHopSource` is not present in the `FillData` but it is required. No valid sources or reverts (didn't dig deep enough to confirm it was a revert)
* If there was no optimal path then we would throw, there's the possibility that there is no optimal path, but there is a MultiHop path available.

[Sims on some pairs which use MultiHop often](https://metabase.spaceship.0x.org/dashboard/139?run_id=fool-squalid-sky&adjusted_amount_bought_win_tolerance__bps_=0.5)

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
